### PR TITLE
Events processing progress fetching endpoint

### DIFF
--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/commands/EventLogProcessingStatus.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/commands/EventLogProcessingStatus.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog.commands
+
+import java.time.temporal.ChronoUnit._
+import java.time.{Duration, Instant}
+
+import cats.MonadError
+import cats.data.NonEmptyList
+import cats.effect.{Bracket, ContextShift, IO}
+import cats.implicits._
+import ch.datascience.db.DbTransactor
+import ch.datascience.dbeventlog.EventStatus._
+import ch.datascience.dbeventlog.{EventLogDB, EventStatus}
+import ch.datascience.graph.model.events.ProjectId
+import doobie.implicits._
+import doobie.util.fragment.Fragment
+import doobie.util.fragments.in
+import eu.timepit.refined.api.RefType.applyRef
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.NonNegative
+
+import scala.language.higherKinds
+import scala.math.BigDecimal.RoundingMode
+
+class EventLogProcessingStatus[Interpretation[_]](
+    transactor: DbTransactor[Interpretation, EventLogDB],
+    now:        () => Instant = () => Instant.now
+)(implicit ME:  Bracket[Interpretation, Throwable]) {
+
+  import EventLogProcessingStatus._
+
+  def fetchStatus(projectId: ProjectId): Interpretation[Option[ProcessingStatus]] =
+    findDoneAndTotal(projectId)
+      .query[(Int, Int)]
+      .option
+      .transact(transactor.get)
+      .flatMap(toProcessingStatus)
+
+  private def findDoneAndTotal(projectId: ProjectId): Fragment = fr"""
+    select done.number, total.number 
+    from (""" ++ findDone(projectId) ++ fr") done, (" ++ findTotal(projectId) ++ fr") total"
+
+  // format: off
+  private def findDone(projectId: ProjectId): Fragment =fr"""
+    select count(*) as number
+    from event_log
+    where project_id = $projectId""" ++
+      `and status IN`(TriplesStore, NonRecoverableFailure) ++ fr"""
+       and created_date > ${now() minus ToBeConsideredAsBeingProcessed}"""
+
+  private def findTotal(projectId: ProjectId): Fragment = fr"""
+    select count(*) as number
+    from event_log
+    where project_id = $projectId 
+      and created_date > ${now() minus ToBeConsideredAsBeingProcessed}"""
+  // format: on
+
+  private def `and status IN`(statuses: EventStatus*) =
+    fr" and " ++ in(fr"status", NonEmptyList.fromListUnsafe(statuses.toList))
+
+  private lazy val toProcessingStatus: Option[(Int, Int)] => Interpretation[Option[ProcessingStatus]] = {
+    case None                => ME.pure(None)
+    case Some((0, 0))        => ME.pure(None)
+    case Some((done, total)) => ProcessingStatus.from[Interpretation](done, total) map Option.apply
+  }
+}
+
+private object EventLogProcessingStatus {
+  val ToBeConsideredAsBeingProcessed = Duration.of(2, MINUTES)
+}
+
+class IOEventLogProcessingStatus(
+    transactor:          DbTransactor[IO, EventLogDB]
+)(implicit contextShift: ContextShift[IO])
+    extends EventLogProcessingStatus[IO](transactor)
+
+import ProcessingStatus._
+
+final case class ProcessingStatus private (
+    done:     Done,
+    total:    Total,
+    progress: Progress
+)
+
+object ProcessingStatus {
+  import cats.implicits._
+
+  type Done     = Int Refined NonNegative
+  type Total    = Int Refined NonNegative
+  type Progress = Double Refined NonNegative
+
+  def from[Interpretation[_]](
+      done:      Int,
+      total:     Int
+  )(implicit ME: MonadError[Interpretation, Throwable]): Interpretation[ProcessingStatus] =
+    for {
+      validDone  <- applyRef[Done](done) getOrError [Interpretation] "ProcessingStatus's 'done' cannot be negative"
+      validTotal <- applyRef[Total](total) getOrError [Interpretation] "ProcessingStatus's 'total' cannot be negative"
+      _          <- checkDoneLessThanTotal[Interpretation](validDone, validTotal)
+      progress   <- progressFrom[Interpretation](validDone, validTotal)
+    } yield new ProcessingStatus(validDone, validTotal, progress)
+
+  private implicit class RefTypeOps[V](maybeValue: Either[String, V]) {
+    def getOrError[Interpretation[_]](
+        message:   String
+    )(implicit ME: MonadError[Interpretation, Throwable]): Interpretation[V] =
+      maybeValue.fold(
+        _ => ME.raiseError[V](new IllegalArgumentException(message)),
+        ME.pure
+      )
+  }
+
+  private def checkDoneLessThanTotal[Interpretation[_]](
+      done:      Done,
+      total:     Total
+  )(implicit ME: MonadError[Interpretation, Throwable]): Interpretation[Unit] =
+    if (done.value <= total.value) ME.unit
+    else ME.raiseError(new IllegalArgumentException("ProcessingStatus with 'done' > 'total' makes no sense"))
+
+  private def progressFrom[Interpretation[_]](
+      done:      Done,
+      total:     Total
+  )(implicit ME: MonadError[Interpretation, Throwable]): Interpretation[Progress] = {
+    val progress =
+      if (total.value == 0) 100D
+      else BigDecimal((done.value.toDouble / total.value) * 100).setScale(2, RoundingMode.HALF_DOWN).toDouble
+    applyRef[Progress](progress) getOrError [Interpretation] s"ProcessingStatus with 'progress' $progress makes no sense"
+  }
+}

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/init/EventLogDbInitializer.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/init/EventLogDbInitializer.scala
@@ -43,6 +43,7 @@ class EventLogDbInitializer[Interpretation[_]](
       _ <- execute(sql"CREATE INDEX IF NOT EXISTS idx_status ON event_log(status)", transactor)
       _ <- execute(sql"CREATE INDEX IF NOT EXISTS idx_execution_date ON event_log(execution_date DESC)", transactor)
       _ <- execute(sql"CREATE INDEX IF NOT EXISTS idx_event_date ON event_log(event_date DESC)", transactor)
+      _ <- execute(sql"CREATE INDEX IF NOT EXISTS idx_created_date ON event_log(created_date DESC)", transactor)
       _ <- logger.info("Event Log database initialization success")
     } yield ()
   } recoverWith logging

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/DbEventLogGenerators.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/DbEventLogGenerators.scala
@@ -18,15 +18,30 @@
 
 package ch.datascience.dbeventlog
 
+import cats.implicits._
 import EventStatus._
