### PR TITLE
build: allow renku-python version override

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .travis*
 helm-chart
 *.enc
+**/Dockerfile

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -1,5 +1,6 @@
 charts:
   - name: renku-graph
+    resetTag: latest
     imagePrefix: renku/
     repo:
       git: SwissDataScienceCenter/helm-charts

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.3.0-ff6f90d
+version: 1.2.3-ff6f90d

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -90,7 +90,7 @@ spec:
             successThreshold: 1
             failureThreshold: 10
             {{- if .Values.triplesGenerator.renkuPythonDevVersion }}
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             {{- end }}
           readinessProbe:
             httpGet:
@@ -100,7 +100,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
             {{- if .Values.triplesGenerator.renkuPythonDevVersion }}
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             {{- end }}
           resources:
   {{- toYaml .Values.triplesGenerator.resources | nindent 12 }}

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -76,6 +76,8 @@ spec:
               value: "{{ .Values.triplesGenerator.threadsNumber }}"
             - name: JAVA_OPTS
               value: -Xmx{{ .Values.triplesGenerator.jvmXmx }} -XX:+UseG1GC
+            - name: RENKU_PYTHON_DEV_VERSION
+              value: "{{ .Values.triplesGenerator.renkuPythonDevVersion }}"
           ports:
             - name: http-triples-gn
               containerPort: 9002
@@ -87,6 +89,9 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 10
+            {{- if .Values.triplesGenerator.renkuPythonDevVersion }}
+            initialDelaySeconds: 60
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /ping
@@ -94,6 +99,9 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
+            {{- if .Values.triplesGenerator.renkuPythonDevVersion }}
+            initialDelaySeconds: 60
+            {{- end }}
           resources:
   {{- toYaml .Values.triplesGenerator.resources | nindent 12 }}
   {{- with .Values.nodeSelector }}

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -41,6 +41,8 @@ triplesGenerator:
   ## a demanded number of concurrent triples generation processes
   generationProcessesNumber: 4
   threadsNumber: 6
+  # set this to a pip-installable renku-python version which will be installed on startup
+  renkuPythonDevVersion:
 
 webhookService:
   image:

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -29,5 +29,6 @@ RUN apk add --no-cache tzdata git git-lfs curl bash python3-dev openssl-dev libf
     git config --global filter.lfs.smudge "git-lfs smudge --skip %f"  && \
     git config --global filter.lfs.process "git-lfs filter-process --skip"
 
-ENTRYPOINT ["bin/triples-generator"]
-CMD []
+COPY triples-generator/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bin/triples-generator"]

--- a/triples-generator/entrypoint.sh
+++ b/triples-generator/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ ! -z "$RENKU_PYTHON_DEV_VERSION" ]
+then
+    /usr/bin/python3 -m pip uninstall --yes renku
+    /usr/bin/python3 -m pip install ${RENKU_PYTHON_DEV_VERSION}
+fi
+
+# run the command
+$@

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.0-SNAPSHOT"
+version in ThisBuild := "1.2.3-SNAPSHOT"


### PR DESCRIPTION
closes #161 

The intended use here is that it shouldn't be necessary to rebuild the triples generator image to test compatibility with a development version of renku-python. Note that the "version" should be  a fully-qualified pip-installable target, e.g.

```
renku==0.10.5
git+https://github.com/swissdatasciencecenter/renku-pyhon@<branch>#egg=renku
```

This image is currently deployed as the TG of rok.dev.renku.ch. 