### PR TITLE
Jena startup error

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.25.0-a4aa122
+version: 0.24.4-a4aa122

--- a/helm-chart/renku-graph/charts/jena/templates/fuseki-server.yaml
+++ b/helm-chart/renku-graph/charts/jena/templates/fuseki-server.yaml
@@ -16,6 +16,8 @@ data:
     # killing Jena if already started as Lucene indexing cannot happen on started Jena
     killall -9 java
 
+    rm $FUSEKI_BASE/databases/{{ .Values.global.graph.jena.dataset }}/tdb.lock
+
     JAVA=$JAVA_HOME/bin/java
     JAR=$FUSEKI_HOME/fuseki-server.jar
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.25.0-SNAPSHOT"
+version in ThisBuild := "0.24.4-SNAPSHOT"


### PR DESCRIPTION
It looks that Jena on environments having DB on persistent volumes cannot start the Lucene indexing as there's some lingering PID in the `tdb.lock` file. This PR removes the file before starting the indexing.