### PR TITLE
Triples error wrongly classified

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.32.0-913601f
+version: 0.31.4-913601f

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesuploading/TriplesUploader.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesuploading/TriplesUploader.scala
@@ -70,9 +70,10 @@ private class IOTriplesUploader(
       .putHeaders(`Content-Type`(`ld+json`))
 
   private lazy val mapResponse: PartialFunction[(Status, Request[IO], Response[IO]), IO[TriplesUploadResult]] = {
-    case (Ok, _, _)                => IO.pure(DeliverySuccess)
-    case (BadRequest, _, response) => singleLineBody(response).map(InvalidTriplesFailure.apply)
-    case (other, _, response)      => singleLineBody(response).map(message => s"$other: $message").map(DeliveryFailure.apply)
+    case (Ok, _, _)                         => IO.pure(DeliverySuccess)
+    case (BadRequest, _, response)          => singleLineBody(response).map(InvalidTriplesFailure.apply)
+    case (InternalServerError, _, response) => singleLineBody(response).map(InvalidTriplesFailure.apply)
+    case (other, _, response)               => singleLineBody(response).map(message => s"$other: $message").map(DeliveryFailure.apply)
   }
 
   private def singleLineBody(response: Response[IO]): IO[String] =

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.32.0-SNAPSHOT"
+version in ThisBuild := "0.31.4-SNAPSHOT"


### PR DESCRIPTION
It looks that for some malformed json-ld payloads Jena responds with 500 instead of 400. This PR fixes the way triples-generator deals with that so events for which `renku log` produces such payloads won't get re-processed.

closes #202 