### PR TITLE
Adding logging to Sentry

### DIFF
--- a/graph-commons/src/main/scala/ch/datascience/http/client/RestClientError.scala
+++ b/graph-commons/src/main/scala/ch/datascience/http/client/RestClientError.scala
@@ -16,8 +16,22 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice
+package ch.datascience.http.client
 
-object exceptions {
-  final case object UnauthorizedException extends RuntimeException("Unauthorized")
+trait RestClientError extends Exception
+
+object RestClientError {
+
+  final case class UnexpectedResponseError(
+      message: String
+  ) extends Exception(message)
+      with RestClientError
+
+  final case class MappingError(
+      message: String,
+      cause:   Throwable
+  ) extends Exception(message, cause)
+      with RestClientError
+
+  final case object UnauthorizedException extends RuntimeException("Unauthorized") with RestClientError
 }

--- a/graph-commons/src/test/scala/ch/datascience/http/client/IORestClientSpec.scala
+++ b/graph-commons/src/test/scala/ch/datascience/http/client/IORestClientSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.http.client
+
+import cats.effect.{ContextShift, IO}
+import ch.datascience.config.ServiceUrl
+import ch.datascience.stubbing.ExternalServiceStubbing
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.http4s.Method.GET
+import org.http4s.{Request, Response, Status, Uri}
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class IORestClientSpec extends WordSpec with ExternalServiceStubbing {
+
+  "send" should {
+
+    "succeed returning value calculated with the given response mapping rules " +
+      "if the response matches the rules" in new TestCase {
+
+      stubFor {
+        get("/resource")
+          .willReturn(ok("1"))
+      }
+
+      client.callRemote.unsafeRunSync() shouldBe 1
+    }
+
+    "fail if remote responds with status which does not match the response mapping rules" in new TestCase {
+
+      stubFor {
+        get("/resource")
+          .willReturn(
+            aResponse
+              .withStatus(Status.NotFound.code)
+              .withBody("some body")
+          )
+      }
+
+      intercept[Exception] {
+        client.callRemote.unsafeRunSync()
+      }.getMessage shouldBe s"GET $hostUrl/resource returned ${Status.NotFound}; body: some body"
+    }
+
+    "fail if remote responds with a body which doesn't match the response mapping rules" in new TestCase {
+
+      stubFor {
+        get("/resource")
+          .willReturn(ok("non int"))
+      }
+
+      intercept[Exception] {
+        client.callRemote.unsafeRunSync()
+      }.getMessage shouldBe s"""GET $hostUrl/resource returned ${Status.Ok}; error: For input string: "non int""""
+    }
+
+    "fail if remote responds with an empty body and status which doesn't match the response mapping rules" in new TestCase {
+
+      stubFor {
+        get("/resource")
+          .willReturn(noContent())
+      }
+
+      intercept[Exception] {
+        client.callRemote.unsafeRunSync()
+      }.getMessage shouldBe s"GET $hostUrl/resource returned ${Status.NoContent}; body: "
+    }
+
+    "fail if there are connectivity problems" in {
+      intercept[Exception] {
+        new TestRestClient(ServiceUrl("http://localhost:1024")).callRemote.unsafeRunSync()
+      }.getMessage shouldBe s"GET http://localhost:1024/resource error: Connection refused"
+    }
+  }
+
+  private trait TestCase {
+    val client = new TestRestClient(hostUrl)
+  }
+
+  private implicit val cs: ContextShift[IO] = IO.contextShift(global)
+  private val hostUrl = ServiceUrl(externalServiceBaseUrl)
+
+  private class TestRestClient(hostUrl: ServiceUrl) extends IORestClient {
+
+    def callRemote: IO[Int] =
+      for {
+        uri         <- validateUri(s"$hostUrl/resource")
+        accessToken <- send(request(GET, uri))(mapResponse)
+      } yield accessToken
+
+    private lazy val mapResponse: PartialFunction[(Status, Request[IO], Response[IO]), IO[Int]] = {
+      case (Status.Ok, _, response) => response.as[String].map(_.toInt)
+    }
+  }
+}

--- a/helm-chart/renku-graph/templates/deployment.yaml
+++ b/helm-chart/renku-graph/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               value: {{ printf "http://$(SELF_IP):9001" | quote }}
               {{- end }}
             - name: SENTRY_DSN
-              value: {{ .Values.sentry.graphSentryDsn }}?stacktrace.app.packages=&servername=webhook-service&environment={{ .Release.Namespace }}
+              value: {{ .Values.sentry.sentryDsnRenkuGraph }}?stacktrace.app.packages=&servername=webhook-service&environment={{ .Release.Namespace }}
           command:
             - bin/webhook-service
           ports:
@@ -92,9 +92,9 @@ spec:
                   name: {{ template "jena.fullname" . }}
                   key: jena-admin-password
             - name: SENTRY_DSN
-              value: {{ .Values.sentry.pythonSentryDsn }}
+              value: {{ .Values.sentry.sentryDsnRenkuPython }}
             - name: GRAPH_SENTRY_DSN
-              value: {{ .Values.sentry.graphSentryDsn }}?stacktrace.app.packages=&servername=triples-generator&environment={{ .Release.Namespace }}
+              value: {{ .Values.sentry.sentryDsnRenkuGraph }}?stacktrace.app.packages=&servername=triples-generator&environment={{ .Release.Namespace }}
           ports:
             - name: http-triples-gn
               containerPort: 9002
@@ -141,7 +141,7 @@ spec:
                   name: {{ template "renku.fullname" . }}
                   key: tokenRepository-postgresPassword
             - name: SENTRY_DSN
-              value: {{ .Values.sentry.graphSentryDsn }}?stacktrace.app.packages=&servername=token-repository&environment={{ .Release.Namespace }}
+              value: {{ .Values.sentry.sentryDsnRenkuGraph }}?stacktrace.app.packages=&servername=token-repository&environment={{ .Release.Namespace }}
           ports:
             - name: http-token-repo
               containerPort: 9003

--- a/helm-chart/renku-graph/templates/deployment.yaml
+++ b/helm-chart/renku-graph/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
               {{- else }}
               value: {{ printf "http://$(SELF_IP):9001" | quote }}
               {{- end }}
+            - name: SENTRY_DSN
+              value: {{ .Values.sentry.graphSentryDsn }}?stacktrace.app.packages=&servername=webhook-service&environment={{ .Release.Namespace }}
           command:
             - bin/webhook-service
           ports:
@@ -90,7 +92,9 @@ spec:
                   name: {{ template "jena.fullname" . }}
                   key: jena-admin-password
             - name: SENTRY_DSN
-              value: {{ .Values.triplesGenerator.renku.sentryDsn }}
+              value: {{ .Values.sentry.pythonSentryDsn }}
+            - name: GRAPH_SENTRY_DSN
+              value: {{ .Values.sentry.graphSentryDsn }}?stacktrace.app.packages=&servername=triples-generator&environment={{ .Release.Namespace }}
           ports:
             - name: http-triples-gn
               containerPort: 9002
@@ -136,6 +140,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "renku.fullname" . }}
                   key: tokenRepository-postgresPassword
