### PR TITLE
fix: triples generation process does not work when no creator in gitlab

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
@@ -72,7 +72,8 @@ class DatasetsResourcesSpec extends FeatureSpec with GivenWhenThen with GraphSer
     }
     val dataset1CommitId = commitIds.generateOne
     val dataset1Creation = addedToProject.generateOne.copy(
-      agent = DatasetAgent(project.created.creator.maybeEmail, project.created.creator.name)
+      agent = DatasetAgent(project.created.maybeCreator.flatMap(_.maybeEmail),
+                           project.created.maybeCreator.map(_.name).getOrElse(userNames.generateOne))
     )
     val dataset1 = datasets.generateOne.copy(
       maybeDescription = Some(datasetDescriptions.generateOne),
@@ -97,10 +98,10 @@ class DatasetsResourcesSpec extends FeatureSpec with GivenWhenThen with GraphSer
           committer     = Person(dataset1Creation.agent.name, dataset1Creation.agent.maybeEmail),
           schemaVersion = currentSchemaVersion
         )(
-          projectPath        = project.path,
-          projectName        = project.name,
-          projectDateCreated = project.created.date,
-          projectCreator     = Person(project.created.creator.name, project.created.creator.maybeEmail)
+          projectPath         = project.path,
+          projectName         = project.name,
+          projectDateCreated  = project.created.date,
+          maybeProjectCreator = project.created.maybeCreator.map(creator => Person(creator.name, creator.maybeEmail))
         )(
           datasetIdentifier         = dataset1.id,
           datasetName               = dataset1.name,
@@ -116,10 +117,10 @@ class DatasetsResourcesSpec extends FeatureSpec with GivenWhenThen with GraphSer
           committer     = Person(dataset2Creation.agent.name, dataset2Creation.agent.maybeEmail),
           schemaVersion = currentSchemaVersion
         )(
-          projectPath        = project.path,
-          projectName        = project.name,
-          projectDateCreated = project.created.date,
-          projectCreator     = Person(project.created.creator.name, project.created.creator.maybeEmail)
+          projectPath         = project.path,
+          projectName         = project.name,
+          projectDateCreated  = project.created.date,
+          maybeProjectCreator = project.created.maybeCreator.map(creator => Person(creator.name, creator.maybeEmail))
         )(
           datasetIdentifier         = dataset2.id,
           datasetName               = dataset2.name,
@@ -136,7 +137,8 @@ class DatasetsResourcesSpec extends FeatureSpec with GivenWhenThen with GraphSer
       `triples updates run`(
         (List(dataset1, dataset2)
           .flatMap(_.published.creators.map(_.maybeEmail))
-          .toSet + dataset1Creation.agent.maybeEmail + dataset2Creation.agent.maybeEmail + project.created.creator.maybeEmail).flatten
+          .toSet + dataset1Creation.agent.maybeEmail + dataset2Creation.agent.maybeEmail + project.created.maybeCreator
+          .flatMap(_.maybeEmail)).flatten
       )
 
       And("the project exists in GitLab")

--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
@@ -41,10 +41,10 @@ object RemoteTriplesGenerator {
         commitId      = commitId,
         schemaVersion = schemaVersion
       )(
-        projectPath        = project.path,
-        projectName        = project.name,
-        projectDateCreated = project.created.date,
-        projectCreator     = Person(project.created.creator.name, project.created.creator.maybeEmail)
+        projectPath         = project.path,
+        projectName         = project.name,
+        projectDateCreated  = project.created.date,
+        maybeProjectCreator = project.created.maybeCreator.map(creator => Person(creator.name, creator.maybeEmail))
       )
     )
 

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/entities/Project.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/entities/Project.scala
@@ -24,7 +24,7 @@ import ch.datascience.graph.model.projects.{DateCreated, Name, Path, ResourceId}
 final case class Project(path:               Path,
                          name:               Name,
                          dateCreated:        DateCreated,
-                         creator:            Person,
+                         maybeCreator:       Option[Person],
                          maybeParentProject: Option[Project] = None,
                          version:            SchemaVersion = SchemaVersion("1"))
 
