### PR TITLE
Fix 339 dataset keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
     - master
     - "/(^hotfix-\\d+\\.\\d+(\\.\\d+)?$)|(^\\d+\\.\\d+\\.\\d+$)/"
 language: scala
-jdk: openjdk12
+jdk: openjdk11
 scala:
   - 2.12.11
 cache:

--- a/.travis/travis-functions.sh
+++ b/.travis/travis-functions.sh
@@ -69,6 +69,7 @@ function updateVersionInRenku() {
   # running helm dep udpate
   cd charts || exit
   helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
+  helm repo add bitnami https://charts.bitnami.com/bitnami
   helm dep update renku
   cd .. || exit
 

--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/tooling/RDFStore.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/tooling/RDFStore.scala
@@ -48,12 +48,12 @@ object RDFStore {
       import org.apache.jena.graph.NodeFactory
       import org.apache.jena.query.DatasetFactory
       import org.apache.jena.query.text.{EntityDefinition, TextDatasetFactory, TextIndexConfig}
-      import org.apache.lucene.store.RAMDirectory
 
       val entityDefinition: EntityDefinition = {
         val definition = new EntityDefinition("uri", "name")
         definition.setPrimaryPredicate(NodeFactory.createURI("http://schema.org/name"))
         definition.set("description", NodeFactory.createURI("http://schema.org/description"))
+        definition.set("alternateName", NodeFactory.createURI("http://schema.org/alternateName"))
         definition
       }
 

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/RdfStoreServer.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/RdfStoreServer.scala
@@ -53,6 +53,7 @@ class RdfStoreServer(port: Int Refined Positive, datasetName: DatasetName)(impli
       val definition = new EntityDefinition("uri", "name")
       definition.setPrimaryPredicate(NodeFactory.createURI("http://schema.org/name"))
       definition.set("description", NodeFactory.createURI("http://schema.org/description"))
+      definition.set("alternateName", NodeFactory.createURI("http://schema.org/alternateName"))
       definition
     }
 

--- a/graph-commons/src/test/scala/ch/datascience/rdfstore/entities/bundles.scala
+++ b/graph-commons/src/test/scala/ch/datascience/rdfstore/entities/bundles.scala
@@ -25,10 +25,10 @@ import ch.datascience.generators.Generators.{listOf, nonEmptySet, setOf}
 import ch.datascience.graph.config.RenkuBaseUrl
 import ch.datascience.graph.model.EventsGenerators.{commitIds, committedDates}
 import ch.datascience.graph.model.GraphModelGenerators._
-import ch.datascience.graph.model.datasets.{Description, Identifier, Name, PartLocation, PartName, PublishedDate, SameAs, Title, Url}
+import ch.datascience.graph.model.datasets.{Description, Identifier, Keyword, Name, PartLocation, PartName, PublishedDate, SameAs, Title, Url}
 import ch.datascience.graph.model.events.{CommitId, CommittedDate}
 import ch.datascience.graph.model.projects.{DateCreated, Path, SchemaVersion}
-import ch.datascience.graph.model.{CliVersion, datasets, projects}
+import ch.datascience.graph.model.{CliVersion, GraphModelGenerators, datasets, projects}
 import ch.datascience.rdfstore.entities.CommandParameter.Mapping.IOStream
 import ch.datascience.rdfstore.entities.CommandParameter.PositionInfo.Position
 import ch.datascience.rdfstore.entities.CommandParameter._
@@ -105,7 +105,8 @@ object bundles extends Schemas {
       maybeDatasetPublishedDate: Option[PublishedDate] = Gen.option(datasetPublishedDates).generateOne,
       datasetCreatedDate:        datasets.DateCreated = datasets.DateCreated(committedDate.value),
       datasetCreators:           Set[Person] = setOf(persons).generateOne,
-      datasetParts:              List[(PartName, PartLocation)] = listOf(dataSetParts).generateOne
+      datasetParts:              List[(PartName, PartLocation)] = listOf(dataSetParts).generateOne,
+      datasetKeywords:           List[Keyword] = listOf(GraphModelGenerators.datasetKeywords).generateOne
   )(implicit renkuBaseUrl:       RenkuBaseUrl, fusekiBaseUrl: FusekiBaseUrl): JsonLD = {
     val project =
       Project(projectPath, projectName, projectDateCreated, maybeProjectCreator, maybeParent, projectVersion)
@@ -129,7 +130,8 @@ object bundles extends Schemas {
             datasetCreators,
             datasetParts.map {
               case (name, location) => DataSetPart.factory(name, location, None)(_)
-            }
+            },
+            datasetKeywords
           )
         )
       )

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.7.0-dfd1004
+version: 1.6.5-dfd1004