+import ch.datascience.dbeventlog.commands.ProcessingStatus
 import ch.datascience.generators.Generators._
 import org.scalacheck.Gen
+
+import scala.util.Try
 
 object DbEventLogGenerators {
 
   implicit val eventBodies:    Gen[EventBody]     = jsons.map(_.noSpaces).map(EventBody.apply)
   implicit val createdDates:   Gen[CreatedDate]   = timestampsNotInTheFuture map CreatedDate.apply
   implicit val executionDates: Gen[ExecutionDate] = timestamps map ExecutionDate.apply
-  implicit val eventStatuses:  Gen[EventStatus]   = Gen.oneOf(New, Processing, TriplesStore, TriplesStoreFailure)
-  implicit val eventMessages:  Gen[EventMessage]  = nonEmptyStrings() map EventMessage.apply
+  implicit val eventStatuses: Gen[EventStatus] = Gen.oneOf(
+    New,
+    Processing,
+    TriplesStore,
+    TriplesStoreFailure,
+    NonRecoverableFailure
+  )
+  implicit val eventMessages: Gen[EventMessage] = nonEmptyStrings() map EventMessage.apply
+  implicit val processingStatuses: Gen[ProcessingStatus] =
+    for {
+      total <- positiveInts(max = Integer.MAX_VALUE)
+      done  <- positiveInts(max = total.value)
+    } yield ProcessingStatus.from[Try](done.value, total.value).fold(throw _, identity)
 }

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogProcessingStatusSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogProcessingStatusSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog.commands
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit._
+
+import cats.data.NonEmptyList
+import ch.datascience.dbeventlog.DbEventLogGenerators.{eventBodies, eventStatuses, executionDates}
+import ch.datascience.dbeventlog.EventStatus._
+import ch.datascience.dbeventlog.{CreatedDate, EventStatus}
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators._
+import ch.datascience.graph.model.events.EventsGenerators.{commitEventIds, committedDates, projectIds}
+import ch.datascience.graph.model.events.ProjectId
+import org.scalacheck.Gen
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+class EventLogProcessingStatusSpec extends WordSpec with InMemoryEventLogDbSpec {
+
+  "fetchStatus" should {
+
+    "return a ProcessingStatus for the given project with " +
+      s"$TriplesStore and $NonRecoverableFailure events counted to done " +
+      "and all to total" in new TestCase {
+
+      storeEventsWithRecentTime(projectIds.generateOne, nonEmptyList(eventStatuses).generateOne)
+
+      val doneEvents = nonEmptyList(
+        Gen.oneOf(TriplesStore, NonRecoverableFailure),
+        minElements = 10,
+        maxElements = 20
+      ).generateOne
+      val toBeProcessedEvents = nonEmptyList(
+        Gen.oneOf(New, Processing, TriplesStoreFailure),
+        minElements = 10,
+        maxElements = 20
+      ).generateOne
+      storeEventsWithRecentTime(projectId, doneEvents ::: toBeProcessedEvents)
+
+      val Some(processingStatus) = processingStatusFinder.fetchStatus(projectId).unsafeRunSync()
+
+      val expectedTotal: Int = doneEvents.size + toBeProcessedEvents.size
+      processingStatus.done.value           shouldBe doneEvents.size
+      processingStatus.total.value          shouldBe expectedTotal
+      processingStatus.progress.value.floor shouldBe ((doneEvents.size.toDouble / expectedTotal) * 100).floor
+    }
+
+    "return a ProcessingStatus for the given project " +
+      "including events only close to the latest created_date" in new TestCase {
+
+      val sameDateEvents = nonEmptyList(eventStatuses).generateOne
+      storeEventsWithRecentTime(projectId, sameDateEvents)
+
+      storeEventsWithOlderDate(projectId, nonEmptyList(eventStatuses).generateOne)
+
+      val Some(processingStatus) = processingStatusFinder.fetchStatus(projectId).unsafeRunSync()
+
+      processingStatus.total.value shouldBe sameDateEvents.size
+    }
+
+    "return None if the last created event was more than 2 minutes ago" in new TestCase {
+
+      storeEventsWithOlderDate(projectId, nonEmptyList(eventStatuses).generateOne)
+
+      processingStatusFinder.fetchStatus(projectId).unsafeRunSync() shouldBe None
+    }
+
+    "return None if there were no events in the last 2 minutes for the project id" in new TestCase {
+
+      storeEventsWithRecentTime(projectIds.generateOne, nonEmptyList(eventStatuses).generateOne)
+
+      processingStatusFinder.fetchStatus(projectId).unsafeRunSync() shouldBe None
+    }
+  }
+
+  private trait TestCase {
+    val projectId              = projectIds.generateOne
+    val processingStatusFinder = new IOEventLogProcessingStatus(transactor)
+
+    def storeEventsWithRecentTime(projectId: ProjectId, statuses: NonEmptyList[EventStatus]): Unit = statuses map {
+      storeEvent(
+        commitEventIds.generateOne.copy(projectId = projectId),
+        _,
+        executionDates.generateOne,
+        committedDates.generateOne,
+        eventBodies.generateOne,
+        CreatedDate(Instant.now)
+      )
+    }
+
+    def storeEventsWithOlderDate(projectId: ProjectId, statuses: NonEmptyList[EventStatus]): Unit = statuses map {
+      storeEvent(
+        commitEventIds.generateOne.copy(projectId = projectId),
+        _,
+        executionDates.generateOne,
+        committedDates.generateOne,
+        eventBodies.generateOne,
+        CreatedDate(Instant.now.minus(122, SECONDS))
+      )
+    }
+  }
+}

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/ProcessingStatusSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/ProcessingStatusSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog.commands
+
+import cats.implicits._
+import ch.datascience.generators.Generators._
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.math.BigDecimal.RoundingMode
+import scala.util.{Failure, Success, Try}
+
+class ProcessingStatusSpec extends WordSpec with ScalaCheckPropertyChecks {
+
+  "from" should {
+
+    "return ProcessingStatus with progress = 100% for done = total = 0" in {
+      val Success(processingStatus) = ProcessingStatus.from[Try](0, 0)
+
+      processingStatus.done.value     shouldBe 0
+      processingStatus.total.value    shouldBe 0
+      processingStatus.progress.value shouldBe 100D
+    }
+
+    "return ProcessingStatus with progress calculated as (done / total) * 100" in {
+      forAll {
+        for {
+          total <- positiveInts(max = Integer.MAX_VALUE)
+          done  <- positiveInts(max = total.value)
+        } yield done.value -> total.value
+      } {
+        case (done, total) =>
+          val Success(processingStatus) = ProcessingStatus.from[Try](done, total)
+
+          processingStatus.done.value  shouldBe done
+          processingStatus.total.value shouldBe total
+
+          val expectedProgress = BigDecimal((done.toDouble / total) * 100).setScale(2, RoundingMode.HALF_DOWN).toDouble
+          processingStatus.progress.value shouldBe expectedProgress
+      }
+    }
+
+    "fail if done negative" in {
+      forAll(negativeInts(min = Integer.MIN_VALUE), nonNegativeInts(max = Integer.MAX_VALUE)) {
+        case (done, total) =>
+          val Failure(exception) = ProcessingStatus.from[Try](done, total)
+          exception            shouldBe an[IllegalArgumentException]
+          exception.getMessage shouldBe "ProcessingStatus's 'done' cannot be negative"
+      }
+    }
+
+    "fail if total negative" in {
+      forAll(nonNegativeInts(max = Integer.MAX_VALUE), negativeInts(min = Integer.MIN_VALUE)) {
+        case (done, total) =>
+          val Failure(exception) = ProcessingStatus.from[Try](done, total)
+          exception            shouldBe an[IllegalArgumentException]
+          exception.getMessage shouldBe "ProcessingStatus's 'total' cannot be negative"
+      }
+    }
+
+    "fail if done > total" in {
+      forAll {
+        for {
+          done  <- positiveInts(max = Integer.MAX_VALUE)
+          total <- positiveInts(max = done.value - 1)
+        } yield done.value -> total.value
+      } {
+        case (done, total) =>
+          val Failure(exception) = ProcessingStatus.from[Try](done, total)
+          exception            shouldBe an[IllegalArgumentException]
+          exception.getMessage shouldBe "ProcessingStatus with 'done' > 'total' makes no sense"
+      }
+    }
+  }
+}

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/init/EventLogDbInitializerSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/init/EventLogDbInitializerSpec.scala
@@ -64,6 +64,7 @@ class EventLogDbInitializerSpec extends WordSpec with InMemoryEventLogDb {
       verifyTrue(sql"DROP INDEX idx_status;")
       verifyTrue(sql"DROP INDEX idx_execution_date;")
       verifyTrue(sql"DROP INDEX idx_event_date;")
+      verifyTrue(sql"DROP INDEX idx_created_date;")
     }
   }
 