+            - name: SENTRY_DSN
+              value: {{ .Values.sentry.graphSentryDsn }}?stacktrace.app.packages=&servername=token-repository&environment={{ .Release.Namespace }}
           ports:
             - name: http-token-repo
               containerPort: 9003

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -23,8 +23,6 @@ triplesGenerator:
   service:
     type: ClusterIP
     port: 9002
-  renku:
-    sentryDsn: ''
 
 webhookService:
   image:
@@ -38,6 +36,10 @@ webhookService:
     ## A secret for signing request header tokens to be sent by GitLab with the Push Events
     ## Generated using: `openssl rand -hex 8|base64`
     secret:
+
+sentry:
+  graphSentryDsn: ''
+  pythonSentryDsn: ''
 
 nameOverride: ''
 fullnameOverride: ''

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -38,8 +38,8 @@ webhookService:
     secret:
 
 sentry:
-  graphSentryDsn: ''
-  pythonSentryDsn: ''
+  sentryDsnRenkuGraph: ''
+  sentryDsnRenkuPython: ''
 
 nameOverride: ''
 fullnameOverride: ''

--- a/token-repository/build.sbt
+++ b/token-repository/build.sbt
@@ -20,6 +20,7 @@ organization := "ch.datascience"
 name := "token-repository"
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
+libraryDependencies += "io.sentry"      % "sentry-logback"  % "1.7.16"
 
 val doobieVersion = "0.6.0"
 libraryDependencies += "org.tpolecat" %% "doobie-core"     % doobieVersion

