### PR TITLE
Fix for a CI and docker issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - sudo apt-get update
 install:
   - travis_retry sudo pip3 install -U pip
-  - travis_retry sudo pip3 install "chartpress==0.3.2" "ruamel.yaml==0.15.54"
+  - travis_retry sudo pip3 install "docker==4.2.2" "chartpress==0.6.0" "ruamel.yaml==0.15.54"
   # Installing Helm
   - wget -q ${HELM_URL}/${HELM_TGZ}
   - tar xzfv ${HELM_TGZ}

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.7.0-c4583f3
+version: 1.6.1-c4583f3

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -24,7 +24,7 @@ ENV TZ UTC
 
 # Installing Renku and other dependencies
 RUN apk add --no-cache tzdata git git-lfs curl bash python3-dev py3-pip py3-wheel openssl-dev libffi-dev linux-headers gcc libxml2-dev libxslt-dev libc-dev yaml-dev && \
-    python3 -m pip install 'git+https://github.com/SwissDataScienceCenter/renku-python.git@1298-calamus-workflows' sentry-sdk && \
+    python3 -m pip install 'git+https://github.com/SwissDataScienceCenter/renku-python.git@master' sentry-sdk && \
     chown -R daemon:daemon . && \
     export RENKU_DISABLE_VERSION_CHECK=true && \
     git config --global user.name 'renku'  && \

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.0-SNAPSHOT"
+version in ThisBuild := "1.6.1-SNAPSHOT"


### PR DESCRIPTION
It looks the docker version on `chartpress` is not pinned so the CI builds stopped to work when a new python docker lib got released.