### PR TITLE
charts: add requests for jena

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.3.0-b1c851a
+version: 1.2.1-b1c851a

--- a/helm-chart/renku-graph/charts/jena/values.yaml
+++ b/helm-chart/renku-graph/charts/jena/values.yaml
@@ -36,7 +36,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -44,9 +44,10 @@ resources: {}
   # limits:
   #  cpu: 100m
   #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  # Request a bit more memory than configured for the Jena JVM
+  requests:
+    cpu: 1000m
+    memory: 3Gi
 
 nodeSelector: {}
 

--- a/helm-chart/renku-graph/charts/jena/values.yaml
+++ b/helm-chart/renku-graph/charts/jena/values.yaml
@@ -46,7 +46,7 @@ resources:
   #  memory: 128Mi
   # Request a bit more memory than configured for the Jena JVM
   requests:
-    cpu: 1000m
+    cpu: 500m
     memory: 3Gi
 
 nodeSelector: {}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.0-SNAPSHOT"
+version in ThisBuild := "1.2.1-SNAPSHOT"


### PR DESCRIPTION
**Motivation**
A Jena pod has been recently evicted because there was not enough memory in the node, but the requests were 0. This should never be the case since we are requesting 2GB for the JVM by default.

**Proposal**
The CPU proposed time is more than what has been observed in production (near 0.08).
The memory proposed request is 1GB more than what JVM uses and ~0.5GB more than observed in production.