### PR TITLE
re-provisioning process fails for project with old format of the project resource

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/LineageQuerySpec.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/LineageQuerySpec.scala
@@ -48,9 +48,10 @@ class LineageQuerySpec extends FeatureSpec with GivenWhenThen with GraphServices
     scenario("As a user I would like to find project's lineage with a GraphQL query") {
 
       Given("some data in the RDF Store")
-      `data in the RDF store`(project,
-                              commitId,
-                              triples(multiFileAndCommit(project.path, data = multiFileAndCommitData)))
+      `data in the RDF store`(
+        project,
+        commitId,
+        triples(multiFileAndCommit(project.path, data = multiFileAndCommitData, schemaVersion = currentSchemaVersion)))
 
       When("user posts a graphql query to fetch lineage")
       val response = knowledgeGraphClient POST lineageQuery

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.21.0-f3cc92f
+version: 0.21.1-f3cc92f

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesRemover.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesRemover.scala
@@ -58,7 +58,7 @@ private class IOOutdatedTriplesRemover(
        |    SELECT ?subject
        |    WHERE {
        |      {
-       |        ?commit dcterms:isPartOf|schema:isPartOf ${triplesToRemove.projectPath.showAs[RdfResource]} .
+       |        ?commit dcterms:isPartOf|schema:isPartOf ${triplesToRemove.projectResource.showAs[RdfResource]} .
        |        FILTER (?commit IN (${triplesToRemove.commits.map(_.showAs[RdfResource]).mkString(",")}))
        |        ?commit ?predicate ?object
        |      }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisioner.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisioner.scala
@@ -71,11 +71,11 @@ class ReProvisioner[Interpretation[_]](
 
   private def reProvisionNextProject(outdatedTriples: OutdatedTriples) =
     for {
-      projectPath <- outdatedTriples.projectPath.as[Interpretation, ProjectPath]
+      projectPath <- outdatedTriples.projectResource.as[Interpretation, ProjectPath]
       commitIds   <- outdatedTriples.commits.toList.map(_.as[Interpretation, CommitId]).sequence
       _           <- markEventsAsNew(projectPath, commitIds.toSet)
       _           <- removeOutdatedTriples(outdatedTriples)
-      _           <- logger.info(s"ReProvisioning '${outdatedTriples.projectPath}' project")
+      _           <- logger.info(s"ReProvisioning '${outdatedTriples.projectResource}' project")
       _           <- startReProvisioning
     } yield ()
 

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOOutdatedTriplesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOOutdatedTriplesRemoverSpec.scala
@@ -52,7 +52,43 @@ class IOOutdatedTriplesRemoverSpec extends WordSpec with InMemoryRdfStore {
         )
       )
 
-      val outdatedTriples = OutdatedTriples(FullProjectPath(renkuBaseUrl, project1), Set(project1Commit1Outdated))
+      val outdatedTriples = OutdatedTriples(
+        projectResource = ProjectResource(FullProjectPath(renkuBaseUrl, project1).toString),
+        commits         = Set(project1Commit1Outdated)
+      )
+
+      triplesRemover
+        .removeOutdatedTriples(outdatedTriples)
+        .unsafeRunSync() shouldBe ((): Unit)
+
+      val leftTriples = runQuery("SELECT ?subject ?o ?p WHERE {?subject ?o ?p}").unsafeRunSync()
+      leftTriples
+        .map(row => row("subject"))
+        .toSet
+        .filter(triplesMatching(outdatedTriples.commits)) shouldBe empty
+    }
+
+    "remove all the triples for the given project and commits when project resource in the old format" in new TestCase {
+
+      val project                = projectPaths.generateOne
+      val projectResource        = ProjectResource((renkuBaseUrl / project).toString)
+      val projectCommit1Outdated = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
+      val projectCommit2UpToDate = commitIdResources(Some(fusekiBaseUrl.toString)).generateOne
+
+      loadToStore(
+        triples(
+          singleFileAndCommit(
+            project,
+            commitId = projectCommit1Outdated.toCommitId
+          ) map projectIdsToOldFormat(projectResource),
+          singleFileAndCommit(
+            project,
+            commitId = projectCommit2UpToDate.toCommitId
+          ) map projectIdsToOldFormat(projectResource)
+        )
+      )
+
+      val outdatedTriples = OutdatedTriples(projectResource, Set(projectCommit1Outdated))
 
       triplesRemover
         .removeOutdatedTriples(outdatedTriples)
@@ -82,7 +118,10 @@ class IOOutdatedTriplesRemoverSpec extends WordSpec with InMemoryRdfStore {
         )
       )
 
-      val outdatedTriples = OutdatedTriples(FullProjectPath(renkuBaseUrl, project), Set(projectCommitOutdated))
+      val outdatedTriples = OutdatedTriples(
+        projectResource = ProjectResource(FullProjectPath(renkuBaseUrl, project).toString),
+        commits         = Set(projectCommitOutdated)
+      )
 
       triplesRemover
         .removeOutdatedTriples(outdatedTriples)
@@ -110,7 +149,10 @@ class IOOutdatedTriplesRemoverSpec extends WordSpec with InMemoryRdfStore {
         )
       )
 
-      val outdatedTriples = OutdatedTriples(FullProjectPath(renkuBaseUrl, project), Set(projectCommitOutdated))
+      val outdatedTriples = OutdatedTriples(
+        projectResource = ProjectResource(FullProjectPath(renkuBaseUrl, project).toString),
+        commits         = Set(projectCommitOutdated)
+      )
 
       triplesRemover
         .removeOutdatedTriples(outdatedTriples)
@@ -143,7 +185,10 @@ class IOOutdatedTriplesRemoverSpec extends WordSpec with InMemoryRdfStore {
         )
       )
 