--- a/token-repository/src/main/resources/logback.xml
+++ b/token-repository/src/main/resources/logback.xml
@@ -19,6 +19,12 @@
         </encoder>
     </appender>
 
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
     <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="FILE"/>
     </appender>
@@ -29,10 +35,12 @@
 
     <logger name="application" level="INFO" additivity="false">
         <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
     </logger>
 
     <root level="WARN">
         <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
     </root>
 
 </configuration>

--- a/triples-generator/build.sbt
+++ b/triples-generator/build.sbt
@@ -21,4 +21,5 @@ name := "triples-generator"
 
 libraryDependencies += "ch.qos.logback"  % "logback-classic"    % "1.2.3"
 libraryDependencies += "com.lihaoyi"     %% "ammonite-ops"      % "1.6.3"
+libraryDependencies += "io.sentry"       % "sentry-logback"     % "1.7.16"
 libraryDependencies += "org.apache.jena" % "jena-rdfconnection" % "3.10.0"

--- a/triples-generator/src/main/resources/logback.xml
+++ b/triples-generator/src/main/resources/logback.xml
@@ -19,6 +19,12 @@
         </encoder>
     </appender>
 
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
     <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="FILE"/>
     </appender>
@@ -29,10 +35,12 @@
 
     <logger name="application" level="INFO" additivity="false">
         <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
     </logger>
 
     <root level="WARN">
         <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
     </root>
 
 </configuration>

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/init/DatasetExistenceChecker.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/init/DatasetExistenceChecker.scala
@@ -20,7 +20,7 @@ package ch.datascience.triplesgenerator.init
 
 import cats.effect.{ContextShift, IO}
 import ch.datascience.http.client.{BasicAuth, IORestClient}
-import ch.datascience.triplesgenerator.config.{FusekiConfig, FusekiConfigProvider}
+import ch.datascience.triplesgenerator.config.FusekiConfig
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
@@ -46,10 +46,8 @@ private class IODatasetExistenceChecker(
       projectInfo <- send(request(GET, uri, BasicAuth(fusekiConfig.username, fusekiConfig.password)))(mapResponse)
     } yield projectInfo
 
-  private def mapResponse(request: Request[IO], response: Response[IO]): IO[Boolean] =
-    response.status match {
-      case Ok       => IO.pure(true)
-      case NotFound => IO.pure(false)
-      case _        => raiseError(request, response)
-    }
+  private lazy val mapResponse: PartialFunction[(Status, Request[IO], Response[IO]), IO[Boolean]] = {
+    case (Ok, _, _)       => IO.pure(true)
+    case (NotFound, _, _) => IO.pure(false)
+  }
 }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/init/DatasetExistenceCreator.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/init/DatasetExistenceCreator.scala
@@ -20,7 +20,7 @@ package ch.datascience.triplesgenerator.init
 
 import cats.effect.{ContextShift, IO}
 import ch.datascience.http.client.{BasicAuth, IORestClient}
-import ch.datascience.triplesgenerator.config.{FusekiConfig, FusekiConfigProvider}
+import ch.datascience.triplesgenerator.config.FusekiConfig
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
@@ -55,9 +55,7 @@ private class IODatasetExistenceCreator(
         )
       )
 
