### PR TITLE
triples-generator hangs on events with PROCESSING status

### DIFF
--- a/graph-commons/src/test/scala/ch/datascience/graph/model/EventsGenerators.scala
+++ b/graph-commons/src/test/scala/ch/datascience/graph/model/EventsGenerators.scala
@@ -18,7 +18,6 @@
 
 package ch.datascience.graph.model
 
-import ch.datascience.generators.CommonGraphGenerators._
 import ch.datascience.generators.Generators._
 import ch.datascience.graph.model.GraphModelGenerators._
 import ch.datascience.graph.model.events._

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 0.56.0-1291691
+version: 0.55.2-1291691

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -38,7 +38,7 @@ triplesGenerator:
   reProvisioningInitialDelay: 1 second
   gitlab:
     rateLimit: 30/sec
-  generationProcessInitialDelay: 20 seconds
+  generationProcessInitialDelay: 2 minutes
   ## a demanded number of concurrent triples generation processes
   generationProcessesNumber: 3
   threadsNumber: 6

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/ProjectEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/projects/rest/ProjectEndpoint.scala
@@ -126,7 +126,7 @@ class ProjectEndpoint[Interpretation[_]: Effect](
       "path":    ${parent.path.value},
       "name":    ${parent.name.value},
       "created": ${parent.created}
-    }""" deepMerge (parent.created.maybeCreator.map(creator => json"""{"creator": $creator}""") getOrElse Json.obj())
+    }"""
   }
 
   private implicit lazy val creationEncoder: Encoder[Creation] = Encoder.instance[Creation] { created =>

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisioningSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/ReProvisioningSpec.scala
@@ -181,7 +181,7 @@ class ReProvisioningSpec extends WordSpec with MockFactory {
 
       val endTime = System.currentTimeMillis()
 
-      (endTime - startTime) should be > someInitialDelay.value.toMillis
+      (endTime - startTime) should be >= someInitialDelay.value.toMillis
     }
   }
 

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/interpreters.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/reprovisioning/interpreters.scala
@@ -21,7 +21,7 @@ package ch.datascience.triplesgenerator.reprovisioning
 import cats.effect._
 import ch.datascience.db.DbTransactor
 import ch.datascience.dbeventlog.EventLogDB
-import ch.datascience.dbeventlog.commands.{EventLogFetch, EventLogReScheduler}
+import ch.datascience.dbeventlog.commands.EventLogReScheduler
 import ch.datascience.logging.ExecutionTimeRecorder
 import io.chrisdavenport.log4cats.Logger
 
@@ -31,7 +31,6 @@ import scala.util.Try
 class IOReProvisioning(triplesFinder:         TriplesVersionFinder[IO],
                        triplesRemover:        TriplesRemover[IO],
                        eventLogReScheduler:   EventLogReScheduler[IO],
-                       eventLogFetch:         EventLogFetch[IO],
                        reProvisioningDelay:   ReProvisioningDelay,
                        executionTimeRecorder: ExecutionTimeRecorder[IO],
                        logger:                Logger[IO],
@@ -39,7 +38,6 @@ class IOReProvisioning(triplesFinder:         TriplesVersionFinder[IO],
     extends ReProvisioning[IO](triplesFinder,
                                triplesRemover,
                                eventLogReScheduler,
-                               eventLogFetch,
                                reProvisioningDelay,
                                executionTimeRecorder,
                                logger,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.56.0-SNAPSHOT"
+version in ThisBuild := "0.55.2-SNAPSHOT"


### PR DESCRIPTION
**Testing scenario:**
Simply watch the outcome of the re-provisioning on the DEV.

**Image for testing:**
```{'repository': 'jachro/triples-generator', 'tag': 'f160523a'}```

closes #290 