--- a/graph-commons/src/main/scala/ch/datascience/controllers/ClientMessages.scala
+++ b/graph-commons/src/main/scala/ch/datascience/controllers/ClientMessages.scala
@@ -60,7 +60,7 @@ object InfoMessage {
         identity
       )
 
-  private implicit val infoMessageEncoder: Encoder[InfoMessage] = Encoder.instance[InfoMessage] { message =>
+  implicit val infoMessageEncoder: Encoder[InfoMessage] = Encoder.instance[InfoMessage] { message =>
     Json.obj("message" -> Json.fromString(message.value))
   }
 

--- a/graph-commons/src/test/scala/ch/datascience/generators/Generators.scala
+++ b/graph-commons/src/test/scala/ch/datascience/generators/Generators.scala
@@ -21,6 +21,7 @@ package ch.datascience.generators
 import java.time.Instant
 import java.time.temporal.ChronoUnit.DAYS
 
+import cats.data.NonEmptyList
 import ch.datascience.config.ServiceUrl
 import ch.datascience.logging.ExecutionTimeRecorder.ElapsedTime
 import eu.timepit.refined.api.Refined
@@ -51,11 +52,11 @@ object Generators {
       lines <- Gen.listOfN(size, nonEmptyStrings())
     } yield lines
 
-  def nonEmptyList[T](generator: Gen[T], minElements: Int = 1, maxElements: Int = 5): Gen[List[T]] =
+  def nonEmptyList[T](generator: Gen[T], minElements: Int = 1, maxElements: Int = 5): Gen[NonEmptyList[T]] =
     for {
       size <- choose(minElements, maxElements)
       list <- Gen.listOfN(size, generator)
-    } yield list
+    } yield NonEmptyList.fromListUnsafe(list)
 
   def positiveInts(max: Int = 1000): Gen[Int Refined Positive] =
     choose(1, max) map Refined.unsafeApply