-  private def mapResponse(request: Request[IO], response: Response[IO]): IO[Unit] =
-    response.status match {
-      case Ok => IO.unit
-      case _  => raiseError(request, response)
-    }
+  private lazy val mapResponse: PartialFunction[(Status, Request[IO], Response[IO]), IO[Unit]] = {
+    case (Ok, _, _) => IO.unit
+  }
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/init/SentryInitializerSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/init/SentryInitializerSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.triplesgenerator.init
+
+import cats.MonadError
+import cats.implicits._
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators._
+import io.sentry.Sentry
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+import scala.util.Try
+
+class SentryInitializerSpec extends WordSpec with MockFactory {
+
+  "run" should {
+
+    "initialise Sentry and succeed if 'GRAPH_SENTRY_DSN' is non-blank" in new TestCase {
+      val sentryDns = nonEmptyStrings().generateOne
+      getEnvVariable.expects("GRAPH_SENTRY_DSN").returning(Some(sentryDns))
+
+      initSentry.expects(sentryDns)
+
+      sentryInitializer.run shouldBe context.unit
+    }
+
+    "do nothing if 'GRAPH_SENTRY_DSN' is blank" in new TestCase {
+      getEnvVariable.expects("GRAPH_SENTRY_DSN").returning(Some("  "))
+
+      sentryInitializer.run shouldBe context.unit
+
+      Sentry.getStoredClient.getServerName
+    }
+
+    "fail if Sentry initialisation fails" in new TestCase {
+      val sentryDns = nonEmptyStrings().generateOne
+      getEnvVariable.expects("GRAPH_SENTRY_DSN").returning(Some(sentryDns))
+
+      val exception = exceptions.generateOne
+      initSentry.expects(sentryDns).throwing(exception)
+
+      sentryInitializer.run shouldBe context.raiseError(exception)
+    }
+  }
+
+  private trait TestCase {
+    val context = MonadError[Try, Throwable]
+
+    val initSentry        = mockFunction[String, Unit]
+    val getEnvVariable    = mockFunction[String, Option[String]]
+    val sentryInitializer = new SentryInitializer[Try](initSentry, getEnvVariable)
+  }
+}

--- a/webhook-service/build.sbt
+++ b/webhook-service/build.sbt
@@ -20,3 +20,4 @@ organization := "ch.datascience"
 name := "webhook-service"
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
+libraryDependencies += "io.sentry"      % "sentry-logback"  % "1.7.16"

--- a/webhook-service/src/main/resources/logback.xml
+++ b/webhook-service/src/main/resources/logback.xml
@@ -19,6 +19,12 @@
         </encoder>
     </appender>
 
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
     <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="FILE"/>
     </appender>
@@ -29,10 +35,12 @@
 
     <logger name="application" level="INFO" additivity="false">
         <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
     </logger>
 
     <root level="WARN">
         <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
     </root>
 
 </configuration>

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpoint.scala
@@ -24,10 +24,10 @@ import cats.implicits._
 import ch.datascience.controllers.ErrorMessage
 import ch.datascience.controllers.ErrorMessage._
 import ch.datascience.graph.model.events._
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.crypto.HookTokenCrypto
 import ch.datascience.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import ch.datascience.webhookservice.eventprocessing.pushevent.{IOPushEventSender, PushEventSender}
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
 import ch.datascience.webhookservice.model.HookToken
 import io.circe.{Decoder, HCursor}
 import org.http4s.circe._

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpoint.scala
@@ -23,7 +23,7 @@ import cats.implicits._
 import ch.datascience.controllers.ErrorMessage
 import ch.datascience.controllers.ErrorMessage._
 import ch.datascience.graph.model.events.ProjectId
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookcreation.HookCreator.HookCreationResult
 import ch.datascience.webhookservice.hookcreation.HookCreator.HookCreationResult.{HookCreated, HookExisted}
 import ch.datascience.webhookservice.security.AccessTokenExtractor

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpoint.scala
@@ -23,7 +23,7 @@ import cats.implicits._
 import ch.datascience.controllers.ErrorMessage
 import ch.datascience.controllers.ErrorMessage._
 import ch.datascience.graph.model.events.ProjectId
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult._
 import ch.datascience.webhookservice.security.AccessTokenExtractor

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidator.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidator.scala
@@ -27,7 +27,7 @@ import ch.datascience.graph.tokenrepository.{AccessTokenFinder, IOAccessTokenFin
 import ch.datascience.http.client.AccessToken
 import ch.datascience.logging.ApplicationLogger
 import ch.datascience.webhookservice.config.GitLabConfigProvider
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult
 import ch.datascience.webhookservice.project._
 import ch.datascience.webhookservice.tokenrepository._

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/security/AccessTokenExtractor.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/security/AccessTokenExtractor.scala
@@ -22,7 +22,7 @@ import cats.MonadError
 import cats.implicits._
 import ch.datascience.http.client.AccessToken
 import ch.datascience.http.client.AccessToken.{OAuthAccessToken, PersonalAccessToken}
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Header, Request}
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/tokenrepository/AccessTokenAssociator.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/tokenrepository/AccessTokenAssociator.scala
@@ -22,6 +22,7 @@ import cats.effect.{ContextShift, IO}
 import ch.datascience.graph.model.events.ProjectId
 import ch.datascience.graph.tokenrepository.TokenRepositoryUrlProvider
 import ch.datascience.http.client.{AccessToken, IORestClient}
