### PR TITLE
Metrics

### DIFF
--- a/acceptance-tests/src/test/resources/application.conf
+++ b/acceptance-tests/src/test/resources/application.conf
@@ -9,6 +9,8 @@ projects-tokens {
   db-url-template = "jdbc:h2:mem:$dbName;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
 }
 
+metrics.enabled = false
+
 triples-generation = "remote-generator"
 
 re-provisioning-initial-delay = 1 day

--- a/acceptance-tests/src/test/resources/logback.xml
+++ b/acceptance-tests/src/test/resources/logback.xml
@@ -3,7 +3,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>
-            <pattern>%d %-5level %logger{5} - %message%n</pattern>
+            <pattern>[%level] %message%n</pattern>
         </encoder>
     </appender>
 
@@ -12,6 +12,10 @@
     </appender>
 
     <logger name="application" level="OFF" additivity="false">
+        <appender-ref ref="ASYNC_STDOUT"/>
+    </logger>
+
+    <logger name="test" level="INFO" additivity="false">
         <appender-ref ref="ASYNC_STDOUT"/>
     </logger>
 

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/commands/EventLogStats.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/commands/EventLogStats.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog.commands
+
+import cats.effect.{Bracket, ContextShift, IO}
+import cats.implicits._
+import ch.datascience.db.DbTransactor
+import ch.datascience.dbeventlog._
+import doobie.implicits._
+
+import scala.language.higherKinds
+
+class EventLogStats[Interpretation[_]](
+    transactor: DbTransactor[Interpretation, EventLogDB]
+)(implicit ME:  Bracket[Interpretation, Throwable]) {
+
+  def statuses: Interpretation[Map[EventStatus, Long]] =
+    sql"""select status, count(event_id) from event_log group by status;""".stripMargin
+      .query[(EventStatus, Long)]
+      .to[List]
+      .transact(transactor.get)
+      .map(_.toMap)
+      .map(addMissingStatues)
+
+  private def addMissingStatues(stats: Map[EventStatus, Long]): Map[EventStatus, Long] =
+    EventStatus.all.map(status => status -> stats.getOrElse(status, 0L)).toMap
+}
+
+class IOEventLogStats(
+    transactor:          DbTransactor[IO, EventLogDB]
+)(implicit contextShift: ContextShift[IO])
+    extends EventLogStats[IO](transactor)

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/model.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/model.scala
@@ -51,6 +51,9 @@ object EventMessage extends TinyTypeFactory[EventMessage](new EventMessage(_)) w
 
 sealed trait EventStatus extends StringTinyType with Product with Serializable
 object EventStatus extends TinyTypeFactory[EventStatus](EventStatusInstantiator) {
+
+  val all: Set[EventStatus] = Set(New, Processing, TriplesStoreFailure, TriplesStore, NonRecoverableFailure)
+
   final case object New extends EventStatus {
     override val value: String = "NEW"
   }
@@ -73,12 +76,9 @@ object EventStatus extends TinyTypeFactory[EventStatus](EventStatusInstantiator)
   }
   type NonRecoverableFailure = NonRecoverableFailure.type
 }
