### PR TITLE
lineage not to show renku updates

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/LineageQuerySpec.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/LineageQuerySpec.scala
@@ -126,35 +126,24 @@ class LineageQuerySpec extends FeatureSpec with GivenWhenThen with GraphServices
 
   private lazy val theExpectedEdges = Right {
     Set(
-      json"""{"source": ${`sha3 zhbikes`.id},             "target": ${`sha8 renku run`.id}}""",
-      json"""{"source": ${`sha7 plot_data`.id},           "target": ${`sha9 renku run`.id}}""",
-      json"""{"source": ${`sha7 plot_data`.id},           "target": ${`sha12 step1 renku update`.id}}""",
-      json"""{"source": ${`sha7 clean_data`.id},          "target": ${`sha8 renku run`.id}}""",
-      json"""{"source": ${`sha7 clean_data`.id},          "target": ${`sha12 step2 renku update`.id}}""",
-      json"""{"source": ${`sha8 renku run`.id},           "target": ${`sha8 parquet`.id}}""",
-      json"""{"source": ${`sha8 parquet`.id},             "target": ${`sha9 renku run`.id}}""",
-      json"""{"source": ${`sha9 renku run`.id},           "target": ${`sha9 plot_data`.id}}""",
-      json"""{"source": ${`sha10 zhbikes`.id},            "target": ${`sha12 step2 renku update`.id}}""",
-      json"""{"source": ${`sha12 parquet`.id},            "target": ${`sha12 step1 renku update`.id}}""",
-      json"""{"source": ${`sha12 step1 renku update`.id}, "target": ${`sha12 step2 grid_plot`.id}}""",
-      json"""{"source": ${`sha12 step2 renku update`.id}, "target": ${`sha12 parquet`.id}}"""
+      json"""{"source": ${`sha3 zhbikes`.location},             "target": ${`sha8 renku run`.location}}""",
+      json"""{"source": ${`sha7 plot_data`.location},           "target": ${`sha9 renku run`.location}}""",
+      json"""{"source": ${`sha7 clean_data`.location},          "target": ${`sha8 renku run`.location}}""",
+      json"""{"source": ${`sha8 renku run`.location},           "target": ${`sha8 parquet`.location}}""",
+      json"""{"source": ${`sha8 parquet`.location},             "target": ${`sha9 renku run`.location}}""",
+      json"""{"source": ${`sha9 renku run`.location},           "target": ${`sha9 plot_data`.location}}"""
     )
   }
 
   private lazy val theExpectedNodes = Right {
     Set(
-      json"""{"id": ${`sha3 zhbikes`.id},             "location": ${`sha3 zhbikes`.location},             "label": ${`sha3 zhbikes`.label},             "type": ${`sha3 zhbikes`.singleWordType}            }""",
-      json"""{"id": ${`sha7 clean_data`.id},          "location": ${`sha7 clean_data`.location},          "label": ${`sha7 clean_data`.label},          "type": ${`sha7 clean_data`.singleWordType}         }""",
-      json"""{"id": ${`sha7 plot_data`.id},           "location": ${`sha7 plot_data`.location},           "label": ${`sha7 plot_data`.label},           "type": ${`sha7 plot_data`.singleWordType}          }""",
-      json"""{"id": ${`sha8 renku run`.id},           "location": ${`sha8 renku run`.location},           "label": ${`sha8 renku run`.label},           "type": ${`sha8 renku run`.singleWordType}          }""",
-      json"""{"id": ${`sha8 parquet`.id},             "location": ${`sha8 parquet`.location},             "label": ${`sha8 parquet`.label},             "type": ${`sha8 parquet`.singleWordType}            }""",
-      json"""{"id": ${`sha9 renku run`.id},           "location": ${`sha9 renku run`.location},           "label": ${`sha9 renku run`.label},           "type": ${`sha9 renku run`.singleWordType}          }""",
-      json"""{"id": ${`sha9 plot_data`.id},           "location": ${`sha9 plot_data`.location},           "label": ${`sha9 plot_data`.label},           "type": ${`sha9 plot_data`.singleWordType}          }""",
-      json"""{"id": ${`sha10 zhbikes`.id},            "location": ${`sha10 zhbikes`.location},            "label": ${`sha10 zhbikes`.label},            "type": ${`sha10 zhbikes`.singleWordType}           }""",
-      json"""{"id": ${`sha12 step1 renku update`.id}, "location": ${`sha12 step1 renku update`.location}, "label": ${`sha12 step1 renku update`.label}, "type": ${`sha12 step1 renku update`.singleWordType}}""",
-      json"""{"id": ${`sha12 step2 grid_plot`.id},    "location": ${`sha12 step2 grid_plot`.location},    "label": ${`sha12 step2 grid_plot`.label},    "type": ${`sha12 step2 grid_plot`.singleWordType}   }""",
-      json"""{"id": ${`sha12 step2 renku update`.id}, "location": ${`sha12 step2 renku update`.location}, "label": ${`sha12 step2 renku update`.label}, "type": ${`sha12 step2 renku update`.singleWordType}}""",
-      json"""{"id": ${`sha12 parquet`.id},            "location": ${`sha12 parquet`.location},            "label": ${`sha12 parquet`.label},            "type": ${`sha12 parquet`.singleWordType}           }"""
+      json"""{"id": ${`sha3 zhbikes`.location},             "location": ${`sha3 zhbikes`.location},             "label": ${`sha3 zhbikes`.label},             "type": ${`sha3 zhbikes`.singleWordType}   }""",
+      json"""{"id": ${`sha7 clean_data`.location},          "location": ${`sha7 clean_data`.location},          "label": ${`sha7 clean_data`.label},          "type": ${`sha7 clean_data`.singleWordType}}""",
+      json"""{"id": ${`sha7 plot_data`.location},           "location": ${`sha7 plot_data`.location},           "label": ${`sha7 plot_data`.label},           "type": ${`sha7 plot_data`.singleWordType} }""",
+      json"""{"id": ${`sha8 renku run`.location},           "location": ${`sha8 renku run`.location},           "label": ${`sha8 renku run`.label},           "type": ${`sha8 renku run`.singleWordType} }""",
+      json"""{"id": ${`sha8 parquet`.location},             "location": ${`sha8 parquet`.location},             "label": ${`sha8 parquet`.label},             "type": ${`sha8 parquet`.singleWordType}   }""",
+      json"""{"id": ${`sha9 renku run`.location},           "location": ${`sha9 renku run`.location},           "label": ${`sha9 renku run`.label},           "type": ${`sha9 renku run`.singleWordType} }""",
+      json"""{"id": ${`sha9 plot_data`.location},           "location": ${`sha9 plot_data`.location},           "label": ${`sha9 plot_data`.label},           "type": ${`sha9 plot_data`.singleWordType} }"""
     )
   }
 

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.48.0-2501cac
+version: 0.47.1-2501cac

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/graphql/modelSchema.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/graphql/modelSchema.scala
@@ -27,7 +27,7 @@ private object modelSchema {
     name        = "node",
     description = "Lineage node",
     fields[Unit, Node](
-      Field("id", StringType, Some("Node identifier"), resolve     = _.value.id.toString),
+      Field("id", StringType, Some("Node identifier"), resolve     = _.value.location.toString),
       Field("location", StringType, Some("Node location"), resolve = _.value.location.toString),
       Field("label", StringType, Some("Node label"), resolve       = _.value.label.toString),
       Field(

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/model.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/model.scala
@@ -32,24 +32,24 @@ object model {
     def from[Interpretation[_]](edges: Set[Edge], nodes: Set[Node])(
         implicit ME:                   MonadError[Interpretation, Throwable]
     ): Interpretation[Lineage] = {
-      val idsFromEdges = collectNodesIds(edges)
-      val idsFromNodes = nodes.map(_.id)
-      if (idsFromEdges == idsFromNodes) ME.pure(Lineage(edges, nodes))
-      else if ((idsFromNodes diff idsFromEdges).nonEmpty)
+      val allEdgesLocations = collectLocations(edges)
+      val allNodesLocations = nodes.map(_.location)
+      if (allEdgesLocations == allNodesLocations) ME.pure(Lineage(edges, nodes))
+      else if ((allNodesLocations diff allEdgesLocations).nonEmpty)
         ME.raiseError(new IllegalArgumentException("There are orphan nodes"))
       else
         ME.raiseError(new IllegalArgumentException("There are edges with no nodes definitions"))
     }
 
-    private def collectNodesIds(edges: Set[Edge]): Set[Node.Id] =
-      edges.foldLeft(Set.empty[Node.Id]) {
+    private def collectLocations(edges: Set[Edge]): Set[Node.Location] =
+      edges.foldLeft(Set.empty[Node.Location]) {
         case (acc, Edge(source, target)) => acc + source + target
       }
   }
 
-  final case class Edge(source: Node.Id, target: Node.Id)
+  final case class Edge(source: Node.Location, target: Node.Location)
 
-  final case class Node(id: Node.Id, location: Node.Location, label: Node.Label, types: Set[Node.Type])
+  final case class Node(location: Node.Location, label: Node.Label, types: Set[Node.Type])
 
   object Node {
     import ch.datascience.tinytypes.constraints.{NonBlank, RelativePath}

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/graphql/QuerySchemaSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/graphql/QuerySchemaSpec.scala
@@ -98,7 +98,10 @@ class QuerySchemaSpec
 
     private val sourceNode = nodes.generateOne
     private val targetNode = nodes.generateOne
-    lazy val lineage       = Lineage(edges = Set(Edge(sourceNode.id, targetNode.id)), nodes = Set(sourceNode, targetNode))
+    lazy val lineage = Lineage(
+      edges = Set(Edge(sourceNode.location, targetNode.location)),
+      nodes = Set(sourceNode, targetNode)
+    )
 
     def json(lineage: Lineage) =
       json"""
@@ -114,7 +117,7 @@ class QuerySchemaSpec
     private def toJson(node: Node) =
       json"""
       {
-        "id": ${node.id.value},
+        "id": ${node.location.value},
         "location": ${node.location.value},
         "label": ${node.label.value},
         "type": ${node.singleWordType.fold(throw _, identity).name}

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/IOLineageFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/IOLineageFinderSpec.scala
@@ -49,18 +49,12 @@ class IOLineageFinderSpec extends WordSpec with InMemoryRdfStore with ExternalSe
         .unsafeRunSync() shouldBe Some(
         Lineage(
           edges = Set(
-            Edge(`sha3 zhbikes`.toNodeId, `sha8 renku run`.toNodeId),
-            Edge(`sha7 plot_data`.toNodeId, `sha9 renku run`.toNodeId),
-            Edge(`sha7 plot_data`.toNodeId, `sha12 step1 renku update`.toNodeId),
-            Edge(`sha7 clean_data`.toNodeId, `sha8 renku run`.toNodeId),
-            Edge(`sha7 clean_data`.toNodeId, `sha12 step2 renku update`.toNodeId),
-            Edge(`sha8 renku run`.toNodeId, `sha8 parquet`.toNodeId),
-            Edge(`sha8 parquet`.toNodeId, `sha9 renku run`.toNodeId),
-            Edge(`sha9 renku run`.toNodeId, `sha9 plot_data`.toNodeId),
-            Edge(`sha10 zhbikes`.toNodeId, `sha12 step2 renku update`.toNodeId),
-            Edge(`sha12 parquet`.toNodeId, `sha12 step1 renku update`.toNodeId),
-            Edge(`sha12 step1 renku update`.toNodeId, `sha12 step2 grid_plot`.toNodeId),
-            Edge(`sha12 step2 renku update`.toNodeId, `sha12 parquet`.toNodeId)
+            Edge(`sha3 zhbikes`.toNodeLocation, `sha8 renku run`.toNodeLocation),
+            Edge(`sha7 plot_data`.toNodeLocation, `sha9 renku run`.toNodeLocation),
+            Edge(`sha7 clean_data`.toNodeLocation, `sha8 renku run`.toNodeLocation),
+            Edge(`sha8 renku run`.toNodeLocation, `sha8 parquet`.toNodeLocation),
+            Edge(`sha8 parquet`.toNodeLocation, `sha9 renku run`.toNodeLocation),
+            Edge(`sha9 renku run`.toNodeLocation, `sha9 plot_data`.toNodeLocation)
           ),
           nodes = Set(
             `sha3 zhbikes`.toNode,
@@ -69,12 +63,7 @@ class IOLineageFinderSpec extends WordSpec with InMemoryRdfStore with ExternalSe
             `sha8 renku run`.toNode,
             `sha8 parquet`.toNode,
             `sha9 renku run`.toNode,
-            `sha9 plot_data`.toNode,
-            `sha10 zhbikes`.toNode,
-            `sha12 step1 renku update`.toNode,
-            `sha12 step2 grid_plot`.toNode,
-            `sha12 step2 renku update`.toNode,
-            `sha12 parquet`.toNode
+            `sha9 plot_data`.toNode
           )
         )
       )
@@ -106,10 +95,9 @@ class IOLineageFinderSpec extends WordSpec with InMemoryRdfStore with ExternalSe
   }
 
   private implicit class NodeDefOps(nodeDef: NodeDef) {
-    lazy val toNodeId: Node.Id = Node.Id(nodeDef.id)
+    lazy val toNodeLocation: Node.Location = Node.Location(nodeDef.location)
     lazy val toNode: Node = Node(
-      nodeDef.toNodeId,
-      Node.Location(nodeDef.location),
+      toNodeLocation,
       Node.Label(nodeDef.label),
       nodeDef.types.map(Node.Type.apply)
     )

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/LineageGenerators.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/LineageGenerators.scala
@@ -39,14 +39,13 @@ object LineageGenerators {
   )
 
   implicit val nodes: Gen[Node] = for {
-    id       <- nodeIds
     location <- nodeLocations
     label    <- nodeLabels
     types    <- nodeTypesSet
-  } yield Node(id, location, label, types)
+  } yield Node(location, label, types)
 
   implicit val edges: Gen[Edge] = for {
-    sourceNodeId <- nodeIds
-    targetNodeId <- nodeIds
-  } yield Edge(sourceNodeId, targetNodeId)
+    sourceNode <- nodeLocations
+    targetNode <- nodeLocations
+  } yield Edge(sourceNode, targetNode)
 }

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/LineageSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/lineage/LineageSpec.scala
@@ -127,6 +127,6 @@ class LineageSpec extends WordSpec with ScalaCheckPropertyChecks {
 
   private def generateNodes(edges: Set[Edge]): Set[Node] =
     edges.foldLeft(Set.empty[Node]) { (acc, edge) =>
-      acc + nodes.generateOne.copy(id = edge.source) + nodes.generateOne.copy(id = edge.target)
+      acc + nodes.generateOne.copy(location = edge.source) + nodes.generateOne.copy(location = edge.target)
     }
 }

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -24,7 +24,7 @@ ENV TZ UTC
 
 # Installing Renku
 RUN apk add --no-cache tzdata git git-lfs curl bash python3-dev openssl-dev libffi-dev linux-headers gcc libxml2-dev libxslt-dev libc-dev && \
-    python3 -m pip install 'renku==0.9.0' sentry-sdk && \
+    python3 -m pip install 'renku==0.9.1' sentry-sdk && \
     chown -R daemon:daemon . && \
     git config --global filter.lfs.smudge "git-lfs smudge --skip %f"  && \
     git config --global filter.lfs.process "git-lfs filter-process --skip"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.48.0-SNAPSHOT"
+version in ThisBuild := "0.47.1-SNAPSHOT"


### PR DESCRIPTION
This PR:
* changes the lineage resource so it doesn't show the `renku update` nodes;
* bumps the version of `renku-python` in `triples-generator` to `0.9.1`;
Closes #169