+import org.http4s.Status
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
@@ -51,9 +52,7 @@ class IOAccessTokenAssociator(
       _ <- send(requestWithPayload)(mapResponse)
     } yield ()
 
-  private def mapResponse(request: Request[IO], response: Response[IO]): IO[Unit] =
-    response.status match {
-      case NoContent => IO.unit
-      case _         => raiseError(request, response)
-    }
+  private lazy val mapResponse: PartialFunction[(Status, Request[IO], Response[IO]), IO[Unit]] = {
+    case (NoContent, _, _) => IO.unit
+  }
 }

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/tokenrepository/AccessTokenRemover.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/tokenrepository/AccessTokenRemover.scala
@@ -22,6 +22,7 @@ import cats.effect.{ContextShift, IO}
 import ch.datascience.graph.model.events.ProjectId
 import ch.datascience.graph.tokenrepository.TokenRepositoryUrlProvider
 import ch.datascience.http.client.IORestClient
+import org.http4s.Status
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
@@ -48,9 +49,7 @@ class IOAccessTokenRemover(
       _                  <- send(request(DELETE, uri))(mapResponse)
     } yield ()
 
-  private def mapResponse(request: Request[IO], response: Response[IO]): IO[Unit] =
-    response.status match {
-      case NoContent => IO.unit
-      case _         => raiseError(request, response)
-    }
+  private lazy val mapResponse: PartialFunction[(Status, Request[IO], Response[IO]), IO[Unit]] = {
+    case (NoContent, _, _) => IO.unit
+  }
 }

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpointSpec.scala
@@ -29,7 +29,7 @@ import ch.datascience.http.server.EndpointTester._
 import ch.datascience.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import ch.datascience.webhookservice.crypto.IOHookTokenCrypto
 import ch.datascience.webhookservice.eventprocessing.pushevent.IOPushEventSender
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.generators.WebhookServiceGenerators._
 import ch.datascience.webhookservice.model.HookToken
 import io.circe.Json

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/pushevent/IOCommitInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/pushevent/IOCommitInfoFinderSpec.scala
@@ -29,7 +29,7 @@ import ch.datascience.graph.model.events.EventsGenerators._
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.GitLabConfigProvider._
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import com.github.tomakehurst.wiremock.client.WireMock._
 import eu.timepit.refined.api.{RefType, Refined}
 import eu.timepit.refined.string.Url
@@ -141,7 +141,7 @@ class IOCommitInfoFinderSpec extends WordSpec with MockFactory with ExternalServ
 
       intercept[Exception] {
         finder.findCommitInfo(projectId, commitId, maybeAccessToken = None).unsafeRunSync()
-      }.getMessage should startWith("Invalid message body")
+      }.getMessage shouldBe s"GET $gitLabUrl/api/v4/projects/$projectId/repository/commits/$commitId returned ${Status.Ok}; error: Invalid message body: Could not decode JSON: {}"
     }
 
     "return an Error if remote client responds with status neither OK nor UNAUTHORIZED" in new TestCase {

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpointSpec.scala
@@ -28,7 +28,7 @@ import ch.datascience.graph.model.events.EventsGenerators._
 import ch.datascience.graph.model.events._
 import ch.datascience.http.client.AccessToken
 import ch.datascience.http.server.EndpointTester._
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookcreation.HookCreator.HookCreationResult.{HookCreated, HookExisted}
 import ch.datascience.webhookservice.security.IOAccessTokenExtractor
 import io.circe.Json

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/IOLatestPushEventFetcherSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/IOLatestPushEventFetcherSpec.scala
@@ -27,7 +27,7 @@ import ch.datascience.graph.model.events.{CommitId, ProjectId, UserId}
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.GitLabConfigProvider.HostUrl
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookcreation.LatestPushEventFetcher.PushEventInfo
 import com.github.tomakehurst.wiremock.client.WireMock._
 import eu.timepit.refined.api.{RefType, Refined}
@@ -135,7 +135,7 @@ class IOLatestPushEventFetcherSpec extends WordSpec with MockFactory with Extern
       } shouldBe UnauthorizedException
     }
 
