### PR TITLE
Tokens in logs

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.32.0-6929c8b
+version: 0.31.1-6929c8b

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/Commands.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/Commands.scala
@@ -81,7 +81,7 @@ private object Commands {
 
   class Git {
 
-    def cloneRepo(
+    def clone(
         repositoryUrl:        ServiceUrl,
         destinationDirectory: Path,
         workDirectory:        Path

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuLogTriplesGenerator.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuLogTriplesGenerator.scala
@@ -59,13 +59,13 @@ class RenkuLogTriplesGenerator private[renkulog] (
     createRepositoryDirectory(commit.project.path)
       .bracket { repositoryDirectory =>
         for {
-          gitRepositoryUrl <- findRepositoryUrl(commit.project.path, maybeAccessToken)
-          _                <- git cloneRepo (gitRepositoryUrl, repositoryDirectory, workDirectory)
-          _                <- git checkout (commit.id, repositoryDirectory)
-          triples          <- findTriples(commit, repositoryDirectory)
+          repositoryUrl <- findRepositoryUrl(commit.project.path, maybeAccessToken)
+          _             <- git clone (repositoryUrl, repositoryDirectory, workDirectory)
+          _             <- git checkout (commit.id, repositoryDirectory)
+          triples       <- findTriples(commit, repositoryDirectory)
         } yield triples
       }(repositoryDirectory => delete(repositoryDirectory))
-      .recoverWith(meaningfulError)
+      .recoverWith(meaningfulError(maybeAccessToken))
 
   private def createRepositoryDirectory(projectPath: ProjectPath): IO[Path] =
     contextShift.shift *> mkdir(tempDirectoryName(repositoryNameFrom(projectPath)))
@@ -86,9 +86,18 @@ class RenkuLogTriplesGenerator private[renkulog] (
     }
   }
 
-  private lazy val meaningfulError: PartialFunction[Throwable, IO[JsonLDTriples]] = {
+  private def meaningfulError(maybeAccessToken: Option[AccessToken]): PartialFunction[Throwable, IO[JsonLDTriples]] = {
     case NonFatal(exception) =>
-      IO.raiseError(new RuntimeException("Triples generation failed", exception))
+      IO.raiseError {
+        (Option(exception.getMessage) -> maybeAccessToken)
+          .mapN { (message, token) =>
+            if (message contains token.value)
+              new Exception(s"Triples generation failed: ${message replaceAll (token.value, token.toString)}")
+            else
+              new Exception("Triples generation failed", exception)
+          }
+          .getOrElse(new Exception("Triples generation failed", exception))
+      }
   }
 }
 

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuLogTriplesGeneratorSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuLogTriplesGeneratorSpec.scala
@@ -62,7 +62,7 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
         .returning(IO.pure(gitRepositoryUrl))
 
       (git
-        .cloneRepo(_: ServiceUrl, _: Path, _: Path))
+        .clone(_: ServiceUrl, _: Path, _: Path))
         .expects(gitRepositoryUrl, repositoryDirectory, workDirectory)
         .returning(IO.pure(successfulCommandResult))
 
@@ -103,7 +103,7 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
         .returning(IO.pure(gitRepositoryUrl))
 
       (git
-        .cloneRepo(_: ServiceUrl, _: Path, _: Path))
+        .clone(_: ServiceUrl, _: Path, _: Path))
         .expects(gitRepositoryUrl, repositoryDirectory, workDirectory)
         .returning(IO.pure(successfulCommandResult))
 
@@ -168,21 +168,23 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
       actual.getCause   shouldBe exception
     }
 
-    "fail if cloning the repo fails" in new TestCase {
+    "fail if cloning the repo fails - exception message should not reveal the access token" in new TestCase {
 
       (file
         .mkdir(_: Path))
         .expects(repositoryDirectory)
         .returning(IO.pure(repositoryDirectory))
 
+      val accessToken                    = accessTokens.generateOne
+      override lazy val maybeAccessToken = Some(accessToken)
       (gitLabRepoUrlFinder
         .findRepositoryUrl(_: ProjectPath, _: Option[AccessToken]))
         .expects(projectPath, maybeAccessToken)
         .returning(IO.pure(gitRepositoryUrl))
 
-      val exception = exceptions.generateOne
+      val exception = new Exception(s"${exceptions.generateOne.getMessage} $gitRepositoryUrl")
       (git
-        .cloneRepo(_: ServiceUrl, _: Path, _: Path))
+        .clone(_: ServiceUrl, _: Path, _: Path))
         .expects(gitRepositoryUrl, repositoryDirectory, workDirectory)
         .returning(IO.raiseError(exception))
 
@@ -195,8 +197,11 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
       val actual = intercept[Exception] {
         triplesGenerator.generateTriples(commitWithoutParent, maybeAccessToken).unsafeRunSync()
       }
-      actual.getMessage shouldBe "Triples generation failed"
-      actual.getCause   shouldBe exception
+
+      actual.getMessage should startWith("Triples generation failed: ")
+      actual.getMessage should not include accessToken.value
+      actual.getMessage should include(accessToken.toString)
+      actual.getCause   shouldBe null
     }
 
     "fail if checking out the sha fails" in new TestCase {
@@ -212,7 +217,7 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
         .returning(IO.pure(gitRepositoryUrl))
 
       (git
-        .cloneRepo(_: ServiceUrl, _: Path, _: Path))
+        .clone(_: ServiceUrl, _: Path, _: Path))
         .expects(gitRepositoryUrl, repositoryDirectory, workDirectory)
         .returning(IO.pure(successfulCommandResult))
 
@@ -248,7 +253,7 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
         .returning(IO.pure(gitRepositoryUrl))
 
       (git
-        .cloneRepo(_: ServiceUrl, _: Path, _: Path))
+        .clone(_: ServiceUrl, _: Path, _: Path))
         .expects(gitRepositoryUrl, repositoryDirectory, workDirectory)
         .returning(IO.pure(successfulCommandResult))
 
