### PR TITLE
Mute gitlab synchro logs

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.31.1-6929c8b
+version: 0.31.3-6929c8b

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.31.1-SNAPSHOT"
+version in ThisBuild := "0.31.3-SNAPSHOT"

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/startcommit/CommitToEventLog.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/eventprocessing/startcommit/CommitToEventLog.scala
@@ -82,6 +82,7 @@ class CommitToEventLog[Interpretation[_]: Monad](
       extends RuntimeException("finding commit events failed", cause)
 
   private def logSummary(startCommit: StartCommit): ((ElapsedTime, List[SendingResult])) => Interpretation[Unit] = {
+    case (_, Nil) => ME.unit
     case (elapsedTime, sendingResults) =>
       val groupedByType = sendingResults groupBy identity
       val stored        = groupedByType.get(Stored).map(_.size).getOrElse(0)


### PR DESCRIPTION
It looks webhook-service generate info log statements for cases when no Commit Events were generated. That causes some noise in the logs. This PR fixes that behaviour.