### PR TITLE
chore: sentry-sdk pinned to 0.18.0

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.10.0-9493f38
+version: 1.9.5-9493f38

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -24,7 +24,7 @@ ENV TZ UTC
 
 # Installing Renku and other dependencies
 RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py3-pip openssl-dev libffi-dev linux-headers gcc libxml2-dev libxslt-dev libc-dev yaml-dev && \
-    python3 -m pip install 'renku==0.11.4' sentry-sdk  && \
+    python3 -m pip install 'renku==0.11.4' 'sentry-sdk==0.18.0'  && \
     chown -R daemon:daemon . && \
     git config --global user.name 'renku'  && \
     git config --global user.email 'renku@renkulab.io'  && \

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.10.0-SNAPSHOT"
+version in ThisBuild := "1.9.5-SNAPSHOT"


### PR DESCRIPTION
There's a problem with sentry-sdk 0.19.0 and renku 0.11.4 so this PR pins version of the sdk to one that works.