### PR TITLE
renku-python version bumb to 0.8.1

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.31.0-05532df
+version: 0.30.1-05532df

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Installing Renku
 RUN apk add --no-cache git git-lfs curl bash python3-dev openssl-dev libffi-dev linux-headers gcc libxml2-dev libxslt-dev libc-dev && \
-    python3 -m pip install 'renku==0.8.0' sentry-sdk && \
+    python3 -m pip install 'renku==0.8.1' sentry-sdk && \ 
     chown -R daemon:daemon . && \
     git config --global filter.lfs.smudge "git-lfs smudge --skip %f"  && \
     git config --global filter.lfs.process "git-lfs filter-process --skip"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.31.0-SNAPSHOT"
+version in ThisBuild := "0.30.1-SNAPSHOT"


### PR DESCRIPTION
We found some tiny bug in renku-python `0.8.0` which was fixed in `0.8.1`. This PR bumps renku-python version in triples-generator's Dockerfile.