### PR TITLE
OAuth access token to be passed in the Bearer

### DIFF
--- a/graph-commons/src/main/scala/ch/datascience/http/client/RestClientError.scala
+++ b/graph-commons/src/main/scala/ch/datascience/http/client/RestClientError.scala
@@ -34,4 +34,5 @@ object RestClientError {
       with RestClientError
 
   final case object UnauthorizedException extends RuntimeException("Unauthorized") with RestClientError
+  type UnauthorizedException = UnauthorizedException.type
 }

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -31,9 +31,10 @@ Creates a webhook for a project with the given `project id`.
 
 **Request format**
 
-The endpoint requires an authorization token. It has to be
-- either `PRIVATE-TOKEN` with user's personal access token in GitLab
-- or `OAUTH-TOKEN` with oauth token obtained from GitLab
+The endpoint requires an authorization token. It can be passed in the request header as:
+- `Authorization: Bearer <token>` with OAuth Token obtained from GitLab
+- `PRIVATE-TOKEN: <token>` with user's Personal Access Token in GitLab
+- `OAUTH-TOKEN: <token>` with OAuth Token obtained from GitLab (deprecated)
 
 **Response**
 
@@ -53,9 +54,10 @@ Validates the webhook for the project with the given `project id`. It succeeds (
 
 **Request format**
 
-The endpoint requires an authorization token. It has to be
-- either `PRIVATE-TOKEN` with user's personal access token in GitLab
-- or `OAUTH-TOKEN` with oauth token obtained from GitLab
+The endpoint requires an authorization token. It can be passed in the request header as:
+- `Authorization: Bearer <token>` with OAuth Token obtained from GitLab
+- `PRIVATE-TOKEN: <token>` with user's Personal Access Token in GitLab
+- `OAUTH-TOKEN: <token>` with OAuth Token obtained from GitLab (deprecated)
 
 **Response**
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/security/AccessTokenExtractor.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/security/AccessTokenExtractor.scala
@@ -19,10 +19,13 @@
 package ch.datascience.webhookservice.security
 
 import cats.MonadError
-import cats.implicits._
+import cats.data.OptionT
 import ch.datascience.http.client.AccessToken
 import ch.datascience.http.client.AccessToken.{OAuthAccessToken, PersonalAccessToken}
 import ch.datascience.http.client.RestClientError.UnauthorizedException
+import org.http4s.AuthScheme.Bearer
+import org.http4s.Credentials.Token
+import org.http4s.headers.Authorization
 import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Header, Request}
 
@@ -30,14 +33,36 @@ import scala.language.higherKinds
 
 class AccessTokenExtractor[Interpretation[_]](implicit ME: MonadError[Interpretation, Throwable]) {
 
-  def findAccessToken(request: Request[Interpretation]): Interpretation[AccessToken] = ME.fromEither {
-    convert(request.headers.get(CaseInsensitiveString("OAUTH-TOKEN")), to = OAuthAccessToken.from)
-      .orElse(convert(request.headers.get(CaseInsensitiveString("PRIVATE-TOKEN")), to = PersonalAccessToken.from))
-      .getOrElse(Left(UnauthorizedException))
+  def findAccessToken(request: Request[Interpretation]): Interpretation[AccessToken] =
+    request.getTokenFromBearer
+      .flatMap(toOAuthAccessToken)
+      .orElse(request.get("OAUTH-TOKEN") flatMap convert(OAuthAccessToken.from))
+      .orElse(request.get("PRIVATE-TOKEN") flatMap convert(PersonalAccessToken.from))
+      .getOrElseF(ME.raiseError(UnauthorizedException))
+
+  private lazy val toOAuthAccessToken: Authorization.HeaderT => OptionT[Interpretation, AccessToken] = {
+    case Authorization(Token(Bearer, token)) => toOptionT(OAuthAccessToken.from(token))
+    case _                                   => OptionT.none
   }
 
-  private def convert(header: Option[Header], to: String => Either[Exception, AccessToken]) =
-    header.map(_.value).map {
-      to(_).leftMap(_ => UnauthorizedException)
+  private def convert(to: String => Either[Exception, AccessToken]): Header => OptionT[Interpretation, AccessToken] = {
+    case Header(_, token) => toOptionT(to(token))
+    case _                => OptionT.none
+  }
+
+  private lazy val toOptionT: Either[Exception, AccessToken] => OptionT[Interpretation, AccessToken] = {
+    case Right(accessToken) => OptionT.some(accessToken)
+    case Left(_)            => OptionT.none
+  }
+
+  private implicit class RequestOps(request: Request[Interpretation]) {
+
+    def get(key: String): OptionT[Interpretation, Header] = OptionT.fromOption {
+      request.headers.get(CaseInsensitiveString(key))
     }
+
+    def getTokenFromBearer: OptionT[Interpretation, Authorization.HeaderT] = OptionT.fromOption {
+      request.headers.get(Authorization)
+    }
+  }
 }


### PR DESCRIPTION
Closes #46 and is explained there in details.

For the time being, I left the support for the `OAUTH-TOKEN` for backwards compatibility.