### PR TITLE
OAUTH-TOKEN header support removal

### DIFF
--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -34,16 +34,15 @@ Creates a webhook for a project with the given `project id`.
 The endpoint requires an authorization token. It can be passed in the request header as:
 - `Authorization: Bearer <token>` with OAuth Token obtained from GitLab
 - `PRIVATE-TOKEN: <token>` with user's Personal Access Token in GitLab
-- `OAUTH-TOKEN: <token>` with OAuth Token obtained from GitLab (deprecated)
 
 **Response**
 
-| Status                     | Description                                                                           |
-|----------------------------|---------------------------------------------------------------------------------------|
-| OK (200)                   | When hook already exists for the project                                              |
-| CREATED (201)              | When a new hook was created                                                           |
-| UNAUTHORIZED (401)         | When there is neither `PRIVATE-TOKEN` nor `OAUTH-TOKEN` in the header or it's invalid |
-| INTERNAL SERVER ERROR (500)| When there are problems with webhook creation                                         |
+| Status                     | Description                                                                                     |
+|----------------------------|-------------------------------------------------------------------------------------------------|
+| OK (200)                   | When hook already exists for the project                                                        |
+| CREATED (201)              | When a new hook was created                                                                     |
+| UNAUTHORIZED (401)         | When there is neither `PRIVATE-TOKEN` nor `AUTHORIZATION: BEARER` in the header or it's invalid |
+| INTERNAL SERVER ERROR (500)| When there are problems with webhook creation                                                   |
 
 #### POST /projects/:id/webhooks/validation
 
@@ -57,7 +56,6 @@ Validates the webhook for the project with the given `project id`. It succeeds (
 The endpoint requires an authorization token. It can be passed in the request header as:
 - `Authorization: Bearer <token>` with OAuth Token obtained from GitLab
 - `PRIVATE-TOKEN: <token>` with user's Personal Access Token in GitLab
-- `OAUTH-TOKEN: <token>` with OAuth Token obtained from GitLab (deprecated)
 
 **Response**
 
@@ -65,7 +63,7 @@ The endpoint requires an authorization token. It can be passed in the request he
 |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | OK (200)                   | When the hook exists for the project and the project is either public or there's a Personal Access Token available for it                                         |
 | NOT_FOUND (404)            | When the hook either does not exists or there's no Personal Access Token available for it. If the hook exists but there's no PAT for it, the hook will be removed |
-| UNAUTHORIZED (401)         | When there is neither `PRIVATE-TOKEN` nor `OAUTH-TOKEN` in the header or it's invalid                                                                             |
+| UNAUTHORIZED (401)         | When there is neither `PRIVATE-TOKEN` nor `AUTHORIZATION: BEARER` in the header or it's invalid                                                                   |
 | INTERNAL SERVER ERROR (500)| When there are problems with validating the hook presence                                                                                                         |
 
 #### POST /webhooks/events

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/security/AccessTokenExtractor.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/security/AccessTokenExtractor.scala
@@ -36,7 +36,6 @@ class AccessTokenExtractor[Interpretation[_]](implicit ME: MonadError[Interpreta
   def findAccessToken(request: Request[Interpretation]): Interpretation[AccessToken] =
     request.getTokenFromBearer
       .flatMap(toOAuthAccessToken)
-      .orElse(request.get("OAUTH-TOKEN") flatMap convert(OAuthAccessToken.from))
       .orElse(request.get("PRIVATE-TOKEN") flatMap convert(PersonalAccessToken.from))
       .getOrElseF(ME.raiseError(UnauthorizedException))
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/security/AccessTokenExtractorSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/security/AccessTokenExtractorSpec.scala
@@ -45,7 +45,7 @@ class AccessTokenExtractorSpec extends WordSpec {
       ) shouldBe context.pure(accessToken)
     }
 
-    "return oauth access token when 'Authorization: Bearer <token>' is present in the header" in new TestCase {
+    "return oauth access token when 'AUTHORIZATION: BEARER <token>' is present in the header" in new TestCase {
 
       val accessToken = oauthAccessTokens.generateOne
 
@@ -54,16 +54,7 @@ class AccessTokenExtractorSpec extends WordSpec {
       ) shouldBe context.pure(accessToken)
     }
 
-    "return oauth access token when OAUTH-TOKEN is present in the header" in new TestCase {
-
-      val accessToken = oauthAccessTokens.generateOne
-
-      finder.findAccessToken(
-        request.withHeaders(Headers.of(Header("OAUTH-TOKEN", accessToken.value)))
-      ) shouldBe context.pure(accessToken)
-    }
-
-    "return oauth access token when both PRIVATE-TOKEN and OAUTH-TOKEN are present" in new TestCase {
+    "return oauth access token when both PRIVATE-TOKEN and AUTHORIZATION: BEARER are present" in new TestCase {
 
       val oauthAccessToken    = oauthAccessTokens.generateOne
       val personalAccessToken = personalAccessTokens.generateOne
@@ -72,14 +63,14 @@ class AccessTokenExtractorSpec extends WordSpec {
         request
           .withHeaders(
             Headers.of(
-              Header("OAUTH-TOKEN", oauthAccessToken.value),
+              Header("PRIVATE-TOKEN", personalAccessToken.value),
               Authorization(Token(Bearer, oauthAccessToken.value))
             )
           )
       ) shouldBe context.pure(oauthAccessToken)
     }
 
-    "fail with UNAUTHORIZED when neither PRIVATE-TOKEN nor OAUTH-TOKEN is not present" in new TestCase {
+    "fail with UNAUTHORIZED when neither PRIVATE-TOKEN nor AUTHORIZATION: BEARER is not present" in new TestCase {
       finder.findAccessToken(request) shouldBe context.raiseError(UnauthorizedException)
     }
 
@@ -95,12 +86,6 @@ class AccessTokenExtractorSpec extends WordSpec {
 
       finder.findAccessToken(
         request.withHeaders(Authorization(Token(Basic, accessToken.value)))
-      ) shouldBe context.raiseError(UnauthorizedException)
-    }
-
-    "fail with UNAUTHORIZED when OAUTH-TOKEN is invalid" in new TestCase {
-      finder.findAccessToken(
-        request.withHeaders(Headers.of(Header("OAUTH-TOKEN", "")))
       ) shouldBe context.raiseError(UnauthorizedException)
     }
   }


### PR DESCRIPTION
There was a PR #56 which allowed passing oauth access tokens in the Authorization: Bearer headers. This PR removes support for passing the tokens in the OAUTH-TOKEN headers.