+
 private object EventStatusInstantiator extends (String => EventStatus) {
-  import EventStatus._
-
-  private val allStatuses = Set(New, Processing, TriplesStoreFailure, TriplesStore, NonRecoverableFailure)
-
-  override def apply(value: String): EventStatus = allStatuses.find(_.value == value).getOrElse {
+  override def apply(value: String): EventStatus = EventStatus.all.find(_.value == value).getOrElse {
     throw new IllegalArgumentException(s"'$value' unknown EventStatus")
   }
 }

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogStatsSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/commands/EventLogStatsSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog.commands
+
+import ch.datascience.dbeventlog.DbEventLogGenerators._
+import ch.datascience.dbeventlog._
+import EventStatus._
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.graph.model.EventsGenerators._
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class EventLogStatsSpec extends WordSpec with InMemoryEventLogDbSpec with ScalaCheckPropertyChecks {
+
+  "statuses" should {
+
+    "return info about number of events grouped by status" in {
+      forAll { statuses: List[EventStatus] =>
+        prepareDbForTest()
+
+        statuses foreach store
+
+        stats.statuses.unsafeRunSync() shouldBe Map(
+          New                   -> statuses.count(_ == New),
+          Processing            -> statuses.count(_ == Processing),
+          TriplesStore          -> statuses.count(_ == TriplesStore),
+          TriplesStoreFailure   -> statuses.count(_ == TriplesStoreFailure),
+          NonRecoverableFailure -> statuses.count(_ == NonRecoverableFailure)
+        )
+      }
+    }
+  }
+
+  private val stats = new EventLogStats(transactor)
+
+  private def store(status: EventStatus): Unit =
+    storeEvent(commitEventIds.generateOne,
+               status,
+               executionDates.generateOne,
+               committedDates.generateOne,
+               eventBodies.generateOne)
+}

--- a/graph-commons/build.sbt
+++ b/graph-commons/build.sbt
@@ -44,10 +44,11 @@ libraryDependencies += "org.tpolecat" %% "doobie-postgres" % doobieVersion
 libraryDependencies += "org.typelevel" %% "cats-core" % "1.6.1"
 
 val http4sVersion = "0.20.10"
-libraryDependencies += "org.http4s" %% "http4s-blaze-client" % http4sVersion
-libraryDependencies += "org.http4s" %% "http4s-blaze-server" % http4sVersion
-libraryDependencies += "org.http4s" %% "http4s-circe"        % http4sVersion
-libraryDependencies += "org.http4s" %% "http4s-dsl"          % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-blaze-client"       % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-blaze-server"       % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-circe"              % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-dsl"                % http4sVersion
+libraryDependencies += "org.http4s" %% "http4s-prometheus-metrics" % http4sVersion
 
 // Test dependencies
 libraryDependencies += "com.github.tomakehurst" % "wiremock" % "2.24.1" % Test

--- a/graph-commons/src/main/resources/application.conf
+++ b/graph-commons/src/main/resources/application.conf
@@ -1,5 +1,7 @@
 logging.elapsed-time-threshold = "500 millis"
 
+metrics.enabled = true
+
 services {
 
   gitlab {

--- a/graph-commons/src/main/scala/ch/datascience/logging/ExecutionTimeRecorder.scala
+++ b/graph-commons/src/main/scala/ch/datascience/logging/ExecutionTimeRecorder.scala
@@ -26,22 +26,28 @@ import ch.datascience.logging.ExecutionTimeRecorder.ElapsedTime
 import ch.datascience.tinytypes.{LongTinyType, TinyTypeFactory}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.chrisdavenport.log4cats.Logger
+import io.prometheus.client.Histogram
 
 import scala.concurrent.duration._
 import scala.language.higherKinds
 
 class ExecutionTimeRecorder[Interpretation[_]](
-    threshold:    ElapsedTime,
-    logger:       Logger[Interpretation]
-)(implicit clock: Clock[Interpretation], ME: MonadError[Interpretation, Throwable]) {
+    threshold:      ElapsedTime,
+    logger:         Logger[Interpretation],
+    maybeHistogram: Option[Histogram]
+)(implicit clock:   Clock[Interpretation], ME: MonadError[Interpretation, Throwable]) {
 
+  // format: off
   def measureExecutionTime[BlockOut](block: => Interpretation[BlockOut]): Interpretation[(ElapsedTime, BlockOut)] =
     for {
-      startTime   <- clock monotonic MILLISECONDS
-      result      <- block
-      endTime     <- clock monotonic MILLISECONDS
-      elapsedTime <- ME.fromEither(ElapsedTime.from(endTime - startTime))
+      startTime           <- clock monotonic MILLISECONDS
+      maybeHistogramTimer = maybeHistogram map (_.startTimer())
+      result              <- block
+      _                   = maybeHistogramTimer map (_.observeDuration())
+      endTime             <- clock monotonic MILLISECONDS
+      elapsedTime         <- ME.fromEither(ElapsedTime.from(endTime - startTime))
     } yield (elapsedTime, result)
+  // format: on
 
   def logExecutionTimeWhen[BlockOut](
       condition: PartialFunction[BlockOut, String]
@@ -73,14 +79,15 @@ class ExecutionTimeRecorder[Interpretation[_]](
 object ExecutionTimeRecorder {
 
   def apply[Interpretation[_]](
-      logger:       Logger[Interpretation],
-      config:       Config = ConfigFactory.load()
-  )(implicit clock: Clock[Interpretation],
-    ME:             MonadError[Interpretation, Throwable]): Interpretation[ExecutionTimeRecorder[Interpretation]] =
+      logger:         Logger[Interpretation],
+      config:         Config = ConfigFactory.load(),
+      maybeHistogram: Option[Histogram] = None
+  )(implicit clock:   Clock[Interpretation],
+    ME:               MonadError[Interpretation, Throwable]): Interpretation[ExecutionTimeRecorder[Interpretation]] =
     for {
       duration  <- find[Interpretation, FiniteDuration]("logging.elapsed-time-threshold", config)
       threshold <- ME.fromEither(ElapsedTime from duration.toMillis)
-    } yield new ExecutionTimeRecorder(threshold, logger)
+    } yield new ExecutionTimeRecorder(threshold, logger, maybeHistogram)
 
   class ElapsedTime private (val value: Long) extends AnyVal with LongTinyType
   object ElapsedTime extends TinyTypeFactory[ElapsedTime](new ElapsedTime(_)) {

--- a/graph-commons/src/main/scala/ch/datascience/metrics/MetricsRegistry.scala
+++ b/graph-commons/src/main/scala/ch/datascience/metrics/MetricsRegistry.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.metrics
+
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.hotspot._
+import pureconfig.loadConfig
+
+import scala.language.higherKinds
+
+object MetricsRegistry {
+
+  private val metricsEnabled = loadConfig[Boolean]("metrics.enabled").getOrElse(true)
+
+  private lazy val registry = addJvmMetrics(new CollectorRegistry())
+
+  private[metrics] def collectorRegistry: CollectorRegistry =
+    if (metricsEnabled) registry
+    else new CollectorRegistry()
+
+  private def addJvmMetrics(registry: CollectorRegistry): CollectorRegistry = {
+    registry.register(new StandardExports())
+    registry.register(new MemoryPoolsExports())
+    registry.register(new BufferPoolsExports())
+    registry.register(new GarbageCollectorExports())
+    registry.register(new ThreadExports())
+    registry.register(new ClassLoadingExports())
+    registry.register(new VersionInfoExports())
+    registry.register(new MemoryAllocationExports())
+    registry
+  }
+
+  def clear(): Unit = collectorRegistry.clear()
+}

--- a/graph-commons/src/main/scala/ch/datascience/metrics/MetricsRegistry.scala
+++ b/graph-commons/src/main/scala/ch/datascience/metrics/MetricsRegistry.scala
@@ -18,8 +18,8 @@
 
 package ch.datascience.metrics
 
-import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.hotspot._
+import io.prometheus.client.{CollectorRegistry, SimpleCollector}
 import pureconfig.loadConfig
 
 import scala.language.higherKinds
@@ -45,6 +45,9 @@ object MetricsRegistry {
     registry.register(new MemoryAllocationExports())
     registry
   }
+
+  def register[Collector <: SimpleCollector[_]](registerTo: CollectorRegistry => Collector): Collector =
+    registerTo(collectorRegistry)
 
   def clear(): Unit = collectorRegistry.clear()
 }

--- a/graph-commons/src/main/scala/ch/datascience/metrics/MetricsRegistry.scala
+++ b/graph-commons/src/main/scala/ch/datascience/metrics/MetricsRegistry.scala
@@ -22,6 +22,7 @@ import io.prometheus.client.hotspot._
 import io.prometheus.client.{CollectorRegistry, SimpleCollector}
 import pureconfig.loadConfig
 
+import scala.collection.JavaConverters._
 import scala.language.higherKinds
 
 object MetricsRegistry {
@@ -50,4 +51,10 @@ object MetricsRegistry {
     registerTo(collectorRegistry)
 
   def clear(): Unit = collectorRegistry.clear()
+
+  def verifyInRegistry(name: String): Boolean =
+    collectorRegistry
+      .metricFamilySamples()
+      .asScala
+      .exists(_.name == name)
 }

--- a/graph-commons/src/main/scala/ch/datascience/metrics/RoutesMetrics.scala
+++ b/graph-commons/src/main/scala/ch/datascience/metrics/RoutesMetrics.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.metrics
+
+import cats.effect.{Clock, ConcurrentEffect}
+import cats.implicits._
+import org.http4s.HttpRoutes
+import org.http4s.metrics.prometheus.{Prometheus, PrometheusExportService}
+import org.http4s.server.middleware.{Metrics => ServerMetrics}
+
+import scala.language.higherKinds
+
+trait RoutesMetrics {
+
+  import MetricsRegistry._
+
+  implicit class RoutesOps[Interpretation[_]](routes: HttpRoutes[Interpretation]) {
+
+    def meter(implicit F: ConcurrentEffect[Interpretation],
+              clock:      Clock[Interpretation]): Interpretation[HttpRoutes[Interpretation]] =
+      for {
+        metrics <- Prometheus[Interpretation](collectorRegistry, "server")
+        meteredRoutes = ServerMetrics[Interpretation](metrics)(routes)
+      } yield meteredRoutes
+
+  }
+
+  def `add GET Root / metrics`[Interpretation[_]](
+      routes:   HttpRoutes[Interpretation]
+  )(implicit F: ConcurrentEffect[Interpretation]): Interpretation[HttpRoutes[Interpretation]] =
+    for {
+      prometheusService <- PrometheusExportService(collectorRegistry).pure[Interpretation]
+    } yield prometheusService.routes <+> routes
+}

--- a/graph-commons/src/test/scala/ch/datascience/http/server/EndpointTester.scala
+++ b/graph-commons/src/test/scala/ch/datascience/http/server/EndpointTester.scala
@@ -40,10 +40,9 @@ object EndpointTester {
   implicit val jsonListEntityDecoder: EntityDecoder[IO, List[Json]] = jsonOf[IO, List[Json]]
   implicit val jsonEntityEncoder:     EntityEncoder[IO, Json]       = jsonEncoderOf[IO, Json]
 
-  implicit class EndpointOps(endpoint: Kleisli[IO, Request[IO], Response[IO]]) {
-
+  implicit class IOEndpointOps(endpoint: IO[Kleisli[IO, Request[IO], Response[IO]]]) {
     def call(request: Request[IO]) = new {
-      private val runResponse: Response[IO] = endpoint.run(request).unsafeRunSync()
+      private val runResponse: Response[IO] = endpoint.flatMap(_.run(request)).unsafeRunSync()
 
       lazy val status: Status = runResponse.status
 

--- a/graph-commons/src/test/scala/ch/datascience/logging/TestExecutionTimeRecorder.scala
+++ b/graph-commons/src/test/scala/ch/datascience/logging/TestExecutionTimeRecorder.scala
@@ -49,7 +49,7 @@ class TestExecutionTimeRecorder[Interpretation[_]](
     threshold:    ElapsedTime,
     logger:       Logger[Interpretation]
 )(implicit clock: Clock[Interpretation], ME: MonadError[Interpretation, Throwable])
-    extends ExecutionTimeRecorder[Interpretation](threshold, logger) {
+    extends ExecutionTimeRecorder[Interpretation](threshold, logger, maybeHistogram = None) {
 
   val elapsedTime:            ElapsedTime = threshold
   lazy val executionTimeInfo: String      = s" in ${threshold}ms"

--- a/helm-chart/renku-graph/templates/knowledge-graph-service.yaml
+++ b/helm-chart/renku-graph/templates/knowledge-graph-service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "graph.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9004'
 spec:
   type: {{ .Values.knowledgeGraph.service.type }}
   ports:

--- a/helm-chart/renku-graph/templates/token-repository-service.yaml
+++ b/helm-chart/renku-graph/templates/token-repository-service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "graph.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9003'
 spec:
   type: {{ .Values.tokenRepository.service.type }}
   ports:

--- a/helm-chart/renku-graph/templates/triples-generator-service.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "graph.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9002'
 spec:
   type: {{ .Values.triplesGenerator.service.type }}
   ports:

--- a/helm-chart/renku-graph/templates/webhook-service-service.yaml
+++ b/helm-chart/renku-graph/templates/webhook-service-service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "graph.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9001'
 spec:
   type: {{ .Values.webhookService.service.type }}
   ports:

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/Microservice.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/Microservice.scala
@@ -52,16 +52,14 @@ object Microservice extends IOMicroservice {
       projectDatasetsEndpoint <- IOProjectDatasetsEndpoint()
       datasetEndpoint         <- IODatasetEndpoint()
       datasetsSearchEndpoint  <- IODatasetsSearchEndpoint()
-      httpServer = new HttpServer[IO](
-        serverPort = 9004,
-        serviceRoutes = new MicroserviceRoutes[IO](
-          queryEndpoint,
-          projectEndpoint,
-          projectDatasetsEndpoint,
-          datasetEndpoint,
-          datasetsSearchEndpoint
-        ).routes
-      )
+      routes <- new MicroserviceRoutes[IO](
+                 queryEndpoint,
+                 projectEndpoint,
+                 projectDatasetsEndpoint,
+                 datasetEndpoint,
+                 datasetsSearchEndpoint
+               ).routes
+      httpServer = new HttpServer[IO](serverPort = 9004, routes)
 
       exitCode <- new MicroserviceRunner(sentryInitializer, httpServer).run(args)
     } yield exitCode

--- a/token-repository/src/main/scala/ch/datascience/tokenrepository/Microservice.scala
+++ b/token-repository/src/main/scala/ch/datascience/tokenrepository/Microservice.scala
@@ -46,14 +46,12 @@ object Microservice extends IOMicroservice {
         sentryInitializer      <- SentryInitializer[IO]
         fetchTokenEndpoint     <- IOFetchTokenEndpoint(transactor, ApplicationLogger)
         associateTokenEndpoint <- IOAssociateTokenEndpoint(transactor, ApplicationLogger)
-        httpServer = new HttpServer[IO](
-          serverPort = 9003,
-          serviceRoutes = new MicroserviceRoutes[IO](
-            fetchTokenEndpoint,
-            associateTokenEndpoint,
-            new IODeleteTokenEndpoint(transactor, ApplicationLogger)
-          ).routes
-        )
+        routes <- new MicroserviceRoutes[IO](
+                   fetchTokenEndpoint,
+                   associateTokenEndpoint,
+                   new IODeleteTokenEndpoint(transactor, ApplicationLogger)
+                 ).routes
+        httpServer = new HttpServer[IO](serverPort = 9003, routes)
 
         exitCode <- new MicroserviceRunner(
                      sentryInitializer,

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/Microservice.scala
@@ -64,6 +64,7 @@ object Microservice extends IOMicroservice {
         reProvisioning           <- IOReProvisioning(triplesGeneration, transactor)
         triplesGenerator         <- TriplesGenerator(triplesGeneration)
         commitEventProcessor     <- IOCommitEventProcessor(transactor, triplesGenerator)
+        routes                   <- new MicroserviceRoutes[IO]().routes
         eventProcessorRunner <- new EventsSource[IO](DbEventProcessorRunner(_, new IOEventLogFetch(transactor)))
                                  .withEventsProcessor(commitEventProcessor)
         exitCode <- new MicroserviceRunner(
@@ -72,7 +73,7 @@ object Microservice extends IOMicroservice {
                      fusekiDatasetInitializer,
                      reProvisioning,
                      eventProcessorRunner,
-                     new HttpServer[IO](serverPort = 9002, serviceRoutes = new MicroserviceRoutes[IO]().routes),
+                     new HttpServer[IO](serverPort = 9002, routes),
                      subProcessesCancelTokens
                    ) run args
       } yield exitCode

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/MicroserviceRoutes.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/MicroserviceRoutes.scala
@@ -18,17 +18,22 @@
 
 package ch.datascience.triplesgenerator
 
-import cats.effect.ConcurrentEffect
+import cats.effect.{Clock, ConcurrentEffect}
+import cats.implicits._
+import ch.datascience.metrics.RoutesMetrics
 import org.http4s.dsl.Http4sDsl
 
 import scala.language.higherKinds
 
-private class MicroserviceRoutes[Interpretation[_]: ConcurrentEffect]() extends Http4sDsl[Interpretation] {
+private class MicroserviceRoutes[F[_]: ConcurrentEffect]()(implicit clock: Clock[F])
+    extends Http4sDsl[F]
+    with RoutesMetrics {
 
   import org.http4s.HttpRoutes
 
-  lazy val routes: HttpRoutes[Interpretation] = HttpRoutes
-    .of[Interpretation] {
+  lazy val routes: F[HttpRoutes[F]] = HttpRoutes
+    .of[F] {
       case GET -> Root / "ping" => Ok("pong")
     }
+    .meter flatMap `add GET Root / metrics`[F]
 }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/CommitEventProcessor.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/CommitEventProcessor.scala
@@ -36,6 +36,7 @@ import ch.datascience.triplesgenerator.eventprocessing.triplesgeneration.Triples
 import ch.datascience.triplesgenerator.eventprocessing.triplesuploading.TriplesUploadResult._
 import ch.datascience.triplesgenerator.eventprocessing.triplesuploading.{IOUploader, TriplesUploadResult, Uploader}
 import io.chrisdavenport.log4cats.Logger
+import io.prometheus.client.Histogram
 
 import scala.concurrent.ExecutionContext
 import scala.language.higherKinds
@@ -201,6 +202,16 @@ class CommitEventProcessor[Interpretation[_]](
 
 object IOCommitEventProcessor {
 
+  import ch.datascience.metrics.MetricsRegistry
+
+  private[triplesgenerator] lazy val eventsProcessingTimes: Histogram = MetricsRegistry.register {
+    Histogram
+      .build()
+      .name("events_processing_times")
+      .help("Commit Events processing times")
+      .register(_)
+  }
+
   def apply(
       transactor:          DbTransactor[IO, EventLogDB],
       triplesGenerator:    TriplesGenerator[IO]
@@ -208,9 +219,10 @@ object IOCommitEventProcessor {
     executionContext:      ExecutionContext,
     timer:                 Timer[IO]): IO[CommitEventProcessor[IO]] =
     for {
-      uploader              <- IOUploader(ApplicationLogger)
-      tokenRepositoryUrl    <- TokenRepositoryUrl[IO]()
-      executionTimeRecorder <- ExecutionTimeRecorder[IO](ApplicationLogger)
+      uploader           <- IOUploader(ApplicationLogger)
+      tokenRepositoryUrl <- TokenRepositoryUrl[IO]()
+      executionTimeRecorder <- ExecutionTimeRecorder[IO](ApplicationLogger,
+                                                         maybeHistogram = Some(eventsProcessingTimes))
     } yield new CommitEventProcessor[IO](
       new CommitEventsDeserialiser[IO](),
       new IOAccessTokenFinder(tokenRepositoryUrl, ApplicationLogger),

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/metrics/EventLogMetrics.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/metrics/EventLogMetrics.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.triplesgenerator.metrics
+
+import cats.MonadError
+import cats.effect.{ContextShift, IO, Timer}
+import cats.implicits._
+import ch.datascience.db.DbTransactor
+import ch.datascience.dbeventlog.commands.{EventLogStats, IOEventLogStats}
+import ch.datascience.dbeventlog.{EventLogDB, EventStatus}
+import ch.datascience.metrics.MetricsRegistry
+import io.chrisdavenport.log4cats.Logger
+import io.prometheus.client.Gauge
+
+import scala.concurrent.duration.FiniteDuration
+import scala.language.{higherKinds, postfixOps}
+import scala.util.control.NonFatal
+
+class EventLogMetrics[Interpretation[_]](
+    eventLogStats: EventLogStats[Interpretation],
+    logger:        Logger[Interpretation],
+    statusesGauge: Gauge = EventLogMetrics.statusesGauge,
+    totalGauge:    Gauge = EventLogMetrics.totalGauge,
+    interval:      FiniteDuration = EventLogMetrics.interval
+)(implicit ME:     MonadError[Interpretation, Throwable], timer: Timer[Interpretation]) {
+
+  def run: Interpretation[Unit] = (timer sleep interval) *> updateCollectors
+
+  private def updateCollectors() = {
+    for {
+      statuses <- eventLogStats.statuses
+      _ = statuses foreach setToGauge
+      _ = totalGauge set statuses.values.sum
+      _ <- run
+    } yield ()
+  } recoverWith logAndRetry
+
+  private lazy val setToGauge: ((EventStatus, Long)) => Unit = {
+    case (status, count) => statusesGauge.labels(status.toString).set(count)
+  }
+
+  private lazy val logAndRetry: PartialFunction[Throwable, Interpretation[Unit]] = {
+    case NonFatal(exception) =>
+      logger.error(exception)("Problem with gathering metrics")
+      (timer sleep interval) *> run
+  }
+}
+
+object EventLogMetrics {
+
+  import scala.concurrent.duration._
+
+  private val interval: FiniteDuration = 30 seconds
+
+  private[metrics] val statusesGauge: Gauge = MetricsRegistry.register {
+    Gauge
+      .build()
+      .name("events_statuses_count")
+      .help("Total events by status.")
+      .labelNames("status")
+      .register(_)
+  }
+
+  private[metrics] val totalGauge: Gauge = MetricsRegistry.register {
+    Gauge
+      .build()
+      .name("events_count")
+      .help("Total events.")
+      .register(_)
+  }
+}
+
+object IOEventLogMetrics {
+
+  def apply(
+      transactor:          DbTransactor[IO, EventLogDB],
+      logger:              Logger[IO]
+  )(implicit contextShift: ContextShift[IO], timer: Timer[IO]): EventLogMetrics[IO] =
+    new EventLogMetrics[IO](new IOEventLogStats(transactor), logger)
+}

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/metrics/EventLogMetrics.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/metrics/EventLogMetrics.scala
@@ -66,13 +66,13 @@ object EventLogMetrics {
 
   import scala.concurrent.duration._
 
-  private val interval: FiniteDuration = 30 seconds
+  private val interval: FiniteDuration = 15 seconds
 
   private[metrics] val statusesGauge: Gauge = MetricsRegistry.register {
     Gauge
       .build()
       .name("events_statuses_count")
-      .help("Total events by status.")
+      .help("Total Commit Events by status.")
       .labelNames("status")
       .register(_)
   }
@@ -81,7 +81,7 @@ object EventLogMetrics {
     Gauge
       .build()
       .name("events_count")
-      .help("Total events.")
+      .help("Total Commit Events.")
       .register(_)
   }
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/MicroserviceRoutesSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/MicroserviceRoutesSpec.scala
@@ -18,14 +18,16 @@
 
 package ch.datascience.triplesgenerator
 
-import cats.effect.IO
+import cats.effect.{Clock, IO}
 import ch.datascience.http.server.EndpointTester._
+import ch.datascience.metrics.MetricsRegistry
 import org.http4s.Status._
 import org.http4s._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
 
+import scala.concurrent.ExecutionContext
 import scala.language.reflectiveCalls
 
 class MicroserviceRoutesSpec extends WordSpec with MockFactory {
@@ -40,9 +42,22 @@ class MicroserviceRoutesSpec extends WordSpec with MockFactory {
       response.status       shouldBe Ok
       response.body[String] shouldBe "pong"
     }
+
+    "define a GET /metrics endpoint returning OK with some prometheus metrics" in new TestCase {
+      val response = routes.call(
+        Request(Method.GET, uri"metrics")
+      )
+
+      response.status       shouldBe Ok
+      response.body[String] should include("server_response_duration_seconds")
+    }
   }
 
+  private implicit val clock: Clock[IO] = IO.timer(ExecutionContext.global).clock
+
   private trait TestCase {
-    val routes = new MicroserviceRoutes[IO]().routes.or(notAvailableResponse)
+    MetricsRegistry.clear()
+
+    val routes = new MicroserviceRoutes[IO]().routes.map(_.or(notAvailableResponse))
   }
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/MicroserviceRunnerSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/MicroserviceRunnerSpec.scala
@@ -21,6 +21,7 @@ package ch.datascience.triplesgenerator
 import java.util.concurrent.ConcurrentHashMap
 
 import cats.effect._
+import ch.datascience.dbeventlog.commands.EventLogStats
 import ch.datascience.dbeventlog.init.IOEventLogDbInitializer
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
@@ -28,7 +29,9 @@ import ch.datascience.http.server.IOHttpServer
 import ch.datascience.interpreters.IOSentryInitializer
 import ch.datascience.triplesgenerator.eventprocessing.IOEventProcessorRunner
 import ch.datascience.triplesgenerator.init.IOFusekiDatasetInitializer
+import ch.datascience.triplesgenerator.metrics.EventLogMetrics
 import ch.datascience.triplesgenerator.reprovisioning.IOReProvisioning
+import io.chrisdavenport.log4cats.Logger
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
@@ -59,6 +62,10 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
         .returning(IO.unit)
 
       (eventProcessorRunner.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (eventLogMetrics.run _)
         .expects()
         .returning(IO.unit)
 
@@ -131,6 +138,10 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
         .expects()
         .returning(IO.unit)
 
+      (eventLogMetrics.run _)
+        .expects()
+        .returning(IO.unit)
+
       (reProvisioning.run _)
         .expects()
         .returning(IO.unit)
@@ -163,6 +174,43 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
         .expects()
         .returning(IO.raiseError(exception))
 
+      (eventLogMetrics.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (reProvisioning.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (httpServer.run _)
+        .expects()
+        .returning(IO.pure(ExitCode.Success))
+
+      microserviceRunner.run(Nil).unsafeRunSync() shouldBe ExitCode.Success
+    }
+
+    "return Success ExitCode even if Event Log Metrics fails" in new TestCase {
+      (sentryInitializer.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (eventLogDbInitializer.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (datasetInitializer.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (eventProcessorRunner.run _)
+        .expects()
+        .returning(IO.unit)
+
+      val exception = exceptions.generateOne
+      (eventLogMetrics.run _)
+        .expects()
+        .returning(IO.raiseError(exception))
+
       (reProvisioning.run _)
         .expects()
         .returning(IO.unit)
@@ -191,6 +239,10 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
         .expects()
         .returning(IO.unit)
 
+      (eventLogMetrics.run _)
+        .expects()
+        .returning(IO.unit)
+
       (httpServer.run _)
         .expects()
         .returning(IO.pure(ExitCode.Success))
@@ -210,6 +262,7 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
     val datasetInitializer    = mock[IOFusekiDatasetInitializer]
     val reProvisioning        = mock[IOReProvisioning]
     val eventProcessorRunner  = mock[IOEventProcessorRunner]
+    val eventLogMetrics       = mock[IOEventLogMetrics]
     val httpServer            = mock[IOHttpServer]
     val microserviceRunner = new MicroserviceRunner(
       sentryInitializer,
@@ -217,10 +270,15 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
       datasetInitializer,
       reProvisioning,
       eventProcessorRunner,
+      eventLogMetrics,
       httpServer,
       new ConcurrentHashMap[CancelToken[IO], Unit]()
     )
   }
 
-  private implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  private implicit val cs:    ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  private implicit val timer: Timer[IO]        = IO.timer(ExecutionContext.global)
+
+  class IOEventLogMetrics(eventLogStats: EventLogStats[IO], logger: Logger[IO])
+      extends EventLogMetrics[IO](eventLogStats, logger)
 }

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/RenkuSpec.scala
@@ -18,8 +18,6 @@
 
 package ch.datascience.triplesgenerator.eventprocessing.triplesgeneration.renkulog
 
-import java.nio.file.Paths
-
 import ammonite.ops.{Bytes, CommandResult, Path}
 import cats.effect.{ContextShift, IO, Timer}
 import ch.datascience.generators.CommonGraphGenerators._

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/metrics/EventLogMetricsSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/metrics/EventLogMetricsSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.triplesgenerator.metrics
+
+import EventLogMetrics.{statusesGauge, totalGauge}
+import cats.effect.{ContextShift, IO, Timer}
+import cats.implicits._
+import ch.datascience.db.DbTransactor
+import ch.datascience.dbeventlog.DbEventLogGenerators._
+import ch.datascience.dbeventlog.commands.EventLogStats
+import ch.datascience.dbeventlog.{EventLogDB, EventStatus}
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators._
+import ch.datascience.interpreters.TestLogger
+import ch.datascience.interpreters.TestLogger.Level.Error
+import org.scalacheck.Gen
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class EventLogMetricsSpec extends WordSpec with MockFactory with Eventually with IntegrationPatience {
+
+  "run" should {
+
+    "update the gauges with the fetched values" in new TestCase {
+      val statuses = statuesGen.generateOne
+      (eventLogStats.statuses _)
+        .expects()
+        .returning(statuses.pure[IO])
+        .atLeastOnce()
+
+      metrics.run.start.unsafeRunCancelable(_ => ())
+
+      eventually {
+        statuses foreach {
+          case (status, count) =>
+            statusesGauge.labels(status.toString).get().toLong shouldBe count
+        }
+      }
+
+      eventually {
+        totalGauge.get().toLong shouldBe statuses.valuesIterator.sum
+      }
+    }
+
+    "log an eventual error and continue collecting the metrics" in new TestCase {
+      val exception = exceptions.generateOne
+      (eventLogStats.statuses _)
+        .expects()
+        .returning(exception.raiseError[IO, Map[EventStatus, Long]])
+      val statuses = statuesGen.generateOne
+      (eventLogStats.statuses _)
+        .expects()
+        .returning(statuses.pure[IO])
+        .atLeastOnce()
+
+      metrics.run.start.unsafeRunCancelable(_ => ())
+
+      eventually {
+        statuses foreach {
+          case (status, count) =>
+            statusesGauge.labels(status.toString).get().toLong shouldBe count
+        }
+      }
+
+      eventually {
+        totalGauge.get().toLong shouldBe statuses.valuesIterator.sum
+      }
+
+      eventually {
+        logger.loggedOnly(Error("Problem with gathering metrics", exception))
+      }
+    }
+  }
+
+  private implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  private implicit val timer:        Timer[IO]        = IO.timer(ExecutionContext.global)
+
+  private trait TestCase {
+    abstract class IOEventLogStats(transactor: DbTransactor[IO, EventLogDB]) extends EventLogStats[IO](transactor)
+    val eventLogStats = mock[IOEventLogStats]
+    val logger        = TestLogger[IO]()
+    val interval      = 100 millis
+    val metrics       = new EventLogMetrics[IO](eventLogStats, logger, statusesGauge, totalGauge, interval)
+  }
+
+  private lazy val statuesGen: Gen[Map[EventStatus, Long]] = nonEmptySet {
+    for {
+      status <- eventStatuses
+      count  <- positiveLongs()
+    } yield status -> count.value
+  }.map(_.toMap)
+}

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
@@ -71,32 +71,29 @@ object Microservice extends IOMicroservice {
         gitLabThrottler       <- Throttler[IO, GitLab](gitLabRateLimit)
         hookTokenCrypto       <- HookTokenCrypto[IO]()
         executionTimeRecorder <- ExecutionTimeRecorder[IO](ApplicationLogger)
-
-        httpServer = new HttpServer[IO](
-          serverPort = 9001,
-          serviceRoutes = new MicroserviceRoutes[IO](
-            new IOHookEventEndpoint(transactor,
-                                    tokenRepositoryUrl,
-                                    gitLabUrl,
-                                    gitLabThrottler,
-                                    hookTokenCrypto,
-                                    executionTimeRecorder),
-            new IOHookCreationEndpoint(transactor,
-                                       tokenRepositoryUrl,
-                                       projectHookUrl,
-                                       gitLabUrl,
-                                       gitLabThrottler,
-                                       hookTokenCrypto,
-                                       executionTimeRecorder),
-            new IOHookValidationEndpoint(tokenRepositoryUrl, projectHookUrl, gitLabUrl, gitLabThrottler),
-            new IOProcessingStatusEndpoint(transactor,
+        routes <- new MicroserviceRoutes[IO](
+                   new IOHookEventEndpoint(transactor,
                                            tokenRepositoryUrl,
-                                           projectHookUrl,
                                            gitLabUrl,
                                            gitLabThrottler,
-                                           executionTimeRecorder)
-          ).routes
-        )
+                                           hookTokenCrypto,
+                                           executionTimeRecorder),
+                   new IOHookCreationEndpoint(transactor,
+                                              tokenRepositoryUrl,
+                                              projectHookUrl,
+                                              gitLabUrl,
+                                              gitLabThrottler,
+                                              hookTokenCrypto,
+                                              executionTimeRecorder),
+                   new IOHookValidationEndpoint(tokenRepositoryUrl, projectHookUrl, gitLabUrl, gitLabThrottler),
+                   new IOProcessingStatusEndpoint(transactor,
+                                                  tokenRepositoryUrl,
+                                                  projectHookUrl,
+                                                  gitLabUrl,
+                                                  gitLabThrottler,
+                                                  executionTimeRecorder)
+                 ).routes
+        httpServer = new HttpServer[IO](serverPort = 9001, routes)
 
         exitCode <- new MicroserviceRunner(
                      sentryInitializer,


### PR DESCRIPTION
This PR introduces `GET /metrics` endpoints for all the graph services. The endpoints provide metrics about JVM health, services endpoints usage plus some service-related metrics like Event Log state.

closes #162 