### PR TITLE
Add fields to dataset metadata

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
@@ -289,7 +289,7 @@ object DatasetsResources {
   }
 
   private implicit lazy val creatorEncoder: Encoder[DatasetCreator] = Encoder.instance[DatasetCreator] {
-    case DatasetCreator(maybeEmail, name) =>
+    case DatasetCreator(maybeEmail, name, _) =>
       json"""{
         "name": $name
       }""" addIfDefined ("email" -> maybeEmail)

--- a/graph-commons/src/main/scala/ch/datascience/graph/model/datasets.scala
+++ b/graph-commons/src/main/scala/ch/datascience/graph/model/datasets.scala
@@ -34,6 +34,12 @@ object datasets {
   final class Description private (val value: String) extends AnyVal with StringTinyType
   implicit object Description extends TinyTypeFactory[Description](new Description(_)) with NonBlank
 
+  final class Url private (val value: String) extends AnyVal with StringTinyType
+  implicit object Url extends TinyTypeFactory[Url](new Url(_)) with constraints.Url
+
+  final class SameAs private (val value: String) extends AnyVal with StringTinyType
+  implicit object SameAs extends TinyTypeFactory[SameAs](new SameAs(_)) with constraints.Url
+
   final class DateCreatedInProject private (val value: Instant) extends AnyVal with InstantTinyType
   implicit object DateCreatedInProject
       extends TinyTypeFactory[DateCreatedInProject](new DateCreatedInProject(_))

--- a/graph-commons/src/test/scala/ch/datascience/graph/model/GraphModelGenerators.scala
+++ b/graph-commons/src/test/scala/ch/datascience/graph/model/GraphModelGenerators.scala
@@ -47,6 +47,8 @@ object GraphModelGenerators {
     .map(Identifier.apply)
   implicit val datasetNames:          Gen[Name]          = nonEmptyStrings() map Name.apply
   implicit val datasetDescriptions:   Gen[Description]   = paragraphs() map (_.value) map Description.apply
+  implicit val datasetUrls:           Gen[Url]           = validatedUrls map (_.value) map Url.apply
+  implicit val datasetSameAs:         Gen[SameAs]        = validatedUrls map (_.value) map SameAs.apply
   implicit val datasetPublishedDates: Gen[PublishedDate] = localDatesNotInTheFuture map PublishedDate.apply
   implicit val datasetPartNames:      Gen[PartName]      = nonEmptyStrings() map PartName.apply
   implicit val datasetPartLocations: Gen[PartLocation] =

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/Dataset.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/entities/Dataset.scala
@@ -34,12 +34,13 @@ object Dataset {
   def apply(id:                        Id,
             projectId:                 Project.Id,
             datasetName:               Name,
+            maybeDatasetUrl:           Option[Url],
+            maybeDatasetSameAs:        Option[SameAs],
             maybeDatasetDescription:   Option[Description],
             maybeDatasetPublishedDate: Option[PublishedDate],
             maybeDatasetCreators:      Set[(UserName, Option[Email], Option[Affiliation])],
             maybeDatasetParts:         List[(PartName, PartLocation)],
             commitId:                  CommitId,
-            maybeDatasetUrl:           Option[String],
             generationPath:            FilePath,
             commitGenerationId:        CommitGeneration.Id)(implicit fusekiBaseUrl: FusekiBaseUrl): List[Json] = {
     val creators = maybeDatasetCreators.toList.map(creator => Person.Id(creator._2) -> creator)
@@ -61,6 +62,7 @@ object Dataset {
         "http://schema.org/name": $datasetName
       }""".deepMerge(`schema:isPartOf`(projectId))
           .deepMerge(maybeDatasetUrl toValue "http://schema.org/url")
+          .deepMerge(maybeDatasetSameAs toValue "http://schema.org/sameAs")
           .deepMerge(maybeDatasetDescription toValue "http://schema.org/description")
           .deepMerge(maybeDatasetPublishedDate toValue ("http://schema.org/datePublished", "http://schema.org/Date"))
           .deepMerge(creators.map(_._1) toResources "http://schema.org/creator")

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/singleFileAndCommitWithDataset.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/triples/singleFileAndCommitWithDataset.scala
@@ -20,7 +20,7 @@ package ch.datascience.rdfstore.triples
 
 import ch.datascience.generators.CommonGraphGenerators.{emails, names, schemaVersions}
 import ch.datascience.generators.Generators.Implicits._
-import ch.datascience.generators.Generators.{httpUrls, listOf, setOf}
+import ch.datascience.generators.Generators.{listOf, setOf}
 import ch.datascience.graph.config.RenkuBaseUrl
 import ch.datascience.graph.model.EventsGenerators._
 import ch.datascience.graph.model.GraphModelGenerators._
@@ -47,11 +47,12 @@ object singleFileAndCommitWithDataset {
       committedDate:             CommittedDate = committedDates.generateOne,
       datasetIdentifier:         Identifier = datasetIds.generateOne,
       datasetName:               Name = datasetNames.generateOne,
+      maybeDatasetUrl:           Option[Url] = Gen.option(datasetUrls).generateOne,
+      maybeDatasetSameAs:        Option[SameAs] = Gen.option(datasetSameAs).generateOne,
       maybeDatasetDescription:   Option[Description] = Gen.option(datasetDescriptions).generateOne,
       maybeDatasetPublishedDate: Option[PublishedDate] = Gen.option(datasetPublishedDates).generateOne,
       maybeDatasetCreators:      Set[(UserName, Option[Email], Option[Affiliation])] = setOf(datasetCreators).generateOne,
       maybeDatasetParts:         List[(PartName, PartLocation)] = listOf(datasetParts).generateOne,
-      maybeDatasetUrl:           Option[String] = Gen.option(datasetUrl).generateOne,
       schemaVersion:             SchemaVersion = schemaVersions.generateOne,
       renkuBaseUrl:              RenkuBaseUrl = renkuBaseUrl
   )(implicit fusekiBaseUrl:      FusekiBaseUrl): List[Json] = {
@@ -96,12 +97,13 @@ object singleFileAndCommitWithDataset {
       datasetId,
       projectId,
       datasetName,
+      maybeDatasetUrl,
+      maybeDatasetSameAs,
       maybeDatasetDescription,
       maybeDatasetPublishedDate,
       maybeDatasetCreators,
       maybeDatasetParts,
       commitId,
-      maybeDatasetUrl,
       datasetGenerationPath,
       commitGenerationId
     )
@@ -111,9 +113,4 @@ object singleFileAndCommitWithDataset {
     name     <- datasetPartNames
     location <- datasetPartLocations
   } yield (name, location)
-
-  private val datasetUrl: Gen[String] = for {
-    url  <- httpUrls
-    uuid <- Gen.uuid.map(_.toString)
-  } yield s"$url/$uuid"
 }

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -110,6 +110,7 @@ Response body example:
     "creator" : [
       {
         "name" : "e wmtnxmcguz"
+        "affiliation" : "SDSC"                    // optional property
       },
       {
         "name" : "iilmadw vcxabmh",

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -102,6 +102,8 @@ Response body example:
   ],
   "identifier" : "6f622603-2129-4058-ad29-3ff927481461",
   "name" : "dataset name",
+  "url" : "http://host/url1",  // optional property
+  "sameAs" : "http://host/url1",  // optional property
   "description" : "vbnqyyjmbiBQpubavGpxlconuqj",  // optional property
   "published" : {
     "datePublished" : "2012-10-14T03:02:25.639Z", // optional property

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/model.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/model.scala
@@ -27,6 +27,8 @@ object model {
 
   final case class Dataset(id:               Identifier,
                            name:             Name,
+                           maybeUrl:         Option[Url],
+                           maybeSameAs:      Option[SameAs],
                            maybeDescription: Option[Description],
                            published:        DatasetPublishing,
                            part:             List[DatasetPart],

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/model.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/model.scala
@@ -21,7 +21,7 @@ package ch.datascience.knowledgegraph.datasets
 import ch.datascience.graph.model.datasets._
 import ch.datascience.graph.model.projects
 import ch.datascience.graph.model.projects.ProjectPath
-import ch.datascience.graph.model.users.{Email, Name => UserName}
+import ch.datascience.graph.model.users.{Affiliation, Email, Name => UserName}
 
 object model {
 
@@ -35,7 +35,7 @@ object model {
                            project:          List[DatasetProject])
 
   final case class DatasetPublishing(maybeDate: Option[PublishedDate], creators: Set[DatasetCreator])
-  final case class DatasetCreator(maybeEmail:   Option[Email], name:             UserName)
+  final case class DatasetCreator(maybeEmail:   Option[Email], name:             UserName, maybeAffiliation: Option[Affiliation])
 
   final case class DatasetPart(name: PartName, atLocation: PartLocation)
 

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpoint.scala
@@ -84,6 +84,8 @@ class DatasetEndpoint[Interpretation[_]: Effect](
       List(
         Some("identifier" -> dataset.id.asJson),
         Some("name" -> dataset.name.asJson),
+        dataset.maybeUrl.map(url => "url" -> url.asJson),
+        dataset.maybeSameAs.map(sameAs => "sameAs" -> sameAs.asJson),
         dataset.maybeDescription.map(description => "description" -> description.asJson),
         Some("published" -> Json.obj(List(
           dataset.published.maybeDate.map(date => "datePublished" -> date.asJson),

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpoint.scala
@@ -104,7 +104,8 @@ class DatasetEndpoint[Interpretation[_]: Effect](
   private implicit lazy val creatorEncoder: Encoder[DatasetCreator] = Encoder.instance[DatasetCreator] { creator =>
     Json.obj(List(
       Some("name" -> creator.name.asJson),
-      creator.maybeEmail.map(email => "email" -> email.asJson)
+      creator.maybeEmail.map(email => "email" -> email.asJson),
+      creator.maybeAffiliation.map(affiliation => "affiliation" -> affiliation.asJson)
     ).flatten: _*)
   }
   // format: on

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsSearchEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsSearchEndpoint.scala
@@ -106,7 +106,7 @@ class DatasetsSearchEndpoint[Interpretation[_]: Effect](
   }
 
   private implicit lazy val creatorEncoder: Encoder[DatasetCreator] = Encoder.instance[DatasetCreator] {
-    case DatasetCreator(maybeEmail, name) =>
+    case DatasetCreator(maybeEmail, name, _) =>
       json"""{
         "name": $name
       }""" addIfDefined ("email" -> maybeEmail)

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
@@ -40,9 +40,10 @@ object DatasetsGenerators {
   } yield Dataset(id, name, maybeUrl, maybeSameAs, maybeDescription, published, part, projects.toList)
 
   implicit lazy val datasetCreators: Gen[DatasetCreator] = for {
-    maybeEmail <- Gen.option(emails)
-    name       <- names
-  } yield DatasetCreator(maybeEmail, name)
+    maybeEmail       <- Gen.option(emails)
+    name             <- names
+    maybeAffiliation <- Gen.option(affiliations)
+  } yield DatasetCreator(maybeEmail, name, maybeAffiliation)
 
   implicit lazy val datasetPublishingInfos: Gen[DatasetPublishing] = for {
     maybePublishedDate <- Gen.option(datasetPublishedDates)

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
@@ -31,11 +31,13 @@ object DatasetsGenerators {
   implicit val datasets: Gen[Dataset] = for {
     id               <- datasetIds
     name             <- datasetNames
+    maybeUrl         <- Gen.option(datasetUrls)
+    maybeSameAs      <- Gen.option(datasetSameAs)
     maybeDescription <- Gen.option(datasetDescriptions)
     published        <- datasetPublishingInfos
     part             <- listOf(datasetPart)
     projects         <- nonEmptyList(datasetProjects)
-  } yield Dataset(id, name, maybeDescription, published, part, projects.toList)
+  } yield Dataset(id, name, maybeUrl, maybeSameAs, maybeDescription, published, part, projects.toList)
 
   implicit lazy val datasetCreators: Gen[DatasetCreator] = for {
     maybeEmail <- Gen.option(emails)

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/graphql/IOProjectDatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/graphql/IOProjectDatasetsFinderSpec.scala
@@ -20,7 +20,6 @@ package ch.datascience.knowledgegraph.datasets.graphql
 
 import cats.effect.IO
 import ch.datascience.generators.Generators.Implicits._
-import ch.datascience.generators.Generators.httpUrls
 import ch.datascience.graph.model.GraphModelGenerators._
 import ch.datascience.graph.model.events.CommittedDate
 import ch.datascience.interpreters.TestLogger
@@ -30,7 +29,6 @@ import ch.datascience.knowledgegraph.datasets.{CreatorsFinder, PartsFinder, Proj
 import ch.datascience.rdfstore.InMemoryRdfStore
 import ch.datascience.rdfstore.triples._
 import ch.datascience.stubbing.ExternalServiceStubbing
-import org.scalacheck.Gen
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -48,10 +46,6 @@ class IOProjectDatasetsFinderSpec
         (projectB, dataset1, projectBDataset1Creation, dataset2, projectBDataset2Creation) =>
           val projectA         = datasetProjects.generateOne
           val projectACreation = datasetInProjectCreations.generateOne
-          val reusedDatasetUrl = (for {
-            url  <- httpUrls
-            uuid <- Gen.uuid
-          } yield s"$url/$uuid").generateOne
 
           loadToStore(
             triples(
@@ -63,12 +57,13 @@ class IOProjectDatasetsFinderSpec
                 committedDate             = projectACreation.date.toUnsafe(date => CommittedDate.from(date.value)),
                 datasetIdentifier         = dataset1.id,
                 datasetName               = dataset1.name,
+                maybeDatasetUrl           = dataset1.maybeUrl,
+                maybeDatasetSameAs        = dataset1.maybeSameAs,
                 maybeDatasetDescription   = dataset1.maybeDescription,
                 maybeDatasetPublishedDate = dataset1.published.maybeDate,
                 maybeDatasetCreators =
                   dataset1.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
-                maybeDatasetParts = dataset1.part.map(part => (part.name, part.atLocation)),
-                maybeDatasetUrl   = Some(reusedDatasetUrl)
+                maybeDatasetParts = dataset1.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(
                 projectB.path,
@@ -78,12 +73,13 @@ class IOProjectDatasetsFinderSpec
                 committedDate             = projectBDataset1Creation.date.toUnsafe(date => CommittedDate.from(date.value)),
                 datasetIdentifier         = dataset1.id,
                 datasetName               = dataset1.name,
+                maybeDatasetUrl           = dataset1.maybeUrl,
+                maybeDatasetSameAs        = dataset1.maybeSameAs,
                 maybeDatasetDescription   = dataset1.maybeDescription,
                 maybeDatasetPublishedDate = dataset1.published.maybeDate,
                 maybeDatasetCreators =
                   dataset1.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
-                maybeDatasetParts = dataset1.part.map(part => (part.name, part.atLocation)),
-                maybeDatasetUrl   = Some(reusedDatasetUrl)
+                maybeDatasetParts = dataset1.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(
                 projectB.path,
@@ -93,6 +89,8 @@ class IOProjectDatasetsFinderSpec
                 committedDate             = projectBDataset2Creation.date.toUnsafe(date => CommittedDate.from(date.value)),
                 datasetIdentifier         = dataset2.id,
                 datasetName               = dataset2.name,
+                maybeDatasetUrl           = dataset2.maybeUrl,
+                maybeDatasetSameAs        = dataset2.maybeSameAs,
                 maybeDatasetDescription   = dataset2.maybeDescription,
                 maybeDatasetPublishedDate = dataset2.published.maybeDate,
                 maybeDatasetCreators =

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/graphql/IOProjectDatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/graphql/IOProjectDatasetsFinderSpec.scala
@@ -61,8 +61,8 @@ class IOProjectDatasetsFinderSpec
                 maybeDatasetSameAs        = dataset1.maybeSameAs,
                 maybeDatasetDescription   = dataset1.maybeDescription,
                 maybeDatasetPublishedDate = dataset1.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset1.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset1.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset1.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(
@@ -77,8 +77,8 @@ class IOProjectDatasetsFinderSpec
                 maybeDatasetSameAs        = dataset1.maybeSameAs,
                 maybeDatasetDescription   = dataset1.maybeDescription,
                 maybeDatasetPublishedDate = dataset1.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset1.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset1.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset1.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(
@@ -93,8 +93,8 @@ class IOProjectDatasetsFinderSpec
                 maybeDatasetSameAs        = dataset2.maybeSameAs,
                 maybeDatasetDescription   = dataset2.maybeDescription,
                 maybeDatasetPublishedDate = dataset2.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset2.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset2.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset2.part.map(part => (part.name, part.atLocation))
               )
             )

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinderSpec.scala
@@ -34,12 +34,14 @@ class BaseDetailsFinderSpec extends WordSpec with ScalaCheckPropertyChecks {
 
   "dataset decoder" should {
 
-    "decode result-set with a blank description to a Dataset object" in {
+    "decode result-set with a blank description, url, and sameAs to a Dataset object" in {
       forAll(datasets, datasetPublishedDates, blankStrings()) { (dataset, publishedDate, description) =>
         resultSet(dataset, publishedDate, description).as[List[Dataset]] shouldBe Right {
           List(
             dataset
               .copy(published = dataset.published.copy(maybeDate = Some(publishedDate), creators = Set.empty))
+              .copy(maybeUrl = None)
+              .copy(maybeSameAs = None)
               .copy(maybeDescription = None)
               .copy(part = Nil)
               .copy(project = Nil)
@@ -49,7 +51,7 @@ class BaseDetailsFinderSpec extends WordSpec with ScalaCheckPropertyChecks {
     }
   }
 
-  private def resultSet(dataset: Dataset, publishedDate: PublishedDate, description: String) = json"""
+  private def resultSet(dataset: Dataset, publishedDate: PublishedDate, blank: String) = json"""
   {
     "results": {
       "bindings": [
@@ -57,7 +59,9 @@ class BaseDetailsFinderSpec extends WordSpec with ScalaCheckPropertyChecks {
           "identifier": {"value": ${dataset.id.value}},
           "name": {"value": ${dataset.name.value}},
           "publishedDate": {"value": ${publishedDate.value}},
-          "description": {"value": $description}
+          "description": {"value": $blank},
+          "url": {"value": $blank},
+          "sameAs": {"value": $blank}
         }
       ]
     }

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
@@ -30,7 +30,7 @@ import ch.datascience.graph.model.GraphModelGenerators._
 import ch.datascience.graph.model.datasets._
 import ch.datascience.graph.model.projects
 import ch.datascience.graph.model.projects.ProjectPath
-import ch.datascience.graph.model.users.{Email, Name => UserName}
+import ch.datascience.graph.model.users.{Affiliation, Email, Name => UserName}
 import ch.datascience.http.rest.Links
 import ch.datascience.http.rest.Links.Rel.Self
 import ch.datascience.http.rest.Links.{Href, Rel}
@@ -166,9 +166,10 @@ class DatasetEndpointSpec extends WordSpec with MockFactory with ScalaCheckPrope
 
   private implicit lazy val datasetCreatorDecoder: Decoder[DatasetCreator] = (cursor: HCursor) =>
     for {
-      name       <- cursor.downField("name").as[UserName]
-      maybeEmail <- cursor.downField("email").as[Option[Email]]
-    } yield DatasetCreator(maybeEmail, name)
+      name             <- cursor.downField("name").as[UserName]
+      maybeEmail       <- cursor.downField("email").as[Option[Email]]
+      maybeAffiliation <- cursor.downField("affiliation").as[Option[Affiliation]]
+    } yield DatasetCreator(maybeEmail, name, maybeAffiliation)
 
   private implicit lazy val datasetPartDecoder: Decoder[DatasetPart] = (cursor: HCursor) =>
     for {

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
@@ -150,11 +150,13 @@ class DatasetEndpointSpec extends WordSpec with MockFactory with ScalaCheckPrope
     for {
       id               <- cursor.downField("identifier").as[Identifier]
       name             <- cursor.downField("name").as[Name]
+      maybeUrl         <- cursor.downField("url").as[Option[Url]]
+      maybeSameAs      <- cursor.downField("sameAs").as[Option[SameAs]]
       maybeDescription <- cursor.downField("description").as[Option[Description]]
       published        <- cursor.downField("published").as[DatasetPublishing]
       parts            <- cursor.downField("hasPart").as[List[DatasetPart]]
       projects         <- cursor.downField("isPartOf").as[List[DatasetProject]]
-    } yield Dataset(id, name, maybeDescription, published, parts, projects)
+    } yield Dataset(id, name, maybeUrl, maybeSameAs, maybeDescription, published, parts, projects)
 
   private implicit lazy val datasetPublishingDecoder: Decoder[DatasetPublishing] = (cursor: HCursor) =>
     for {

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsSearchEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsSearchEndpointSpec.scala
@@ -152,7 +152,7 @@ class DatasetsSearchEndpointSpec extends WordSpec with MockFactory with ScalaChe
     }
 
     private implicit lazy val creatorEncoder: Encoder[DatasetCreator] = Encoder.instance[DatasetCreator] {
-      case DatasetCreator(maybeEmail, name) =>
+      case DatasetCreator(maybeEmail, name, _) =>
         json"""{
         "name": $name
       }""" addIfDefined ("email" -> maybeEmail)

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetFinderSpec.scala
@@ -56,6 +56,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 committedDate             = project1DatasetCreationDate,
                 datasetIdentifier         = dataset.id,
                 datasetName               = dataset.name,
+                maybeDatasetUrl           = dataset.maybeUrl,
+                maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
                 maybeDatasetCreators =
@@ -71,6 +73,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 committedDate             = CommittedDate(project1DatasetCreationDate.value.plusSeconds(10)),
                 datasetIdentifier         = dataset.id,
                 datasetName               = dataset.name,
+                maybeDatasetUrl           = dataset.maybeUrl,
+                maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
                 maybeDatasetCreators =
@@ -86,6 +90,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 committedDate             = project2DatasetCreation.date.toUnsafe(date => CommittedDate.from(date.value)),
                 datasetIdentifier         = dataset.id,
                 datasetName               = dataset.name,
+                maybeDatasetUrl           = dataset.maybeUrl,
+                maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
                 maybeDatasetCreators =
@@ -122,6 +128,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 committedDate             = datasetCreationDate,
                 datasetIdentifier         = dataset.id,
                 datasetName               = dataset.name,
+                maybeDatasetUrl           = dataset.maybeUrl,
+                maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
                 maybeDatasetCreators =
@@ -137,6 +145,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 committedDate             = CommittedDate(datasetCreationDate.value.plusSeconds(10)),
                 datasetIdentifier         = dataset.id,
                 datasetName               = dataset.name,
+                maybeDatasetUrl           = dataset.maybeUrl,
+                maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
                 maybeDatasetCreators =
@@ -152,6 +162,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 committedDate             = datasetCreationDate,
                 datasetIdentifier         = dataset.id,
                 datasetName               = dataset.name,
+                maybeDatasetUrl           = dataset.maybeUrl,
+                maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
                 maybeDatasetCreators =

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetFinderSpec.scala
@@ -60,8 +60,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset( // to reflect a file added to the dataset in another commit
@@ -77,8 +77,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(
@@ -94,8 +94,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(projectPaths.generateOne, projectNames.generateOne)
@@ -132,8 +132,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset( // to reflect a file added later to the dataset in another commit
@@ -149,8 +149,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset.part.map(part => (part.name, part.atLocation))
               ),
               singleFileAndCommitWithDataset(
@@ -166,8 +166,8 @@ class IODatasetFinderSpec extends WordSpec with InMemoryRdfStore with ScalaCheck
                 maybeDatasetSameAs        = dataset.maybeSameAs,
                 maybeDatasetDescription   = dataset.maybeDescription,
                 maybeDatasetPublishedDate = dataset.published.maybeDate,
-                maybeDatasetCreators =
-                  dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None)),
+                maybeDatasetCreators = dataset.published.creators
+                  .map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation)),
                 maybeDatasetParts = dataset.part.map(part => (part.name, part.atLocation))
               )
             )

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetsFinderSpec.scala
@@ -184,7 +184,8 @@ class IODatasetsFinderSpec
         creators = Set(
           DatasetCreator(
             Gen.option(emails).generateOne,
-            sentenceContaining(nonEmptyPhrase).map(_.value).map(UserName.apply).generateOne
+            sentenceContaining(nonEmptyPhrase).map(_.value).map(UserName.apply).generateOne,
+            Gen.option(affiliations).generateOne
           )
         )
       )
@@ -210,7 +211,8 @@ class IODatasetsFinderSpec
         datasetName               = dataset.name,
         maybeDatasetDescription   = dataset.maybeDescription,
         maybeDatasetPublishedDate = dataset.published.maybeDate,
-        maybeDatasetCreators      = dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None))
+        maybeDatasetCreators =
+          dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation))
       ) flatMap unlinkDatasetFromProject
     case projects =>
       projects.flatMap { project =>
@@ -220,7 +222,8 @@ class IODatasetsFinderSpec
           datasetName               = dataset.name,
           maybeDatasetDescription   = dataset.maybeDescription,
           maybeDatasetPublishedDate = dataset.published.maybeDate,
-          maybeDatasetCreators      = dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, None))
+          maybeDatasetCreators =
+            dataset.published.creators.map(creator => (creator.name, creator.maybeEmail, creator.maybeAffiliation))
         )
       }
   }


### PR DESCRIPTION
This PR introduces changes described in #130 

Images for testing:
```
'repository': 'jachro/token-repository', 'tag': '65a2e42'
'repository': 'jachro/webhook-service', 'tag': '65a2e42'
'repository': 'jachro/triples-generator', 'tag': '65a2e42'
'repository': 'jachro/knowledge-graph', 'tag': '65a2e42'
```

closes #130 