--- a/helm-chart/renku-graph/charts/jena/templates/lucene-config.yaml
+++ b/helm-chart/renku-graph/charts/jena/templates/lucene-config.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   {{ .Values.global.graph.jena.dataset }}.ttl: |-
 
-    @prefix :        <#> .
+    @prefix:        <#> .
     @prefix fuseki:  <http://jena.apache.org/fuseki#> .
     @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
@@ -48,6 +48,7 @@ data:
       text:defaultField     "name" ;
       text:entityField      "uri" ;
       text:map (
-          [ text:field "name" ; text:predicate <http://schema.org/name> ]
-          [ text:field "description" ; text:predicate <http://schema.org/description> ]
+        [ text:field "name" ; text:predicate <http://schema.org/name> ]
+        [ text:field "description" ; text:predicate <http://schema.org/description> ]
+        [ text:field "alternateName" ; text:predicate <http://schema.org/alternateName> ]
       ) .

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -189,6 +189,10 @@ Response body example:
         }
       }
     }
+  ],
+  keywords: [
+    "rldzpwo",
+    "gfioui"
   ]
 }
 ```

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/model.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/model.scala
@@ -33,7 +33,8 @@ object model {
                            maybeDescription: Option[Description],
                            published:        DatasetPublishing,
                            parts:            List[DatasetPart],
-                           projects:         List[DatasetProject])
+                           projects:         List[DatasetProject],
+                           keywords:         List[Keyword])
 
   final case class DatasetPublishing(maybeDate: Option[PublishedDate], creators: Set[DatasetCreator])
   final case class DatasetCreator(maybeEmail:   Option[Email], name:             UserName, maybeAffiliation: Option[Affiliation])

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinder.scala
@@ -21,11 +21,12 @@ package ch.datascience.knowledgegraph.datasets.rest
 import cats.MonadError
 import cats.effect.{ContextShift, IO, Timer}
 import ch.datascience.graph.config.RenkuBaseUrl
-import ch.datascience.graph.model.datasets.Identifier
+import ch.datascience.graph.model.datasets.{Identifier, Keyword}
 import ch.datascience.knowledgegraph.datasets.model.Dataset
 import ch.datascience.rdfstore._
 import eu.timepit.refined.auto._
 import io.chrisdavenport.log4cats.Logger
+import io.circe.Decoder.decodeList
 import io.circe.HCursor
 
 import scala.concurrent.ExecutionContext
@@ -54,7 +55,7 @@ private class BaseDetailsFinder(
       "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
       "PREFIX schema: <http://schema.org/>"
     ),
-    s"""|SELECT DISTINCT ?datasetId ?identifier ?name ?alternateName ?url (?topmostSameAs AS ?sameAs) ?description ?publishedDate
+    s"""|SELECT DISTINCT ?datasetId ?identifier ?name ?alternateName ?url (?topmostSameAs AS ?sameAs) ?description ?publishedDate 
         |WHERE {
         |  {
         |    SELECT ?topmostSameAs
@@ -103,6 +104,59 @@ private class BaseDetailsFinder(
         |""".stripMargin
   )
 
+  def findKeywords(identifier: Identifier): IO[List[Keyword]] =
+    queryExpecting[List[Keyword]](using = queryKeywords(identifier)).flatMap(s => ME.pure(s))
+
+  private def queryKeywords(identifier: Identifier) = SparqlQuery(
+    name = "ds by id - keyword details",
+    Set(
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
+      "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+      "PREFIX schema: <http://schema.org/>"
+    ),
+    s"""|SELECT DISTINCT ?datasetId ?keyword
+        |WHERE {
+        |  {
+        |    SELECT ?topmostSameAs
+        |    WHERE {
+        |      {
+        |        ?l0 rdf:type <http://schema.org/Dataset>;
+        |            schema:identifier "$identifier"
+        |      } {
+        |        {
+        |          {
+        |            ?l0 schema:sameAs+/schema:url ?l1.
+        |            FILTER NOT EXISTS { ?l1 schema:sameAs ?l2 }
+        |            BIND (?l1 AS ?topmostSameAs)
+        |          } UNION {
+        |            ?l0 rdf:type <http://schema.org/Dataset>.
+        |            FILTER NOT EXISTS { ?l0 schema:sameAs ?l1 }
+        |            BIND (?l0 AS ?topmostSameAs)
+        |          }
+        |        } UNION {
+        |          ?l0 schema:sameAs+/schema:url ?l1.
+        |          ?l1 schema:sameAs+/schema:url ?l2
+        |          FILTER NOT EXISTS { ?l2 schema:sameAs ?l3 }
+        |          BIND (?l2 AS ?topmostSameAs)
+        |        } UNION {
+        |          ?l0 schema:sameAs+/schema:url ?l1.
+        |          ?l1 schema:sameAs+/schema:url ?l2.
+        |          ?l2 schema:sameAs+/schema:url ?l3
+        |          FILTER NOT EXISTS { ?l3 schema:sameAs ?l4 }
+        |          BIND (?l3 AS ?topmostSameAs)
+        |        }
+        |      }
+        |    }
+        |    GROUP BY ?topmostSameAs
+        |    HAVING (COUNT(*) > 0)
+        |  } {
+        |    ?datasetId schema:identifier "$identifier" ;
+        |               schema:keywords ?keyword .
+        |  }
+        |}ORDER BY ASC(?keyword)
+        |""".stripMargin
+  )
+
   private lazy val toSingleDataset: List[Dataset] => IO[Option[Dataset]] = {
     case Nil            => ME.pure(None)
     case dataset +: Nil => ME.pure(Some(dataset))
@@ -111,13 +165,13 @@ private class BaseDetailsFinder(
 }
 
 private object BaseDetailsFinder {
+  import ch.datascience.tinytypes.json.TinyTypeDecoders._
   import io.circe.Decoder
 
   private[rest] implicit val maybeRecordDecoder: Decoder[List[Dataset]] = {
     import Decoder._
     import ch.datascience.graph.model.datasets._
     import ch.datascience.knowledgegraph.datasets.model._
-    import ch.datascience.tinytypes.json.TinyTypeDecoders._
 
     def extract[T](property: String, from: HCursor)(implicit decoder: Decoder[T]): Result[T] =
       from.downField(property).downField("value").as[T]
@@ -143,10 +197,22 @@ private object BaseDetailsFinder {
         maybeDescription,
         DatasetPublishing(maybePublishedDate, Set.empty),
         parts    = List.empty,
-        projects = List.empty
+        projects = List.empty,
+        keywords = List.empty
       )
     }
 
     _.downField("results").downField("bindings").as(decodeList(dataset))
+  }
+
+  private implicit val keywordsDecoder: Decoder[List[Keyword]] = {
+
+    implicit val keywordDecoder: Decoder[Keyword] = { cursor =>
+      for {
+        keywordString <- cursor.downField("keyword").downField("value").as[String]
+      } yield Keyword(keywordString)
+    }
+
+    _.downField("results").downField("bindings").as(decodeList[Keyword])
   }
 }

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinder.scala
@@ -110,49 +110,12 @@ private class BaseDetailsFinder(
   private def queryKeywords(identifier: Identifier) = SparqlQuery(
     name = "ds by id - keyword details",
     Set(
-      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>",
-      "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
       "PREFIX schema: <http://schema.org/>"
     ),
-    s"""|SELECT DISTINCT ?datasetId ?keyword
+    s"""|SELECT DISTINCT ?keyword
         |WHERE {
-        |  {
-        |    SELECT ?topmostSameAs
-        |    WHERE {
-        |      {
-        |        ?l0 rdf:type <http://schema.org/Dataset>;
-        |            schema:identifier "$identifier"
-        |      } {
-        |        {
-        |          {
-        |            ?l0 schema:sameAs+/schema:url ?l1.
-        |            FILTER NOT EXISTS { ?l1 schema:sameAs ?l2 }
-        |            BIND (?l1 AS ?topmostSameAs)
-        |          } UNION {
-        |            ?l0 rdf:type <http://schema.org/Dataset>.
-        |            FILTER NOT EXISTS { ?l0 schema:sameAs ?l1 }
-        |            BIND (?l0 AS ?topmostSameAs)
-        |          }
-        |        } UNION {
-        |          ?l0 schema:sameAs+/schema:url ?l1.
-        |          ?l1 schema:sameAs+/schema:url ?l2
-        |          FILTER NOT EXISTS { ?l2 schema:sameAs ?l3 }
-        |          BIND (?l2 AS ?topmostSameAs)
-        |        } UNION {
-        |          ?l0 schema:sameAs+/schema:url ?l1.
-        |          ?l1 schema:sameAs+/schema:url ?l2.
-        |          ?l2 schema:sameAs+/schema:url ?l3
-        |          FILTER NOT EXISTS { ?l3 schema:sameAs ?l4 }
-        |          BIND (?l3 AS ?topmostSameAs)
-        |        }
-        |      }
-        |    }
-        |    GROUP BY ?topmostSameAs
-        |    HAVING (COUNT(*) > 0)
-        |  } {
         |    ?datasetId schema:identifier "$identifier" ;
         |               schema:keywords ?keyword .
-        |  }
         |}ORDER BY ASC(?keyword)
         |""".stripMargin
   )

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpoint.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpoint.scala
@@ -94,7 +94,8 @@ class DatasetEndpoint[Interpretation[_]: Effect](
           Some("creator" -> dataset.published.creators.toList.asJson)
         ).flatten: _*)),
         Some("hasPart" -> dataset.parts.asJson),
-        Some("isPartOf" -> dataset.projects.asJson)
+        Some("isPartOf" -> dataset.projects.asJson),
+        Some("keywords" -> dataset.keywords.asJson)
       ).flatten: _*
     ) deepMerge _links(
       Link(Rel.Self -> Href(renkuResourcesUrl / "datasets" / dataset.id))

--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetFinder.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetFinder.scala
@@ -49,10 +49,12 @@ private class IODatasetFinder(
   def findDataset(identifier: Identifier): IO[Option[Dataset]] =
     for {
       maybeDetailsFiber <- findBaseDetails(identifier).start
+      keywordsFiber     <- findKeywords(identifier).start
       creatorsFiber     <- findCreators(identifier).start
       partsFiber        <- findParts(identifier).start
       projectsFiber     <- findProjects(identifier).start
       maybeDetails      <- maybeDetailsFiber.join
+      keywords          <- keywordsFiber.join
       creators          <- creatorsFiber.join
       parts             <- partsFiber.join
       projects          <- projectsFiber.join
@@ -60,7 +62,8 @@ private class IODatasetFinder(
       details.copy(
         published = details.published.copy(creators = creators),
         parts     = parts,
-        projects  = projects
+        projects  = projects,
+        keywords  = keywords
       )
     }
 }

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
@@ -41,10 +41,20 @@ object DatasetsGenerators {
       maybeUrl         <- Gen.option(datasetUrls)
       sameas           <- sameAs
       maybeDescription <- Gen.option(datasetDescriptions)
+      keywords         <- nonEmptyList(datasetKeywords)
       published        <- datasetPublishingInfos
       part             <- listOf(datasetParts)
       projects         <- projects
-    } yield Dataset(id, title, name, sameas, maybeUrl, maybeDescription, published, part, projects.toList)
+    } yield Dataset(id,
+                    title,
+                    name,
+                    sameas,
+                    maybeUrl,
+                    maybeDescription,
+                    published,
+                    part,
+                    projects.toList,
+                    keywords.toList)
 
   implicit lazy val datasetCreators: Gen[DatasetCreator] = for {
     maybeEmail       <- Gen.option(userEmails)

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/DatasetsGenerators.scala
@@ -41,20 +41,11 @@ object DatasetsGenerators {
       maybeUrl         <- Gen.option(datasetUrls)
       sameas           <- sameAs
       maybeDescription <- Gen.option(datasetDescriptions)
-      keywords         <- nonEmptyList(datasetKeywords)
+      keywords         <- listOf(datasetKeywords)
       published        <- datasetPublishingInfos
       part             <- listOf(datasetParts)
       projects         <- projects
-    } yield Dataset(id,
-                    title,
-                    name,
-                    sameas,
-                    maybeUrl,
-                    maybeDescription,
-                    published,
-                    part,
-                    projects.toList,
-                    keywords.toList)
+    } yield Dataset(id, title, name, sameas, maybeUrl, maybeDescription, published, part, projects.toList, keywords)
 
   implicit lazy val datasetCreators: Gen[DatasetCreator] = for {
     maybeEmail       <- Gen.option(userEmails)

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/BaseDetailsFinderSpec.scala
@@ -37,6 +37,7 @@ class BaseDetailsFinderSpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
   private implicit val renkuBaseUrl: RenkuBaseUrl = renkuBaseUrls.generateOne
 
   import BaseDetailsFinder._
+  import io.circe.syntax._
 
   "dataset decoder" should {
 
@@ -51,6 +52,7 @@ class BaseDetailsFinderSpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
               .copy(maybeDescription = None)
               .copy(parts = Nil)
               .copy(projects = Nil)
+              .copy(keywords = Nil)
           )
         }
       }
@@ -69,7 +71,8 @@ class BaseDetailsFinderSpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
           "publishedDate": {"value": ${publishedDate.value}},
           "description": {"value": $blank},
           "url": {"value": $blank},
-          "sameAs": {"value": $blank}
+          "sameAs": {"value": $blank},
+          "keywords": {"value": ${dataset.keywords.map(_.value).asJson}}
         }
       ]
     }

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
@@ -66,9 +66,8 @@ class DatasetEndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPr
 
         val response = getDataset(dataset.id).unsafeRunSync()
 
-        response.status      shouldBe Ok
-        response.contentType shouldBe Some(`Content-Type`(MediaType.application.json))
-
+        response.status                    shouldBe Ok
+        response.contentType               shouldBe Some(`Content-Type`(MediaType.application.json))
         response.as[Dataset].unsafeRunSync shouldBe dataset
         response.as[Json].unsafeRunSync._links shouldBe Right(
           Links.of(Self -> Href(renkuResourcesUrl / "datasets" / dataset.id))
@@ -157,7 +156,8 @@ class DatasetEndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPr
       published        <- cursor.downField("published").as[DatasetPublishing]
       parts            <- cursor.downField("hasPart").as[List[DatasetPart]]
       projects         <- cursor.downField("isPartOf").as[List[DatasetProject]]
-    } yield Dataset(id, title, name, sameAs, maybeUrl, maybeDescription, published, parts, projects)
+      keywords         <- cursor.downField("keywords").as[List[Keyword]]
+    } yield Dataset(id, title, name, sameAs, maybeUrl, maybeDescription, published, parts, projects, keywords)
 
   private implicit lazy val datasetPublishingDecoder: Decoder[DatasetPublishing] = (cursor: HCursor) =>
     for {

--- a/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/ch/datascience/knowledgegraph/datasets/rest/IODatasetFinderSpec.scala
@@ -24,7 +24,7 @@ import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.generators.Generators._
 import ch.datascience.graph.model.EventsGenerators._
 import ch.datascience.graph.model.GraphModelGenerators._
-import ch.datascience.graph.model.datasets.{DateCreated, DateCreatedInProject, SameAs}
+import ch.datascience.graph.model.datasets.{DateCreated, DateCreatedInProject, Keyword, SameAs}
 import ch.datascience.graph.model.events.CommittedDate
 import ch.datascience.interpreters.TestLogger
 import ch.datascience.knowledgegraph.datasets.DatasetsGenerators._
@@ -65,7 +65,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreatedDate        = DateCreated(addedToProject1.date.value),
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate adding a file to the data-set in another commit
               committedDate = CommittedDate(project1DatasetCreationDate.value plusSeconds 10)
@@ -82,7 +83,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreatedDate        = DateCreated(addedToProject1.date.value),
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate adding the same data-set to another project
               committedDate = addedToProject2.date.toUnsafe(date => CommittedDate.from(date.value)),
@@ -99,7 +101,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             randomDataSetCommit
           )
@@ -108,7 +111,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             dataset.copy(
               parts = dataset.parts.sorted,
               projects = List(DatasetProject(project1.path, project1.name, addedToProject1),
-                              DatasetProject(project2.path, project2.name, addedToProject2)).sorted
+                              DatasetProject(project2.path, project2.name, addedToProject2)).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -135,7 +139,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreatedDate        = DateCreated(addedToProject1.date.value),
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // simulating dataset modification
               committedDate = CommittedDate(addedToProject1.date.value).shiftToFuture
@@ -152,7 +157,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreatedDate        = DateCreated(addedToProject1.date.value),
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate adding first project's data-set to another project
               committedDate = addedToProject2.date.toUnsafe(date => CommittedDate.from(date.value)),
@@ -169,7 +175,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             randomDataSetCommit
           )
@@ -179,7 +186,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               sameAs = dataset.entityId.asSameAs,
               parts  = dataset.parts.sorted,
               projects = List(DatasetProject(project1.path, project1.name, addedToProject1),
-                              DatasetProject(project2.path, project2.name, addedToProject2)).sorted
+                              DatasetProject(project2.path, project2.name, addedToProject2)).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -205,7 +213,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             maybeDatasetPublishedDate = dataset.published.maybeDate,
             datasetCreatedDate        = DateCreated(addedToProject.date.value),
             datasetCreators           = dataset.published.creators map toPerson,
-            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+            datasetKeywords           = dataset.keywords
           ),
           dataSetCommit( // simulating dataset modification
             committedDate = CommittedDate(addedToProject.date.value).shiftToFuture
@@ -222,7 +231,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             maybeDatasetPublishedDate = dataset.published.maybeDate,
             datasetCreatedDate        = DateCreated(addedToProject.date.value),
             datasetCreators           = dataset.published.creators map toPerson,
-            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+            datasetKeywords           = dataset.keywords
           ),
           randomDataSetCommit
         )
@@ -230,7 +240,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
         datasetFinder.findDataset(dataset.id).unsafeRunSync() shouldBe Some(
           dataset.copy(
             parts    = dataset.parts.sorted,
-            projects = List(DatasetProject(project.path, project.name, addedToProject))
+            projects = List(DatasetProject(project.path, project.name, addedToProject)),
+            keywords = dataset.keywords.sorted
           )
         )
       }
@@ -256,7 +267,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             maybeDatasetPublishedDate = dataset.published.maybeDate,
             datasetCreatedDate        = DateCreated(addedToProject.date.value),
             datasetCreators           = dataset.published.creators map toPerson,
-            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+            datasetKeywords           = dataset.keywords
           ),
           dataSetCommit( // simulating dataset modification
             committedDate = CommittedDate(addedToProject.date.value).shiftToFuture
@@ -273,7 +285,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             maybeDatasetPublishedDate = dataset.published.maybeDate,
             datasetCreatedDate        = DateCreated(addedToProject.date.value),
             datasetCreators           = dataset.published.creators map toPerson,
-            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+            datasetKeywords           = dataset.keywords
           ),
           randomDataSetCommit
         )
@@ -282,7 +295,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
           dataset.copy(
             sameAs   = dataset.entityId.asSameAs,
             parts    = dataset.parts.sorted,
-            projects = List(DatasetProject(project.path, project.name, addedToProject))
+            projects = List(DatasetProject(project.path, project.name, addedToProject)),
+            keywords = dataset.keywords.sorted
           )
         )
       }
@@ -316,7 +330,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate adding the same data-set to another project
               commitId      = project2DatasetCommit,
@@ -334,7 +349,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate forking project2
               commitId      = project2DatasetCommit,
@@ -352,7 +368,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             )
           )
 
@@ -363,7 +380,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
                 DatasetProject(project1.path, project1.name, addedToProject1),
                 DatasetProject(project2.path, project2.name, addedToProject2),
                 DatasetProject(project2Fork.path, project2Fork.name, addedToProject2)
-              ).sorted
+              ).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -399,7 +417,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate adding first project's data-set to another project
               commitId      = project2DatasetCommit,
@@ -417,7 +436,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit( // to simulate forking project2
               commitId      = project2DatasetCommit,
@@ -435,7 +455,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             )
           )
 
@@ -447,7 +468,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
                 DatasetProject(project1.path, project1.name, addedToProject1),
                 DatasetProject(project2.path, project2.name, addedToProject2),
                 DatasetProject(project2Fork.path, project2Fork.name, addedToProject2)
-              ).sorted
+              ).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -475,7 +497,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit(
               commitId      = commitId,
@@ -493,7 +516,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             )
           )
 
@@ -504,7 +528,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               projects = List(
                 DatasetProject(sourceProject.path, sourceProject.name, addedToProject),
                 DatasetProject(forkProject.path, forkProject.name, addedToProject)
-              ).sorted
+              ).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -532,7 +557,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             ),
             dataSetCommit(
               commitId      = commitId,
@@ -550,7 +576,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             )
           )
 
@@ -560,7 +587,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               projects = List(
                 DatasetProject(sourceProject.path, sourceProject.name, addedToProject),
                 DatasetProject(forkProject.path, forkProject.name, addedToProject)
-              ).sorted
+              ).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -587,7 +615,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             maybeDatasetDescription   = dataset.maybeDescription,
             maybeDatasetPublishedDate = dataset.published.maybeDate,
             datasetCreators           = dataset.published.creators map toPerson,
-            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+            datasetKeywords           = dataset.keywords
           )
           val parentProjectDataSet = dataSetCommit(
             commitId      = commitId,
@@ -605,7 +634,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             maybeDatasetDescription   = dataset.maybeDescription,
             maybeDatasetPublishedDate = dataset.published.maybeDate,
             datasetCreators           = dataset.published.creators map toPerson,
-            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+            datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+            datasetKeywords           = dataset.keywords
           )
           loadToStore(
             grandparentProjectDataSet,
@@ -626,7 +656,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
               maybeDatasetDescription   = dataset.maybeDescription,
               maybeDatasetPublishedDate = dataset.published.maybeDate,
               datasetCreators           = dataset.published.creators map toPerson,
-              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation))
+              datasetParts              = dataset.parts.map(part => (part.name, part.atLocation)),
+              datasetKeywords           = dataset.keywords
             )
           )
 
@@ -638,7 +669,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
                 DatasetProject(grandparentProject.path, grandparentProject.name, addedToProject),
                 DatasetProject(parentProject.path, parentProject.name, addedToProject),
                 DatasetProject(childProject.path, childProject.name, addedToProject)
-              ).sorted
+              ).sorted,
+              keywords = dataset.keywords.sorted
             )
           )
       }
@@ -677,7 +709,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             dataset1Project,
             dataset2Project,
             dataset3Project
-          ).sorted
+          ).sorted,
+          keywords = dataset1.keywords.sorted
         )
       )
     }
@@ -713,7 +746,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             dataset1Project,
             dataset2Project,
             dataset3Project
-          ).sorted
+          ).sorted,
+          keywords = dataset1.keywords.sorted
         )
       )
     }
@@ -750,7 +784,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             dataset1Project,
             dataset2Project,
             dataset3Project
-          ).sorted
+          ).sorted,
+          keywords = dataset2.keywords.sorted
         )
       )
     }
@@ -787,7 +822,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             dataset1Project,
             dataset2Project,
             dataset3Project
-          ).sorted
+          ).sorted,
+          keywords = dataset3.keywords.sorted
         )
       )
     }
@@ -823,7 +859,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
             dataset1Project,
             dataset2Project,
             dataset3Project
-          ).sorted
+          ).sorted,
+          keywords = dataset1.keywords.sorted
         )
       )
     }
@@ -886,7 +923,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
           maybeDatasetPublishedDate = dataSet.published.maybeDate,
           datasetCreatedDate        = DateCreated(project.created.date.value),
           datasetCreators           = dataSet.published.creators map toPerson,
-          datasetParts              = dataSet.parts.map(part => (part.name, part.atLocation))
+          datasetParts              = dataSet.parts.map(part => (part.name, part.atLocation)),
+          datasetKeywords           = dataSet.keywords
         )
       case _ => fail("Not prepared to work datasets having multiple projects")
     }
@@ -899,4 +937,8 @@ class IODatasetFinderSpec extends AnyWordSpec with InMemoryRdfStore with ScalaCh
 
   private implicit lazy val projectsAlphabeticalOrdering: Ordering[DatasetProject] =
     (project1: DatasetProject, project2: DatasetProject) => project1.name.value compareTo project2.name.value
+
+  private implicit lazy val keywordsAlphabeticalOrdering: Ordering[Keyword] =
+    (keyword1: Keyword, keyword2: Keyword) => keyword1.value compareTo keyword2.value
+
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.0-SNAPSHOT"
+version in ThisBuild := "1.6.5-SNAPSHOT"


### PR DESCRIPTION
Added proper index in Jena for schema:alternateName. Returning schema:keywords when querying dataset details