### PR TITLE
All triples removal bug

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.1.0-3e4932d
+version: 1.0.2-476a4df

--- a/helm-chart/renku-graph/charts/jena/values.yaml
+++ b/helm-chart/renku-graph/charts/jena/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: stain/jena-fuseki
-  tag: 3.10.0
+  tag: 3.14.0
   pullPolicy: IfNotPresent
 
 persistence:

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesRemover.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/OutdatedTriplesRemover.scala
@@ -43,7 +43,7 @@ private class IOTriplesRemover(
     SparqlQuery(
       name     = "all triples remove",
       prefixes = Set.empty,
-      body     = "CLEAR DEFAULT"
+      body     = "DROP DEFAULT"
     )
   }
 }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/TriplesRemover.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/TriplesRemover.scala
@@ -29,6 +29,10 @@ private trait TriplesRemover[Interpretation[_]] {
   def removeAllTriples(): Interpretation[Unit]
 }
 
+private object TriplesRemover {
+  val TriplesRemovalBatchSize: Long = 50000
+}
+
 private class IOTriplesRemover(
     rdfStoreConfig:          RdfStoreConfig,
     logger:                  Logger[IO],
@@ -37,13 +41,59 @@ private class IOTriplesRemover(
     extends IORdfStoreClient(rdfStoreConfig, logger, timeRecorder)
     with TriplesRemover[IO] {
 
+  import TriplesRemover._
+  import cats.implicits._
   import eu.timepit.refined.auto._
+  import io.circe.Decoder
 
-  override def removeAllTriples(): IO[Unit] = updateWitNoResult {
-    SparqlQuery(
-      name     = "all triples remove",
-      prefixes = Set.empty,
-      body     = "CLEAR DEFAULT"
-    )
+  import scala.util.Try
+
+  override def removeAllTriples(): IO[Unit] =
+    queryExpecting[Long](findTriplesCount)(countDecoder) flatMap {
+      case 0 => IO.unit
+      case _ =>
+        for {
+          _ <- updateWitNoResult(removeTriplesBatch)
+          _ <- removeAllTriples()
+        } yield ()
+    }
+
+  private val findTriplesCount = SparqlQuery(
+    name     = "triples remove - count",
+    prefixes = Set.empty,
+    """|SELECT (COUNT(*) AS ?count)
+       |WHERE { ?s ?p ?o }
+       |""".stripMargin
+  )
+
+  private val removeTriplesBatch = SparqlQuery(
+    name     = "triples remove - delete",
+    prefixes = Set.empty,
+    s"""|DELETE { ?s ?p ?o }
+        |WHERE { 
+        |  SELECT  ?s ?p ?o 
+        |  WHERE { ?s ?p ?o }
+        |  LIMIT $TriplesRemovalBatchSize
+        |}
+        |""".stripMargin
+  )
+
+  private implicit val countDecoder: Decoder[Long] = {
+    import io.circe.Decoder.decodeList
+    import io.circe.DecodingFailure
+
+    val rows: Decoder[Long] = _.downField("count")
+      .downField("value")
+      .as[String]
+      .flatMap { count =>
+        Try(count.toLong).toEither.leftMap { ex =>
+          DecodingFailure(s"Triples count in non-number format: $ex", Nil)
+        }
+      }
+
+    _.downField("results")
+      .downField("bindings")
+      .as[List[Long]](decodeList(rows))
+      .map(_.headOption.getOrElse(0))
   }
 }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/TriplesRemover.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/reprovisioning/TriplesRemover.scala
@@ -43,7 +43,7 @@ private class IOTriplesRemover(
     SparqlQuery(
       name     = "all triples remove",
       prefixes = Set.empty,
-      body     = "DROP DEFAULT"
+      body     = "CLEAR DEFAULT"
     )
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0-SNAPSHOT"
+version in ThisBuild := "1.0.2-SNAPSHOT"


### PR DESCRIPTION
As described in #302 the `CLEAR DEFAULT` operation does not seem to work in all Jena instances. This PR fixes that with a simple `DELETE` query removing batches of triples until the dataset is empty. The batching approach is needed from Jena's health point of view as it can simply blow up when trying to remove all the triples in one go.

**Testing image:**
`'repository': 'jachro/triples-generator', 'tag': 'f2a52b79'`
This image was already successfully tested on `renku-kuba`.

**Testing scenarios:**
* simply drop mentioned image to an environment of your choice and observe the [Grafana Event Log metrics](https://grafana.dev.renku.ch/d/cb9J1WBZz/event-log?orgId=1&from=now-1h&to=now&refresh=30s&var-kube_env_name=renku-kuba-renku) to see if all the events get re-scheduled for re-processing.

closes #302 