### PR TITLE
Jena jvmXmx and users in the chart values.yaml

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.1.0-7e4cfee
+version: 1.0.1-7e4cfee

--- a/helm-chart/renku-graph/charts/jena/values.yaml
+++ b/helm-chart/renku-graph/charts/jena/values.yaml
@@ -55,14 +55,13 @@ tolerations: []
 affinity: {}
 
 # Jena configuration
-jena:
-  jvmXmx: 2G
-  users:
-    admin:
-      ## Admin user password
-      ## Generate one using: `openssl rand -hex 16`
-      password:
-    renku:
-      ## Dataset user password
-      ## Generate one using: `openssl rand -hex 16`
-      password:
+jvmXmx: 2G
+users:
+  admin:
+    ## Admin user password
+    ## Generate one using: `openssl rand -hex 16`
+    password:
+  renku:
+    ## Dataset user password
+    ## Generate one using: `openssl rand -hex 16`
+    password:

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0-SNAPSHOT"
+version in ThisBuild := "1.0.1-SNAPSHOT"


### PR DESCRIPTION
It looks like the defaults for `jvmXmx` as well as `users` are wrongly nested under `jena` in the Jena chart `values.yaml`. This PR fixes that.