### PR TITLE
POST /projects/:id/webhooks/validation to work for public projects

### DIFF
--- a/graph-commons/src/test/scala/ch/datascience/controllers/ErrorMessageSpec.scala
+++ b/graph-commons/src/test/scala/ch/datascience/controllers/ErrorMessageSpec.scala
@@ -20,7 +20,7 @@ package ch.datascience.controllers
 
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
-import play.api.libs.json.{JsError, JsPath, Json, KeyPathNode}
+import play.api.libs.json._
 
 class ErrorMessageSpec extends WordSpec {
 

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -46,6 +46,9 @@ The endpoint requires an authorization token. It has to be
 
 #### POST /projects/:id/webhooks/validation
 
+**Notice**
+This endpoint is under development and works just for public projects. For non-public projects it responds with INTERNAL SERVER ERROR (500).
+
 Validates the webhook for the project with the given `project id`. It succeeds (OK) if either the project is public and there's a hook for it or it's private, there's a hook for it and a Personal Access Token (PAT). If either there's no webhook or there's no PAT in case of a private project, the call results with NOT_FOUND. In case of private projects, if there's a hook created for a project but no PAT available (or the PAT doesn't work), the hook will be removed as part of the validation process.
 
 **Request format**

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -7,12 +7,13 @@ This is a microservice which:
 
 ## API
 
-| Method | Path                               | Description                               |
-|--------|------------------------------------|-------------------------------------------|
-|  GET   | ```/ping```                        | To check if service is healthy            |
-|  POST  | ```/projects/:id/webhooks```       | Creates a webhook for a project in GitLab |
-|  POST  | ```/webhooks/events```             | Consumes push events sent from GitLab     |
-
+| Method | Path                                      | Description                                    |
+|--------|-------------------------------------------|------------------------------------------------|
+|  GET   | ```/ping```                               | To check if service is healthy                 |
+|  POST  | ```/projects/:id/webhooks```              | Creates a webhook for a project in GitLab      |
+|  POST  | ```/projects/:id/webhooks/validation```   | Validates the project's webhook                |
+|  POST  | ```/webhooks/events```                    | Consumes push events sent from GitLab          |
+     
 #### GET /ping
 
 Verifies service health.
@@ -41,7 +42,26 @@ The endpoint requires an authorization token. It has to be
 | OK (200)                   | When hook already exists for the project                                              |
 | CREATED (201)              | When a new hook was created                                                           |
 | UNAUTHORIZED (401)         | When there is neither `PRIVATE-TOKEN` nor `OAUTH-TOKEN` in the header or it's invalid |
-| INTERNAL SERVER ERROR (500)| When there were problems with webhook creation                                        |
+| INTERNAL SERVER ERROR (500)| When there are problems with webhook creation                                         |
+
+#### POST /projects/:id/webhooks/validation
+
+Validates the webhook for the project with the given `project id`. It succeeds (OK) if either the project is public and there's a hook for it or it's private, there's a hook for it and a Personal Access Token (PAT). If either there's no webhook or there's no PAT in case of a private project, the call results with NOT_FOUND. In case of private projects, if there's a hook created for a project but no PAT available (or the PAT doesn't work), the hook will be removed as part of the validation process.
+
+**Request format**
+
+The endpoint requires an authorization token. It has to be
+- either `PRIVATE-TOKEN` with user's personal access token in GitLab
+- or `OAUTH-TOKEN` with oauth token obtained from GitLab
+
+**Response**
+
+| Status                     | Description                                                                                                                                                       |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| OK (200)                   | When the hook exists for the project and the project is either public or there's a Personal Access Token available for it                                         |
+| NOT_FOUND (404)            | When the hook either does not exists or there's no Personal Access Token available for it. If the hook exists but there's no PAT for it, the hook will be removed |
+| UNAUTHORIZED (401)         | When there is neither `PRIVATE-TOKEN` nor `OAUTH-TOKEN` in the header or it's invalid                                                                             |
+| INTERNAL SERVER ERROR (500)| When there are problems with validating the hook presence                                                                                                         |
 
 #### POST /webhooks/events
 

--- a/webhook-service/app/ch/datascience/webhookservice/hookcreation/HookCreator.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/hookcreation/HookCreator.scala
@@ -28,10 +28,10 @@ import ch.datascience.logging.IOLogger
 import ch.datascience.webhookservice.crypto.{HookTokenCrypto, IOHookTokenCrypto}
 import ch.datascience.webhookservice.hookcreation.HookCreator.{HookAlreadyCreated, HookCreationResult}
 import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
-import ch.datascience.webhookservice.hookcreation.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.model.HookToken
-import ch.datascience.webhookservice.project.{IOProjectInfoFinder, ProjectInfoFinder}
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
+import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
+import ch.datascience.webhookservice.project._
 import io.chrisdavenport.log4cats.Logger
 import javax.inject.{Inject, Singleton}
 

--- a/webhook-service/app/ch/datascience/webhookservice/hookcreation/HookCreator.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/hookcreation/HookCreator.scala
@@ -31,6 +31,7 @@ import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
 import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
 import ch.datascience.webhookservice.hookcreation.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.model.HookToken
+import ch.datascience.webhookservice.project.{IOProjectInfoFinder, ProjectInfoFinder}
 import io.chrisdavenport.log4cats.Logger
 import javax.inject.{Inject, Singleton}
 

--- a/webhook-service/app/ch/datascience/webhookservice/hookcreation/ProjectHookCreator.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/hookcreation/ProjectHookCreator.scala
@@ -24,7 +24,7 @@ import ch.datascience.graph.events.ProjectId
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
 import ch.datascience.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.ExecutionContext

--- a/webhook-service/app/ch/datascience/webhookservice/hookvalidation/HookValidator.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/hookvalidation/HookValidator.scala
@@ -18,6 +18,7 @@
 
 package ch.datascience.webhookservice.hookvalidation
 
+import ProjectHookVerifier.HookIdentifier
 import cats.MonadError
 import cats.effect.IO
 import cats.implicits._
@@ -26,7 +27,6 @@ import ch.datascience.graph.events.ProjectId
 import ch.datascience.logging.IOLogger
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult
 import ch.datascience.webhookservice.model.ProjectInfo
-import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.project._
 import io.chrisdavenport.log4cats.Logger
 import javax.inject.{Inject, Singleton}
@@ -34,7 +34,7 @@ import javax.inject.{Inject, Singleton}
 import scala.language.higherKinds
 import scala.util.control.NonFatal
 
-private class HookValidator[Interpretation[_]](
+class HookValidator[Interpretation[_]](
     projectInfoFinder:    ProjectInfoFinder[Interpretation],
     projectHookUrlFinder: ProjectHookUrlFinder[Interpretation],
     projectHookVerifier:  ProjectHookVerifier[Interpretation],
@@ -75,7 +75,7 @@ private class HookValidator[Interpretation[_]](
   }
 }
 
-private object HookValidator {
+object HookValidator {
 
   sealed trait HookValidationResult
   object HookValidationResult {
@@ -85,7 +85,7 @@ private object HookValidator {
 }
 
 @Singleton
-private class IOHookValidator @Inject()(
+class IOHookValidator @Inject()(
     projectInfoFinder:    IOProjectInfoFinder,
     projectHookUrlFinder: IOProjectHookUrlFinder,
     projectHookVerifier:  IOProjectHookVerifier,

--- a/webhook-service/app/ch/datascience/webhookservice/hookvalidation/HookValidator.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/hookvalidation/HookValidator.scala
@@ -16,20 +16,30 @@
  * limitations under the License.
  */
 
-package ch.datascience.clients
+package ch.datascience.webhookservice.hookvalidation
 
-import ch.datascience.tinytypes.constraints.NonBlank
-import ch.datascience.tinytypes.{Sensitive, TinyType, TinyTypeFactory}
+import cats.effect.IO
+import ch.datascience.graph.events.ProjectId
+import javax.inject.Singleton
 
-sealed trait AccessToken extends Any with TinyType[String] with Sensitive
+import scala.language.higherKinds
 
-object AccessToken {
+private class HookValidator[Interpretation[_]] {
+  import HookValidator._
+  import ch.datascience.clients.AccessToken
 
-  final class PersonalAccessToken private (val value: String) extends AnyVal with AccessToken
-  object PersonalAccessToken
-      extends TinyTypeFactory[String, PersonalAccessToken](new PersonalAccessToken(_))
-      with NonBlank
+  def validateHook(id: ProjectId, accessToken: AccessToken): Interpretation[HookValidationResult] = ???
 
-  final class OAuthAccessToken private (val value: String) extends AnyVal with AccessToken
-  object OAuthAccessToken extends TinyTypeFactory[String, OAuthAccessToken](new OAuthAccessToken(_)) with NonBlank
 }
+
+private object HookValidator {
+
+  sealed trait HookValidationResult
+  object HookValidationResult {
+    final case object HookExists  extends HookValidationResult
+    final case object HookMissing extends HookValidationResult
+  }
+}
+
+@Singleton
+private class IOHookValidator extends HookValidator[IO] {}

--- a/webhook-service/app/ch/datascience/webhookservice/hookvalidation/ProjectHookVerifier.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/hookvalidation/ProjectHookVerifier.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.project
+package ch.datascience.webhookservice.hookvalidation
 
 import ProjectHookVerifier.HookIdentifier
 import cats.effect.IO
@@ -30,14 +30,14 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
-trait ProjectHookVerifier[Interpretation[_]] {
+private trait ProjectHookVerifier[Interpretation[_]] {
   def checkProjectHookPresence(
       projectHookId: HookIdentifier,
       accessToken:   AccessToken
   ): Interpretation[Boolean]
 }
 
-object ProjectHookVerifier {
+private object ProjectHookVerifier {
 
   final case class HookIdentifier(
       projectId:      ProjectId,
@@ -46,7 +46,7 @@ object ProjectHookVerifier {
 }
 
 @Singleton
-class IOProjectHookVerifier @Inject()(
+private class IOProjectHookVerifier @Inject()(
     gitLabUrlProvider:       IOGitLabConfigProvider
 )(implicit executionContext: ExecutionContext)
     extends IORestClient

--- a/webhook-service/app/ch/datascience/webhookservice/model.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/model.scala
@@ -19,6 +19,8 @@
 package ch.datascience.webhookservice
 
 import ch.datascience.graph.events.{ProjectId, ProjectPath, UserId}
+import ch.datascience.tinytypes.TinyType
+import io.circe.Decoder
 
 object model {
 
@@ -30,9 +32,37 @@ object model {
       id: UserId
   )
 
+  sealed trait ProjectVisibility extends TinyType[String] with Product with Serializable
+  object ProjectVisibility {
+
+    val all: Set[ProjectVisibility] = Set(Public, Private, Internal)
+
+    implicit lazy val projectVisibilityDecoder: Decoder[ProjectVisibility] =
+      Decoder.decodeString.flatMap { decoded =>
+        all.find(_.value == decoded) match {
+          case Some(value) => Decoder.const(value)
+          case None =>
+            Decoder.failedWithMessage(
+              s"'$decoded' is not a valid project visibility. Allowed values are: ${all.mkString(", ")}"
+            )
+        }
+      }
+
+    final case object Private extends ProjectVisibility {
+      override val value: String = "private"
+    }
+    final case object Internal extends ProjectVisibility {
+      override val value: String = "internal"
+    }
+    final case object Public extends ProjectVisibility {
+      override val value: String = "public"
+    }
+  }
+
   final case class ProjectInfo(
-      id:    ProjectId,
-      path:  ProjectPath,
-      owner: ProjectOwner
+      id:         ProjectId,
+      visibility: ProjectVisibility,
+      path:       ProjectPath,
+      owner:      ProjectOwner
   )
 }

--- a/webhook-service/app/ch/datascience/webhookservice/project/ProjectHookUrlFinder.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/project/ProjectHookUrlFinder.scala
@@ -16,21 +16,21 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
+import ProjectHookUrlFinder.ProjectHookUrl
 import cats.MonadError
 import cats.effect.IO
 import cats.implicits._
 import ch.datascience.tinytypes.{TinyType, TinyTypeFactory}
 import ch.datascience.webhookservice.eventprocessing.routes.WebhookEventEndpoint
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
 import eu.timepit.refined.api.{RefType, Refined}
 import io.circe.Decoder
 import javax.inject.{Inject, Singleton}
 
 import scala.language.higherKinds
 
-private class ProjectHookUrlFinder[Interpretation[_]](
+class ProjectHookUrlFinder[Interpretation[_]](
     selfUrlConfig: SelfUrlConfig[Interpretation]
 )(implicit ME:     MonadError[Interpretation, Throwable]) {
 
@@ -41,7 +41,7 @@ private class ProjectHookUrlFinder[Interpretation[_]](
     } yield projectHookUrl
 }
 
-private object ProjectHookUrlFinder {
+object ProjectHookUrlFinder {
   import eu.timepit.refined.string.Url
 
   class ProjectHookUrl private (val value: String) extends AnyVal with TinyType[String]
@@ -60,6 +60,6 @@ private object ProjectHookUrlFinder {
 }
 
 @Singleton
-private class IOProjectHookUrlFinder @Inject()(
+class IOProjectHookUrlFinder @Inject()(
     selfUrlConfig: IOSelfUrlConfigProvider
 ) extends ProjectHookUrlFinder[IO](selfUrlConfig)

--- a/webhook-service/app/ch/datascience/webhookservice/project/ProjectHookVerifier.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/project/ProjectHookVerifier.scala
@@ -16,28 +16,28 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
+import ProjectHookVerifier.HookIdentifier
 import cats.effect.IO
 import ch.datascience.clients.{AccessToken, IORestClient}
 import ch.datascience.graph.events.ProjectId
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
-import ch.datascience.webhookservice.hookcreation.ProjectHookVerifier.HookIdentifier
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
 import io.circe.Decoder.decodeList
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
-private trait ProjectHookVerifier[Interpretation[_]] {
+trait ProjectHookVerifier[Interpretation[_]] {
   def checkProjectHookPresence(
       projectHookId: HookIdentifier,
       accessToken:   AccessToken
   ): Interpretation[Boolean]
 }
 
-private object ProjectHookVerifier {
+object ProjectHookVerifier {
 
   final case class HookIdentifier(
       projectId:      ProjectId,
@@ -46,7 +46,7 @@ private object ProjectHookVerifier {
 }
 
 @Singleton
-private class IOProjectHookVerifier @Inject()(
+class IOProjectHookVerifier @Inject()(
     gitLabUrlProvider:       IOGitLabConfigProvider
 )(implicit executionContext: ExecutionContext)
     extends IORestClient

--- a/webhook-service/app/ch/datascience/webhookservice/project/ProjectInfoFinder.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/project/ProjectInfoFinder.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 import ch.datascience.clients.{AccessToken, IORestClient}
 import ch.datascience.graph.events._
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
-import ch.datascience.webhookservice.model.{ProjectInfo, ProjectOwner}
+import ch.datascience.webhookservice.model.{ProjectInfo, ProjectOwner, ProjectVisibility}
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.ExecutionContext
@@ -67,10 +67,11 @@ class IOProjectInfoFinder @Inject()(gitLabConfigProvider: IOGitLabConfigProvider
   private implicit lazy val projectInfoDecoder: EntityDecoder[IO, ProjectInfo] = {
     implicit val hookNameDecoder: Decoder[ProjectInfo] = (cursor: HCursor) =>
       for {
-        id      <- cursor.downField("id").as[ProjectId]
-        path    <- cursor.downField("path_with_namespace").as[ProjectPath]
-        ownerId <- cursor.downField("owner").downField("id").as[UserId]
-      } yield ProjectInfo(id, path, ProjectOwner(ownerId))
+        id         <- cursor.downField("id").as[ProjectId]
+        visibility <- cursor.downField("visibility").as[ProjectVisibility]
+        path       <- cursor.downField("path_with_namespace").as[ProjectPath]
+        ownerId    <- cursor.downField("owner").downField("id").as[UserId]
+      } yield ProjectInfo(id, visibility, path, ProjectOwner(ownerId))
 
     jsonOf[IO, ProjectInfo]
   }

--- a/webhook-service/app/ch/datascience/webhookservice/project/ProjectInfoFinder.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/project/ProjectInfoFinder.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
 import cats.effect.IO
 import ch.datascience.clients.{AccessToken, IORestClient}
@@ -28,7 +28,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
 
-private trait ProjectInfoFinder[Interpretation[_]] {
+trait ProjectInfoFinder[Interpretation[_]] {
   def findProjectInfo(
       projectId:   ProjectId,
       accessToken: AccessToken
@@ -36,8 +36,8 @@ private trait ProjectInfoFinder[Interpretation[_]] {
 }
 
 @Singleton
-private class IOProjectInfoFinder @Inject()(gitLabConfigProvider: IOGitLabConfigProvider)(
-    implicit executionContext:                                    ExecutionContext)
+class IOProjectInfoFinder @Inject()(gitLabConfigProvider: IOGitLabConfigProvider)(
+    implicit executionContext:                            ExecutionContext)
     extends IORestClient
     with ProjectInfoFinder[IO] {
 

--- a/webhook-service/app/ch/datascience/webhookservice/project/SelfUrlConfig.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/project/SelfUrlConfig.scala
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
+import SelfUrlConfig.SelfUrl
 import cats.MonadError
 import cats.effect.IO
 import cats.implicits._
 import ch.datascience.config.ConfigLoader
 import ch.datascience.tinytypes.{TinyType, TinyTypeFactory}
-import ch.datascience.webhookservice.hookcreation.SelfUrlConfig.SelfUrl
 import eu.timepit.refined.api.{RefType, Refined}
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration

--- a/webhook-service/app/ch/datascience/webhookservice/security/AccessTokenFinder.scala
+++ b/webhook-service/app/ch/datascience/webhookservice/security/AccessTokenFinder.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice.security
+
+import cats.MonadError
+import cats.effect.IO
+import cats.implicits._
+import ch.datascience.clients.AccessToken
+import ch.datascience.clients.AccessToken.{OAuthAccessToken, PersonalAccessToken}
+import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import javax.inject.Singleton
+import play.api.mvc.Request
+
+import scala.language.higherKinds
+
+class AccessTokenFinder[Interpretation[_]](implicit ME: MonadError[Interpretation, Throwable]) {
+
+  def findAccessToken(request: Request[_]): Interpretation[AccessToken] = ME.fromEither {
+    convert(request.headers.get("OAUTH-TOKEN"), to = OAuthAccessToken.from)
+      .orElse(convert(request.headers.get("PRIVATE-TOKEN"), to = PersonalAccessToken.from))
+      .getOrElse(Left(UnauthorizedException))
+  }
+
+  private def convert(headers: Option[String], to: String => Either[Exception, AccessToken]) =
+    headers.map {
+      to(_).leftMap(_ => UnauthorizedException)
+    }
+}
+
+@Singleton
+class IOAccessTokenFinder extends AccessTokenFinder[IO]

--- a/webhook-service/conf/routes
+++ b/webhook-service/conf/routes
@@ -1,4 +1,5 @@
-GET     /ping                    ch.datascience.webhookservice.HealthCheckController.ping
+GET     /ping                               ch.datascience.webhookservice.HealthCheckController.ping
 
-POST    /webhooks/events         ch.datascience.webhookservice.eventprocessing.WebhookEventEndpoint.processPushEvent
-POST    /projects/:id/webhooks   ch.datascience.webhookservice.hookcreation.HookCreationEndpoint.createHook(id: ProjectId)
+POST    /webhooks/events                    ch.datascience.webhookservice.eventprocessing.WebhookEventEndpoint.processPushEvent
+POST    /projects/:id/webhooks              ch.datascience.webhookservice.hookcreation.HookCreationEndpoint.createHook(id: ProjectId)
+POST    /projects/:id/webhooks/validation   ch.datascience.webhookservice.hookvalidation.HookValidationEndpoint.validateHook(id: ProjectId)

--- a/webhook-service/test/ch/datascience/webhookservice/ProjectVisibilitySpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/ProjectVisibilitySpec.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ch.datascience.webhookservice
 
 import ch.datascience.webhookservice.model.ProjectVisibility

--- a/webhook-service/test/ch/datascience/webhookservice/ProjectVisibilitySpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/ProjectVisibilitySpec.scala
@@ -1,0 +1,27 @@
+package ch.datascience.webhookservice
+
+import ch.datascience.webhookservice.model.ProjectVisibility
+import io.circe.{DecodingFailure, Json}
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+class ProjectVisibilitySpec extends WordSpec {
+
+  "projectVisibilityDecoder" should {
+
+    ProjectVisibility.all foreach { visibility =>
+      s"deserialize $visibility" in {
+        Json.fromString(visibility.value).as[ProjectVisibility] shouldBe Right(visibility)
+      }
+    }
+
+    "fail for unknown value" in {
+      Json.fromString("unknown").as[ProjectVisibility] shouldBe Left(
+        DecodingFailure(
+          s"'unknown' is not a valid project visibility. Allowed values are: ${ProjectVisibility.all.mkString(", ")}",
+          Nil
+        )
+      )
+    }
+  }
+}

--- a/webhook-service/test/ch/datascience/webhookservice/generators/ServiceTypesGenerators.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/generators/ServiceTypesGenerators.scala
@@ -24,7 +24,6 @@ import ch.datascience.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import ch.datascience.webhookservice.eventprocessing.PushEvent
 import ch.datascience.webhookservice.model._
 import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
-import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.project.SelfUrlConfig.SelfUrl
 import eu.timepit.refined.api.RefType
 import org.scalacheck.Gen
@@ -66,9 +65,4 @@ object ServiceTypesGenerators {
 
   implicit val projectHookUrls: Gen[ProjectHookUrl] =
     validatedUrls map (url => ProjectHookUrl.apply(url.value))
-
-  implicit val projectHookIds: Gen[HookIdentifier] = for {
-    projectId <- projectIds
-    hookUrl   <- projectHookUrls
-  } yield HookIdentifier(projectId, hookUrl)
 }

--- a/webhook-service/test/ch/datascience/webhookservice/generators/ServiceTypesGenerators.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/generators/ServiceTypesGenerators.scala
@@ -23,7 +23,7 @@ import ch.datascience.graph.events.EventsGenerators._
 import ch.datascience.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import ch.datascience.webhookservice.eventprocessing.PushEvent
 import ch.datascience.webhookservice.hookcreation.SelfUrlConfig.SelfUrl
-import ch.datascience.webhookservice.model.{HookToken, ProjectInfo, ProjectOwner}
+import ch.datascience.webhookservice.model._
 import eu.timepit.refined.api.RefType
 import org.scalacheck.Gen
 
@@ -50,11 +50,14 @@ object ServiceTypesGenerators {
     id <- userIds
   } yield ProjectOwner(id)
 
+  implicit val projectVisibilities: Gen[ProjectVisibility] = Gen.oneOf(ProjectVisibility.all.toList)
+
   implicit val projectInfos: Gen[ProjectInfo] = for {
-    id    <- projectIds
-    path  <- projectPaths
-    owner <- projectOwner
-  } yield ProjectInfo(id, path, owner)
+    id         <- projectIds
+    visibility <- projectVisibilities
+    path       <- projectPaths
+    owner      <- projectOwner
+  } yield ProjectInfo(id, visibility, path, owner)
 
   implicit val selfUrls: Gen[SelfUrl] =
     validatedUrls map (url => SelfUrl.apply(url.value))

--- a/webhook-service/test/ch/datascience/webhookservice/generators/ServiceTypesGenerators.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/generators/ServiceTypesGenerators.scala
@@ -22,8 +22,10 @@ import ch.datascience.generators.Generators._
 import ch.datascience.graph.events.EventsGenerators._
 import ch.datascience.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import ch.datascience.webhookservice.eventprocessing.PushEvent
-import ch.datascience.webhookservice.hookcreation.SelfUrlConfig.SelfUrl
 import ch.datascience.webhookservice.model._
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
+import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
+import ch.datascience.webhookservice.project.SelfUrlConfig.SelfUrl
 import eu.timepit.refined.api.RefType
 import org.scalacheck.Gen
 
@@ -61,4 +63,12 @@ object ServiceTypesGenerators {
 
   implicit val selfUrls: Gen[SelfUrl] =
     validatedUrls map (url => SelfUrl.apply(url.value))
+
+  implicit val projectHookUrls: Gen[ProjectHookUrl] =
+    validatedUrls map (url => ProjectHookUrl.apply(url.value))
+
+  implicit val projectHookIds: Gen[HookIdentifier] = for {
+    projectId <- projectIds
+    hookUrl   <- projectHookUrls
+  } yield HookIdentifier(projectId, hookUrl)
 }

--- a/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreationGenerators.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreationGenerators.scala
@@ -18,20 +18,14 @@
 
 package ch.datascience.webhookservice.hookcreation
 
-import ch.datascience.generators.Generators.validatedUrls
-import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
-import org.scalacheck.Gen
 import ch.datascience.graph.events.EventsGenerators._
 import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
 import ch.datascience.webhookservice.hookcreation.LatestPushEventFetcher.PushEventInfo
-import ch.datascience.webhookservice.hookcreation.ProjectHookVerifier.HookIdentifier
+import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
 import ch.datascience.webhookservice.hookcreation.UserInfoFinder.UserInfo
+import org.scalacheck.Gen
 
 private object HookCreationGenerators {
-
-  implicit val projectHookUrls: Gen[ProjectHookUrl] =
-    validatedUrls map (url => ProjectHookUrl.apply(url.value))
 
   implicit val projectHooks: Gen[ProjectHook] = for {
     projectId           <- projectIds
@@ -43,16 +37,6 @@ private object HookCreationGenerators {
       hookUrl,
       serializedHookToken
     )
-
-  implicit val projectHookIds: Gen[HookIdentifier] = for {
-    projectId <- projectIds
-    hookUrl   <- projectHookUrls
-  } yield
-    HookIdentifier(
-      projectId,
-      hookUrl,
-    )
-
   implicit val pushEventInfos: Gen[PushEventInfo] = for {
     projectId <- projectIds
     userId    <- userIds

--- a/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -34,9 +34,9 @@ import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
 import ch.datascience.webhookservice.hookcreation.HookCreationGenerators._
 import ch.datascience.webhookservice.hookcreation.HookCreator.HookCreationResult.{HookCreated, HookExisted}
 import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
-import ch.datascience.webhookservice.hookcreation.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.model.{HookToken, ProjectInfo}
-import ch.datascience.webhookservice.project.ProjectInfoFinder
+import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
+import ch.datascience.webhookservice.project._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
@@ -257,15 +257,10 @@ class HookCreatorSpec extends WordSpec with MockFactory {
 
     val context = MonadError[Try, Throwable]
 
-    val logger              = TestLogger[Try]()
-    val projectInfoFinder   = mock[ProjectInfoFinder[Try]]
-    val projectHookVerifier = mock[ProjectHookVerifier[Try]]
-    val projectHookCreator  = mock[ProjectHookCreator[Try]]
-
-    class TryProjectHookUrlFinder(
-        selfUrlConfig: SelfUrlConfig[Try]
-    )(implicit ME:     MonadError[Try, Throwable])
-        extends ProjectHookUrlFinder[Try](selfUrlConfig)
+    val logger               = TestLogger[Try]()
+    val projectInfoFinder    = mock[ProjectInfoFinder[Try]]
+    val projectHookVerifier  = mock[ProjectHookVerifier[Try]]
+    val projectHookCreator   = mock[ProjectHookCreator[Try]]
     val projectHookUrlFinder = mock[TryProjectHookUrlFinder]
 
     class TryHookTokenCrypt(secret: Secret) extends HookTokenCrypto[Try](secret)

--- a/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -31,7 +31,6 @@ import ch.datascience.interpreters.TestLogger.Level._
 import ch.datascience.webhookservice.crypto.HookTokenCrypto
 import ch.datascience.webhookservice.eventprocessing.pushevent.PushEventSender
 import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
-import ch.datascience.webhookservice.hookcreation.HookCreationGenerators._
 import ch.datascience.webhookservice.hookcreation.HookCreator.HookCreationResult.{HookCreated, HookExisted}
 import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
 import ch.datascience.webhookservice.model.{HookToken, ProjectInfo}

--- a/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -36,6 +36,7 @@ import ch.datascience.webhookservice.hookcreation.HookCreator.HookCreationResult
 import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
 import ch.datascience.webhookservice.hookcreation.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.model.{HookToken, ProjectInfo}
+import ch.datascience.webhookservice.project.ProjectInfoFinder
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec

--- a/webhook-service/test/ch/datascience/webhookservice/hookcreation/ProjectHookUrlSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookcreation/ProjectHookUrlSpec.scala
@@ -21,7 +21,7 @@ package ch.datascience.webhookservice.hookcreation
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
 import ch.datascience.tinytypes.TinyType
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
 
@@ -48,7 +48,7 @@ class ProjectHookUrlSpec extends WordSpec {
       val Left(exception) = ProjectHookUrl.from("123")
 
       exception            shouldBe an[IllegalArgumentException]
-      exception.getMessage shouldBe "'123' is not a valid ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl"
+      exception.getMessage shouldBe "'123' is not a valid ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl"
     }
   }
 }

--- a/webhook-service/test/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice.hookvalidation
+
+import cats.MonadError
+import cats.implicits._
+import ch.datascience.clients.AccessToken
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators.exceptions
+import ch.datascience.graph.events.GraphCommonsGenerators._
+import ch.datascience.graph.events.ProjectId
+import ch.datascience.interpreters.TestLogger
+import ch.datascience.interpreters.TestLogger.Level.{Error, Info}
+import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
+import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult.{HookExists, HookMissing}
+import ch.datascience.webhookservice.model.ProjectVisibility
+import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
+import ch.datascience.webhookservice.project.{ProjectHookVerifier, ProjectInfoFinder, TryProjectHookUrlFinder}
+import org.scalacheck.Arbitrary
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+import scala.util.{Failure, Try}
+
+class HookValidatorSpec extends WordSpec with MockFactory {
+
+  "validateHook" should {
+
+    "succeed with HookExists if project is public and there's a hook for it" in new TestCase {
+
+      val projectInfo = projectInfos.generateOne.copy(visibility = ProjectVisibility.Public)
+      val projectId   = projectInfo.id
+
+      (projectInfoFinder
+        .findProjectInfo(_: ProjectId, _: AccessToken))
+        .expects(projectId, accessToken)
+        .returning(context.pure(projectInfo))
+
+      val projectHookUrl = projectHookUrls.generateOne
+      (projectHookUrlFinder.findProjectHookUrl _)
+        .expects()
+        .returning(context.pure(projectHookUrl))
+
+      (projectHookVerifier
+        .checkProjectHookPresence(_: HookIdentifier, _: AccessToken))
+        .expects(HookIdentifier(projectId, projectHookUrl), accessToken)
+        .returning(context.pure(true))
+
+      validator.validateHook(projectId, accessToken) shouldBe context.pure(HookExists)
+
+      logger.loggedOnly(Info(s"Hook exists for project with id $projectId"))
+    }
+
+    "succeed with HookMissing if project is public and there's no hook for it" in new TestCase {
+
+      val projectInfo = projectInfos.generateOne.copy(visibility = ProjectVisibility.Public)
+      val projectId   = projectInfo.id
+
+      (projectInfoFinder
+        .findProjectInfo(_: ProjectId, _: AccessToken))
+        .expects(projectId, accessToken)
+        .returning(context.pure(projectInfo))
+
+      val projectHookUrl = projectHookUrls.generateOne
+      (projectHookUrlFinder.findProjectHookUrl _)
+        .expects()
+        .returning(context.pure(projectHookUrl))
+
+      (projectHookVerifier
+        .checkProjectHookPresence(_: HookIdentifier, _: AccessToken))
+        .expects(HookIdentifier(projectId, projectHookUrl), accessToken)
+        .returning(context.pure(false))
+
+      validator.validateHook(projectId, accessToken) shouldBe context.pure(HookMissing)
+
+      logger.loggedOnly(Info(s"Hook missing for project with id $projectId"))
+    }
+
+    "throw NotImplementedError for a non-public project" in new TestCase {
+
+      val projectInfo = projectInfos.generateOne.copy(
+        visibility = projectVisibilities.generateDifferentThan(ProjectVisibility.Public)
+      )
+      val projectId = projectInfo.id
+
+      (projectInfoFinder
+        .findProjectInfo(_: ProjectId, _: AccessToken))
+        .expects(projectId, accessToken)
+        .returning(context.pure(projectInfo))
+
+      val projectHookUrl = projectHookUrls.generateOne
+      (projectHookUrlFinder.findProjectHookUrl _)
+        .expects()
+        .returning(context.pure(projectHookUrl))
+
+      (projectHookVerifier
+        .checkProjectHookPresence(_: HookIdentifier, _: AccessToken))
+        .expects(HookIdentifier(projectId, projectHookUrl), accessToken)
+        .returning(context.pure(Arbitrary.arbBool.arbitrary.generateOne))
+
+      val Failure(exception) = validator.validateHook(projectId, accessToken)
+
+      exception shouldBe an[NotImplementedError]
+
+      logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
+    }
+
+    "log an error if project info fetching fails" in new TestCase {
+
+      val projectInfo = projectInfos.generateOne
+      val projectId   = projectInfo.id
+
+      val exception: Exception    = exceptions.generateOne
+      val error:     Try[Nothing] = context.raiseError(exception)
+      (projectInfoFinder
+        .findProjectInfo(_: ProjectId, _: AccessToken))
+        .expects(projectId, accessToken)
+        .returning(error)
+
+      validator.validateHook(projectId, accessToken) shouldBe error
+
+      logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
+    }
+
+    "log an error if finding project hook url fails" in new TestCase {
+
+      val projectInfo = projectInfos.generateOne
+      val projectId   = projectInfo.id
+
+      (projectInfoFinder
+        .findProjectInfo(_: ProjectId, _: AccessToken))
+        .expects(projectId, accessToken)
+        .returning(context.pure(projectInfo))
+
+      val exception: Exception    = exceptions.generateOne
+      val error:     Try[Nothing] = context.raiseError(exception)
+      (projectHookUrlFinder.findProjectHookUrl _)
+        .expects()
+        .returning(error)
+
+      validator.validateHook(projectId, accessToken) shouldBe error
+
+      logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
+    }
+
+    "log an error if finding hook verification fails" in new TestCase {
+
+      val projectInfo = projectInfos.generateOne
+      val projectId   = projectInfo.id
+
+      (projectInfoFinder
+        .findProjectInfo(_: ProjectId, _: AccessToken))
+        .expects(projectId, accessToken)
+        .returning(context.pure(projectInfo))
+
+      val projectHookUrl = projectHookUrls.generateOne
+      (projectHookUrlFinder.findProjectHookUrl _)
+        .expects()
+        .returning(context.pure(projectHookUrl))
+
+      val exception: Exception    = exceptions.generateOne
+      val error:     Try[Nothing] = context.raiseError(exception)
+      (projectHookVerifier
+        .checkProjectHookPresence(_: HookIdentifier, _: AccessToken))
+        .expects(HookIdentifier(projectId, projectHookUrl), accessToken)
+        .returning(error)
+
+      validator.validateHook(projectId, accessToken) shouldBe error
+
+      logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
+    }
+  }
+
+  private trait TestCase {
+    val context = MonadError[Try, Throwable]
+
+    val accessToken = accessTokens.generateOne
+
+    val projectInfoFinder    = mock[ProjectInfoFinder[Try]]
+    val projectHookUrlFinder = mock[TryProjectHookUrlFinder]
+    val projectHookVerifier  = mock[ProjectHookVerifier[Try]]
+    val logger               = TestLogger[Try]()
+    val validator            = new HookValidator[Try](projectInfoFinder, projectHookUrlFinder, projectHookVerifier, logger)
+  }
+}

--- a/webhook-service/test/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -18,6 +18,7 @@
 
 package ch.datascience.webhookservice.hookvalidation
 
+import ProjectHookVerifier.HookIdentifier
 import cats.MonadError
 import cats.implicits._
 import ch.datascience.clients.AccessToken
@@ -30,8 +31,8 @@ import ch.datascience.interpreters.TestLogger.Level.{Error, Info}
 import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult.{HookExists, HookMissing}
 import ch.datascience.webhookservice.model.ProjectVisibility
-import ch.datascience.webhookservice.project.ProjectHookVerifier.HookIdentifier
-import ch.datascience.webhookservice.project.{ProjectHookVerifier, ProjectInfoFinder, TryProjectHookUrlFinder}
+import ch.datascience.webhookservice.project._
+import io.chrisdavenport.log4cats.Logger
 import org.scalacheck.Arbitrary
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
@@ -200,3 +201,10 @@ class HookValidatorSpec extends WordSpec with MockFactory {
     val validator            = new HookValidator[Try](projectInfoFinder, projectHookUrlFinder, projectHookVerifier, logger)
   }
 }
+
+class TryHookValidator(
+    projectInfoFinder:    ProjectInfoFinder[Try],
+    projectHookUrlFinder: ProjectHookUrlFinder[Try],
+    projectHookVerifier:  ProjectHookVerifier[Try],
+    logger:               Logger[Try]
+) extends HookValidator[Try](projectInfoFinder, projectHookUrlFinder, projectHookVerifier, logger)

--- a/webhook-service/test/ch/datascience/webhookservice/hookvalidation/IOProjectHookVerifierSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/hookvalidation/IOProjectHookVerifierSpec.scala
@@ -16,23 +16,26 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.project
+package ch.datascience.webhookservice.hookvalidation
 
 import cats.effect.IO
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
+import ch.datascience.graph.events.EventsGenerators.projectIds
 import ch.datascience.graph.events.GraphCommonsGenerators._
 import ch.datascience.graph.events.ProjectId
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.{GitLabConfig, IOGitLabConfigProvider}
 import ch.datascience.webhookservice.exceptions.UnauthorizedException
 import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
+import ch.datascience.webhookservice.hookvalidation.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
 import com.github.tomakehurst.wiremock.client.WireMock._
 import eu.timepit.refined.api.{RefType, Refined}
 import eu.timepit.refined.string.Url
 import io.circe.Json
 import org.http4s.Status
+import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
@@ -184,4 +187,9 @@ class IOProjectHookVerifierSpec extends WordSpec with MockFactory with ExternalS
     RefType
       .applyRef[String Refined Url](value)
       .getOrElse(throw new IllegalArgumentException("Invalid url value"))
+
+  private val projectHookIds: Gen[HookIdentifier] = for {
+    projectId <- projectIds
+    hookUrl   <- projectHookUrls
+  } yield HookIdentifier(projectId, hookUrl)
 }

--- a/webhook-service/test/ch/datascience/webhookservice/project/IOProjectHookVerifierSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/project/IOProjectHookVerifierSpec.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
 import cats.effect.IO
 import ch.datascience.generators.Generators.Implicits._
@@ -26,8 +26,8 @@ import ch.datascience.graph.events.ProjectId
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.{GitLabConfig, IOGitLabConfigProvider}
 import ch.datascience.webhookservice.exceptions.UnauthorizedException
-import ch.datascience.webhookservice.hookcreation.HookCreationGenerators._
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
+import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
 import com.github.tomakehurst.wiremock.client.WireMock._
 import eu.timepit.refined.api.{RefType, Refined}
 import eu.timepit.refined.string.Url

--- a/webhook-service/test/ch/datascience/webhookservice/project/IOProjectInfoFinderSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/project/IOProjectInfoFinderSpec.scala
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
-import cats.effect.{IO, Sync}
+import cats.effect.IO
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators.exceptions
 import ch.datascience.graph.events.EventsGenerators._

--- a/webhook-service/test/ch/datascience/webhookservice/project/IOProjectInfoFinderSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/project/IOProjectInfoFinderSpec.scala
@@ -27,6 +27,7 @@ import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.GitLabConfig.HostUrl
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
 import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
 import ch.datascience.webhookservice.model.{ProjectInfo, ProjectOwner}
 import com.github.tomakehurst.wiremock.client.WireMock._
 import eu.timepit.refined.api.{RefType, Refined}
@@ -55,6 +56,7 @@ class IOProjectInfoFinderSpec extends WordSpec with MockFactory with ExternalSer
 
       projectInfoFinder.findProjectInfo(projectId, personalAccessToken).unsafeRunSync() shouldBe ProjectInfo(
         projectId,
+        projectVisibility,
         projectPath,
         ProjectOwner(userId)
       )
@@ -72,6 +74,7 @@ class IOProjectInfoFinderSpec extends WordSpec with MockFactory with ExternalSer
 
       projectInfoFinder.findProjectInfo(projectId, oauthAccessToken).unsafeRunSync() shouldBe ProjectInfo(
         projectId,
+        projectVisibility,
         projectPath,
         ProjectOwner(userId)
       )
@@ -135,10 +138,11 @@ class IOProjectInfoFinderSpec extends WordSpec with MockFactory with ExternalSer
   }
 
   private trait TestCase {
-    val gitLabUrl   = url(externalServiceBaseUrl)
-    val projectId   = projectIds.generateOne
-    val projectPath = projectPaths.generateOne
-    val userId      = userIds.generateOne
+    val gitLabUrl         = url(externalServiceBaseUrl)
+    val projectId         = projectIds.generateOne
+    val projectVisibility = projectVisibilities.generateOne
+    val projectPath       = projectPaths.generateOne
+    val userId            = userIds.generateOne
 
     val configProvider = mock[IOGitLabConfigProvider]
 
@@ -152,6 +156,7 @@ class IOProjectInfoFinderSpec extends WordSpec with MockFactory with ExternalSer
     lazy val projectJson: String = Json
       .obj(
         "id"                  -> Json.fromInt(projectId.value),
+        "visibility"          -> Json.fromString(projectVisibility.value),
         "path_with_namespace" -> Json.fromString(projectPath.value),
         "owner" -> Json.obj(
           "id" -> Json.fromInt(userId.value)

--- a/webhook-service/test/ch/datascience/webhookservice/project/ProjectHookUrlFinderSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/project/ProjectHookUrlFinderSpec.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
 import cats.MonadError
 import cats.implicits._
@@ -24,8 +24,8 @@ import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
 import ch.datascience.webhookservice.eventprocessing.routes.WebhookEventEndpoint
 import ch.datascience.webhookservice.generators.ServiceTypesGenerators._
-import ch.datascience.webhookservice.hookcreation.ProjectHookUrlFinder.ProjectHookUrl
-import ch.datascience.webhookservice.hookcreation.SelfUrlConfig.SelfUrl
+import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl
+import ch.datascience.webhookservice.project.SelfUrlConfig.SelfUrl
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
@@ -71,3 +71,5 @@ class ProjectHookUrlFinderSpec extends WordSpec with MockFactory {
     val hookUrlFinder = new ProjectHookUrlFinder[Try](selfUrlConfig)
   }
 }
+
+class TryProjectHookUrlFinder(selfUrlConfig: SelfUrlConfig[Try]) extends ProjectHookUrlFinder[Try](selfUrlConfig)

--- a/webhook-service/test/ch/datascience/webhookservice/project/SelfUrlConfigProviderSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/project/SelfUrlConfigProviderSpec.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice.hookcreation
+package ch.datascience.webhookservice.project
 
 import cats.MonadError
 import cats.implicits._
@@ -63,7 +63,7 @@ class SelfUrlConfigProviderSpec extends WordSpec {
       val Failure(exception) = new SelfUrlConfig[Try](config).get()
 
       exception.getMessage should include(
-        "'123' is not a valid ch.datascience.webhookservice.hookcreation.SelfUrlConfig.SelfUrl"
+        "'123' is not a valid ch.datascience.webhookservice.project.SelfUrlConfig.SelfUrl"
       )
     }
 

--- a/webhook-service/test/ch/datascience/webhookservice/security/AccessTokenFinderSpec.scala
+++ b/webhook-service/test/ch/datascience/webhookservice/security/AccessTokenFinderSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice.security
+
+import cats.MonadError
+import cats.implicits._
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.graph.events.GraphCommonsGenerators._
+import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import play.api.test.FakeRequest
+
+import scala.util.Try
+
+class AccessTokenFinderSpec extends WordSpec {
+
+  "findAccessToken" should {
+
+    "return personal access token when PRIVATE-TOKEN is present" in new TestCase {
+
+      val accessToken = personalAccessTokens.generateOne
+
+      finder.findAccessToken(
+        request.withHeaders("PRIVATE-TOKEN" -> accessToken.value)
+      ) shouldBe context.pure(accessToken)
+    }
+
+    "return oauth access token when OAUTH-TOKEN is present in the header" in new TestCase {
+
+      val accessToken = oauthAccessTokens.generateOne
+
+      finder.findAccessToken(
+        request.withHeaders("OAUTH-TOKEN" -> accessToken.value)
+      ) shouldBe context.pure(accessToken)
+    }
+
+    "return oauth access token when both PRIVATE-TOKEN and OAUTH-TOKEN are present" in new TestCase {
+
+      val oauthAccessToken    = oauthAccessTokens.generateOne
+      val personalAccessToken = personalAccessTokens.generateOne
+
+      finder.findAccessToken(
+        request
+          .withHeaders("OAUTH-TOKEN" -> oauthAccessToken.value)
+          .withHeaders("PRIVATE-TOKEN" -> personalAccessToken.value)
+      ) shouldBe context.pure(oauthAccessToken)
+    }
+
+    "fail with UNAUTHORIZED when neither PRIVATE-TOKEN nor OAUTH-TOKEN is not present" in new TestCase {
+      finder.findAccessToken(request) shouldBe context.raiseError(UnauthorizedException)
+    }
+
+    "fail with UNAUTHORIZED when PRIVATE-TOKEN is invalid" in new TestCase {
+      finder.findAccessToken(
+        request.withHeaders("PRIVATE-TOKEN" -> "")
+      ) shouldBe context.raiseError(UnauthorizedException)
+    }
+
+    "fail with UNAUTHORIZED when OAUTH-TOKEN is invalid" in new TestCase {
+      finder.findAccessToken(
+        request.withHeaders("OAUTH-TOKEN" -> "")
+      ) shouldBe context.raiseError(UnauthorizedException)
+    }
+  }
+
+  private trait TestCase {
+    val context = MonadError[Try, Throwable]
+
+    val request = FakeRequest()
+
+    val finder = new AccessTokenFinder[Try]()
+  }
+}


### PR DESCRIPTION
As a `webhook-service` user I need a POST /projects/:id/webhooks/validation which checks if there's a webhook created for a project with the given id.

Testing
The endpoint should respond with:
200 - if project has the webhook
404 - if there's no webhook
401 - if the given access tokens are missing or invalid
500 - for non-public projects or if there's an error during the check