### PR TITLE
Event log service

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/tooling/GraphServices.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/tooling/GraphServices.scala
@@ -39,10 +39,12 @@ trait GraphServices extends BeforeAndAfterAll {
   protected val tokenRepositoryClient:  ServiceClient        = GraphServices.tokenRepositoryClient
   protected val triplesGeneratorClient: ServiceClient        = GraphServices.triplesGeneratorClient
   protected val knowledgeGraphClient:   KnowledgeGraphClient = GraphServices.knowledgeGraphClient
+  protected val eventLogClient:         ServiceClient        = GraphServices.eventLogClient
   protected val webhookService:         ServiceRun           = GraphServices.webhookService
   protected val tokenRepository:        ServiceRun           = GraphServices.tokenRepository
   protected val triplesGenerator:       ServiceRun           = GraphServices.triplesGenerator
   protected val knowledgeGraph:         ServiceRun           = GraphServices.knowledgeGraph
+  protected val eventLog:               ServiceRun           = GraphServices.eventLog
 
   protected override def beforeAll(): Unit = {
     super.beforeAll()
@@ -52,7 +54,8 @@ trait GraphServices extends BeforeAndAfterAll {
         webhookService,
         tokenRepository,
         triplesGenerator,
-        knowledgeGraph
+        knowledgeGraph,
+        eventLog
       )
       .unsafeRunSync()
   }
@@ -71,10 +74,12 @@ object GraphServices {
   val triplesGeneratorClient = TriplesGeneratorClient()
   val tokenRepositoryClient  = TokenRepositoryClient()
   val knowledgeGraphClient   = KnowledgeGraphClient()
+  val eventLogClient         = EventLogClient()
 
   val webhookService  = ServiceRun("webhook-service", webhookservice.Microservice, webhookServiceClient)
   val tokenRepository = ServiceRun("token-repository", tokenrepository.Microservice, tokenRepositoryClient)
   val knowledgeGraph  = ServiceRun("knowledge-graph", knowledgegraph.Microservice, knowledgeGraphClient)
+  val eventLog        = ServiceRun("event-log", dbeventlog.Microservice, eventLogClient)
   val triplesGenerator = ServiceRun(
     "triples-generator",
     service          = triplesgenerator.Microservice,

--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/tooling/ServicesClients.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/tooling/ServicesClients.scala
@@ -128,6 +128,15 @@ object KnowledgeGraphClient {
   }
 }
 
+object EventLogClient {
+  def apply()(implicit executionContext: ExecutionContext,
+              contextShift:              ContextShift[IO],
+              timer:                     Timer[IO]): ServiceClient =
+    new ServiceClient {
+      override val baseUrl: String Refined Url = "http://localhost:9005"
+    }
+}
+
 abstract class ServiceClient(implicit executionContext: ExecutionContext,
                              contextShift:              ContextShift[IO],
                              timer:                     Timer[IO])

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val dbEventLog = Project(
   graphCommons % "compile->compile",
   graphCommons % "test->test"
 ).enablePlugins(
+  JavaAppPackaging,
   AutomateHeaderPlugin
 )
 

--- a/db-event-log/Dockerfile
+++ b/db-event-log/Dockerfile
@@ -1,0 +1,29 @@
+# This is a multi-stage build, see reference:
+# https://docs.docker.com/develop/develop-images/multistage-build/
+
+FROM openjdk:8-jre-alpine3.9 as builder
+
+WORKDIR /work
+
+COPY . .
+
+RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk add --no-cache --virtual .build-dependencies sbt && \
+    sbt "project db-event-log" stage && \
+    apk del .build-dependencies
+
+FROM openjdk:8-jre-alpine3.9
+
+WORKDIR /opt/token-repository
+
+# Add artifacts from builder
+COPY --from=builder /work/token-repository/target/universal/stage .
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV TZ UTC
+
+RUN apk add --no-cache tzdata curl bash && \
+    chown -R daemon:daemon .
+
+ENTRYPOINT ["bin/db-event-log"]
+CMD []

--- a/db-event-log/Dockerfile
+++ b/db-event-log/Dockerfile
@@ -14,10 +14,10 @@ RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositor
 
 FROM openjdk:8-jre-alpine3.9
 
-WORKDIR /opt/token-repository
+WORKDIR /opt/db-event-log
 
 # Add artifacts from builder
-COPY --from=builder /work/token-repository/target/universal/stage .
+COPY --from=builder /work/db-event-log/target/universal/stage .
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV TZ UTC

--- a/db-event-log/README.md
+++ b/db-event-log/README.md
@@ -1,0 +1,36 @@
+# event-log
+
+This is a microservice which provides CRUD operations for Event Log DB.
+
+## API
+
+| Method  | Path                               | Description                                        |
+|---------|------------------------------------|----------------------------------------------------|
+|  GET    | ```/ping```                        | To check if service is healthy                     |
+
+#### GET /ping
+
+Verifies service health.
+
+**Response**
+
+| Status                     | Description           |
+|----------------------------|-----------------------|
+| OK (200)                   | If service is healthy |
+| INTERNAL SERVER ERROR (500)| Otherwise             |
+
+## Trying out
+
+The event-log is a part of multi-module sbt project thus it has to be built from the root level.
+
+- build the docker image
+
+```bash
+docker build -f event-log/Dockerfile -t event-log .
+```
+
+- run the service
+
+```bash
+docker run --rm -p 9005:9005 event-log
+```

--- a/db-event-log/README.md
+++ b/db-event-log/README.md
@@ -26,11 +26,11 @@ The event-log is a part of multi-module sbt project thus it has to be built from
 - build the docker image
 
 ```bash
-docker build -f event-log/Dockerfile -t event-log .
+docker build -f db-event-log/Dockerfile -t event-log .
 ```
 
 - run the service
 
 ```bash
-docker run --rm -p 9005:9005 event-log
+docker run --rm -p 9005:9005 db-event-log
 ```

--- a/db-event-log/build.sbt
+++ b/db-event-log/build.sbt
@@ -17,3 +17,5 @@
  */
 
 name := "db-event-log"
+
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/db-event-log/src/main/resources/application.conf
+++ b/db-event-log/src/main/resources/application.conf
@@ -13,3 +13,14 @@ db-event-log {
   max-connection-lifetime = 30 seconds
   max-connection-lifetime = ${?EVENT_LOG_POSTGRES_MAX_LIFETIME}
 }
+
+services {
+
+  sentry {
+    enabled = false
+    enabled = ${?SENTRY_ENABLED}
+    url = ${?SENTRY_BASE_URL}
+    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
+    service-name = "event-log"
+  }
+}

--- a/db-event-log/src/main/resources/logback.xml
+++ b/db-event-log/src/main/resources/logback.xml
@@ -1,0 +1,46 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d %-5level %logger{5} - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT"/>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>/tmp/microservice-access.log</file>
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d %-5level %logger{5} - %message%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <logger name="org.http4s.blaze.channel.nio1.NIO1SocketServerGroup" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC_FILE"/>
+    </logger>
+
+    <logger name="application" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
+    </logger>
+
+    <root level="WARN">
+        <appender-ref ref="ASYNC_STDOUT"/>
+        <appender-ref ref="SENTRY"/>
+    </root>
+
+</configuration>

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/Microservice.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/Microservice.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog
+
+import cats.effect._
+import ch.datascience.config.sentry.SentryInitializer
+import ch.datascience.db.DbTransactorResource
+import ch.datascience.dbeventlog.init.IODbInitializer
+import ch.datascience.http.server.HttpServer
+import ch.datascience.logging.ApplicationLogger
+import ch.datascience.metrics.{MetricsRegistry, RoutesMetrics}
+import ch.datascience.microservices.IOMicroservice
+
+import scala.language.higherKinds
+
+object Microservice extends IOMicroservice {
+
+  override def run(args: List[String]): IO[ExitCode] =
+    for {
+      transactorResource <- new EventLogDbConfigProvider[IO] map DbTransactorResource[IO, EventLogDB]
+      exitCode           <- runMicroservice(transactorResource, args)
+    } yield exitCode
+
+  private def runMicroservice(transactorResource: DbTransactorResource[IO, EventLogDB], args: List[String]) =
+    transactorResource.use { transactor =>
+      for {
+        sentryInitializer <- SentryInitializer[IO]
+        metricsRegistry   <- MetricsRegistry()
+        routes <- new MicroserviceRoutes[IO](
+                   new RoutesMetrics[IO](metricsRegistry)
+                 ).routes
+        httpServer = new HttpServer[IO](serverPort = 9005, routes)
+
+        exitCode <- new MicroserviceRunner(
+                     sentryInitializer,
+                     new IODbInitializer(transactor, ApplicationLogger),
+                     httpServer
+                   ) run args
+      } yield exitCode
+    }
+}
+
+private class MicroserviceRunner(
+    sentryInitializer:     SentryInitializer[IO],
+    eventLogDbInitializer: IODbInitializer,
+    httpServer:            HttpServer[IO]
+) {
+
+  def run(args: List[String]): IO[ExitCode] =
+    for {
+      _      <- sentryInitializer.run
+      _      <- eventLogDbInitializer.run
+      result <- httpServer.run
+    } yield result
+}

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/MicroserviceRoutes.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/MicroserviceRoutes.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog
+
+import cats.effect.{Clock, ConcurrentEffect}
+import cats.implicits._
+import ch.datascience.metrics.RoutesMetrics
+import org.http4s.dsl.Http4sDsl
+
+import scala.language.higherKinds
+
+private class MicroserviceRoutes[F[_]: ConcurrentEffect](
+    routesMetrics: RoutesMetrics[F]
+)(implicit clock:  Clock[F])
+    extends Http4sDsl[F] {
+
+  import org.http4s.HttpRoutes
+  import routesMetrics._
+
+  // format: off
+  lazy val routes: F[HttpRoutes[F]] = HttpRoutes.of[F] {
+    case           GET    -> Root / "ping"                                           => Ok("pong")
+  }.meter flatMap `add GET Root / metrics`
+  // format: on
+}

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/init/DbInitializer.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/init/DbInitializer.scala
@@ -29,7 +29,7 @@ import io.chrisdavenport.log4cats.Logger
 import scala.language.higherKinds
 import scala.util.control.NonFatal
 
-class EventLogDbInitializer[Interpretation[_]](
+class DbInitializer[Interpretation[_]](
     projectPathAdder: ProjectPathAdder[Interpretation],
     batchDateAdder:   BatchDateAdder[Interpretation],
     transactor:       DbTransactor[Interpretation, EventLogDB],
@@ -78,12 +78,13 @@ class EventLogDbInitializer[Interpretation[_]](
   }
 }
 
-class IOEventLogDbInitializer(
-    transactor:          DbTransactor[IO, EventLogDB]
+class IODbInitializer(
+    transactor:          DbTransactor[IO, EventLogDB],
+    logger:              Logger[IO]
 )(implicit contextShift: ContextShift[IO])
-    extends EventLogDbInitializer[IO](
-      new ProjectPathAdder[IO](transactor, ApplicationLogger),
-      new BatchDateAdder[IO](transactor, ApplicationLogger),
+    extends DbInitializer[IO](
+      new ProjectPathAdder[IO](transactor, logger),
+      new BatchDateAdder[IO](transactor, logger),
       transactor,
-      ApplicationLogger
+      logger
     )

--- a/db-event-log/src/main/scala/ch/datascience/dbeventlog/metrics/EventLogMetrics.scala
+++ b/db-event-log/src/main/scala/ch/datascience/dbeventlog/metrics/EventLogMetrics.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.triplesgenerator.metrics
+package ch.datascience.dbeventlog.metrics
 
 import cats.MonadError
 import cats.effect.{ContextShift, IO, Timer}

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/MicroserviceRoutesSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/MicroserviceRoutesSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.datascience.dbeventlog
+
+import cats.effect.{Clock, IO}
+import ch.datascience.http.server.EndpointTester._
+import ch.datascience.interpreters.TestRoutesMetrics
+import org.http4s.Status._
+import org.http4s._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Matchers._
+import org.scalatest.WordSpec
+
+import scala.concurrent.ExecutionContext
+import scala.language.reflectiveCalls
+
+class MicroserviceRoutesSpec extends WordSpec with MockFactory {
+
+  "routes" should {
+
+    "define a GET /ping endpoint returning OK with 'pong' body" in new TestCase {
+      val response = routes.call(
+        Request(Method.GET, uri"ping")
+      )
+
+      response.status       shouldBe Ok
+      response.body[String] shouldBe "pong"
+    }
+
+    "define a GET /metrics endpoint returning OK with some prometheus metrics" in new TestCase {
+      val response = routes.call(
+        Request(Method.GET, uri"metrics")
+      )
+
+      response.status       shouldBe Ok
+      response.body[String] should include("server_response_duration_seconds")
+    }
+  }
+
+  private implicit val clock: Clock[IO] = IO.timer(ExecutionContext.global).clock
+
+  private trait TestCase {
+
+    val routesMetrics = TestRoutesMetrics()
+    val routes = new MicroserviceRoutes[IO](
+      routesMetrics
+    ).routes.map(_.or(notAvailableResponse))
+  }
+}

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/MicroserviceRunnerSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/MicroserviceRunnerSpec.scala
@@ -16,107 +16,95 @@
  * limitations under the License.
  */
 
-package ch.datascience.webhookservice
+package ch.datascience.dbeventlog
 
 import cats.MonadError
 import cats.effect._
-import ch.datascience.generators.Generators
+import ch.datascience.dbeventlog.init.IODbInitializer
 import ch.datascience.generators.Generators.Implicits._
+import ch.datascience.generators.Generators._
 import ch.datascience.http.server.IOHttpServer
 import ch.datascience.interpreters.IOSentryInitializer
-import ch.datascience.webhookservice.missedevents._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class MicroserviceRunnerSpec extends WordSpec with MockFactory {
 
   "run" should {
 
-    "return Success Exit Code if " +
-      "Sentry initialisation is fine and " +
-      "Events Synchronization Scheduler and Http Server start up" in new TestCase {
+    "return Success Exit Code if Sentry and the DB initialisation are fine and http server starts up" in new TestCase {
 
       (sentryInitializer.run _)
         .expects()
         .returning(IO.unit)
 
-      (eventsSynchronizationScheduler.run _)
-        .expects()
-        .returning(IO.unit)
-
-      (httpServer.run _)
-        .expects()
-        .returning(context.pure(ExitCode.Success))
-
-      runner.run(Nil).unsafeRunSync() shouldBe ExitCode.Success
-    }
-
-    "fail if Sentry initialization fails" in new TestCase {
-
-      val exception = Generators.exceptions.generateOne
-      (sentryInitializer.run _)
-        .expects()
-        .returning(context.raiseError(exception))
-
-      intercept[Exception] {
-        runner.run(Nil).unsafeRunSync()
-      } shouldBe exception
-    }
-
-    "fail if starting the Events Synchronization Scheduler fails" in new TestCase {
-
-      (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      (httpServer.run _)
-        .expects()
-        .returning(context.pure(ExitCode.Success))
-
-      val exception = Generators.exceptions.generateOne
-      (eventsSynchronizationScheduler.run _)
-        .expects()
-        .returning(context.raiseError(exception))
-
-      intercept[Exception] {
-        runner.run(Nil).unsafeRunSync()
-      } shouldBe exception
-    }
-
-    "return Success ExitCode even if the Http Server fails to start" in new TestCase {
-
-      (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      val exception = Generators.exceptions.generateOne
-      (httpServer.run _)
-        .expects()
-        .returning(context.raiseError(exception))
-
-      (eventsSynchronizationScheduler.run _)
+      (dbInitializer.run _)
         .expects()
         .returning(context.unit)
 
+      (httpServer.run _)
+        .expects()
+        .returning(context.pure(ExitCode.Success))
+
       runner.run(Nil).unsafeRunSync() shouldBe ExitCode.Success
     }
-  }
 
-  private implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+    "fail if Sentry initialisation fails" in new TestCase {
+
+      val exception = exceptions.generateOne
+      (sentryInitializer.run _)
+        .expects()
+        .returning(context.raiseError(exception))
+
+      intercept[Exception] {
+        runner.run(Nil).unsafeRunSync()
+      } shouldBe exception
+    }
+
+    "fail if DB initialisation fails" in new TestCase {
+
+      (sentryInitializer.run _)
+        .expects()
+        .returning(IO.unit)
+
+      val exception = exceptions.generateOne
+      (dbInitializer.run _)
+        .expects()
+        .returning(context.raiseError(exception))
+
+      intercept[Exception] {
+        runner.run(Nil).unsafeRunSync()
+      } shouldBe exception
+    }
+
+    "fail if starting the http server fails" in new TestCase {
+
+      (sentryInitializer.run _)
+        .expects()
+        .returning(IO.unit)
+
+      (dbInitializer.run _)
+        .expects()
+        .returning(context.unit)
+
+      val exception = exceptions.generateOne
+      (httpServer.run _)
+        .expects()
+        .returning(context.raiseError(exception))
+
+      intercept[Exception] {
+        runner.run(Nil).unsafeRunSync()
+      } shouldBe exception
+    }
+  }
 
   private trait TestCase {
     val context = MonadError[IO, Throwable]
 
-    val sentryInitializer              = mock[IOSentryInitializer]
-    val eventsSynchronizationScheduler = mock[TestIOEventsSynchronizationScheduler]
-    val httpServer                     = mock[IOHttpServer]
-    val runner = new MicroserviceRunner(
-      sentryInitializer,
-      eventsSynchronizationScheduler,
-      httpServer
-    )
+    val sentryInitializer = mock[IOSentryInitializer]
+    val dbInitializer     = mock[IODbInitializer]
+    val httpServer        = mock[IOHttpServer]
+    val runner            = new MicroserviceRunner(sentryInitializer, dbInitializer, httpServer)
   }
 }

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/init/DbInitializerSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/init/DbInitializerSpec.scala
@@ -36,7 +36,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
 
-class EventLogDbInitializerSpec extends WordSpec with DbInitSpec with MockFactory {
+class DbInitializerSpec extends WordSpec with DbInitSpec with MockFactory {
 
   "run" should {
 
@@ -168,7 +168,7 @@ class EventLogDbInitializerSpec extends WordSpec with DbInitSpec with MockFactor
     val projectPathAdder = mock[IOProjectPathAdder]
     val batchDateAdder   = mock[IOBatchDateAdder]
     val logger           = TestLogger[IO]()
-    val dbInitializer    = new EventLogDbInitializer[IO](projectPathAdder, batchDateAdder, transactor, logger)
+    val dbInitializer    = new DbInitializer[IO](projectPathAdder, batchDateAdder, transactor, logger)
   }
 
   private class IOProjectPathAdder(transactor: DbTransactor[IO, EventLogDB], logger: Logger[IO])

--- a/db-event-log/src/test/scala/ch/datascience/dbeventlog/metrics/EventLogMetricsSpec.scala
+++ b/db-event-log/src/test/scala/ch/datascience/dbeventlog/metrics/EventLogMetricsSpec.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package ch.datascience.triplesgenerator.metrics
+package ch.datascience.dbeventlog.metrics
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -29,7 +29,7 @@ import ch.datascience.dbeventlog.commands.EventLogStats
 import ch.datascience.dbeventlog.{EventLogDB, EventStatus}
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
-import ch.datascience.graph.model.GraphModelGenerators.projectPaths
+import ch.datascience.graph.model.GraphModelGenerators._
 import ch.datascience.graph.model.projects.Path
 import ch.datascience.interpreters.TestLogger.Level.Error
 import ch.datascience.interpreters.{TestDbTransactor, TestLogger}

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -23,3 +23,7 @@ charts:
         contextPath: ..
         dockerfilePath: ../knowledge-graph/Dockerfile
         valuesPath: knowledgeGraph.image
+      event-log:
+        contextPath: ..
+        dockerfilePath: ../db-event-log/Dockerfile
+        valuesPath: eventLog.image

--- a/helm-chart/renku-graph/templates/_helpers.tpl
+++ b/helm-chart/renku-graph/templates/_helpers.tpl
@@ -18,6 +18,10 @@ Expand the name of the chart.
 {{- "knowledge-graph" -}}
 {{- end -}}
 
+{{- define "eventLog.name" -}}
+{{- "event-log" -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -52,6 +56,14 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-knowledge-graph" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "eventLog.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-event-log" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm-chart/renku-graph/templates/event-log-deployment.yaml
+++ b/helm-chart/renku-graph/templates/event-log-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 {{- else }}
                   name: {{ template "eventLog.fullname" . }}
 {{- end }}
-                  key: graph-eventLog-postgresPassword
+                  key: graph-dbEventLog-postgresPassword
             - name: EVENT_LOG_POSTGRES_CONNECTION_POOL
               value: "{{ .Values.eventLog.connectionPool }}"
             - name: SENTRY_DSN

--- a/helm-chart/renku-graph/templates/event-log-deployment.yaml
+++ b/helm-chart/renku-graph/templates/event-log-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "eventLog.fullname" . }}
+  labels:
+    app: {{ template "eventLog.name" . }}
+    chart: {{ template "graph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ include "eventLog.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "eventLog.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: event-log
+          image: "{{ .Values.eventLog.image.repository }}:{{ .Values.eventLog.image.tag }}"
+          imagePullPolicy: {{ .Values.eventLog.image.pullPolicy }}
+          env:
+            - name: EVENT_LOG_POSTGRES_HOST
+              value: "{{ template "postgresql.fullname" . }}:5432"
+            - name: EVENT_LOG_POSTGRES_USER
+              value: {{ .Values.global.graph.dbEventLog.postgresUser }}
+            - name: EVENT_LOG_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+{{- if .Values.global.graph.dbEventLog.existingSecret }}
+                  name: {{ tpl .Values.global.graph.dbEventLog.existingSecret . }}
+{{- else }}
+                  name: {{ template "eventLog.fullname" . }}
+{{- end }}
+                  key: graph-eventLog-postgresPassword
+            - name: EVENT_LOG_POSTGRES_CONNECTION_POOL
+              value: "{{ .Values.eventLog.connectionPool }}"
+            - name: SENTRY_DSN
+              value: {{ .Values.sentry.sentryDsnRenkuPython }}
+            - name: SENTRY_ENABLED
+              value: "{{ .Values.sentry.enabled }}"
+              {{- if .Values.sentry.enabled }}
+            - name: SENTRY_BASE_URL
+              value: {{ .Values.sentry.url }}
+            - name: SENTRY_ENVIRONMENT_NAME
+              value: {{ .Values.sentry.environmentName }}
+              {{- end }}
+            - name: THREADS_NUMBER
+              value: "{{ .Values.eventLog.threadsNumber }}"
+            - name: JAVA_OPTS
+              value: -Xmx{{ .Values.eventLog.jvmXmx }} -XX:+UseG1GC
+          ports:
+            - name: http-event-log
+              containerPort: 9005
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http-event-log
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http-event-log
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+  {{ toYaml .Values.eventLog.resources | indent 12 }}
+  {{- with .Values.nodeSelector }}
+nodeSelector:
+  {{ toYaml . | indent 8 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+affinity:
+  {{ toYaml . | indent 8 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+tolerations:
+  {{ toYaml . | indent 8 }}
+  {{- end }}

--- a/helm-chart/renku-graph/templates/event-log-secret.yaml
+++ b/helm-chart/renku-graph/templates/event-log-secret.yaml
@@ -1,8 +1,8 @@
-{{- if not .Values.global.graph.eventLog.existingSecret }}
+{{- if not .Values.global.graph.dbEventLog.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "eventLog.fullname" . }}-postgres
+  name: {{ include "eventLog.fullname" . }}
   labels:
     app: {{ template "eventLog.name" . }}
     chart: {{ template "graph.chart" . }}
@@ -17,5 +17,5 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
-  graph-eventLog-postgresPassword: {{ default (randAlphaNum 64) .Values.global.graph.dbEventLog.postgresPassword.value | b64enc | quote }}
+  graph-dbEventLog-postgresPassword: {{ default (randAlphaNum 64) .Values.global.graph.dbEventLog.postgresPassword.value | b64enc | quote }}
 {{- end }}

--- a/helm-chart/renku-graph/templates/event-log-secret.yaml
+++ b/helm-chart/renku-graph/templates/event-log-secret.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.global.graph.eventLog.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "eventLog.fullname" . }}-postgres
+  labels:
+    app: {{ template "eventLog.name" . }}
+    chart: {{ template "graph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{ if or .Values.global.graph.dbEventLog.postgresPassword.value .Values.global.graph.dbEventLog.postgresPassword.overwriteOnHelmUpgrade -}}
+    "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
+    {{- else -}}
+    "helm.sh/hook": "pre-install,pre-rollback"
+    {{- end }}
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  graph-eventLog-postgresPassword: {{ default (randAlphaNum 64) .Values.global.graph.dbEventLog.postgresPassword.value | b64enc | quote }}
+{{- end }}

--- a/helm-chart/renku-graph/templates/event-log-service.yaml
+++ b/helm-chart/renku-graph/templates/event-log-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "eventLog.fullname" . }}
+  labels:
+    app: {{ template "eventLog.name" . }}
+    chart: {{ template "graph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/metrics'
+    prometheus.io/port: '9005'
+spec:
+  type: {{ .Values.eventLog.service.type }}
+  ports:
+    - port: {{ .Values.eventLog.service.port }}
+      targetPort: http-event-log
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "eventLog.name" . }}
+    release: {{ .Release.Name }}

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -91,6 +91,21 @@ knowledgeGraph:
       ## Renku resource are available at: https://{global.renku.domain}/knowledge-graph
       resourcesPath: "/knowledge-graph"
 
+eventLog:
+  image:
+    repository: renku/db-event-log
+    tag: 'latest'
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 9005
+  resources:
+    limits:
+      memory: 250Mi
+  jvmXmx: 250m
+  threadsNumber: 6
+  connectionPool: 10
+
 sentry:
   enabled: false
   url: '' # Sentry url

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -35,7 +35,7 @@ triplesGenerator:
       memory: 2000Mi
   jvmXmx: 1G
   renkuLogTimeout: 60 minutes
-  reProvisioningInitialDelay: 1 second
+  reProvisioningInitialDelay: 1 minute
   gitlab:
     rateLimit: 30/sec
   generationProcessInitialDelay: 2 minutes

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/Microservice.scala
@@ -27,7 +27,6 @@ import ch.datascience.config.sentry.SentryInitializer
 import ch.datascience.control.{RateLimit, Throttler}
 import ch.datascience.db.DbTransactorResource
 import ch.datascience.dbeventlog.commands.IOEventLogFetch
-import ch.datascience.dbeventlog.init.IOEventLogDbInitializer
 import ch.datascience.dbeventlog.{EventLogDB, EventLogDbConfigProvider}
 import ch.datascience.http.server.HttpServer
 import ch.datascience.logging.ApplicationLogger
@@ -85,7 +84,6 @@ object Microservice extends IOMicroservice {
                                  .withEventsProcessor(commitEventProcessor)
         exitCode <- new MicroserviceRunner(
                      sentryInitializer,
-                     new IOEventLogDbInitializer(transactor),
                      fusekiDatasetInitializer,
                      reProvisioning,
                      eventProcessorRunner,
@@ -99,7 +97,6 @@ object Microservice extends IOMicroservice {
 
 private class MicroserviceRunner(
     sentryInitializer:        SentryInitializer[IO],
-    eventLogDbInitializer:    IOEventLogDbInitializer,
     datasetInitializer:       FusekiDatasetInitializer[IO],
     reProvisioning:           ReProvisioning[IO],
     eventProcessorRunner:     EventProcessorRunner[IO],
@@ -111,7 +108,6 @@ private class MicroserviceRunner(
   def run(args: List[String]): IO[ExitCode] =
     for {
       _        <- sentryInitializer.run
-      _        <- eventLogDbInitializer.run
       _        <- datasetInitializer.run
       _        <- reProvisioning.run.start.map(gatherCancelToken)
       _        <- eventProcessorRunner.run.start.map(gatherCancelToken)

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/MicroserviceRunnerSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/MicroserviceRunnerSpec.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 import cats.effect._
 import ch.datascience.dbeventlog.commands.EventLogStats
-import ch.datascience.dbeventlog.init.IOEventLogDbInitializer
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
 import ch.datascience.http.server.IOHttpServer
@@ -44,13 +43,9 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
   "run" should {
 
     "return Success ExitCode if " +
-      "Sentry, Event Log db and RDF dataset initialize fine and " +
+      "Sentry and RDF dataset initialisation are fine and " +
       "the re-provisioning, the Event Processor and the http server start up" in new TestCase {
       (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      (eventLogDbInitializer.run _)
         .expects()
         .returning(IO.unit)
 
@@ -88,27 +83,8 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
       } shouldBe exception
     }
 
-    "fail if Event Log db verification fails" in new TestCase {
-      (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      val exception = exceptions.generateOne
-      (eventLogDbInitializer.run _)
-        .expects()
-        .returning(IO.raiseError(exception))
-
-      intercept[Exception] {
-        microserviceRunner.run(Nil).unsafeRunSync()
-      } shouldBe exception
-    }
-
     "fail if RDF dataset verification fails" in new TestCase {
       (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      (eventLogDbInitializer.run _)
         .expects()
         .returning(IO.unit)
 
@@ -124,10 +100,6 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
 
     "fail if starting the Http Server fails" in new TestCase {
       (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      (eventLogDbInitializer.run _)
         .expects()
         .returning(IO.unit)
 
@@ -162,10 +134,6 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
         .expects()
         .returning(IO.unit)
 
-      (eventLogDbInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
       (datasetInitializer.run _)
         .expects()
         .returning(IO.unit)
@@ -192,10 +160,6 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
 
     "return Success ExitCode even if Event Log Metrics fails" in new TestCase {
       (sentryInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
-      (eventLogDbInitializer.run _)
         .expects()
         .returning(IO.unit)
 
@@ -228,10 +192,6 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
         .expects()
         .returning(IO.unit)
 
-      (eventLogDbInitializer.run _)
-        .expects()
-        .returning(IO.unit)
-
       (datasetInitializer.run _)
         .expects()
         .returning(IO.unit)
@@ -258,16 +218,14 @@ class MicroserviceRunnerSpec extends WordSpec with MockFactory {
   }
 
   private trait TestCase {
-    val sentryInitializer     = mock[IOSentryInitializer]
-    val eventLogDbInitializer = mock[IOEventLogDbInitializer]
-    val datasetInitializer    = mock[IOFusekiDatasetInitializer]
-    val reProvisioning        = mock[IOReProvisioning]
-    val eventProcessorRunner  = mock[IOEventProcessorRunner]
-    val eventLogMetrics       = mock[IOEventLogMetrics]
-    val httpServer            = mock[IOHttpServer]
+    val sentryInitializer    = mock[IOSentryInitializer]
+    val datasetInitializer   = mock[IOFusekiDatasetInitializer]
+    val reProvisioning       = mock[IOReProvisioning]
+    val eventProcessorRunner = mock[IOEventProcessorRunner]
+    val eventLogMetrics      = mock[IOEventLogMetrics]
+    val httpServer           = mock[IOHttpServer]
     val microserviceRunner = new MicroserviceRunner(
       sentryInitializer,
-      eventLogDbInitializer,
       datasetInitializer,
       reProvisioning,
       eventProcessorRunner,

--- a/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
+++ b/webhook-service/src/main/scala/ch/datascience/webhookservice/Microservice.scala
@@ -25,7 +25,6 @@ import ch.datascience.config.GitLab
 import ch.datascience.config.sentry.SentryInitializer
 import ch.datascience.control.{RateLimit, Throttler}
 import ch.datascience.db.DbTransactorResource
-import ch.datascience.dbeventlog.init.IOEventLogDbInitializer
 import ch.datascience.dbeventlog.{EventLogDB, EventLogDbConfigProvider}
 import ch.datascience.graph.config.GitLabUrl
 import ch.datascience.graph.tokenrepository.TokenRepositoryUrl
@@ -100,7 +99,6 @@ object Microservice extends IOMicroservice {
 
         exitCode <- new MicroserviceRunner(
                      sentryInitializer,
-                     new IOEventLogDbInitializer(transactor),
                      new IOEventsSynchronizationScheduler(transactor,
                                                           tokenRepositoryUrl,
                                                           gitLabUrl,
@@ -113,7 +111,6 @@ object Microservice extends IOMicroservice {
 }
 
 class MicroserviceRunner(sentryInitializer:              SentryInitializer[IO],
-                         eventLogDbInitializer:          IOEventLogDbInitializer,
                          eventsSynchronizationScheduler: EventsSynchronizationScheduler[IO],
                          httpServer:                     HttpServer[IO])(implicit contextShift: ContextShift[IO]) {
   import cats.implicits._
@@ -121,7 +118,6 @@ class MicroserviceRunner(sentryInitializer:              SentryInitializer[IO],
   def run(args: List[String]): IO[ExitCode] =
     for {
       _ <- sentryInitializer.run
-      _ <- eventLogDbInitializer.run
       _ <- List(httpServer.run.start, eventsSynchronizationScheduler.run).sequence
     } yield ExitCode.Success
 }


### PR DESCRIPTION
This PR addresses the initial work of creating a new event-log service.

**Testing scenarios:**
There's not much to test at this stage but as Event Log metrics are now being served by the new service, it can be verified that something is shown here:
https://grafana.dev.renku.ch/d/cb9J1WBZz/event-log?orgId=1&refresh=30s&from=now-1h&to=now&var-kube_env_name=renku-kuba-renku-event-log

closes #269 