### PR TITLE
fix: Wrong secretKeyRef for token-repository

### DIFF
--- a/helm-chart/renku-graph/templates/deployment.yaml
+++ b/helm-chart/renku-graph/templates/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "renku.fullname" . }}
+                  name: {{ template "graph.fullname" . }}
                   key: tokenRepository-postgresPassword
             - name: SENTRY_DSN
               value: {{ .Values.sentry.sentryDsnRenkuGraph }}?stacktrace.app.packages=&servername=token-repository&environment={{ .Release.Namespace }}


### PR DESCRIPTION
There was a problem with deploying Graph Services on UI-team environment. I found there was a wrong template linked in the `deployment.yaml` of the Graph Services so instead of `graph`, `renku` template was used.