### PR TITLE
fix: skipping untracked files on travis box

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.12.8"
 packagedArtifacts := Map.empty
 
 releaseVersionBump := sbtrelease.Version.Bump.Minor
+releaseIgnoreUntrackedFiles := true
 releaseTagName := (version in ThisBuild).value.toString
 
 lazy val root = Project(


### PR DESCRIPTION
It seems Travis is generating some files when running the build. This change skips them during the release process.