### PR TITLE
Changing default dataset type from `mem` to `tdb`

### DIFF
--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -10,7 +10,7 @@ services {
     url = ${?JENA_BASE_URL}
     dataset-name = "renku"
     dataset-name = ${?JENA_DATASET_NAME}
-    dataset-type = "mem"
+    dataset-type = "tdb"
     dataset-type = ${?JENA_DATASET_TYPE}
     username = "admin"
     password = ${?JENA_ADMIN_PASSWORD}


### PR DESCRIPTION
This is a one-liner changing default dataset type of our Renku triples store from `mem` to `tdb` so the store gets persisted to disk instead of being just in-memory.