### PR TITLE
Add pull reminders badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)
+
 # renku-graph
 
 #### Repository structure


### PR DESCRIPTION
This allows to use the pull reminders slack integration for free for open source projects.