### PR TITLE
Defaulted jena.dataset to {{ .Release.Namespace }}

### DIFF
--- a/helm-chart/renku-graph/templates/deployment.yaml
+++ b/helm-chart/renku-graph/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
               {{- if .Values.global.graph.jena.dataset }}
               value: {{ .Values.global.graph.jena.dataset }}
               {{- else }}
-              value: renku
+              value: {{ .Release.Namespace }}
               {{- end }}
             - name: JENA_BASE_URL
               value: "http://{{ template "jena.fullname" . }}:{{ .Values.jena.service.port }}"


### PR DESCRIPTION
This is a tiny change for `global.graph.jena.dataset` default value. Instead of `renku` it defaults now to `{{ .Release.Namespace }}`.

Tested on my local `renku-kuba`.