### PR TITLE
find dataset's projects query improvements

### DIFF
--- a/.travis/travis-publish.sh
+++ b/.travis/travis-publish.sh
@@ -25,5 +25,6 @@ if [[ -n $TRAVIS_TAG ]]; then
   publishCharts
   git clean -dffx
   chartpress --tag $TRAVIS_TAG --push --publish-chart
+  sleep 2m
   updateVersionInRenku
 fi

--- a/.travis/travis-release.sh
+++ b/.travis/travis-release.sh
@@ -24,8 +24,4 @@ source $(dirname "$0")/travis-functions.sh
 COMMIT_MESSAGE_PATTERN="Setting version to .*"
 if [[ -z $TRAVIS_TAG ]] && [[ ! $TRAVIS_COMMIT_MESSAGE =~ $COMMIT_MESSAGE_PATTERN ]]; then
   createRelease
-  publishCharts
-# publish charts if this build is not triggered by a tag and a new snapshot setting push
-elif [[ -z $TRAVIS_TAG ]] && [[ $TRAVIS_COMMIT_MESSAGE =~ $COMMIT_MESSAGE_PATTERN ]]; then
-  publishCharts
 fi

--- a/acceptance-tests/src/test/resources/application.conf
+++ b/acceptance-tests/src/test/resources/application.conf
@@ -15,6 +15,7 @@ metrics.enabled = false
 
 triples-generation = "remote-generator"
 
+generation-process-initial-delay = 1 millisecond
 generation-processes-number = 1
 
 re-provisioning-initial-delay = 1 day

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -81,6 +81,8 @@ spec:
             - name: SENTRY_ENVIRONMENT_NAME
               value: {{ .Values.sentry.environmentName }}
               {{- end }}
+            - name: GENERATION_PROCESSES_INITIAL_DELAY
+              value: "{{ .Values.triplesGenerator.generationProcessInitialDelay }}"
             - name: GENERATION_PROCESSES_NUMBER
               value: "{{ .Values.triplesGenerator.generationProcessesNumber }}"
             - name: THREADS_NUMBER

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -33,9 +33,10 @@ triplesGenerator:
       memory: 2000Mi
   jvmXmx: 1G
   renkuLogTimeout: 60 minutes
-  reProvisioningInitialDelay: 2 minutes
+  reProvisioningInitialDelay: 1 second
   gitlab:
     rateLimit: 30/sec
