### PR TITLE
chore: renku-python pinned to v0.10.5

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.3.0-102b89a
+version: 1.2.2-102b89a

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -24,7 +24,7 @@ ENV TZ UTC
 
 # Installing Renku and other dependencies
 RUN apk add --no-cache tzdata git git-lfs curl bash python3-dev openssl-dev libffi-dev linux-headers gcc libxml2-dev libxslt-dev libc-dev && \
-    python3 -m pip install 'git+https://github.com/SwissDataScienceCenter/renku-python.git@temporary-softwareagent-fix-hack' sentry-sdk && \
+    python3 -m pip install 'renku==0.10.5' sentry-sdk && \
     chown -R daemon:daemon . && \
     git config --global filter.lfs.smudge "git-lfs smudge --skip %f"  && \
     git config --global filter.lfs.process "git-lfs filter-process --skip"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.0-SNAPSHOT"
+version in ThisBuild := "1.2.2-SNAPSHOT"


### PR DESCRIPTION
This PR bumps the version of renku-python to v0.10.5