### PR TITLE
charts: Fix liveness probe for jena

### DIFF
--- a/helm-chart/renku-graph/charts/jena/templates/deployment.yaml
+++ b/helm-chart/renku-graph/charts/jena/templates/deployment.yaml
@@ -31,11 +31,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /$/ping
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /$/ping
               port: http
           volumeMounts:
             - name: shiro-config


### PR DESCRIPTION
An unauthenticated request to `/` on jena returns a `401` which for example on minikube (but strangely enough not on our dev cluster, maybe a k8s version question) interpreted as a failed liveness- or readiness probe. This PR fixes this by using an authentication-free endpoint.