### PR TITLE
renku-python upgrade to a hotfix of 0.10.4

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.1.0-87655d4
+version: 1.0.5-87655d4

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -24,7 +24,7 @@ ENV TZ UTC
 
 # Installing Renku and other dependencies
 RUN apk add --no-cache tzdata git git-lfs curl bash python3-dev openssl-dev libffi-dev linux-headers gcc libxml2-dev libxslt-dev libc-dev && \
-    python3 -m pip install 'renku==0.10.4' sentry-sdk && \
+    python3 -m pip install 'git+https://github.com/SwissDataScienceCenter/renku-python.git@temporary-softwareagent-fix-hack' sentry-sdk && \
     chown -R daemon:daemon . && \
     git config --global filter.lfs.smudge "git-lfs smudge --skip %f"  && \
     git config --global filter.lfs.process "git-lfs filter-process --skip"

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/persondetails/PersonDetailsUpdater.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplescuration/persondetails/PersonDetailsUpdater.scala
@@ -69,7 +69,7 @@ private[triplescuration] class PersonDetailsUpdater[Interpretation[_]](
               for {
                 foundPerson <- personData.toPerson
                 _ = persons add foundPerson
-              } yield removeNameAndEmail(foundPerson.id, json)
+              } yield removeNameAndEmail(json)
           }
         case _ => json.pure[Interpretation]
       }
@@ -99,7 +99,7 @@ private[triplescuration] class PersonDetailsUpdater[Interpretation[_]](
       }
     }
 
-    private def removeNameAndEmail(resourceId: ResourceId, json: Json) =
+    private def removeNameAndEmail(json: Json) =
       json
         .remove("http://schema.org/name")
         .remove("http://schema.org/email")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0-SNAPSHOT"
+version in ThisBuild := "1.0.5-SNAPSHOT"


### PR DESCRIPTION
This hotfix on renku-python fixes missing properties on the SoftwareAgent Person entity.

For more details see [this](https://github.com/SwissDataScienceCenter/renku-python/pull/1323).