### PR TITLE
ErrorMessage hiding the real error for Exception with null message

### DIFF
--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/graphql/QueryEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/graphql/QueryEndpoint.scala
@@ -70,8 +70,8 @@ class QueryEndpoint[Interpretation[_]: Effect](
   private case class BadRequestError(cause: Throwable) extends Exception(cause)
 
   private lazy val httpResponse: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
-    case BadRequestError(exception) => BadRequest(ErrorMessage(exception.getMessage))
-    case NonFatal(exception)        => InternalServerError(ErrorMessage(exception.getMessage))
+    case BadRequestError(exception) => BadRequest(ErrorMessage(exception))
+    case NonFatal(exception)        => InternalServerError(ErrorMessage(exception))
   }
 
   private implicit lazy val queryEntityDecoder: EntityDecoder[Interpretation, UserQuery] =

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/graphql/QueryEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/graphql/QueryEndpointSpec.scala
@@ -101,7 +101,7 @@ class QueryEndpointSpec extends WordSpec with MockFactory {
 
       response.status                   shouldBe BadRequest
       response.contentType              shouldBe Some(`Content-Type`(application.json))
-      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(exception.getMessage).asJson
+      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(exception).asJson
     }
 
     "respond with INTERNAL_SERVER_ERROR if running the query fails" in new TestCase {
@@ -118,7 +118,7 @@ class QueryEndpointSpec extends WordSpec with MockFactory {
 
       response.status                   shouldBe InternalServerError
       response.contentType              shouldBe Some(`Content-Type`(application.json))
-      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(exception.getMessage).asJson
+      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(exception).asJson
     }
   }
 

--- a/token-repository/src/main/scala/ch/datascience/tokenrepository/repository/association/AssociateTokenEndpoint.scala
+++ b/token-repository/src/main/scala/ch/datascience/tokenrepository/repository/association/AssociateTokenEndpoint.scala
@@ -64,7 +64,7 @@ class AssociateTokenEndpoint[Interpretation[_]: Effect](
 
   private def httpResponse(projectId: ProjectId): PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
     case BadRequestError(exception) =>
-      BadRequest(ErrorMessage(exception.getMessage))
+      BadRequest(ErrorMessage(exception))
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage(s"Associating token with projectId: $projectId failed")
       logger.error(exception)(errorMessage.value)

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpoint.scala
@@ -92,13 +92,12 @@ class HookEventEndpoint[Interpretation[_]: Effect](
   }
 
   private lazy val httpResponse: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
-    case BadRequestError(exception) =>
-      BadRequest(ErrorMessage(exception.getMessage))
+    case BadRequestError(exception) => BadRequest(ErrorMessage(exception))
     case ex @ UnauthorizedException =>
       Response[Interpretation](Status.Unauthorized)
-        .withEntity[ErrorMessage](ErrorMessage(ex.getMessage))
+        .withEntity[ErrorMessage](ErrorMessage(ex))
         .pure[Interpretation]
-    case NonFatal(exception) => InternalServerError(ErrorMessage(exception.getMessage))
+    case NonFatal(exception) => InternalServerError(ErrorMessage(exception))
   }
 }
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpoint.scala
@@ -80,7 +80,7 @@ class ProcessingStatusEndpoint[Interpretation[_]: Effect](
   }
 
   private lazy val httpResponse: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
-    case NonFatal(exception) => InternalServerError(ErrorMessage(exception.getMessage))
+    case NonFatal(exception) => InternalServerError(ErrorMessage(exception))
   }
 }
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpoint.scala
@@ -61,9 +61,9 @@ class HookCreationEndpoint[Interpretation[_]: Effect](
   private lazy val httpResponse: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
     case ex @ UnauthorizedException =>
       Response[Interpretation](Status.Unauthorized)
-        .withEntity[ErrorMessage](ErrorMessage(ex.getMessage))
+        .withEntity[ErrorMessage](ErrorMessage(ex))
         .pure[Interpretation]
-    case NonFatal(exception) => InternalServerError(ErrorMessage(exception.getMessage))
+    case NonFatal(exception) => InternalServerError(ErrorMessage(exception))
   }
 }
 

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpoint.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpoint.scala
@@ -59,9 +59,9 @@ class HookValidationEndpoint[Interpretation[_]: Effect](
   private lazy val withHttpResult: PartialFunction[Throwable, Interpretation[Response[Interpretation]]] = {
     case ex @ UnauthorizedException =>
       Response[Interpretation](Status.Unauthorized)
-        .withEntity[ErrorMessage](ErrorMessage(ex.getMessage))
+        .withEntity[ErrorMessage](ErrorMessage(ex))
         .pure[Interpretation]
-    case NonFatal(exception) => InternalServerError(ErrorMessage(exception.getMessage))
+    case NonFatal(exception) => InternalServerError(ErrorMessage(exception))
   }
 }
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/HookEventEndpointSpec.scala
@@ -84,7 +84,7 @@ class HookEventEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe InternalServerError
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception).asJson
     }
 
     "return BAD_REQUEST for invalid push event payload" in new TestCase {
@@ -95,9 +95,11 @@ class HookEventEndpointSpec extends WordSpec with MockFactory {
 
       val response = processPushEvent(request).unsafeRunSync()
 
-      response.status                 shouldBe BadRequest
-      response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage("Invalid message body: Could not decode JSON: {}").asJson
+      response.status      shouldBe BadRequest
+      response.contentType shouldBe Some(`Content-Type`(MediaType.application.json))
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(
+        s"Invalid message body: Could not decode JSON: ${Json.obj()}"
+      ).asJson
     }
 
     "return UNAUTHORIZED if X-Gitlab-Token token is not present in the header" in new TestCase {
@@ -109,7 +111,7 @@ class HookEventEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
 
     "return UNAUTHORIZED when user X-Gitlab-Token is invalid" in new TestCase {
@@ -127,7 +129,7 @@ class HookEventEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
 
     "return UNAUTHORIZED when X-Gitlab-Token decryption fails" in new TestCase {
@@ -146,7 +148,7 @@ class HookEventEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
   }
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/ProcessingStatusEndpointSpec.scala
@@ -135,7 +135,7 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe InternalServerError
       response.contentType            shouldBe Some(`Content-Type`(application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception).asJson
     }
 
     "return INTERNAL_SERVER_ERROR when finding progress status fails" in new TestCase {
@@ -155,7 +155,7 @@ class ProcessingStatusEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe InternalServerError
       response.contentType            shouldBe Some(`Content-Type`(application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(exception).asJson
     }
   }
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookcreation/HookCreationEndpointSpec.scala
@@ -103,7 +103,7 @@ class HookCreationEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
 
     "return INTERNAL_SERVER_ERROR when there was an error during hook creation" in new TestCase {
@@ -149,7 +149,7 @@ class HookCreationEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
   }
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
@@ -103,7 +103,7 @@ class HookValidationEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
 
     "return INTERNAL_SERVER_ERROR when there was an error during hook validation" in new TestCase {
@@ -147,7 +147,7 @@ class HookValidationEndpointSpec extends WordSpec with MockFactory {
 
       response.status                 shouldBe Unauthorized
       response.contentType            shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException.getMessage).asJson
+      response.as[Json].unsafeRunSync shouldBe ErrorMessage(UnauthorizedException).asJson
     }
   }
 


### PR DESCRIPTION
It was observed that when an exception has a null message, graph-services logs a NullPointerException raised from the internals of the ErrorMessage class hiding the real exception. This PR fixes that bug and logs Exception class name instead.