### PR TITLE
Made HOOK_TOKEN_SECRET be injected to the `webhook-service` on deploy

### DIFF
--- a/helm-chart/minikube-values.yaml
+++ b/helm-chart/minikube-values.yaml
@@ -8,6 +8,8 @@ gitlab:
 webhookService:
   play:
     secret: cx0GU>c/tlS[Haa3_ArAn2V>p@aZZvi;QH]dRzONQjz@h28XlPcqJTdCDCDtnG<l
+  hookToken:
+    secret: ZjQ0ZjdiODdmYjllY2MxOAo=
 
 triplesGenerator:
   play:

--- a/helm-chart/renku-graph/templates/deployment.yaml
+++ b/helm-chart/renku-graph/templates/deployment.yaml
@@ -75,6 +75,11 @@ spec:
           image: "{{ .Values.webhookService.image.repository }}:{{ .Values.webhookService.image.tag }}"
           imagePullPolicy: {{ .Values.webhookService.image.pullPolicy }}
           env:
+            - name: HOOK_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "graph.fullname" . }}
+                  key: webhookService-hookToken-secret
             - name: FILE_EVENT_LOG_PATH
               value: /events/log.txt
             - name: PLAY_APPLICATION_SECRET

--- a/helm-chart/renku-graph/templates/secret.yaml
+++ b/helm-chart/renku-graph/templates/secret.yaml
@@ -11,3 +11,4 @@ type: Opaque
 data:
   triplesGenerator-play-secret: {{ required "Fill in .Values.triplesGenerator.play.secret with `sbt playGenerateSecret`" .Values.triplesGenerator.play.secret | b64enc | quote }}
   webhookService-play-secret: {{ required "Fill in .Values.webhookService.play.secret with `sbt playGenerateSecret`" .Values.webhookService.play.secret | b64enc | quote }}
+  webhookService-hookToken-secret: {{ required "Fill in .Values.webhookService.hookToken.secret with `openssl rand -hex 8|base64`" .Values.webhookService.hookToken.secret | b64enc | quote }}

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -10,6 +10,10 @@ triplesGenerator:
   service:
     type: ClusterIP
     port: 80
+  play:
+    ## A Play app secret used for built in encryption utilities
+    ## Generated using: `sbt playGenerateSecret`
+    secret:
 
 webhookService:
   image:
@@ -19,6 +23,14 @@ webhookService:
   service:
     type: ClusterIP
     port: 80
+  play:
+    ## A Play app secret used for built in encryption utilities
+    ## Generated using: `sbt playGenerateSecret`
+    secret:
+  hookToken:
+    ## A secret for signing request header tokens to be sent by GitLab with the Push Events
+    ## Generated using: `openssl rand -hex 8|base64`
+    secret:
 
 nameOverride: ''
 fullnameOverride: ''
@@ -39,7 +51,7 @@ ingress:
   enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/tls-acme: "true"
   paths: []
   hosts:
     - chart-example.local
@@ -58,7 +70,7 @@ resources: {}
   #  memory: 128Mi
   # requests:
   #  cpu: 100m
-  #  memory: 128Mi
+#  memory: 128Mi
 
 nodeSelector: {}
 

--- a/webhook-service/conf/application.conf
+++ b/webhook-service/conf/application.conf
@@ -3,7 +3,7 @@ include "service-commons.base.conf"
 play.http.filters = "ch.datascience.webhookservice.Filters"
 
 pidfile.path = "/dev/null"
-play.http.context="/"
+play.http.context = "/"
 
 play.modules.enabled += "ch.datascience.webhookservice.FileEventLogModule"
 play.modules.enabled += "ch.datascience.webhookservice.ServiceModule"
@@ -17,11 +17,6 @@ file-event-log {
   file-path = ${?FILE_EVENT_LOG_PATH}
   delete-on-exit = false
   delete-on-exit = ${?DELETE_ON_EXIT}
-}
-
-event-log {
-  hook-access-token-secret = "eUF0aUo5cmdubUtkRmJyVw=="
-  hook-access-token-secret = ${?HOOK_ACCESS_TOKEN_SECRET}
 }
 
 services {


### PR DESCRIPTION
This secret I forgot the other day and effectively all the environments would be using the same secret for encrypting the hook tokens send from Gitlab