-      val outdatedTriples = OutdatedTriples(FullProjectPath(renkuBaseUrl, project1), Set(project1OutdatedCommit))
+      val outdatedTriples = OutdatedTriples(
+        projectResource = ProjectResource(FullProjectPath(renkuBaseUrl, project1).toString),
+        commits         = Set(project1OutdatedCommit)
+      )
 
       triplesRemover
         .removeOutdatedTriples(outdatedTriples)

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ProjectResourceSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ProjectResourceSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.triplesgenerator.reprovisioning
+
+import cats.implicits._
+import ch.datascience.generators.Generators.httpUrls
+import ch.datascience.graph.model.GraphModelGenerators.projectPaths
+import ch.datascience.graph.model.projects.ProjectPath
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.util.{Success, Try}
+
+class ProjectResourceSpec extends WordSpec with ScalaCheckPropertyChecks {
+
+  "toProjectPath" should {
+
+    "return a ProjectPath for the new project resource format" in {
+      forAll(httpUrls, projectPaths) { (url, projectPath) =>
+        ProjectResource(s"$url/projects/$projectPath").as[Try, ProjectPath] shouldBe Success(projectPath)
+      }
+    }
+
+    "return a ProjectPath for the old project resource format" in {
+      forAll(httpUrls, projectPaths) { (url, projectPath) =>
+        ProjectResource(s"$url/$projectPath").as[Try, ProjectPath] shouldBe Success(projectPath)
+      }
+    }
+  }
+}

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisionerSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisionerSpec.scala
@@ -58,7 +58,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(project1OutdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(project1OutdatedTriples.projectPath.toProjectPath, project1OutdatedTriples.commits.toCommitIds)
+          .expects(project1OutdatedTriples.projectResource.toProjectPath, project1OutdatedTriples.commits.toCommitIds)
           .returning(context.unit)
         (triplesRemover
           .removeOutdatedTriples(_: OutdatedTriples))
@@ -74,7 +74,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(project2OutdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(project2OutdatedTriples.projectPath.toProjectPath, project2OutdatedTriples.commits.toCommitIds)
+          .expects(project2OutdatedTriples.projectResource.toProjectPath, project2OutdatedTriples.commits.toCommitIds)
           .returning(context.unit)
         (triplesRemover
           .removeOutdatedTriples(_: OutdatedTriples))
@@ -97,8 +97,8 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
       reProvisioner.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(
-        Info(s"ReProvisioning '${project1OutdatedTriples.projectPath}' project"),
-        Info(s"ReProvisioning '${project2OutdatedTriples.projectPath}' project"),
+        Info(s"ReProvisioning '${project1OutdatedTriples.projectResource}' project"),
+        Info(s"ReProvisioning '${project2OutdatedTriples.projectResource}' project"),
         Info("All projects' triples up to date")
       )
     }
@@ -115,7 +115,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(outdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(outdatedTriples.projectPath.toProjectPath, outdatedTriples.commits.toCommitIds)
+          .expects(outdatedTriples.projectResource.toProjectPath, outdatedTriples.commits.toCommitIds)
           .returning(context.unit)
         (triplesRemover
           .removeOutdatedTriples(_: OutdatedTriples))
@@ -236,7 +236,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(outdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(outdatedTriples.projectPath.toProjectPath, outdatedTriples.commits.toCommitIds)
+          .expects(outdatedTriples.projectResource.toProjectPath, outdatedTriples.commits.toCommitIds)
           .returning(context.raiseError(exception))
 
         (eventLogFetch.isEventToProcess _)
@@ -248,7 +248,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(outdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(outdatedTriples.projectPath.toProjectPath, outdatedTriples.commits.toCommitIds)
+          .expects(outdatedTriples.projectResource.toProjectPath, outdatedTriples.commits.toCommitIds)
           .returning(context.unit)
         (triplesRemover
           .removeOutdatedTriples(_: OutdatedTriples))
@@ -272,7 +272,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
 
       logger.loggedOnly(
         Error("Re-provisioning failure", exception),
-        Info(s"ReProvisioning '${outdatedTriples.projectPath}' project"),
+        Info(s"ReProvisioning '${outdatedTriples.projectResource}' project"),
         Info("All projects' triples up to date")
       )
     }
@@ -291,7 +291,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(outdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(outdatedTriples.projectPath.toProjectPath, outdatedTriples.commits.toCommitIds)
+          .expects(outdatedTriples.projectResource.toProjectPath, outdatedTriples.commits.toCommitIds)
           .returning(context.unit)
         (triplesRemover
           .removeOutdatedTriples(_: OutdatedTriples))
@@ -307,7 +307,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
           .returning(OptionT.liftF(context.pure(outdatedTriples)))
         (eventLogMarkNew
           .markEventsAsNew(_: ProjectPath, _: Set[CommitId]))
-          .expects(outdatedTriples.projectPath.toProjectPath, outdatedTriples.commits.toCommitIds)
+          .expects(outdatedTriples.projectResource.toProjectPath, outdatedTriples.commits.toCommitIds)
           .returning(context.unit)
         (triplesRemover
           .removeOutdatedTriples(_: OutdatedTriples))
@@ -331,7 +331,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
 
       logger.loggedOnly(
         Error("Re-provisioning failure", exception),
-        Info(s"ReProvisioning '${outdatedTriples.projectPath}' project"),
+        Info(s"ReProvisioning '${outdatedTriples.projectResource}' project"),
         Info("All projects' triples up to date")
       )
     }
@@ -425,7 +425,7 @@ class ReProvisionerSpec extends WordSpec with MockFactory {
     lazy val toCommitIds = commitIdResources.map(_.as[Try, CommitId].fold(throw _, identity))
   }
 
-  private implicit class FullProjectPathOps(projectPath: FullProjectPath) {
-    lazy val toProjectPath = projectPath.as[Try, ProjectPath].fold(throw _, identity)
+  private implicit class ProjectResourceOps(projectResource: ProjectResource) {
+    lazy val toProjectPath = projectResource.as[Try, ProjectPath].fold(throw _, identity)
   }
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisioningGenerators.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisioningGenerators.scala
@@ -25,6 +25,13 @@ import org.scalacheck.Gen._
 
 private object ReProvisioningGenerators {
 
+  private def projectResources: Gen[ProjectResource] =
+    for {
+      url                  <- httpUrls
+      maybeProjectsSegment <- Gen.oneOf("/projects", "")
+      path                 <- projectPaths
+    } yield ProjectResource.from(s"$url$maybeProjectsSegment/$path").fold(throw _, identity)
+
   def commitIdResources(maybeUrl: Option[String] = None): Gen[CommitIdResource] =
     for {
       url <- maybeUrl.map(const).getOrElse(httpUrls)
@@ -33,8 +40,8 @@ private object ReProvisioningGenerators {
 
   def outdatedTriplesSets(maybeUrl: Option[String] = None): Gen[OutdatedTriples] =
     for {
-      projectPath          <- fullProjectPaths
+      projectResource      <- projectResources
       removedCommitsNumber <- positiveInts(100)
       removedCommits       <- setOf(commitIdResources(maybeUrl), removedCommitsNumber)
-    } yield OutdatedTriples(projectPath, removedCommits)
+    } yield OutdatedTriples(projectResource, removedCommits)
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/package.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.triplesgenerator
+
+import io.circe.Json
+import io.circe.literal._
+
+package object reprovisioning {
+
+  def projectIdsToOldFormat(projectResource: ProjectResource): Json => Json = _ deepMerge json"""{
+    "schema:isPartOf": {
+      "@id": ${projectResource.toString}
+    }
+  }"""
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.21.0-SNAPSHOT"
+version in ThisBuild := "0.21.1-SNAPSHOT"


### PR DESCRIPTION
When the new format of project resources got introduced, the re-provisioning process got updated the way it can work with the new format of project resources only. This fix changes that so the process can work with all formats of project resources