+  generationProcessInitialDelay: 10 seconds
   ## a demanded number of concurrent triples generation processes
   generationProcessesNumber: 4
   threadsNumber: 6

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinder.scala
@@ -48,7 +48,7 @@ private class BaseDetailsFinder(
     queryExpecting[List[Dataset]](using = query(identifier)) flatMap toSingleDataset
 
   private def query(identifier: Identifier) = SparqlQuery(
-    name = "base dataset details",
+    name = "ds by id - base details",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/CreatorsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/CreatorsFinder.scala
@@ -47,7 +47,7 @@ private class CreatorsFinder(
       .map(_.toSet)
 
   private def query(identifier: Identifier) = SparqlQuery(
-    name = "dataset creators",
+    name = "ds by id - creators",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsFinder.scala
@@ -96,12 +96,16 @@ private class IODatasetsFinder(
         s"""|SELECT ?identifier ?name ?maybeDescription ?maybePublishedDate ?projectsCount
             |WHERE {
             |  {
+            |    # locating earliest commit (date) where dataset with same origin was added
             |    SELECT ?topmostSameAs (MIN(?dateCreated) AS ?minDateCreated) ?projectsCount
             |    WHERE {
             |      {
+            |        # grouping datasets by sameAs and finding number of projects sharing the sameAs
             |        SELECT ?topmostSameAs (COUNT(DISTINCT ?projectId) AS ?projectsCount)
             |        WHERE {
             |          {
+            |            # finding datasets matching the phrase 
+            |            # (to narrow down the ds ids set and to prevent from additional lookups to lucene)
             |            SELECT ?topmostSameAs
             |            WHERE {
             |              {
@@ -130,6 +134,7 @@ private class IODatasetsFinder(
             |                GROUP BY ?l0
             |                HAVING (COUNT(*) > 0)
             |              } {
+            |                # flattening project the import hierarchy
             |                {
             |                  {
             |                    ?l0 schema:sameAs+/schema:url ?l1.
@@ -237,11 +242,14 @@ private class IODatasetsFinder(
         s"""|SELECT ?identifier ?name ?maybeDescription ?maybePublishedDate ?projectsCount
             |WHERE {
             |  {
+            |    # locating earliest commit (date) where dataset with same origin was added
             |    SELECT ?topmostSameAs (MIN(?dateCreated) AS ?minDateCreated) ?projectsCount
             |    WHERE {
             |      {
+            |        # grouping datasets by sameAs and finding number of projects sharing the sameAs 
             |        SELECT ?topmostSameAs (COUNT(DISTINCT ?projectId) AS ?projectsCount)
             |        WHERE {
+            |          # flattening project the import hierarchy
             |          {
             |            {
             |              ?l0 schema:sameAs+/schema:url ?l1;

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetsFinder.scala
@@ -83,7 +83,7 @@ private class IODatasetsFinder(
   }
 
   private def sparqlQuery(maybePhrase: Option[Phrase], sort: Sort.By): SparqlQuery = SparqlQuery(
-    name = "free-text datasets search",
+    name = "ds free-text search",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
@@ -319,7 +319,7 @@ private class IODatasetsFinder(
   )
 
   private def countQuery(maybePhrase: Option[Phrase]): SparqlQuery = SparqlQuery(
-    name = "free-text datasets count",
+    name = "ds free-text search - count",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX schema: <http://schema.org/>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/PartsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/PartsFinder.scala
@@ -44,7 +44,7 @@ private class PartsFinder(
     queryExpecting[List[DatasetPart]](using = query(identifier))
 
   private def query(identifier: Identifier) = SparqlQuery(
-    name = "dataset parts",
+    name = "ds by id - parts",
     Set(
       "PREFIX prov: <http://www.w3.org/ns/prov#>",
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/ProjectDatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/ProjectDatasetsFinder.scala
@@ -50,7 +50,7 @@ private class IOProjectDatasetsFinder(
     queryExpecting[List[(Identifier, Name)]](using = query(projectPath))
 
   private def query(path: ProjectPath) = SparqlQuery(
-    name = "project datasets",
+    name = "ds projects",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/ProjectsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/ProjectsFinder.scala
@@ -49,7 +49,7 @@ private class ProjectsFinder(
     queryExpecting[List[DatasetProject]](using = query(identifier))
 
   private def query(identifier: Identifier) = SparqlQuery(
-    name = "projects sharing dataset",
+    name = "ds by id - projects",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/ProjectsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/ProjectsFinder.scala
@@ -62,6 +62,39 @@ private class ProjectsFinder(
         |    SELECT ?l0 ?projectId (MIN(?dateCreated) AS ?minDateCreated)
         |    WHERE {
         |      {
+        |        SELECT ?topmostSameAs
+        |        WHERE {
+        |          {
+        |            ?l0 rdf:type <http://schema.org/Dataset>;
+        |                schema:identifier "$identifier"
+        |          } {
+        |            {
+        |              {
+        |                ?l0 schema:sameAs+/schema:url ?l1.
+        |                FILTER NOT EXISTS { ?l1 schema:sameAs ?l2 }
+        |                BIND (?l1 AS ?topmostSameAs)
+        |              } UNION {
+        |                ?l0 rdf:type <http://schema.org/Dataset>.
+        |                FILTER NOT EXISTS { ?l0 schema:sameAs ?l1 }
+        |                BIND (?l0 AS ?topmostSameAs)
+        |              }
+        |            } UNION {
+        |              ?l0 schema:sameAs+/schema:url ?l1.
+        |              ?l1 schema:sameAs+/schema:url ?l2
+        |              FILTER NOT EXISTS { ?l2 schema:sameAs ?l3 }
+        |              BIND (?l2 AS ?topmostSameAs)
+        |            } UNION {
+        |              ?l0 schema:sameAs+/schema:url ?l1.
+        |              ?l1 schema:sameAs+/schema:url ?l2.
+        |              ?l2 schema:sameAs+/schema:url ?l3
+        |              FILTER NOT EXISTS { ?l3 schema:sameAs ?l4 }
+        |              BIND (?l3 AS ?topmostSameAs)
+        |            }
+        |          }
+        |        }
+        |        GROUP BY ?topmostSameAs
+        |        HAVING (COUNT(*) > 0)
+        |      } {
         |        {
         |          {
         |            ?l0 schema:sameAs+/schema:url ?topmostSameAs;
@@ -89,42 +122,6 @@ private class ProjectsFinder(
         |          ?l2 schema:sameAs+/schema:url ?topmostSameAs
         |          FILTER NOT EXISTS { ?topmostSameAs schema:sameAs ?l4 }
         |        }
-        |      } {
-        |        SELECT ?topmostSameAs
-        |        WHERE {
-        |          {
-        |            {
-        |              {
-        |                ?l0 schema:sameAs+/schema:url ?l1.
-        |                FILTER NOT EXISTS { ?l1 schema:sameAs ?l2 }
-        |                BIND (?l1 AS ?topmostSameAs)
-        |              } UNION {
-        |                ?l0 rdf:type <http://schema.org/Dataset>.
-        |                FILTER NOT EXISTS { ?l0 schema:sameAs ?l1 }
-        |                BIND (?l0 AS ?topmostSameAs)
-        |              }
-        |            } UNION {
-        |              ?l0 schema:sameAs+/schema:url ?l1.
-        |              ?l1 schema:sameAs+/schema:url ?l2
-        |              FILTER NOT EXISTS { ?l2 schema:sameAs ?l3 }
-        |              BIND (?l2 AS ?topmostSameAs)
-        |            } UNION {
-        |              ?l0 schema:sameAs+/schema:url ?l1.
-        |              ?l1 schema:sameAs+/schema:url ?l2.
-        |              ?l2 schema:sameAs+/schema:url ?l3
-        |              FILTER NOT EXISTS { ?l3 schema:sameAs ?l4 }
-        |              BIND (?l3 AS ?topmostSameAs)
-        |            }
-        |          } {
-        |            SELECT ?l0
-        |            WHERE {
-        |              ?l0 rdf:type <http://schema.org/Dataset>;
-        |                  schema:identifier "$identifier"
-        |            }
-        |          }
-        |        }
-        |        GROUP BY ?topmostSameAs
-        |        HAVING (COUNT(*) > 0)
         |      }
         |    }
         |    GROUP BY ?l0 ?projectId

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/LineageFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/LineageFinder.scala
@@ -70,7 +70,7 @@ class IOLineageFinder(
     val commitResource     = (fusekiBaseUrl / "commit" / commitId).showAs[RdfResource]
     val generationResource = (fusekiBaseUrl / "blob" / commitId / filePath).showAs[RdfResource]
     SparqlQuery(
-      name = "lineage finding",
+      name = "lineage",
       Set(
         "PREFIX prov: <http://www.w3.org/ns/prov#>",
         "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/KGProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/KGProjectFinder.scala
@@ -65,7 +65,7 @@ private class IOKGProjectFinder(
   }
 
   private def query(path: ProjectPath) = SparqlQuery(
-    name = "project details",
+    name = "project by id",
     Set(
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/IOLineageFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/IOLineageFinderSpec.scala
@@ -75,7 +75,7 @@ class IOLineageFinderSpec extends WordSpec with InMemoryRdfStore with ExternalSe
         )
       )
 
-      logger.loggedOnly(Warn(s"lineage finding finished${executionTimeRecorder.executionTimeInfo}"))
+      logger.loggedOnly(Warn(s"lineage finished${executionTimeRecorder.executionTimeInfo}"))
     }
 
     "return None if there's no lineage for the project" in new InMemoryStoreTestCase {
@@ -87,7 +87,7 @@ class IOLineageFinderSpec extends WordSpec with InMemoryRdfStore with ExternalSe
         .findLineage(projectPath, commitId, filePath)
         .unsafeRunSync() shouldBe None
 
-      logger.loggedOnly(Warn(s"lineage finding finished${executionTimeRecorder.executionTimeInfo}"))
+      logger.loggedOnly(Warn(s"lineage finished${executionTimeRecorder.executionTimeInfo}"))
     }
   }
 

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -1,13 +1,15 @@
+generation-process-initial-delay = 10 seconds
+generation-process-initial-delay = ${?GENERATION_PROCESSES_INITIAL_DELAY}
 generation-processes-number = 2
 generation-processes-number = ${?GENERATION_PROCESSES_NUMBER}
 
-threads-number = 4
+threads-number = 2
 threads-number = ${?THREADS_NUMBER}
 
-renku-log-timeout = 3 minutes
+renku-log-timeout = 1 hour
 renku-log-timeout = ${?RENKU_LOG_TIMEOUT}
 
-re-provisioning-initial-delay = 1 minute
+re-provisioning-initial-delay = 1 second
 re-provisioning-initial-delay = ${?RE_PROVISIONING_INITIAL_DELAY}
 
 triples-generation = "renku-log"

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/PersonDetailsUpdater.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/PersonDetailsUpdater.scala
@@ -135,7 +135,7 @@ private object PersonDetailsUpdater {
       Update(
         s"Deleting Person $resource schema:name",
         SparqlQuery(
-          name = "deleting person name",
+          name = "upload - person name delete",
           Set("PREFIX schema: <http://schema.org/>"),
           s"""|DELETE { $resource schema:name ?name }
               |WHERE  { $resource schema:name ?name }
@@ -151,7 +151,7 @@ private object PersonDetailsUpdater {
           Update(
             s"Inserting Person $resource schema:name",
             SparqlQuery(
-              name = "inserting person name",
+              name = "upload - person name insert",
               Set("PREFIX schema: <http://schema.org/>"),
               s"""|${`INSERT DATA`(resource, "schema:name", NonEmptyList.fromListUnsafe(names.toList))}
                   |""".stripMargin
@@ -164,7 +164,7 @@ private object PersonDetailsUpdater {
       Update(
         s"Deleting Person $resource schema:email",
         SparqlQuery(
-          name = "deleting person email",
+          name = "upload - person email delete",
           Set("PREFIX schema: <http://schema.org/>"),
           s"""|DELETE { $resource schema:email ?email }
               |WHERE  { $resource schema:email ?email }
@@ -181,7 +181,7 @@ private object PersonDetailsUpdater {
           Update(
             s"Inserting Person $resource schema:email",
             SparqlQuery(
-              name = "inserting person email",
+              name = "upload - person email insert",
               Set("PREFIX schema: <http://schema.org/>"),
               s"""|${`INSERT DATA`(resource, "schema:email", NonEmptyList.fromListUnsafe(emails.toList))}
                   |""".stripMargin
@@ -194,7 +194,7 @@ private object PersonDetailsUpdater {
       Update(
         s"Deleting Person $resource rdfs:label",
         SparqlQuery(
-          name = "deleting person label",
+          name = "upload - person label delete",
           Set("PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"),
           s"""|DELETE { $resource rdfs:label ?label }
               |WHERE  { $resource rdfs:label ?label }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesRemover.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesRemover.scala
@@ -41,7 +41,7 @@ private class IOTriplesRemover(
 
   override def removeAllTriples(): IO[Unit] = updateWitNoResult {
     SparqlQuery(
-      name = "removing all triples",
+      name = "all triples remove",
       Set.empty,
       "DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }"
     )

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/TriplesVersionFinder.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/TriplesVersionFinder.scala
@@ -50,7 +50,7 @@ private class IOTriplesVersionFinder(
 
   private def findCommitAgents = queryExpecting[List[String]] {
     SparqlQuery(
-      name = "renku version finding",
+      name = "renku version find",
       Set(
         "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
         "PREFIX prov: <http://www.w3.org/ns/prov#>"

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/DbEventProcessorRunnerSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/DbEventProcessorRunnerSpec.scala
@@ -146,9 +146,14 @@ class DbEventProcessorRunnerSpec extends WordSpec with Eventually with Integrati
 
   private trait TestCase {
 
-    val eventLogFetch  = new TestEventLogFetch()
-    val logger         = TestLogger[IO]()
-    private val config = ConfigFactory.parseMap(Map("generation-processes-number" -> 5).asJava)
+    val eventLogFetch = new TestEventLogFetch()
+    val logger        = TestLogger[IO]()
+    private val config = ConfigFactory.parseMap(
+      Map(
+        "generation-process-initial-delay" -> "1 millisecond",
+        "generation-processes-number"      -> 5
+      ).asJava
+    )
 
     def eventSourceWith(processor:     EventProcessor[IO],
                         eventLogFetch: EventLogFetch[IO] = eventLogFetch): EventProcessorRunner[IO] = {

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOTriplesVersionFinderSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOTriplesVersionFinderSpec.scala
@@ -46,7 +46,7 @@ class IOTriplesVersionFinderSpec extends WordSpec with InMemoryRdfStore {
 
       triplesVersionFinder.triplesUpToDate.unsafeRunSync() shouldBe true
 
-      logger.loggedOnly(Warn(s"renku version finding finished${executionTimeRecorder.executionTimeInfo}"))
+      logger.loggedOnly(Warn(s"renku version find finished${executionTimeRecorder.executionTimeInfo}"))
     }
 
     "return false if there's a single SoftwareAgent entity with some old version of Renku" in new TestCase {
@@ -55,7 +55,7 @@ class IOTriplesVersionFinderSpec extends WordSpec with InMemoryRdfStore {
 
       triplesVersionFinder.triplesUpToDate.unsafeRunSync() shouldBe false
 
-      logger.loggedOnly(Warn(s"renku version finding finished${executionTimeRecorder.executionTimeInfo}"))
+      logger.loggedOnly(Warn(s"renku version find finished${executionTimeRecorder.executionTimeInfo}"))
     }
 
     "return false if there are multiple SoftwareAgent entities with different versions of Renku" in new TestCase {
@@ -65,7 +65,7 @@ class IOTriplesVersionFinderSpec extends WordSpec with InMemoryRdfStore {
 
       triplesVersionFinder.triplesUpToDate.unsafeRunSync() shouldBe false
 
-      logger.loggedOnly(Warn(s"renku version finding finished${executionTimeRecorder.executionTimeInfo}"))
+      logger.loggedOnly(Warn(s"renku version find finished${executionTimeRecorder.executionTimeInfo}"))
     }
 
     "return false if SoftwareAgent points to the current versions of Renku but it's not linked to a commit activity" in new TestCase {
@@ -74,7 +74,7 @@ class IOTriplesVersionFinderSpec extends WordSpec with InMemoryRdfStore {
 
       triplesVersionFinder.triplesUpToDate.unsafeRunSync() shouldBe false
 
-      logger.loggedOnly(Warn(s"renku version finding finished${executionTimeRecorder.executionTimeInfo}"))
+      logger.loggedOnly(Warn(s"renku version find finished${executionTimeRecorder.executionTimeInfo}"))
     }
   }
 


### PR DESCRIPTION
This PR:
* optimizes dataset's projects finding query
* improves `query_id` naming to make queries groups more visible
* prevents travis from building a chart on non-tag events
* explains free-text dataset search queries