@@ -63,11 +64,13 @@ object Generators {
   def positiveLongs(max: Long = 1000): Gen[Long Refined Positive] =
     choose(1L, max) map Refined.unsafeApply
 
+  def nonNegativeInts(max: Int = 1000): Gen[Int] = choose(0, max)
+
+  def negativeInts(min: Int = -1000): Gen[Int] = choose(min, 0)
+
   def durations(max: FiniteDuration = 5 seconds): Gen[FiniteDuration] =
     choose(1, max.toMillis)
       .map(FiniteDuration(_, MILLISECONDS))
-
-  def nonNegativeInts(max: Int = 1000): Gen[Int] = choose(0, max)
 
   def relativePaths(minSegments: Int = 1, maxSegments: Int = 10): Gen[String] =
     for {

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -32,11 +32,11 @@ Fetches information about processing progress of project events.
 
 **Response**
 
-| Status                     | Description                                                |
-|----------------------------|------------------------------------------------------------|
-| OK (200)                   | When there are events in the Event Log for that project    |
-| NOT_FOUND (404)            | When there are no events in the Event Log for that project |
-| INTERNAL SERVER ERROR (500)| When there are problems with finding the status            |
+| Status                     | Description                                                                                          |
+|----------------------------|------------------------------------------------------------------------------------------------------|
+| OK (200)                   | When there are events in the Event Log for that project                                              |
+| NOT_FOUND (404)            | When there are no events in the Event Log for that project or the project has no Graph Services hook |
+| INTERNAL SERVER ERROR (500)| When there are problems with finding the status                                                      |
 
 Examples of valid responses:
 - all events from the latest batch are processed

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -7,12 +7,13 @@ This microservice:
 
 ## API
 
-| Method | Path                                      | Description                                    |
-|--------|-------------------------------------------|------------------------------------------------|
-|  GET   | ```/ping```                               | To check if service is healthy                 |
-|  POST  | ```/projects/:id/webhooks```              | Creates a webhook for a project in GitLab      |
-|  POST  | ```/projects/:id/webhooks/validation```   | Validates the project's webhook                |
-|  POST  | ```/webhooks/events```                    | Consumes push events sent from GitLab          |
+| Method | Path                                      | Description                                           |
+|--------|-------------------------------------------|-------------------------------------------------------|
+|  GET   | ```/ping```                               | To check if service is healthy                        |
+|  GET   | ```/projects/:id/events/status```         | Gives info about processing progress of recent events |
+|  POST  | ```/projects/:id/webhooks```              | Creates a webhook for a project in GitLab             |
+|  POST  | ```/projects/:id/webhooks/validation```   | Validates the project's webhook                       |
+|  POST  | ```/webhooks/events```                    | Consumes push events sent from GitLab                 |
      
 #### GET /ping
 
@@ -24,6 +25,27 @@ Verifies service health.
 |----------------------------|-------------------------|
 | OK (200)                   | If service is healthy   |
 | INTERNAL SERVER ERROR (500)| Otherwise               |
+
+#### GET /projects/:id/events/status
+
+Fetches information about processing progress of project events.
+
+**Response**
+
+| Status                     | Description                                                                   |
+|----------------------------|-------------------------------------------------------------------------------|
+| OK (200)                   | When there are recent events                                                  |
+| NOT_FOUND (404)            | When there is either no recent events for a project or project does not exist |
+| INTERNAL SERVER ERROR (500)| When there are problems with finding the status                               |
+
+Example of a valid response:
+```
+{
+  "done": 10,
+  "total": 20,
+  "progress": 50.00
+}
+```
 
 #### POST /projects/:id/webhooks
 

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -32,11 +32,11 @@ Fetches information about processing progress of project events.
 
 **Response**
 
-| Status                     | Description                                                                                          |
-|----------------------------|------------------------------------------------------------------------------------------------------|
-| OK (200)                   | When there are events in the Event Log for that project                                              |
-| NOT_FOUND (404)            | When there are no events in the Event Log for that project or the project has no Graph Services hook |
-| INTERNAL SERVER ERROR (500)| When there are problems with finding the status                                                      |
+| Status                     | Description                                          |
+|----------------------------|------------------------------------------------------|
+| OK (200)                   | When there is Graph Services hook for the project    |
+| NOT_FOUND (404)            | When there is no Graph Services hook for the project |
+| INTERNAL SERVER ERROR (500)| When there are problems with finding the status      |
 
 Examples of valid responses:
 - all events from the latest batch are processed
@@ -53,6 +53,13 @@ Examples of valid responses:
   "done": 10,
   "total": 20,
   "progress": 50.00
+}
+```
+- no events in the Event Log
+```
+{
+  "done": 0,
+  "total": 0
 }
 ```
 

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -32,13 +32,22 @@ Fetches information about processing progress of project events.
 
 **Response**
 
-| Status                     | Description                                                                   |
-|----------------------------|-------------------------------------------------------------------------------|
-| OK (200)                   | When there are recent events                                                  |
-| NOT_FOUND (404)            | When there is either no recent events for a project or project does not exist |
-| INTERNAL SERVER ERROR (500)| When there are problems with finding the status                               |
+| Status                     | Description                                                |
+|----------------------------|------------------------------------------------------------|
+| OK (200)                   | When there are events in the Event Log for that project    |
+| NOT_FOUND (404)            | When there are no events in the Event Log for that project |
+| INTERNAL SERVER ERROR (500)| When there are problems with finding the status            |
 
-Example of a valid response:
+Examples of valid responses:
+- all events from the latest batch are processed
+```
+{
+  "done": 20,
+  "total": 20,
+  "progress": 100.00
+}
+```
+- some events from the latest batch are being processed
 ```
 {
   "done": 10,

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
@@ -26,7 +26,7 @@ import ch.datascience.dbeventlog.{EventLogDB, EventLogDbConfigProvider}
 import ch.datascience.dbeventlog.init.IOEventLogDbInitializer
 import ch.datascience.graph.gitlab.{GitLabRateLimitProvider, GitLabThrottler}
 import ch.datascience.http.server.HttpServer
-import ch.datascience.webhookservice.eventprocessing.IOHookEventEndpoint
+import ch.datascience.webhookservice.eventprocessing.{IOHookEventEndpoint, IOProcessingStatusEndpoint}
 import ch.datascience.webhookservice.hookcreation.IOHookCreationEndpoint
 import ch.datascience.webhookservice.hookvalidation.IOHookValidationEndpoint
 import ch.datascience.webhookservice.missedevents.{EventsSynchronizationScheduler, EventsSynchronizationThrottler, IOEventsSynchronizationScheduler}
@@ -64,7 +64,8 @@ object Microservice extends IOApp {
           serviceRoutes = new MicroserviceRoutes[IO](
             new IOHookEventEndpoint(transactor, gitLabThrottler),
             new IOHookCreationEndpoint(transactor, gitLabThrottler),
-            new IOHookValidationEndpoint(gitLabThrottler)
+            new IOHookValidationEndpoint(gitLabThrottler),
+            new IOProcessingStatusEndpoint(transactor)
           ).routes
         )
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
@@ -65,7 +65,7 @@ object Microservice extends IOApp {
             new IOHookEventEndpoint(transactor, gitLabThrottler),
             new IOHookCreationEndpoint(transactor, gitLabThrottler),
             new IOHookValidationEndpoint(gitLabThrottler),
-            new IOProcessingStatusEndpoint(transactor)
+            new IOProcessingStatusEndpoint(transactor, gitLabThrottler)
           ).routes
         )
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/MicroserviceRoutes.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/MicroserviceRoutes.scala
@@ -20,7 +20,7 @@ package ch.datascience.webhookservice
 
 import cats.effect.ConcurrentEffect
 import ch.datascience.graph.http.server.ProjectIdPathBinder
-import ch.datascience.webhookservice.eventprocessing.HookEventEndpoint
+import ch.datascience.webhookservice.eventprocessing.{HookEventEndpoint, ProcessingStatusEndpoint}
 import ch.datascience.webhookservice.hookcreation.HookCreationEndpoint
 import ch.datascience.webhookservice.hookvalidation.HookValidationEndpoint
 import org.http4s.dsl.Http4sDsl
@@ -28,9 +28,10 @@ import org.http4s.dsl.Http4sDsl
 import scala.language.higherKinds
 
 private class MicroserviceRoutes[F[_]: ConcurrentEffect](
-    hookEventEndpoint:      HookEventEndpoint[F],
-    hookCreationEndpoint:   HookCreationEndpoint[F],
-    hookValidationEndpoint: HookValidationEndpoint[F]
+    hookEventEndpoint:        HookEventEndpoint[F],
+    hookCreationEndpoint:     HookCreationEndpoint[F],
+    hookValidationEndpoint:   HookValidationEndpoint[F],
+    processingStatusEndpoint: ProcessingStatusEndpoint[F]
 ) extends Http4sDsl[F] {
 
   import org.http4s.HttpRoutes
@@ -44,5 +45,7 @@ private class MicroserviceRoutes[F[_]: ConcurrentEffect](
         hookCreationEndpoint.createHook(projectId, request)
       case request @ POST -> Root / "projects" / ProjectIdPathBinder(projectId) / "webhooks" / "validation" =>
         hookValidationEndpoint.validateHook(projectId, request)
+      case GET -> Root / "projects" / ProjectIdPathBinder(projectId) / "events" / "status" =>
+        processingStatusEndpoint.fetchProcessingStatus(projectId)
     }
 }

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpoint.scala
@@ -19,14 +19,19 @@
 package ch.datascience.webhookservice.eventprocessing
 
 import cats.MonadError
+import cats.data.OptionT
 import cats.effect._
 import cats.implicits._
+import ch.datascience.control.Throttler
 import ch.datascience.controllers.ErrorMessage._
 import ch.datascience.controllers.{ErrorMessage, InfoMessage}
 import ch.datascience.db.DbTransactor
 import ch.datascience.dbeventlog.EventLogDB
 import ch.datascience.dbeventlog.commands.{EventLogProcessingStatus, IOEventLogProcessingStatus, ProcessingStatus}
+import ch.datascience.graph.gitlab.GitLab
 import ch.datascience.graph.model.events._
+import ch.datascience.webhookservice.hookvalidation.HookValidator.{HookValidationResult, NoAccessTokenException}
+import ch.datascience.webhookservice.hookvalidation.{HookValidator, IOHookValidator}
 import io.circe.Encoder
 import io.circe.literal._
 import io.circe.syntax._
@@ -39,18 +44,31 @@ import scala.language.higherKinds
 import scala.util.control.NonFatal
 
 class ProcessingStatusEndpoint[Interpretation[_]: Effect](
+    hookValidator:          HookValidator[Interpretation],
     eventsProcessingStatus: EventLogProcessingStatus[Interpretation]
 )(implicit ME:              MonadError[Interpretation, Throwable])
     extends Http4sDsl[Interpretation] {
 
+  import HookValidationResult._
   import ProcessingStatusEndpoint._
   import eventsProcessingStatus._
+  import hookValidator._
 
-  def fetchProcessingStatus(projectId: ProjectId): Interpretation[Response[Interpretation]] =
-    fetchStatus(projectId)
-      .semiflatMap(processingStatus => Ok(processingStatus.asJson))
-      .getOrElseF(NotFound(InfoMessage(s"Project: $projectId not found")))
-      .recoverWith(httpResponse)
+  def fetchProcessingStatus(projectId: ProjectId): Interpretation[Response[Interpretation]] = {
+    for {
+      _        <- OptionT(validateHook(projectId, maybeAccessToken = None) map hookMissingToNone recover noAccessTokenToNone)
+      response <- fetchStatus(projectId) semiflatMap (processingStatus => Ok(processingStatus.asJson))
+    } yield response
+  } getOrElseF NotFound(InfoMessage(s"Progress status for project '$projectId' not found")) recoverWith httpResponse
+
+  private lazy val hookMissingToNone: HookValidationResult => Option[Unit] = {
+    case HookExists => Some(())
+    case _          => None
+  }
+
+  private lazy val noAccessTokenToNone: PartialFunction[Throwable, Option[Unit]] = {
+    case NoAccessTokenException(_) => None
+  }
 
   private lazy val httpResponse: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
     case NonFatal(exception) => InternalServerError(ErrorMessage(exception.getMessage))
@@ -70,6 +88,8 @@ private object ProcessingStatusEndpoint {
 }
 
 class IOProcessingStatusEndpoint(
-    transactor:              DbTransactor[IO, EventLogDB]
+    transactor:              DbTransactor[IO, EventLogDB],
+    gitLabThrottler:         Throttler[IO, GitLab]
 )(implicit executionContext: ExecutionContext, contextShift: ContextShift[IO], clock: Clock[IO])
-    extends ProcessingStatusEndpoint[IO](new IOEventLogProcessingStatus(transactor))
+    extends ProcessingStatusEndpoint[IO](new IOHookValidator(gitLabThrottler),
+                                         new IOEventLogProcessingStatus(transactor))

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpoint.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice.eventprocessing
+
+import cats.MonadError
+import cats.effect._
+import cats.implicits._
+import ch.datascience.controllers.ErrorMessage._
+import ch.datascience.controllers.{ErrorMessage, InfoMessage}
+import ch.datascience.db.DbTransactor
+import ch.datascience.dbeventlog.EventLogDB
+import ch.datascience.dbeventlog.commands.{EventLogProcessingStatus, IOEventLogProcessingStatus, ProcessingStatus}
+import ch.datascience.graph.model.events._
+import io.circe.Encoder
+import io.circe.literal._
+import io.circe.syntax._
+import org.http4s.Response
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
+
+import scala.concurrent.ExecutionContext
+import scala.language.higherKinds
+import scala.util.control.NonFatal
+
+class ProcessingStatusEndpoint[Interpretation[_]: Effect](
+    eventsProcessingStatus: EventLogProcessingStatus[Interpretation]
+)(implicit ME:              MonadError[Interpretation, Throwable])
+    extends Http4sDsl[Interpretation] {
+
+  import eventsProcessingStatus._
+  import ProcessingStatusEndpoint._
+
+  def fetchProcessingStatus(projectId: ProjectId): Interpretation[Response[Interpretation]] = {
+    for {
+      maybeProcessingStatus <- fetchStatus(projectId)
+      response <- maybeProcessingStatus match {
+                   case Some(processingStatus) => Ok(processingStatus.asJson)
+                   case None                   => NotFound(InfoMessage(s"Project: $projectId not found"))
+                 }
+    } yield response
+  } recoverWith httpResponse
+
+  private lazy val httpResponse: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
+    case NonFatal(exception) => InternalServerError(ErrorMessage(exception.getMessage))
+  }
+}
+
+private object ProcessingStatusEndpoint {
+
+  implicit val processingStatusEncoder: Encoder[ProcessingStatus] = {
+    case ProcessingStatus(done, total, progress) => json"""
+      {
+       "done": ${done.value},
+       "total": ${total.value},
+       "progress": ${progress.value}
+      }"""
+  }
+}
+
+class IOProcessingStatusEndpoint(
+    transactor:              DbTransactor[IO, EventLogDB]
+)(implicit executionContext: ExecutionContext, contextShift: ContextShift[IO], clock: Clock[IO])
+    extends ProcessingStatusEndpoint[IO](new IOEventLogProcessingStatus(transactor))

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookcreation/HookCreator.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookcreation/HookCreator.scala
@@ -71,7 +71,7 @@ private class HookCreator[Interpretation[_]](
   def createHook(projectId: ProjectId, accessToken: AccessToken): Interpretation[CreationResult] = {
     for {
       projectHookUrl      <- right(findProjectHookUrl)
-      hookValidation      <- right(validateHook(projectId, accessToken))
+      hookValidation      <- right(validateHook(projectId, Some(accessToken)))
       _                   <- leftIfProjectHookExists(hookValidation, projectId, projectHookUrl)
       projectInfo         <- right(findProjectInfo(projectId, Some(accessToken)))
       serializedHookToken <- right(encrypt(HookToken(projectInfo.id)))

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpoint.scala
@@ -46,7 +46,7 @@ class HookValidationEndpoint[Interpretation[_]: Effect](
   def validateHook(projectId: ProjectId, request: Request[Interpretation]): Interpretation[Response[Interpretation]] = {
     for {
       accessToken    <- findAccessToken(request)
-      creationResult <- hookValidator.validateHook(projectId, accessToken)
+      creationResult <- hookValidator.validateHook(projectId, Some(accessToken))
       response       <- toHttpResponse(creationResult)
     } yield response
   } recoverWith withHttpResult

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpointSpec.scala
@@ -20,7 +20,7 @@ package ch.datascience.webhookservice.eventprocessing
 
 import cats.MonadError
 import cats.effect.IO
-import ch.datascience.controllers.ErrorMessage
+import ch.datascience.controllers.{ErrorMessage, InfoMessage}
 import ch.datascience.controllers.ErrorMessage._
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
@@ -63,7 +63,7 @@ class HookEventEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Accepted
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe json"""{"message": "Event accepted"}"""
+      response.as[Json].unsafeRunSync shouldBe InfoMessage("Event accepted").asJson
     }
 
     "return INTERNAL_SERVER_ERROR when storing push event in the event log fails" in new TestCase {

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
@@ -19,11 +19,12 @@
 package ch.datascience.webhookservice.eventprocessing
 
 import cats.MonadError
+import cats.data.OptionT
 import cats.effect.IO
 import ch.datascience.controllers.InfoMessage._
 import ch.datascience.controllers.{ErrorMessage, InfoMessage}
 import ch.datascience.dbeventlog.DbEventLogGenerators.processingStatuses
-import ch.datascience.dbeventlog.commands.IOEventLogProcessingStatus
+import ch.datascience.dbeventlog.commands.{IOEventLogProcessingStatus, ProcessingStatus}
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators.exceptions
 import ch.datascience.graph.model.events.EventsGenerators.projectIds
@@ -50,7 +51,7 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
       (eventsProcessingStatus
         .fetchStatus(_: ProjectId))
         .expects(projectId)
-        .returning(context.pure(Some(processingStatus)))
+        .returning(OptionT.some(processingStatus))
 
       val response = fetchProcessingStatus(projectId).unsafeRunSync()
 
@@ -69,7 +70,7 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
       (eventsProcessingStatus
         .fetchStatus(_: ProjectId))
         .expects(projectId)
-        .returning(context.pure(None))
+        .returning(OptionT.none[IO, ProcessingStatus])
 
       val response = fetchProcessingStatus(projectId).unsafeRunSync()
 
@@ -84,7 +85,7 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
       (eventsProcessingStatus
         .fetchStatus(_: ProjectId))
         .expects(projectId)
-        .returning(context.raiseError(exception))
+        .returning(OptionT.liftF(context.raiseError(exception)))
 
       val response = fetchProcessingStatus(projectId).unsafeRunSync()
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
@@ -72,8 +72,8 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
       }"""
     }
 
-    "return NOT_FOUND if no progress status can be found for the projectId " +
-      "even if the webhook exists" in new TestCase {
+    "return OK the progress status with done = total = 0 if the webhook exists " +
+      "but there are no events in the Event Log yet" in new TestCase {
 
       (hookValidator
         .validateHook(_: ProjectId, _: Option[AccessToken]))
@@ -87,9 +87,12 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
 
       val response = fetchProcessingStatus(projectId).unsafeRunSync()
 
-      response.status                 shouldBe NotFound
+      response.status                 shouldBe Ok
       response.contentType            shouldBe Some(`Content-Type`(application.json))
-      response.as[Json].unsafeRunSync shouldBe InfoMessage(s"Progress status for project '$projectId' not found").asJson
+      response.as[Json].unsafeRunSync shouldBe json"""{
+        "done": ${0},
+        "total": ${0}
+      }"""
     }
 
     "return NOT_FOUND if the webhook does not exist" in new TestCase {

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice.eventprocessing
+
+import cats.MonadError
+import cats.effect.IO
+import ch.datascience.controllers.InfoMessage._
+import ch.datascience.controllers.{ErrorMessage, InfoMessage}
+import ch.datascience.dbeventlog.DbEventLogGenerators.processingStatuses
+import ch.datascience.dbeventlog.commands.IOEventLogProcessingStatus
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators.exceptions
+import ch.datascience.graph.model.events.EventsGenerators.projectIds
+import ch.datascience.graph.model.events.ProjectId
+import ch.datascience.http.server.EndpointTester._
+import io.circe.Json
+import io.circe.literal._
+import io.circe.syntax._
+import org.http4s.MediaType.application
+import org.http4s.Status._
+import org.http4s.headers.`Content-Type`
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
+
+  "fetchProcessingStatus" should {
+
+    "return OK with the progress status with the given projectId" in new TestCase {
+
+      val processingStatus = processingStatuses.generateOne
+
+      (eventsProcessingStatus
+        .fetchStatus(_: ProjectId))
+        .expects(projectId)
+        .returning(context.pure(Some(processingStatus)))
+
+      val response = fetchProcessingStatus(projectId).unsafeRunSync()
+
+      response.status      shouldBe Ok
+      response.contentType shouldBe Some(`Content-Type`(application.json))
+      response.as[Json].unsafeRunSync shouldBe
+        json"""{
+                "done": ${processingStatus.done.value},
+                "total": ${processingStatus.total.value},
+                "progress": ${processingStatus.progress.value}
+              }"""
+    }
+
+    "return NOT_FOUND if no progress status can be found for the projectId" in new TestCase {
+
+      (eventsProcessingStatus
+        .fetchStatus(_: ProjectId))
+        .expects(projectId)
+        .returning(context.pure(None))
+
+      val response = fetchProcessingStatus(projectId).unsafeRunSync()
+
+      response.status                 shouldBe NotFound
+      response.contentType            shouldBe Some(`Content-Type`(application.json))
+      response.as[Json].unsafeRunSync shouldBe InfoMessage(s"Project: $projectId not found").asJson
+    }
+
+    "return INTERNAL_SERVER_ERROR when finding progress status fails" in new TestCase {
+
+      val exception = exceptions.generateOne
+      (eventsProcessingStatus
+        .fetchStatus(_: ProjectId))
+        .expects(projectId)
+        .returning(context.raiseError(exception))
+
+      val response = fetchProcessingStatus(projectId).unsafeRunSync()
+
+      response.status                 shouldBe InternalServerError
+      response.contentType            shouldBe Some(`Content-Type`(application.json))
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception.getMessage).asJson
+    }
+  }
+
+  private trait TestCase {
+    val context = MonadError[IO, Throwable]
+
+    val projectId = projectIds.generateOne
+
+    val eventsProcessingStatus = mock[IOEventLogProcessingStatus]
+
+    val fetchProcessingStatus = new ProcessingStatusEndpoint[IO](
+      eventsProcessingStatus
+    ).fetchProcessingStatus _
+  }
+}

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -54,8 +54,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       (projectInfoFinder
@@ -92,8 +92,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookExists))
 
       hookCreation.createHook(projectId, accessToken).unsafeRunSync() shouldBe HookExisted
@@ -123,8 +123,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
 
       val exception = exceptions.generateOne
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.raiseError(exception))
 
       intercept[Exception] {
@@ -141,8 +141,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       val exception = exceptions.generateOne
@@ -165,8 +165,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       (projectInfoFinder
@@ -194,8 +194,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       (projectInfoFinder
@@ -228,8 +228,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       (projectInfoFinder
@@ -267,8 +267,8 @@ class HookCreatorSpec extends WordSpec with MockFactory {
         .returning(context.pure(projectHookUrl))
 
       (projectHookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       (projectInfoFinder

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
@@ -55,8 +55,8 @@ class HookValidationEndpointSpec extends WordSpec with MockFactory {
         .returning(context.pure(accessToken))
 
       (hookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookExists))
 
       val request = Request[IO](Method.POST, uri"projects" / projectId.toString / "webhooks" / "validation")
@@ -77,8 +77,8 @@ class HookValidationEndpointSpec extends WordSpec with MockFactory {
         .returning(context.pure(accessToken))
 
       (hookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(context.pure(HookMissing))
 
       val request = Request[IO](Method.POST, uri"projects" / projectId.toString / "webhooks" / "validation")
@@ -115,8 +115,8 @@ class HookValidationEndpointSpec extends WordSpec with MockFactory {
 
       val errorMessage = ErrorMessage("some error")
       (hookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(IO.raiseError(new Exception(errorMessage.toString())))
 
       val request = Request[IO](Method.POST, uri"projects" / projectId.toString / "webhooks" / "validation")
@@ -137,8 +137,8 @@ class HookValidationEndpointSpec extends WordSpec with MockFactory {
         .returning(context.pure(accessToken))
 
       (hookValidator
-        .validateHook(_: ProjectId, _: AccessToken))
-        .expects(projectId, accessToken)
+        .validateHook(_: ProjectId, _: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
         .returning(IO.raiseError(UnauthorizedException))
 
       val request = Request[IO](Method.POST, uri"projects" / projectId.toString / "webhooks" / "validation")

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -32,6 +32,7 @@ import ch.datascience.interpreters.TestLogger
 import ch.datascience.interpreters.TestLogger.Level.Error
 import ch.datascience.webhookservice.generators.WebhookServiceGenerators._
 import ch.datascience.webhookservice.hookvalidation.HookValidator.HookValidationResult.{HookExists, HookMissing}
+import ch.datascience.webhookservice.hookvalidation.HookValidator.NoAccessTokenException
 import ch.datascience.webhookservice.project.ProjectVisibility._
 import ch.datascience.webhookservice.project._
 import ch.datascience.webhookservice.tokenrepository.{AccessTokenAssociator, AccessTokenRemover}
@@ -48,8 +49,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
 
     "fail if finding project info with the given access token fails" in new TestCase {
 
-      val projectInfo = projectInfos.generateOne.copy(visibility = Internal)
-      val projectId   = projectInfo.id
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
 
       val exception: Exception    = exceptions.generateOne
       val error:     Try[Nothing] = context.raiseError(exception)
@@ -58,15 +58,45 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(projectId, Some(givenAccessToken))
         .returning(error)
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe error
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
       logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
     }
 
-    "fail if finding stored access token fails" in new TestCase {
+    "fail if finding stored access token fails when no access token given" in new TestCase {
 
-      val projectInfo = projectInfos.generateOne.copy(visibility = Internal)
-      val projectId   = projectInfo.id
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
+
+      val exception: Exception    = exceptions.generateOne
+      val error:     Try[Nothing] = context.raiseError(exception)
+      (accessTokenFinder
+        .findAccessToken(_: ProjectId))
+        .expects(projectId)
+        .returning(error)
+
+      validator.validateHook(projectId, maybeAccessToken = None) shouldBe error
+
+      logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
+    }
+
+    "fail if finding stored access token return NOT_FOUND when no access token given" in new TestCase {
+
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
+
+      (accessTokenFinder
+        .findAccessToken(_: ProjectId))
+        .expects(projectId)
+        .returning(context.pure(None))
+
+      val noAccessTokenException = NoAccessTokenException(s"No access token found for projectId $projectId")
+      validator.validateHook(projectId, maybeAccessToken = None) shouldBe context.raiseError(noAccessTokenException)
+
+      logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", noAccessTokenException))
+    }
+
+    "fail if finding stored access token fails when an invalid access token given" in new TestCase {
+
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
 
       (projectInfoFinder
         .findProjectInfo(_: ProjectId, _: Option[AccessToken]))
@@ -81,15 +111,14 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(projectId)
         .returning(error)
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe error
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
       logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
     }
 
     "fail if finding project info with stored access token fails" in new TestCase {
 
-      val projectInfo = projectInfos.generateOne.copy(visibility = Internal)
-      val projectId   = projectInfo.id
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
 
       (projectInfoFinder
         .findProjectInfo(_: ProjectId, _: Option[AccessToken]))
@@ -109,15 +138,14 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(projectId, Some(storedAccessToken))
         .returning(error)
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe error
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
       logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
     }
 
     "fail if finding project info with stored access token fails with UnauthorizedException" in new TestCase {
 
-      val projectInfo = projectInfos.generateOne.copy(visibility = Internal)
-      val projectId   = projectInfo.id
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
 
       (projectInfoFinder
         .findProjectInfo(_: ProjectId, _: Option[AccessToken]))
@@ -135,7 +163,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(projectId, Some(storedAccessToken))
         .returning(context.raiseError(UnauthorizedException))
 
-      val Failure(exception) = validator.validateHook(projectId, givenAccessToken)
+      val Failure(exception) = validator.validateHook(projectId, Some(givenAccessToken))
 
       exception            shouldBe an[Exception]
       exception.getMessage shouldBe s"Stored access token for $projectId is invalid"
@@ -145,8 +173,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
 
     "fail if finding stored access token return None" in new TestCase {
 
-      val projectInfo = projectInfos.generateOne.copy(visibility = Internal)
-      val projectId   = projectInfo.id
+      val projectId = projectInfos.generateOne.copy(visibility = Internal).id
 
       (projectInfoFinder
         .findProjectInfo(_: ProjectId, _: Option[AccessToken]))
@@ -158,7 +185,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(projectId)
         .returning(context.pure(None))
 
-      val Failure(exception) = validator.validateHook(projectId, givenAccessToken)
+      val Failure(exception) = validator.validateHook(projectId, Some(givenAccessToken))
 
       exception            shouldBe an[Exception]
       exception.getMessage shouldBe s"No access token found for projectId $projectId"
@@ -189,7 +216,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(HookIdentifier(projectId, projectHookUrl), givenAccessToken)
         .returning(context.pure(true))
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe context.pure(HookExists)
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe context.pure(HookExists)
 
       logger.expectNoLogs()
     }
@@ -214,7 +241,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(HookIdentifier(projectId, projectHookUrl), givenAccessToken)
         .returning(context.pure(false))
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe context.pure(HookMissing)
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe context.pure(HookMissing)
 
       logger.expectNoLogs()
     }
@@ -235,7 +262,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects()
         .returning(error)
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe error
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
       logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
     }
@@ -262,7 +289,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
         .expects(HookIdentifier(projectId, projectHookUrl), givenAccessToken)
         .returning(error)
 
-      validator.validateHook(projectId, givenAccessToken) shouldBe error
+      validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
       logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
     }
@@ -296,7 +323,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(projectId, givenAccessToken)
           .returning(context.unit)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe context.pure(HookExists)
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe context.pure(HookExists)
 
         logger.expectNoLogs()
       }
@@ -326,7 +353,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(projectId)
           .returning(context.unit)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe context.pure(HookMissing)
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe context.pure(HookMissing)
 
         logger.expectNoLogs()
       }
@@ -347,7 +374,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects()
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }
@@ -374,7 +401,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(HookIdentifier(projectId, projectHookUrl), givenAccessToken)
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }
@@ -406,7 +433,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(projectId, givenAccessToken)
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }
@@ -438,7 +465,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(projectId)
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }
@@ -474,7 +501,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(HookIdentifier(projectId, projectHookUrl), storedAccessToken)
           .returning(context.pure(true))
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe context.pure(HookExists)
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe context.pure(HookExists)
 
         logger.expectNoLogs()
       }
@@ -512,7 +539,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(projectId)
           .returning(context.unit)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe context.pure(HookMissing)
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe context.pure(HookMissing)
 
         logger.expectNoLogs()
       }
@@ -541,7 +568,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects()
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }
@@ -576,7 +603,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(HookIdentifier(projectId, projectHookUrl), storedAccessToken)
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }
@@ -616,7 +643,7 @@ class HookValidatorSpec extends WordSpec with MockFactory {
           .expects(projectId)
           .returning(error)
 
-        validator.validateHook(projectId, givenAccessToken) shouldBe error
+        validator.validateHook(projectId, Some(givenAccessToken)) shouldBe error
 
         logger.loggedOnly(Error(s"Hook validation fails for project with id $projectId", exception))
       }

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/missedevents/IOMissedEventsLoaderSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/missedevents/IOMissedEventsLoaderSpec.scala
@@ -61,7 +61,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
     "do nothing if the latest eventIds in the Event Log " +
       "matches the latest commits in GitLab for relevant projects" in new TestCase {
 
-      val latestEventsList = nonEmptyList(commitEventIds).generateOne
+      val latestEventsList = nonEmptyList(commitEventIds).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 
@@ -80,7 +80,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
       "for projects with the latest eventIds different than the latest commits in GitLab" in new TestCase {
 
       val latestEventsList @ event1 +: event2 +: event3 +: Nil =
-        nonEmptyList(commitEventIds, minElements = 3, maxElements = 3).generateOne
+        nonEmptyList(commitEventIds, minElements = 3, maxElements = 3).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 
@@ -111,7 +111,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
 
     "do nothing if the latest PushEvent does not exists" in new TestCase {
       val latestEventsList @ event1 +: event2 +: Nil =
-        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne
+        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 
@@ -131,7 +131,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
 
     "not break processing if finding Access Token for one of the event(s) fails" in new TestCase {
 
-      val latestEventsList = nonEmptyList(commitEventIds, minElements = 2).generateOne
+      val latestEventsList = nonEmptyList(commitEventIds, minElements = 2).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 
@@ -161,7 +161,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
     "not break processing if finding the latest Push Event for one of the events fails" in new TestCase {
 
       val latestEventsList @ event1 +: event2 +: Nil =
-        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne
+        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 
@@ -186,7 +186,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
     "not break processing if finding Project Info for one of the events fails" in new TestCase {
 
       val latestEventsList @ event1 +: event2 +: Nil =
-        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne
+        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 
@@ -214,7 +214,7 @@ class IOMissedEventsLoaderSpec extends WordSpec with MockFactory {
     "not break processing if storing Push Event for one of the events fails" in new TestCase {
 
       val latestEventsList @ event1 +: event2 +: Nil =
-        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne
+        nonEmptyList(commitEventIds, minElements = 2, maxElements = 2).generateOne.toList
       givenFetchLogLatestEvents
         .returning(context.pure(latestEventsList))
 


### PR DESCRIPTION
This PR introduces a new endpoint which fetches info about events processing progress of a project with the given id.

The endpoint is accessible on the webhook-service at:
`GET <webhook-service>/projects/:id/events/status`

Valid 200 response looks like:
`{ "done": 10, "total": 20, "progress": 50.00 }`