### PR TITLE
Throttler not to pass items scheduled after a long running one

### DIFF
--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogFetchSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogFetchSpec.scala
@@ -21,7 +21,6 @@ package ch.datascience.dbeventlog.commands
 import java.time.Instant
 import java.time.temporal.ChronoUnit._
 
-import cats.implicits._
 import ch.datascience.dbeventlog.DbEventLogGenerators._
 import ch.datascience.dbeventlog._
 import EventStatus._
@@ -130,7 +129,7 @@ class EventLogFetchSpec extends WordSpec with InMemoryEventLogDbSpec with MockFa
 
       findEvents(EventStatus.Processing) shouldBe List.empty
 
-      parallelPopEventToProcess.unsafeRunSync() shouldBe List(event3Body)
+      eventLogFetch.popEventToProcess.unsafeRunSync() shouldBe Some(event3Body)
 
       findEvents(EventStatus.Processing) shouldBe List(event3Id -> executionDate)
 
@@ -222,11 +221,5 @@ class EventLogFetchSpec extends WordSpec with InMemoryEventLogDbSpec with MockFa
     val now           = Instant.now()
     val executionDate = ExecutionDate(now)
     currentTime.expects().returning(now).anyNumberOfTimes()
-
-    def parallelPopEventToProcess =
-      List(
-        eventLogFetch.popEventToProcess,
-        eventLogFetch.popEventToProcess
-      ).parSequence.map(_.flatten)
   }
 }

--- a/triples-generator/build.sbt
+++ b/triples-generator/build.sbt
@@ -22,3 +22,5 @@ libraryDependencies += "ch.qos.logback"  % "logback-classic"    % "1.2.3"
 libraryDependencies += "com.lihaoyi"     %% "ammonite-ops"      % "1.6.6"
 libraryDependencies += "io.sentry"       % "sentry-logback"     % "1.7.22"
 libraryDependencies += "org.apache.jena" % "jena-rdfconnection" % "3.10.0"
+
+parallelExecution in Test := false


### PR DESCRIPTION
There was a bug in the throttling mechanism which was suspending the rate limit when a single task was executing longer than the rate limit was set. For instance, if a rate was 2/sec and there a first scheduled task was executing for 2s and in the meantime, two other tasks arrived, the Throttler would allow them to be executed immediately after their arrival. This fix would prevent such behaviour and would allow only one of the two later tasks to be executed immediately while the other would have to wait another 500ms.