@@ -289,7 +294,7 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
         .returning(IO.pure(gitRepositoryUrl))
 
       (git
-        .cloneRepo(_: ServiceUrl, _: Path, _: Path))
+        .clone(_: ServiceUrl, _: Path, _: Path))
         .expects(gitRepositoryUrl, repositoryDirectory, workDirectory)
         .returning(IO.pure(successfulCommandResult))
 
@@ -323,11 +328,13 @@ class RenkuLogTriplesGeneratorSpec extends WordSpec with MockFactory {
   private trait TestCase {
     val successfulCommandResult = CommandResult(exitCode = 0, chunks = Nil)
 
-    val repositoryName   = nonEmptyStrings().generateOne
-    val projectPath      = ProjectPath(s"user/$repositoryName")
-    val maybeAccessToken = Gen.option(accessTokens).generateOne
-    val gitRepositoryUrl = serviceUrls.generateOne / s"$projectPath.git"
-    val commitWithoutParent @ CommitWithoutParent(commitId, _) =
+    lazy val repositoryName   = nonEmptyStrings().generateOne
+    lazy val projectPath      = ProjectPath(s"user/$repositoryName")
+    lazy val maybeAccessToken = Gen.option(accessTokens).generateOne
+    lazy val gitRepositoryUrl = serviceUrls.generateOne / maybeAccessToken
+      .map(_.value)
+      .getOrElse("path") / s"$projectPath.git"
+    lazy val commitWithoutParent @ CommitWithoutParent(commitId, _) =
       CommitWithoutParent(commitIds.generateOne, Project(projectIds.generateOne, projectPath))
 
     def toCommitWithParent(commitWithoutParent: CommitWithoutParent): CommitWithParent =

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuSpec.scala
@@ -106,8 +106,4 @@ class RenkuSpec extends WordSpec {
     case None           => CommitWithoutParent(commitId, project)
     case Some(parentId) => CommitWithParent(commitId, parentId, project)
   }
-
-  private val paths: Gen[os.Path] = for {
-    path <- relativePaths()
-  } yield os.Path(Paths.get(s"/$path"))
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/package.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.triplesgenerator.eventprocessing.triplesgeneration
+
+import java.nio.file.Paths
+
+import ch.datascience.generators.Generators.relativePaths
+import org.scalacheck.Gen
+
+package object renkulog {
+
+  val paths: Gen[os.Path] = for {
+    path <- relativePaths()
+  } yield os.Path(Paths.get(s"/$path"))
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.32.0-SNAPSHOT"
+version in ThisBuild := "0.31.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.31.1-SNAPSHOT"
+version in ThisBuild := "0.31.2-SNAPSHOT"


### PR DESCRIPTION
It was found out that for failures in `git clone` command, triples-generator logs users' access tokens. This PR fixes that.