@@ -41,7 +41,7 @@ object Project {
       schema / "name"          -> entity.name.asJsonLD,
       schema / "dateCreated"   -> entity.dateCreated.asJsonLD,
       schema / "dateUpdated"   -> entity.dateCreated.asJsonLD,
-      schema / "creator"       -> entity.creator.asJsonLD,
+      schema / "creator"       -> entity.maybeCreator.asJsonLD,
       schema / "schemaVersion" -> entity.version.asJsonLD,
       prov / "wasDerivedFrom"  -> entity.maybeParentProject.asJsonLD
     )

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/entities/bundles.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/entities/bundles.scala
@@ -50,7 +50,7 @@ object bundles extends Schemas {
       projectPath:         Path = projectPaths.generateOne,
       projectName:         projects.Name = projectNames.generateOne,
       projectDateCreated:  projects.DateCreated = DateCreated(committedDate.value),
-      projectCreator:      Person = committer,
+      maybeProjectCreator: Option[Person] = projectCreators.generateOption,
       maybeParent:         Option[Project] = None
   )(implicit renkuBaseUrl: RenkuBaseUrl, fusekiBaseUrl: FusekiBaseUrl): JsonLD =
     ArtifactEntity(
@@ -60,7 +60,7 @@ object bundles extends Schemas {
           commitId,
           committedDate,
           committer,
-          Project(projectPath, projectName, projectDateCreated, projectCreator, maybeParent),
+          Project(projectPath, projectName, projectDateCreated, maybeProjectCreator, maybeParent),
           Agent(schemaVersion)
         )
       )
