### PR TITLE
fix: allow blanks in Commit's author and committer email and username

### DIFF
--- a/graph-commons/src/main/scala/ch/datascience/graph/model/users.scala
+++ b/graph-commons/src/main/scala/ch/datascience/graph/model/users.scala
@@ -27,7 +27,20 @@ object users {
   implicit object Id extends TinyTypeFactory[Id](new Id(_)) with NonBlank
 
   final class Email private (val value: String) extends AnyVal with StringTinyType
-  implicit object Email extends TinyTypeFactory[Email](new Email(_)) with NonBlank
+  implicit object Email extends TinyTypeFactory[Email](new Email(_)) with NonBlank {
+
+    addConstraint(
+      check = _.split('@').toList match {
+        case head +: tail +: Nil => head.trim.nonEmpty && tail.trim.nonEmpty
+        case _                   => false
+      },
+      message = value => s"'$value' is not a valid email"
+    )
+
+    implicit class EmailOps(email: Email) {
+      lazy val extractUsername: Username = Username(email.value.split('@').head)
+    }
+  }
 
   final class Name private (val value: String) extends AnyVal with StringTinyType
   implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank

--- a/graph-commons/src/test/scala/ch/datascience/graph/model/EventsGenerators.scala
+++ b/graph-commons/src/test/scala/ch/datascience/graph/model/EventsGenerators.scala
@@ -32,10 +32,23 @@ object EventsGenerators {
   implicit val committedDates: Gen[CommittedDate] = timestampsNotInTheFuture map CommittedDate.apply
   implicit val batchDates:     Gen[BatchDate]     = timestampsNotInTheFuture map BatchDate.apply
 
-  implicit val users: Gen[User] = for {
-    username <- usernames
-    email    <- emails
-  } yield User(username, email)
+  implicit val authors: Gen[Author] = Gen.oneOf(
+    usernames map Author.withUsername,
+    emails map Author.withEmail,
+    for {
+      username <- usernames
+      email    <- emails
+    } yield Author(username, email)
+  )
+
+  implicit val committers: Gen[Committer] = Gen.oneOf(
+    usernames map Committer.withUsername,
+    emails map Committer.withEmail,
+    for {
+      username <- usernames
+      email    <- emails
+    } yield Committer(username, email)
+  )
 
   implicit val projects: Gen[Project] = for {
     projectId <- projectIds
@@ -62,8 +75,8 @@ object EventsGenerators {
     project       <- projects
     message       <- commitMessages
     committedDate <- committedDates
-    author        <- users
-    committer     <- users
+    author        <- authors
+    committer     <- committers
     parentsIds    <- parentsIdsLists()
     batchDate     <- batchDates
   } yield CommitEvent(commitId, project, message, committedDate, author, committer, parentsIds, batchDate)

--- a/graph-commons/src/test/scala/ch/datascience/graph/model/eventsSpec.scala
+++ b/graph-commons/src/test/scala/ch/datascience/graph/model/eventsSpec.scala
@@ -20,11 +20,14 @@ package ch.datascience.graph.model
 
 import java.time.{Clock, Instant, ZoneId}
 
+import ch.datascience.generators.CommonGraphGenerators._
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.graph.model.EventsGenerators._
 import ch.datascience.graph.model.events._
+import ch.datascience.graph.model.users.Email
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class CommitEventSpec extends WordSpec {
 
@@ -63,6 +66,30 @@ class BatchDateSpec extends WordSpec {
       BatchDate(clock).value shouldBe fixedNow
 
       Clock.system(systemZone)
+    }
+  }
+}
+
+class AuthorSpec extends WordSpec with ScalaCheckPropertyChecks {
+
+  "withEmail" should {
+
+    "instantiate a new Author with username extracted from the email" in {
+      forAll { email: Email =>
+        Author.withEmail(email) shouldBe Author(email.extractUsername, email)
+      }
+    }
+  }
+}
+
+class CommitterSpec extends WordSpec with ScalaCheckPropertyChecks {
+
+  "withEmail" should {
+
+    "instantiate a new Committer with username extracted from the email" in {
+      forAll { email: Email =>
+        Committer.withEmail(email) shouldBe Committer(email.extractUsername, email)
+      }
     }
   }
 }

--- a/graph-commons/src/test/scala/ch/datascience/graph/model/usersSpec.scala
+++ b/graph-commons/src/test/scala/ch/datascience/graph/model/usersSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.graph.model
+
+import ch.datascience.generators.CommonGraphGenerators.emails
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators._
+import ch.datascience.graph.model.users.Email
+import ch.datascience.tinytypes.constraints.NonBlank
+import eu.timepit.refined.auto._
+import org.scalacheck.Gen
+import org.scalacheck.Gen._
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class EmailSpec extends WordSpec with ScalaCheckPropertyChecks {
+
+  "Email" should {
+
+    "be a NonBlank" in {
+      Email shouldBe a[NonBlank]
+    }
+  }
+
+  "instantiation" should {
+
+    "be successful for valid emails" in {
+      forAll(emailStrings) { email =>
+        Email(email).value shouldBe email
+      }
+    }
+
+    "fail blank emails" in {
+      val Left(exception) = Email.from(blankStrings().generateOne)
+      exception shouldBe an[IllegalArgumentException]
+    }
+
+    Set(
+      nonBlankStrings().generateOne.value,
+      s"${blankStrings().generateOne}@${nonBlankStrings().generateOne}",
+      s"${nonBlankStrings().generateOne}@${blankStrings().generateOne}",
+      s"${nonBlankStrings().generateOne}@${nonBlankStrings().generateOne}@${nonBlankStrings().generateOne}"
+    ) foreach { invalidEmail =>
+      s"fail '$invalidEmail'" in {
+
+        val Left(exception) = Email.from(invalidEmail)
+
+        exception            shouldBe an[IllegalArgumentException]
+        exception.getMessage shouldBe s"'$invalidEmail' is not a valid email"
+      }
+    }
+  }
+
+  "extract username" should {
+
+    "return the username part from the email" in {
+      forAll { email: Email =>
+        email.extractUsername.value shouldBe email.value.substring(0, email.value.indexOf("@"))
+      }
+    }
+  }
+
+  private implicit val emailStrings: Gen[String] = {
+    val firstCharGen    = frequency(6 -> alphaChar, 2 -> numChar, 1 -> Gen.oneOf("!#$%&*+-/=?_~".toList))
+    val nonFirstCharGen = frequency(6 -> alphaChar, 2 -> numChar, 1 -> Gen.oneOf("!#$%&*+-/=?_~.".toList))
+    val beforeAts = for {
+      firstChar  <- firstCharGen
+      otherChars <- nonEmptyList(nonFirstCharGen, minElements = 5, maxElements = 10)
+    } yield s"$firstChar${otherChars.toList.mkString("")}"
+
+    for {
+      beforeAt <- beforeAts
+      afterAt  <- nonEmptyStrings()
+    } yield s"$beforeAt@$afterAt"
+  }
+}

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/commits/CommitInfo.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/commits/CommitInfo.scala
@@ -32,6 +32,7 @@ case class CommitInfo(
 
 object CommitInfo {
 
+  import cats.implicits._
   import ch.datascience.tinytypes.json.TinyTypeDecoders._
   import io.circe._
 
@@ -41,7 +42,7 @@ object CommitInfo {
       lazy val toMaybeUsername: Decoder.Result[Option[Username]] =
         cursor.as[Option[String]].map(blankToNone).flatMap(toOption[Username])
       lazy val toMaybeEmail: Decoder.Result[Option[Email]] =
-        cursor.as[Option[String]].map(blankToNone).flatMap(toOption[Email])
+        cursor.as[Option[String]].map(blankToNone).flatMap(toOption[Email]).leftFlatMap(_ => Right(None))
     }
 
     for {

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/CommitInfoSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/CommitInfoSpec.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice.commits
+
+import ch.datascience.generators.CommonGraphGenerators._
+import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators._
+import ch.datascience.graph.model.events.{Author, Committer}
+import ch.datascience.webhookservice.generators.WebhookServiceGenerators.commitInfos
+import io.circe.literal._
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class CommitInfoSpec extends WordSpec with ScalaCheckPropertyChecks {
+
+  "CommitInfo Decoder" should {
+
+    "decode valid JSON to a CommitInfo object" in {
+      forAll { commitInfo: CommitInfo =>
+        json"""{
+          "id":              ${commitInfo.id.value},
+          "author_name":     ${commitInfo.author.username.value},
+          "author_email":    ${commitInfo.author.emailToJson},
+          "committer_name":  ${commitInfo.committer.username.value},
+          "committer_email": ${commitInfo.committer.emailToJson},
+          "message":         ${commitInfo.message.value},
+          "committed_date":  ${commitInfo.committedDate.value},
+          "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+        }""".as[CommitInfo] shouldBe Right(commitInfo)
+      }
+    }
+
+    "decode valid JSON with blank emails to a CommitInfo object" in {
+      val commitInfo        = commitInfos.generateOne
+      val authorUsername    = usernames.generateOne
+      val committerUsername = usernames.generateOne
+      json"""{
+        "id":              ${commitInfo.id.value},
+        "author_name":     ${authorUsername.value},
+        "author_email":    ${blankStrings().generateOne},
+        "committer_name":  ${committerUsername.value},
+        "committer_email": ${blankStrings().generateOne},
+        "message":         ${commitInfo.message.value},
+        "committed_date":  ${commitInfo.committedDate.value},
+        "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+      }""".as[CommitInfo] shouldBe Right(
+        commitInfo.copy(
+          author    = Author.withUsername(authorUsername),
+          committer = Committer.withUsername(committerUsername)
+        )
+      )
+    }
+
+    "decode valid JSON with blank usernames to a CommitInfo object" in {
+      val commitInfo     = commitInfos.generateOne
+      val authorEmail    = emails.generateOne
+      val committerEmail = emails.generateOne
+      json"""{
+        "id":              ${commitInfo.id.value},
+        "author_name":     ${blankStrings().generateOne},
+        "author_email":    ${authorEmail.value},
+        "committer_name":  ${blankStrings().generateOne},
+        "committer_email": ${committerEmail.value},
+        "message":         ${commitInfo.message.value},
+        "committed_date":  ${commitInfo.committedDate.value},
+        "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+      }""".as[CommitInfo] shouldBe Right(
+        commitInfo.copy(
+          author    = Author.withEmail(authorEmail),
+          committer = Committer.withEmail(committerEmail)
+        )
+      )
+    }
+
+    "fail if there are blanks for author username and email" in {
+      val commitInfo = commitInfos.generateOne
+
+      val Left(exception) = json"""{
+        "id":              ${commitInfo.id.value},
+        "author_name":     ${blankStrings().generateOne},
+        "author_email":    ${blankStrings().generateOne},
+        "committer_name":  ${usernames.generateOne.value},
+        "committer_email": ${emails.generateOne.value},
+        "message":         ${commitInfo.message.value},
+        "committed_date":  ${commitInfo.committedDate.value},
+        "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+      }""".as[CommitInfo]
+
+      exception.getMessage() shouldBe "Neither author name nor email"
+    }
+
+    "fail if there are blanks for committer username and email" in {
+      val commitInfo = commitInfos.generateOne
+
+      val Left(exception) = json"""{
+        "id":              ${commitInfo.id.value},
+        "author_name":     ${usernames.generateOne.value},
+        "author_email":    ${emails.generateOne.value},
+        "committer_name":  ${blankStrings().generateOne},
+        "committer_email": ${blankStrings().generateOne},
+        "message":         ${commitInfo.message.value},
+        "committed_date":  ${commitInfo.committedDate.value},
+        "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+      }""".as[CommitInfo]
+
+      exception.getMessage() shouldBe "Neither committer name nor email"
+    }
+  }
+}

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/CommitInfoSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/CommitInfoSpec.scala
@@ -89,6 +89,27 @@ class CommitInfoSpec extends WordSpec with ScalaCheckPropertyChecks {
       )
     }
 
+    "decode invalid emails to Nones" in {
+      val commitInfo        = commitInfos.generateOne
+      val authorUsername    = usernames.generateOne
+      val committerUsername = usernames.generateOne
+      json"""{
+        "id":              ${commitInfo.id.value},
+        "author_name":     ${authorUsername.value},
+        "author_email":    "author invalid email",
+        "committer_name":  ${committerUsername.value},
+        "committer_email": "committer invalid email",
+        "message":         ${commitInfo.message.value},
+        "committed_date":  ${commitInfo.committedDate.value},
+        "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+      }""".as[CommitInfo] shouldBe Right(
+        commitInfo.copy(
+          author    = Author.withUsername(authorUsername),
+          committer = Committer.withUsername(committerUsername)
+        )
+      )
+    }
+
     "fail if there are blanks for author username and email" in {
       val commitInfo = commitInfos.generateOne
 

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/IOCommitInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/IOCommitInfoFinderSpec.scala
@@ -150,17 +150,16 @@ class IOCommitInfoFinderSpec extends WordSpec with MockFactory with ExternalServ
     val commitId      = commitIds.generateOne
     val commitMessage = commitMessages.generateOne
     val committedDate = CommittedDate(LocalDateTime.of(2012, 9, 20, 9, 6, 12).atOffset(ZoneOffset.ofHours(3)).toInstant)
-    val author        = users.generateOne
-    val committer     = users.generateOne
+    val author        = authors.generateOne
+    val committer     = committers.generateOne
     val parents       = parentsIdsLists().generateOne
 
-    lazy val responseJson = json"""
-    {
+    lazy val responseJson = json"""{
       "id":              ${commitId.value},
       "author_name":     ${author.username.value},
-      "author_email":    ${author.email.value},
+      "author_email":    ${author.emailToJson},
       "committer_name":  ${committer.username.value},
-      "committer_email": ${committer.email.value},
+      "committer_email": ${committer.emailToJson},
       "message":         ${commitMessage.value},
       "committed_date":  "2012-09-20T09:06:12+03:00",
       "parent_ids":      ${parents.map(_.value).toArray}

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/IOLatestCommitFinderSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/IOLatestCommitFinderSpec.scala
@@ -154,15 +154,14 @@ class IOLatestCommitFinderSpec extends WordSpec with MockFactory with ExternalSe
   private def commitsJson(from: CommitInfo) =
     Json.arr(commitJson(from)).noSpaces
 
-  private def commitJson(commitInfo: CommitInfo) = json"""
-    {
-      "id":              ${commitInfo.id.value},
-      "author_name":     ${commitInfo.author.username.value},
-      "author_email":    ${commitInfo.author.email.value},
-      "committer_name":  ${commitInfo.committer.username.value},
-      "committer_email": ${commitInfo.committer.email.value},
-      "message":         ${commitInfo.message.value},
-      "committed_date":  ${commitInfo.committedDate.value},
-      "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
-    }"""
+  private def commitJson(commitInfo: CommitInfo) = json"""{
+    "id":              ${commitInfo.id.value},
+    "author_name":     ${commitInfo.author.username.value},
+    "author_email":    ${commitInfo.author.emailToJson},
+    "committer_name":  ${commitInfo.committer.username.value},
+    "committer_email": ${commitInfo.committer.emailToJson},
+    "message":         ${commitInfo.message.value},
+    "committed_date":  ${commitInfo.committedDate.value},
+    "parent_ids":      ${commitInfo.parents.map(_.value).toArray}
+  }"""
 }

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/package.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/commits/package.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.webhookservice
+
+import ch.datascience.graph.model.events
+import ch.datascience.graph.model.events.Person
+import io.circe.Json
+import io.circe.syntax._
+
+package object commits {
+
+  implicit class PersonOps(person: Person) {
+
+    lazy val emailToJson: Json = person match {
+      case person: events.Person.WithEmail => person.email.value.asJson
+      case _ => Json.Null
+    }
+  }
+}

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/startcommit/CommitToEventLogSpec.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/eventprocessing/startcommit/CommitToEventLogSpec.scala
@@ -290,8 +290,8 @@ class CommitToEventLogSpec extends WordSpec with MockFactory {
       for {
         message       <- commitMessages
         committedDate <- committedDates
-        author        <- users
-        committer     <- users
+        author        <- authors
+        committer     <- committers
         parentsIds    <- parentsIdsLists()
       } yield CommitEvent(
         id            = commitId,

--- a/webhook-service/src/test/scala/ch/datascience/webhookservice/generators/WebhookServiceGenerators.scala
+++ b/webhook-service/src/test/scala/ch/datascience/webhookservice/generators/WebhookServiceGenerators.scala
@@ -59,8 +59,8 @@ object WebhookServiceGenerators {
     id            <- commitIds
     message       <- commitMessages
     committedDate <- committedDates
-    author        <- users
-    committer     <- users
+    author        <- authors
+    committer     <- committers
     parents       <- listOf(commitIds)
   } yield CommitInfo(id, message, committedDate, author, committer, parents)
 }


### PR DESCRIPTION
closes #244 

Images to test with:
```
'repository': 'jachro/token-repository', 'tag': '557df698'
'repository': 'jachro/webhook-service', 'tag': '653d787c'
'repository': 'jachro/triples-generator', 'tag': '557df698'
'repository': 'jachro/knowledge-graph', 'tag': '557df698'
```