### PR TITLE
Inject JENA_DATASET_NAME to `triples-generator` during deployment

### DIFF
--- a/helm-chart/renku-graph/templates/deployment.yaml
+++ b/helm-chart/renku-graph/templates/deployment.yaml
@@ -35,6 +35,12 @@ spec:
                   key: triplesGenerator-play-secret
             - name: GITLAB_BASE_URL
               value: {{ .Values.gitlab.url }}
+            - name: JENA_DATASET_NAME
+              {{- if .Values.global.jena.dataset }}
+              value: {{ .Values.global.jena.dataset }}
+              {{- else }}
+              value: renku
+              {{- end }}
             - name: JENA_BASE_URL
               value: "http://{{ template "jena.fullname" . }}:{{ .Values.jena.service.port }}"
             - name: JENA_ADMIN_PASSWORD


### PR DESCRIPTION
As we would like to have different datasets per developer on a shared Jena in the `dev` environment, it has to be possible for the `triples-generator`s to create datasets with certain names. As `triples-generator` was already configurable to do that, a tiny tweak to its helm chart had to be done.