### PR TITLE
Re-provisioning in loop

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/flows/RdfStoreProvisioning.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/flows/RdfStoreProvisioning.scala
@@ -42,7 +42,7 @@ object RdfStoreProvisioning extends Eventually with AcceptanceTestPatience {
   def `data in the RDF store`(project: Project, commitId: CommitId, schemaVersion: SchemaVersion): Assertion =
     `data in the RDF store`(project,
                             commitId,
-                            triples(singleFileAndCommit(project.path, commitId, Some(schemaVersion))),
+                            triples(singleFileAndCommit(project.path, commitId, schemaVersion = schemaVersion)),
                             schemaVersion)
 
   def `data in the RDF store`(project:       Project,

--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
@@ -34,7 +34,7 @@ object RemoteTriplesGenerator {
     `GET <triples-generator>/projects/:id/commits/:id returning OK`(
       project,
       commitId,
-      triples(singleFileAndCommit(project.path, commitId, Some(schemaVersion))),
+      triples(singleFileAndCommit(project.path, commitId, schemaVersion = schemaVersion)),
       schemaVersion)
 
   def `GET <triples-generator>/projects/:id/commits/:id returning OK`(

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.12.8"
 // This project contains nothing to package, like pure POM maven project
 packagedArtifacts := Map.empty
 
-releaseVersionBump := sbtrelease.Version.Bump.Minor
+releaseVersionBump := sbtrelease.Version.Bump.Bugfix
 releaseIgnoreUntrackedFiles := true
 releaseTagName := (version in ThisBuild).value.toString
 

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogMarkDoneSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogMarkDoneSpec.scala
@@ -58,16 +58,14 @@ class EventLogMarkDoneSpec extends WordSpec with InMemoryEventLogDbSpec with Moc
       findEvents(status = TriplesStore) shouldBe List((eventId, ExecutionDate(now)))
     }
 
-    s"fail when updating event with status different than $Processing" in new TestCase {
+    "do nothing when updating event did not change any row" in new TestCase {
 
       val eventId       = commitEventIds.generateOne
       val eventStatus   = eventStatuses generateDifferentThan Processing
       val executionDate = executionDates.generateOne
       storeEvent(eventId, eventStatus, executionDate, committedDates.generateOne, eventBodies.generateOne)
 
-      intercept[RuntimeException] {
-        eventLogMarkDone.markEventDone(eventId).unsafeRunSync()
-      }.getMessage shouldBe s"Event with $eventId couldn't be updated; either no event or not with status $Processing"
+      eventLogMarkDone.markEventDone(eventId).unsafeRunSync() shouldBe ((): Unit)
 
       findEvents(status = eventStatus) shouldBe List((eventId, executionDate))
     }

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/Agent.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/Agent.scala
@@ -24,14 +24,14 @@ import io.circe.literal._
 
 private[triples] object Agent {
 
-  def apply(schemaVersion: SchemaVersion) = json"""
+  def apply(id: Id) = json"""
   {
-    "@id": ${Id(schemaVersion)},
+    "@id": $id,
     "@type": [
       "prov:SoftwareAgent",
       "http://purl.org/wf4ever/wfprov#WorkflowEngine"
     ],
-    "rdfs:label": ${s"renku $schemaVersion"}
+    "rdfs:label": ${s"renku ${id.schemaVersion}"}
   }"""
 
   final case class Id(schemaVersion: SchemaVersion) extends EntityId {

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/CommitActivity.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/CommitActivity.scala
@@ -33,18 +33,18 @@ private[triples] object CommitActivity {
   def apply(commitId:          CommitId,
             projectId:         Project.Id,
             committedDate:     CommittedDate,
-            maybeAgentId:      Option[Agent.Id],
-            maybePersonId:     Option[Person.Id],
+            agentId:           Agent.Id,
+            personId:          Person.Id,
             maybeInfluencedBy: List[CommitCollectionEntity.Id],
             comment:           String Refined NonEmpty)(implicit fusekiBaseUrl: FusekiBaseUrl): Json =
-    apply(Id(commitId), projectId, committedDate, maybeAgentId, maybePersonId, maybeInfluencedBy, comment)
+    apply(Id(commitId), projectId, committedDate, agentId, personId, maybeInfluencedBy, comment)
 
   // format: off
   def apply(id:                Id,
             projectId:         Project.Id,
             committedDate:     CommittedDate,
-            maybeAgentId:      Option[Agent.Id],
-            maybePersonId:     Option[Person.Id] = None,
+            agentId:           Agent.Id,
+            personId:          Person.Id,
             maybeInfluencedBy: List[CommitCollectionEntity.Id] = Nil,
             comment:           String Refined NonEmpty = "some change"
   ): Json = json"""
@@ -63,9 +63,9 @@ private[triples] object CommitActivity {
       "@id": $id
     },
     "rdfs:comment": ${comment.value},
-    "rdfs:label": ${id.commitId.value}
+    "rdfs:label": ${id.commitId.value},
+    "prov:agent": [${agentId.toIdJson}, ${personId.toIdJson}]
   }""".deepMerge(`schema:isPartOf`(projectId))
-      .deepMerge(List(maybeAgentId, maybePersonId).flatten toResources "prov:agent")
       .deepMerge(maybeInfluencedBy toResources "prov:influenced")
   // format: on
 

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/Person.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/Person.scala
@@ -33,7 +33,8 @@ object Person {
       "schema:Person",
       "prov:Person"
     ],
-    "schema:name": ${id.userName}
+    "schema:name": ${id.userName},
+    "rdfs:label": ${id.userName}
   }""" deepMerge (maybeEmail to "schema:email")
 
   final case class Id(userName: Name) extends EntityId {

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/multiFileAndCommit.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/multiFileAndCommit.scala
@@ -18,12 +18,13 @@
 
 package ch.datascience.rdfstore.triples
 
-import ch.datascience.generators.CommonGraphGenerators.schemaVersions
+import ch.datascience.generators.CommonGraphGenerators.{emails, names, schemaVersions}
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.graph.model.EventsGenerators.committedDates
 import ch.datascience.graph.model.SchemaVersion
 import ch.datascience.graph.model.events.CommitId
 import ch.datascience.graph.model.projects.{FilePath, ProjectPath}
+import ch.datascience.graph.model.users.{Email, Name => UserName}
 import ch.datascience.rdfstore.FusekiBaseUrl
 import ch.datascience.rdfstore.triples.entities._
 import ch.datascience.tinytypes.constraints.NonBlank
@@ -80,14 +81,18 @@ object multiFileAndCommit {
   )(implicit fusekiBaseUrl: FusekiBaseUrl): List[Json] = {
     val projectId = Project.Id(renkuBaseUrl, projectPath)
     val agentId   = Agent.Id(schemaVersion)
+    val committerName:  UserName = names.generateOne
+    val committerEmail: Email    = emails.generateOne
+    val committerPersonId = Person.Id(committerName)
     import data._
 
     // format: off
     List(
       Project(projectId),
-      Agent(schemaVersion),
+      Agent(agentId),
+      Person(committerPersonId, Some(committerEmail)),
 
-      CommitActivity(commit1ActivityId, projectId, committedDates.generateOne, Some(agentId), comment = "renku dataset add zhbikes external.csv"),
+      CommitActivity(commit1ActivityId, projectId, committedDates.generateOne, agentId, committerPersonId, comment = "renku dataset add zhbikes external.csv"),
       GenerationActivity(commit1Id, FilePath("tree/input-data/external.csv"), commit1ActivityId),
       GenerationActivity(commit1DatasetGenerationId, commit1ActivityId),
       GenerationArtifact(commit1Id, FilePath(".renku/datasets/f0d5e338c7644f1995484ac00108d525/metadata.yml"), CommitGeneration.Id(commit1Id, FilePath("tree/.renku/datasets/f0d5e338c7644f1995484ac00108d525/metadata.yml")), projectId),
@@ -102,7 +107,7 @@ object multiFileAndCommit {
       GenerationArtifact(commit1Id, FilePath(".renku/refs/datasets/zhbikes"), commit1DatasetGenerationId, projectId),
       GenerationActivity(commit1Id, FilePath("tree/.renku/datasets/f0d5e338c7644f1995484ac00108d525/metadata.yml"), commit1ActivityId),
 
-      CommitActivity(commit2Id, projectId, committedDates.generateOne, Some(agentId), maybePersonId = None, maybeInfluencedBy = Nil, comment = "added refactored scripts"),
+      CommitActivity(commit2Id, projectId, committedDates.generateOne, agentId, committerPersonId, maybeInfluencedBy = Nil, comment = "added refactored scripts"),
       CommitCollectionEntity(commit2Id, FilePath("src"), projectId),
       GenerationActivity(commit2Source2GenerationActivityId, commit2ActivityId),
       GenerationArtifact(commit2Source1GenerationId, commit2Source1GenerationActivityId, projectId),

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/package.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/package.scala
@@ -58,11 +58,16 @@ package object triples {
         .getOrElse(Json.obj())
   }
 
+  implicit class IdOps[ID <: EntityId](id: ID) {
+
+    lazy val toIdJson: Json = Json.obj("@id" -> id.asJson)
+  }
+
   implicit class OptionIdOps[V <: EntityId](maybeValue: Option[V]) {
 
     def toResource[ID <: EntityId](property: String): Json =
       maybeValue
-        .map(id => Json.obj(property -> Json.obj("@id" -> id.asJson)))
+        .map(id => Json.obj(property -> id.toIdJson))
         .getOrElse(Json.obj())
   }
 
@@ -70,7 +75,7 @@ package object triples {
     def toResources(property: String, toId: V => EntityId = identity): Json =
       Json.obj(
         property -> Json.arr(
-          values.map(toId).map(id => Json.obj("@id" -> id.asJson)): _*
+          values.map(toId).map(id => id.toIdJson): _*
         )
       )
   }

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/singleFileAndCommitWithDataset.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/singleFileAndCommitWithDataset.scala
@@ -61,14 +61,17 @@ object singleFileAndCommitWithDataset {
     val datasetGenerationPath            = FilePath("tree") / datasetPath
     val datasetId                        = Dataset.Id(datasetIdentifier)
     val commitGenerationId               = CommitGeneration.Id(commitId, datasetGenerationPath)
+    val committerPersonId                = Person.Id(committerName)
+    val agentId                          = Agent.Id(schemaVersion)
+
     List(
       Project(projectId),
       CommitActivity(
         commitActivityId,
         projectId,
         committedDate,
-        Some(Agent.Id(schemaVersion)),
-        Some(Person.Id(committerName)),
+        agentId,
+        committerPersonId,
         maybeInfluencedBy = List(
           renkuCommitCollectionEntityId,
           datasetsCommitCollectionEntityId,
@@ -79,8 +82,8 @@ object singleFileAndCommitWithDataset {
       CommitCollectionEntity(datasetsCommitCollectionEntityId, projectId, hadMember = datasetCommitCollectionEntityId),
       CommitCollectionEntity(datasetCommitCollectionEntityId, projectId, hadMember  = datasetId),
       CommitGeneration(commitGenerationId, commitActivityId),
-      Agent(schemaVersion),
-      Person(Person.Id(committerName), Some(committerEmail))
+      Agent(agentId),
+      Person(committerPersonId, Some(committerEmail))
     ) ++ Dataset(
       datasetId,
       projectId,

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesFinder.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesFinder.scala
@@ -61,18 +61,20 @@ private class IOOutdatedTriplesFinder(
                          |  SELECT ?project
                          |  WHERE {
                          |    {
-                         |        ?commit dcterms:isPartOf|schema:isPartOf ?project .
-                         |        ?commit rdf:type prov:Activity .
-                         |        ?commit prov:agent ?agent .
-                         |        ?agent  rdfs:label ?version
+                         |        ?commit dcterms:isPartOf|schema:isPartOf ?project ;
+                         |                rdf:type prov:Activity ;
+                         |                prov:agent ?agent .
+                         |        ?agent  rdf:type prov:SoftwareAgent ;
+                         |                rdfs:label ?version .
                          |        FILTER (?version != "renku $schemaVersion")
                          |    }
                          |    UNION
                          |    {
-                         |        ?commit dcterms:isPartOf|schema:isPartOf ?project .
-                         |        ?commit rdf:type prov:Activity .
+                         |        ?commit dcterms:isPartOf|schema:isPartOf ?project ;
+                         |                rdf:type prov:Activity .
                          |        FILTER NOT EXISTS {
                          |          ?commit prov:agent ?agent .
+                         |          ?agent  rdf:type prov:SoftwareAgent .
                          |        }
                          |    }
                          |  }
@@ -81,18 +83,20 @@ private class IOOutdatedTriplesFinder(
                          |  }
                          |  # finding all the commits for the found project with either no agent or agent with a different version
                          |  {
-                         |	  ?commit dcterms:isPartOf|schema:isPartOf ?project .
-                         |    ?commit rdf:type prov:Activity .
-                         |    ?commit prov:agent ?agent .
-                         |    ?agent  rdfs:label ?version
+                         |	  ?commit dcterms:isPartOf|schema:isPartOf ?project ;
+                         |            rdf:type prov:Activity ;
+                         |            prov:agent ?agent .
+                         |    ?agent  rdf:type prov:SoftwareAgent ;
+                         |            rdfs:label ?version .
                          |    FILTER (?version != "renku $schemaVersion")
                          |  }
                          |  UNION
                          |  {
-                         |	  ?commit dcterms:isPartOf|schema:isPartOf ?project .
-                         |    ?commit rdf:type prov:Activity .
+                         |	  ?commit dcterms:isPartOf|schema:isPartOf ?project ;
+                         |            rdf:type prov:Activity .
                          |    FILTER NOT EXISTS {
                          |      ?commit prov:agent ?agent .
+                         |      ?agent  rdf:type prov:SoftwareAgent .
                          |    }
                          |  }
                          |}

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOOutdatedTriplesFinderSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOOutdatedTriplesFinderSpec.scala
@@ -36,8 +36,8 @@ class IOOutdatedTriplesFinderSpec extends WordSpec with InMemoryRdfStore {
 
   "findOutdatedTriples" should {
 
-    "return single project's commits having triples with either no agent or agent with version different that the current one " +
-      "if there are multiple projects with outdated triples" in new TestCase {
+    "return single project's commits if related to agent with version different than the current one - " +
+      "case with multiple projects with outdated triples" in new TestCase {
 
       val project1               = projectPaths.generateOne
       val project1OutdatedCommit = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
@@ -46,8 +46,8 @@ class IOOutdatedTriplesFinderSpec extends WordSpec with InMemoryRdfStore {
 
       loadToStore(
         triples(
-          singleFileAndCommit(project1, project1OutdatedCommit.toCommitId, maybeSchemaVersion = None),
-          singleFileAndCommit(project2, project2OutdatedCommit.toCommitId, maybeSchemaVersion = None)
+          singleFileAndCommit(project1, project1OutdatedCommit.toCommitId, schemaVersion = schemaVersions.generateOne),
+          singleFileAndCommit(project2, project2OutdatedCommit.toCommitId, schemaVersion = schemaVersions.generateOne)
         )
       )
 
@@ -60,7 +60,7 @@ class IOOutdatedTriplesFinderSpec extends WordSpec with InMemoryRdfStore {
       // format: on
     }
 
-    "return all project's commits having triples with no agent or agent with different version in one result" in new TestCase {
+    "return all project's commits having triples related to agent version different than the current one" in new TestCase {
 
       val project1                = projectPaths.generateOne
       val project1Commit1NoAgent  = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
@@ -69,9 +69,9 @@ class IOOutdatedTriplesFinderSpec extends WordSpec with InMemoryRdfStore {
 
       loadToStore(
         triples(
-          singleFileAndCommit(project1, project1Commit1NoAgent.toCommitId, maybeSchemaVersion = None),
-          singleFileAndCommit(project1, project1Commit2Outdated.toCommitId, Some(schemaVersions.generateOne)),
-          singleFileAndCommit(project1, project1Commit3UpToDate.toCommitId, Some(schemaVersion))
+          singleFileAndCommit(project1, project1Commit1NoAgent.toCommitId, schemaVersion  = schemaVersions.generateOne),
+          singleFileAndCommit(project1, project1Commit2Outdated.toCommitId, schemaVersion = schemaVersions.generateOne),
+          singleFileAndCommit(project1, project1Commit3UpToDate.toCommitId, schemaVersion = schemaVersion)
         )
       )
 
@@ -88,7 +88,7 @@ class IOOutdatedTriplesFinderSpec extends WordSpec with InMemoryRdfStore {
 
       loadToStore(
         triples(
-          singleFileAndCommit(project, projectCommitUpToDate.toCommitId, Some(schemaVersion))
+          singleFileAndCommit(project, projectCommitUpToDate.toCommitId, schemaVersion = schemaVersion)
         )
       )
 

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOOutdatedTriplesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOOutdatedTriplesRemoverSpec.scala
@@ -39,23 +39,20 @@ class IOOutdatedTriplesRemoverSpec extends WordSpec with InMemoryRdfStore {
     "remove all and only the triples from a given project related to the given commits" in new TestCase {
 
       val project1                = projectPaths.generateOne
-      val project1Commit1NoAgent  = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
-      val project1Commit2Outdated = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
-      val project1Commit3UpToDate = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
+      val project1Commit1Outdated = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
+      val project1Commit2UpToDate = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
       val project2                = projectPaths.generateOne
       val project2OutdatedCommit  = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
 
       loadToStore(
         triples(
-          singleFileAndCommit(project1, project1Commit1NoAgent.toCommitId, None),
-          singleFileAndCommit(project1, project1Commit2Outdated.toCommitId, None),
-          singleFileAndCommit(project1, project1Commit3UpToDate.toCommitId, Some(schemaVersions.generateOne)),
-          singleFileAndCommit(project2, project2OutdatedCommit.toCommitId, None)
+          singleFileAndCommit(project1, project1Commit1Outdated.toCommitId),
+          singleFileAndCommit(project1, project1Commit2UpToDate.toCommitId),
+          singleFileAndCommit(project2, project2OutdatedCommit.toCommitId)
         )
       )
 
-      val outdatedTriples = OutdatedTriples(FullProjectPath.from(renkuBaseUrl, project1),
-                                            Set(project1Commit1NoAgent, project1Commit2Outdated))
+      val outdatedTriples = OutdatedTriples(FullProjectPath.from(renkuBaseUrl, project1), Set(project1Commit1Outdated))
 
       triplesRemover
         .removeOutdatedTriples(outdatedTriples)


### PR DESCRIPTION
There was a regression bug introduced when an `rdfs:label` was introduced to the `person` entity in the KG. That broke the re-provisioning process which was looking for agent's `rdfs:label` not matching certain version of Renku CLI. That condition was simply always true as there are at least two agent triples on the commit entity one pointing to the version of Renku CLI, other pointing to people who did the commits.

closes #145 