@@ -75,11 +75,11 @@ object bundles extends Schemas {
       committer:     Person        = Person(userNames.generateOne, userEmails.generateOne),
       schemaVersion: SchemaVersion = schemaVersions.generateOne
   )(
-      projectPath:        Path                 = projectPaths.generateOne,
-      projectName:        projects.Name        = projectNames.generateOne,
-      projectDateCreated: projects.DateCreated = DateCreated(committedDate.value),
-      projectCreator:     Person               = committer,
-      maybeParent:        Option[Project]      = None
+      projectPath:         Path                 = projectPaths.generateOne,
+      projectName:         projects.Name        = projectNames.generateOne,
+      projectDateCreated:  projects.DateCreated = DateCreated(committedDate.value),
+      maybeProjectCreator: Option[Person]       = projectCreators.generateOption,
+      maybeParent:         Option[Project]      = None
   )(
       datasetIdentifier:         Identifier = datasetIdentifiers.generateOne,
       datasetName:               Name = datasetNames.generateOne,
@@ -91,7 +91,7 @@ object bundles extends Schemas {
       datasetCreators:           Set[Person] = setOf(persons).generateOne,
       datasetParts:              List[(PartName, PartLocation)] = listOf(dataSetParts).generateOne
   )(implicit renkuBaseUrl:       RenkuBaseUrl, fusekiBaseUrl: FusekiBaseUrl): JsonLD = {
-    val project: Project = Project(projectPath, projectName, projectDateCreated, projectCreator, maybeParent)
+    val project: Project = Project(projectPath, projectName, projectDateCreated, maybeProjectCreator, maybeParent)
     DataSet(
       datasetIdentifier,
       datasetName,
@@ -191,11 +191,10 @@ object bundles extends Schemas {
         projectPath:         Path = projectPaths.generateOne,
         schemaVersion:       SchemaVersion = schemaVersions.generateOne
     )(implicit renkuBaseUrl: RenkuBaseUrl, fusekiBaseUrl: FusekiBaseUrl): (List[JsonLD], ExamplarData) = {
-
-      val projectCreator = Person(userNames.generateOne, userEmails.generateOne)
-      val project        = Project(projectPath, projectNames.generateOne, projectCreatedDates.generateOne, projectCreator)
-      val agent          = Agent(schemaVersion)
-      val dataSetId      = datasets.Identifier("d67a1653-0b6e-463b-89a0-afe72a53c8bb")
+      val project =
+        Project(projectPath, projectNames.generateOne, projectCreatedDates.generateOne, projectCreators.generateOption)
+      val agent     = Agent(schemaVersion)
+      val dataSetId = datasets.Identifier("d67a1653-0b6e-463b-89a0-afe72a53c8bb")
 
       val commit3Id  = CommitId("000003")
       val commit7Id  = CommitId("000007")
@@ -476,4 +475,9 @@ object bundles extends Schemas {
       ) -> examplarData
     }
   }
+
+  private val projectCreators: Gen[Person] = for {
+    name  <- userNames
+    email <- userEmails
+  } yield Person(name, email)
 }

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.56.0-9d59122
+version: 0.55.1-9d59122

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -291,7 +291,7 @@ Response body example:
   "visibility":  "public|private|internal",
   "created": {
     "dateCreated": "2001-09-05T10:48:29.457Z",
-    "creator": {
+    "creator": { // optional
       "name":  "author name",
       "email": "author@mail.org" // optional
     }
@@ -310,7 +310,7 @@ Response body example:
       "name":       "Parent project name",
       "created": {
         "dateCreated": "2001-09-04T10:48:29.457Z",
-        "creator": {
+        "creator": { // optional
           "name":  "parent author name", 
           "email": "parent.author@mail.org" // optional
         }

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/model.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/model.scala
@@ -63,7 +63,7 @@ object model {
     implicit object DateUpdated extends TinyTypeFactory[DateUpdated](new DateUpdated(_)) with InstantNotInTheFuture
   }
 
-  final case class Creation(date: DateCreated, creator: Creator)
+  final case class Creation(date: DateCreated, maybeCreator: Option[Creator])
 
   final case class Creator(maybeEmail: Option[users.Email], name: users.Name)
 

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/ProjectEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/ProjectEndpoint.scala
@@ -86,10 +86,7 @@ class ProjectEndpoint[Interpretation[_]: Effect](
       "path":       ${project.path.value},
       "name":       ${project.name.value},
       "visibility": ${project.visibility.value},
-      "created": {
-        "dateCreated": ${project.created.date.value},
-        "creator":     ${project.created.creator}
-      },
+      "created":    ${project.created},
       "updatedAt":  ${project.updatedAt.value},
       "urls":       ${project.urls},
       "forking":    ${project.forking},
@@ -126,13 +123,16 @@ class ProjectEndpoint[Interpretation[_]: Effect](
 
   private implicit lazy val parentProjectEncoder: Encoder[ParentProject] = Encoder.instance[ParentProject] { parent =>
     json"""{
-      "path":       ${parent.path.value},
-      "name":       ${parent.name.value},
-      "created": {
-        "dateCreated": ${parent.created.date.value},
-        "creator":     ${parent.created.creator}
-      }
-    }"""
+      "path":    ${parent.path.value},
+      "name":    ${parent.name.value},
+      "created": ${parent.created}
+    }""" deepMerge (parent.created.maybeCreator.map(creator => json"""{"creator": $creator}""") getOrElse Json.obj())
+  }
+
+  private implicit lazy val creationEncoder: Encoder[Creation] = Encoder.instance[Creation] { created =>
+    json"""{
+      "dateCreated": ${created.date.value}
+    }""" deepMerge (created.maybeCreator.map(creator => json"""{"creator": $creator}""") getOrElse Json.obj())
   }
 
   private implicit lazy val permissionsEncoder: Encoder[Permissions] = Encoder.instance[Permissions] {

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/ProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/ProjectFinder.scala
@@ -67,8 +67,8 @@ class IOProjectFinder(
       maybeDescription = gitLabProject.maybeDescription,
       visibility       = gitLabProject.visibility,
       created = Creation(
-        date    = kgProject.created.date,
-        creator = Creator(kgProject.created.creator.maybeEmail, kgProject.created.creator.name)
+        date         = kgProject.created.date,
+        maybeCreator = kgProject.created.maybeCreator.map(creator => Creator(creator.maybeEmail, creator.name))
       ),
       updatedAt   = gitLabProject.updatedAt,
       urls        = gitLabProject.urls,
@@ -86,7 +86,8 @@ class IOProjectFinder(
           ParentProject(
             path,
             parent.name,
-            Creation(parent.created.date, Creator(parent.created.creator.maybeEmail, parent.created.creator.name))
+            Creation(parent.created.date,
+                     parent.created.maybeCreator.map(creator => Creator(creator.maybeEmail, creator.name)))
           )
       }
   }

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/projects/ProjectsGenerators.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/projects/ProjectsGenerators.scala
@@ -50,8 +50,8 @@ object ProjectsGenerators {
     maybeDescription = gitLabProject.maybeDescription,
     visibility       = gitLabProject.visibility,
     created = Creation(
-      date    = kgProject.created.date,
-      creator = Creator(maybeEmail = kgProject.created.creator.maybeEmail, name = kgProject.created.creator.name)
+      date         = kgProject.created.date,
+      maybeCreator = kgProject.created.maybeCreator.map(creator => Creator(creator.maybeEmail, creator.name))
     ),
     updatedAt = gitLabProject.updatedAt,
     urls      = gitLabProject.urls,
@@ -61,7 +61,8 @@ object ProjectsGenerators {
         ParentProject(
           parent.resourceId.toUnsafe[Path],
           parent.name,
-          Creation(parent.created.date, Creator(parent.created.creator.maybeEmail, parent.created.creator.name))
+          Creation(parent.created.date,
+                   parent.created.maybeCreator.map(creator => Creator(creator.maybeEmail, creator.name)))
         )
       }
     ),
@@ -148,9 +149,9 @@ object ProjectsGenerators {
   private implicit lazy val webUrls: Gen[WebUrl] = urls() map WebUrl.apply
 
   implicit lazy val projectCreations: Gen[ProjectCreation] = for {
-    created <- projectCreatedDates
-    creator <- projectCreators
-  } yield ProjectCreation(created, creator)
+    created      <- projectCreatedDates
+    maybeCreator <- projectCreators.toGeneratorOfOptions
+  } yield ProjectCreation(created, maybeCreator)
 
   implicit lazy val projectCreators: Gen[ProjectCreator] = for {
     maybeEmail <- userEmails.toGeneratorOfOptions

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/projects/rest/ProjectEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/projects/rest/ProjectEndpointSpec.scala
@@ -176,7 +176,7 @@ class ProjectEndpointSpec extends WordSpec with MockFactory with ScalaCheckPrope
   private implicit lazy val createdDecoder: Decoder[Creation] = cursor =>
     for {
       date    <- cursor.downField("dateCreated").as[DateCreated]
-      creator <- cursor.downField("creator").as[Creator]
+      creator <- cursor.downField("creator").as[Option[Creator]]
     } yield Creation(date, creator)
 
   private implicit lazy val creatorDecoder: Decoder[Creator] = cursor =>

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/projects/rest/ProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/projects/rest/ProjectFinderSpec.scala
@@ -215,18 +215,20 @@ class ProjectFinderSpec extends WordSpec with MockFactory {
       maybeDescription = gitLabProject.maybeDescription,
       visibility       = gitLabProject.visibility,
       created = Creation(
-        date    = kgProject.created.date,
-        creator = Creator(kgProject.created.creator.maybeEmail, kgProject.created.creator.name)
+        date         = kgProject.created.date,
+        maybeCreator = kgProject.created.maybeCreator.map(creator => Creator(creator.maybeEmail, creator.name))
       ),
       updatedAt = gitLabProject.updatedAt,
       urls      = gitLabProject.urls,
       forking = Forking(
         gitLabProject.forksCount,
         kgProject.maybeParent.map { parent =>
-          ParentProject(parent.resourceId.toUnsafe[Path],
-                        parent.name,
-                        Creation(parent.created.date,
-                                 Creator(parent.created.creator.maybeEmail, parent.created.creator.name)))
+          ParentProject(
+            parent.resourceId.toUnsafe[Path],
+            parent.name,
+            Creation(parent.created.date,
+                     parent.created.maybeCreator.map(creator => Creator(creator.maybeEmail, creator.name)))
+          )
         }
       ),
       tags        = gitLabProject.tags,

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/ForkInfoUpdater.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/ForkInfoUpdater.scala
@@ -198,6 +198,8 @@ private[triplescuration] class IOForkInfoUpdater(
 
   private implicit class KGProjectOps(kgProject: KGProject) {
     lazy val maybeParentPath: Option[Path] = kgProject.maybeParentResourceId.flatMap(_.getPath)
+    lazy val maybeEmail = kgProject.maybeCreator.flatMap(_.maybeEmail)
+    lazy val maybeName  = kgProject.maybeCreator.map(_.name)
   }
 
   private implicit class GitLabProjectOps(gitLabProject: GitLabProject) {
@@ -211,15 +213,15 @@ private[triplescuration] class IOForkInfoUpdater(
         .getOrElse(false)
 
     def hasEmailSameAs(kgProject: KGProject): Boolean =
-      (kgProject.creator.maybeEmail -> gitLabProject.maybeCreator.flatMap(_.maybeEmail))
+      (kgProject.maybeEmail -> gitLabProject.maybeEmail)
         .mapN { case (kgEmail, gitLabEmail) => kgEmail == gitLabEmail }
         .getOrElse(false)
 
     def hasNoEmailAs(kgProject: KGProject): Boolean =
-      gitLabProject.maybeEmail.isEmpty && kgProject.creator.maybeEmail.isEmpty
+      gitLabProject.maybeEmail.isEmpty && kgProject.maybeEmail.isEmpty
 
     def hasUserNameSameAs(kgProject: KGProject): Boolean =
-      (kgProject.creator.maybeName -> gitLabProject.maybeCreator.flatMap(_.maybeName))
+      (kgProject.maybeName -> gitLabProject.maybeName)
         .mapN { case (kgName, gitLabName) => kgName == gitLabName }
         .getOrElse(false)
 

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/model.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/model.scala
@@ -31,7 +31,7 @@ final case class GitLabCreator(maybeEmail: Option[Email], maybeName: Option[user
 
 final case class KGProject(resourceId:            ResourceId,
                            maybeParentResourceId: Option[ResourceId],
-                           creator:               KGCreator,
+                           maybeCreator:          Option[KGCreator],
                            dateCreated:           DateCreated)
 
-final case class KGCreator(resourceId: users.ResourceId, maybeEmail: Option[Email], maybeName: Option[users.Name])
+final case class KGCreator(resourceId: users.ResourceId, maybeEmail: Option[Email], name: users.Name)

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/ForkInfoUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/ForkInfoUpdaterSpec.scala
@@ -179,8 +179,8 @@ class ForkInfoUpdaterSpec extends WordSpec with MockFactory {
 
       val kgProject = given {
         kgProjects(projectResourceIds.toGeneratorOfSomes).generateOne.copy(
-          creator     = kgCreator(commonEmail).generateOne,
-          dateCreated = dateCreatedInGitLab
+          maybeCreator = kgCreator(commonEmail).generateSome,
+          dateCreated  = dateCreatedInGitLab
         )
       }.existsInKG
 
@@ -204,20 +204,20 @@ class ForkInfoUpdaterSpec extends WordSpec with MockFactory {
       "but user names and dateCreated are the same in the absence of emails" in new TestCase {
 
       val forkInGitLab        = projectPaths.generateOne
-      val commonUserName      = userNames.generateSome
+      val commonUserName      = userNames.generateOne
       val dateCreatedInGitLab = projectCreatedDates.generateOne
 
       val gitLabProject = given {
         gitLabProjects(forkInGitLab).generateOne.copy(
-          maybeCreator = gitLabCreator(maybeEmail = None, maybeName = commonUserName).generateSome,
+          maybeCreator = gitLabCreator(maybeEmail = None, maybeName = commonUserName.some).generateSome,
           dateCreated  = dateCreatedInGitLab
         )
       }.existsInGitLab
 
       val kgProject = given {
         kgProjects(projectResourceIds.toGeneratorOfSomes).generateOne.copy(
-          creator     = kgCreator(maybeEmail = None, maybeName = commonUserName).generateOne,
-          dateCreated = dateCreatedInGitLab
+          maybeCreator = kgCreator(maybeEmail = None, name = commonUserName).generateSome,
+          dateCreated  = dateCreatedInGitLab
         )
       }.existsInKG
 
@@ -250,7 +250,7 @@ class ForkInfoUpdaterSpec extends WordSpec with MockFactory {
 
       val kgProject = given {
         kgProjects(projectResourceIds.toGeneratorOfSomes).generateOne.copy(
-          creator = kgCreator(userEmails.generateSome).generateOne
+          maybeCreator = kgCreator(userEmails.generateSome).generateSome
         )
       }.existsInKG
 
@@ -300,7 +300,7 @@ class ForkInfoUpdaterSpec extends WordSpec with MockFactory {
 
       val kgProject = given {
         kgProjects(projectResourceIds.toGeneratorOfSomes).generateOne.copy(
-          creator = kgCreator(userEmails.generateSome).generateOne
+          maybeCreator = kgCreator(userEmails.generateSome).generateSome
         )
       }.existsInKG
 
@@ -432,7 +432,7 @@ class ForkInfoUpdaterSpec extends WordSpec with MockFactory {
 
       given {
         kgProjects(projectResourceIds.toGeneratorOfSomes).generateOne.copy(
-          creator = kgCreator(userEmails.generateSome).generateOne
+          maybeCreator = kgCreator(userEmails.generateSome).generateSome
         )
       }.existsInKG
 

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/ProjectPropertiesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/ProjectPropertiesRemoverSpec.scala
@@ -49,11 +49,11 @@ class ProjectPropertiesRemoverSpec extends WordSpec with ScalaCheckPropertyCheck
           JsonLD
             .arr(
               fileCommit()(
-                projectPath        = project.path,
-                projectName        = project.name,
-                projectDateCreated = project.dateCreated,
-                projectCreator     = project.creator,
-                maybeParent        = project.maybeParentProject
+                projectPath         = project.path,
+                projectName         = project.name,
+                projectDateCreated  = project.dateCreated,
+                maybeProjectCreator = project.maybeCreator,
+                maybeParent         = project.maybeParentProject
               ),
               project.asJsonLD
             )
@@ -65,13 +65,13 @@ class ProjectPropertiesRemoverSpec extends WordSpec with ScalaCheckPropertyCheck
           TransformedProject(
             project,
             project.dateCreated.some,
-            project.creator.asJsonLD.entityId
+            project.maybeCreator.asJsonLD.entityId
           ).some,
           project.maybeParentProject.map { parent =>
             TransformedProject(
               parent,
               parent.dateCreated.some,
-              parent.creator.asJsonLD.entityId
+              parent.maybeCreator.asJsonLD.entityId
             )
           }
         ).flatten

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/forks/UpdatesCreatorSpec.scala
@@ -114,11 +114,11 @@ class UpdatesCreatorSpec extends WordSpec with InMemoryRdfStore {
 
   "swapCreator" should {
 
-    "change change Project's link to a Person to the given one" in new TestCase {
+    "change Project's link to a Person to the given one" in new TestCase {
       val creator1 = entitiesPersons(userEmails.generateSome).generateOne
       val creator2 = entitiesPersons(userEmails.generateSome).generateOne
-      val project1 = entitiesProjects(creator1).generateOne
-      val project2 = entitiesProjects(creator2).generateOne
+      val project1 = entitiesProjects(creator1.some).generateOne
+      val project2 = entitiesProjects(creator2.some).generateOne
 
       loadToStore(project1.asJsonLD, project2.asJsonLD)
 
@@ -141,8 +141,8 @@ class UpdatesCreatorSpec extends WordSpec with InMemoryRdfStore {
     "create a new Person and link it to the given Project" in new TestCase {
       val creator1 = entitiesPersons().generateOne
       val creator2 = entitiesPersons().generateOne
-      val project1 = entitiesProjects(creator1).generateOne
-      val project2 = entitiesProjects(creator2).generateOne
+      val project1 = entitiesProjects(creator1.some).generateOne
+      val project2 = entitiesProjects(creator2.some).generateOne
 
       loadToStore(project1.asJsonLD, project2.asJsonLD)
 

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/persondetails/PersonDetailsUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/persondetails/PersonDetailsUpdaterSpec.scala
@@ -63,8 +63,8 @@ class PersonDetailsUpdaterSpec extends WordSpec {
         dataSetCommit(
           committer = entities.Person(committerName, committerEmail)
         )(
-          projectPath    = projectPaths.generateOne,
-          projectCreator = entities.Person(projectCreatorName, projectCreatorEmail)
+          projectPath         = projectPaths.generateOne,
+          maybeProjectCreator = entities.Person(projectCreatorName, projectCreatorEmail).some
         )(
           datasetCreators = datasetCreatorsSet
         ).toJson

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOTriplesVersionFinderSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/IOTriplesVersionFinderSpec.scala
@@ -28,10 +28,10 @@ import ch.datascience.graph.model.events.CommitId
 import ch.datascience.interpreters.TestLogger
 import ch.datascience.interpreters.TestLogger.Level.Warn
 import ch.datascience.logging.TestExecutionTimeRecorder
-import ch.datascience.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
 import ch.datascience.rdfstore.entities.Person.persons
 import ch.datascience.rdfstore.entities.bundles._
-import ch.datascience.rdfstore.entities.{Activity, Agent, Person, Project}
+import ch.datascience.rdfstore.entities.{Activity, Agent, Project}
+import ch.datascience.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
 import io.renku.jsonld.syntax._
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
@@ -86,14 +86,12 @@ class IOTriplesVersionFinderSpec extends WordSpec with InMemoryRdfStore {
     val triplesVersionFinder       = new IOTriplesVersionFinder(rdfStoreConfig, schemaVersion, logger, sparqlTimeRecorder)
   }
 
-  private def commitActivity(schemaVersion: SchemaVersion, commitId: CommitId = commitIds.generateOne) = {
-    val committer: Person = persons.generateOne
+  private def commitActivity(schemaVersion: SchemaVersion, commitId: CommitId = commitIds.generateOne) =
     Activity(
       commitIds.generateOne,
       committedDates.generateOne,
-      committer,
-      Project(projectPaths.generateOne, projectNames.generateOne, projectCreatedDates.generateOne, committer),
+      persons.generateOne,
+      Project(projectPaths.generateOne, projectNames.generateOne, projectCreatedDates.generateOne, maybeCreator = None),
       Agent(schemaVersion)
     ).asJsonLD
-  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.56.0-SNAPSHOT"
+version in ThisBuild := "0.55.1-SNAPSHOT"


### PR DESCRIPTION
There are cases when GitLab does not return `creator_id` when calling the projects API. This PR makes the project creator info optional in KG.

**Testing scenario:**
* The easiest way to verify the fix works is to look at the outcome of the re-provisioning process on the DEV. Effectively, before the fix, 10.5K of 16K events failed during the process.