### PR TITLE
fix: so the publish job succeeds

### DIFF
--- a/.travis/travis-functions.sh
+++ b/.travis/travis-functions.sh
@@ -69,6 +69,7 @@ function updateVersionInRenku() {
   # running helm dep udpate
   cd charts || exit
   helm repo add renku https://swissdatasciencecenter.github.io/helm-charts/
+  helm repo add bitnami https://charts.bitnami.com/bitnami
   helm dep update renku
   cd .. || exit
 

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.7.0-dfd1004
+version: 1.6.5-dfd1004

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7.0-SNAPSHOT"
+version in ThisBuild := "1.6.5-SNAPSHOT"


### PR DESCRIPTION
It looks that the publishing process cannot succeed on our CI. It fails with:
```
Error: no repository definition for https://charts.bitnami.com/bitnami. Please add them via 'helm repo add'
```
https://travis-ci.org/github/SwissDataScienceCenter/renku-graph/builds/719663096

This change tries to address that.

Reference: https://github.com/bitnami/charts