### PR TITLE
Jena startup problem

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.25.0-54aadae
+version: 0.24.5-54aadae

--- a/helm-chart/renku-graph/charts/jena/templates/fuseki-server.yaml
+++ b/helm-chart/renku-graph/charts/jena/templates/fuseki-server.yaml
@@ -15,7 +15,6 @@ data:
 
     # killing Jena if already started as Lucene indexing cannot happen on started Jena
     killall -9 java
-
     rm $FUSEKI_BASE/databases/{{ .Values.global.graph.jena.dataset }}/tdb.lock
 
     JAVA=$JAVA_HOME/bin/java
@@ -24,6 +23,7 @@ data:
     echo Rebuilding Lucene indices...
     DATASET_CONFIG=$FUSEKI_BASE/configuration/{{ .Values.global.graph.jena.dataset }}.ttl
     $JAVA -Xmx2G -cp $JAR jena.textindexer --desc=$DATASET_CONFIG
+    rm $FUSEKI_BASE/databases/{{ .Values.global.graph.jena.dataset }}/tdb.lock
 
     echo Starting Fuseki...
     JVM_ARGS=${JVM_ARGS:--Xmx2G}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.25.0-SNAPSHOT"
+version in ThisBuild := "0.24.5-SNAPSHOT"


### PR DESCRIPTION
It looks there is a general problem with removing the `tdb.lock` file on the DEV environment. This change removes the lock file after Lucene indexing is done.