-    "return a RuntimeException if remote client responds with status neither OK nor UNAUTHORIZED" in new TestCase {
+    "return an Exception if remote client responds with status neither OK nor UNAUTHORIZED" in new TestCase {
       expectGitLabConfigProvider(returning = IO.pure(gitLabUrl))
       val personalAccessToken = personalAccessTokens.generateOne
 
@@ -150,7 +150,7 @@ class IOLatestPushEventFetcherSpec extends WordSpec with MockFactory with Extern
       }.getMessage shouldBe s"GET $gitLabUrl/api/v4/projects/$projectId/events?action=pushed returned ${Status.BadRequest}; body: some error"
     }
 
-    "return a RuntimeException if remote client responds with unexpected body" in new TestCase {
+    "return an Exception if remote client responds with unexpected body" in new TestCase {
       expectGitLabConfigProvider(returning = IO.pure(gitLabUrl))
       val personalAccessToken = personalAccessTokens.generateOne
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/IOProjectHookCreatorSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/IOProjectHookCreatorSpec.scala
@@ -24,7 +24,7 @@ import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.{GitLabConfigProvider, IOGitLabConfigProvider}
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookcreation.HookCreationGenerators._
 import ch.datascience.webhookservice.hookcreation.ProjectHookCreator.ProjectHook
 import com.github.tomakehurst.wiremock.client.WireMock._

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/IOUserInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/IOUserInfoFinderSpec.scala
@@ -27,7 +27,7 @@ import ch.datascience.graph.model.events.UserId
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.GitLabConfigProvider.HostUrl
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookcreation.HookCreationGenerators._
 import ch.datascience.webhookservice.hookcreation.UserInfoFinder.UserInfo
 import com.github.tomakehurst.wiremock.client.WireMock._

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
@@ -28,7 +28,7 @@ import ch.datascience.graph.model.events.EventsGenerators.projectIds
 import ch.datascience.graph.model.events.ProjectId
 import ch.datascience.http.client.AccessToken
 import ch.datascience.http.server.EndpointTester._
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult._
 import ch.datascience.webhookservice.security.IOAccessTokenExtractor
 import io.circe.Json

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -29,7 +29,7 @@ import ch.datascience.graph.tokenrepository.AccessTokenFinder
 import ch.datascience.http.client.AccessToken
 import ch.datascience.interpreters.TestLogger
 import ch.datascience.interpreters.TestLogger.Level.{Error, Info}
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.generators.WebhookServiceGenerators._
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult.{HookExists, HookMissing}
 import ch.datascience.webhookservice.project.ProjectVisibility._

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/IOProjectHookVerifierSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/IOProjectHookVerifierSpec.scala
@@ -26,7 +26,7 @@ import ch.datascience.graph.model.events.EventsGenerators.projectIds
 import ch.datascience.graph.model.events.ProjectId
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.{GitLabConfigProvider, IOGitLabConfigProvider}
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.generators.WebhookServiceGenerators._
 import ch.datascience.webhookservice.hookvalidation.ProjectHookVerifier.HookIdentifier
 import ch.datascience.webhookservice.project.ProjectHookUrlFinder.ProjectHookUrl

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/project/IOProjectInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/project/IOProjectInfoFinderSpec.scala
@@ -26,7 +26,7 @@ import ch.datascience.graph.model.events.EventsGenerators._
 import ch.datascience.stubbing.ExternalServiceStubbing
 import ch.datascience.webhookservice.config.GitLabConfigProvider.HostUrl
 import ch.datascience.webhookservice.config.IOGitLabConfigProvider
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import ch.datascience.webhookservice.generators.WebhookServiceGenerators._
 import com.github.tomakehurst.wiremock.client.WireMock._
 import eu.timepit.refined.api.{RefType, Refined}

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/security/AccessTokenExtractorSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/security/AccessTokenExtractorSpec.scala
@@ -22,7 +22,7 @@ import cats.MonadError
 import cats.implicits._
 import ch.datascience.generators.CommonGraphGenerators._
 import ch.datascience.generators.Generators.Implicits._
-import ch.datascience.webhookservice.exceptions.UnauthorizedException
+import ch.datascience.http.client.RestClientError.UnauthorizedException
 import org.http4s.{Header, Headers, Request}
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec


### PR DESCRIPTION
This PR introduces support for Sentry. All `warning` and `error` log statements are being delivered to Sentry now along with `environment` and `server_name` tags.

I also did some improvements in the way errors from calling remote services are reported.