### PR TITLE
fix: cloning to classify connectivity issues as Recoverable

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.10.0-c3a8b2e
+version: 1.9.8-c3a8b2e

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/Commands.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/Commands.scala
@@ -116,7 +116,8 @@ private object Commands {
     private val recoverableErrors = Set("SSL_ERROR_SYSCALL",
                                         "the remote end hung up unexpectedly",
                                         "The requested URL returned error: 502",
-                                        "Could not resolve host:"
+                                        "Could not resolve host:",
+                                        "Host is unreachable"
     )
     private lazy val relevantError: PartialFunction[Throwable, IO[Either[GenerationRecoverableError, Unit]]] = {
       case ShelloutException(result) =>

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/GitSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/eventprocessing/triplesgeneration/renkulog/GitSpec.scala
@@ -50,7 +50,8 @@ class GitSpec extends AnyWordSpec with MockFactory with should.Matchers {
       Refined.unsafeApply(
         s"fatal: unable to access 'https://renkulab.io/gitlab/${projectPaths.generateOne}.git/': The requested URL returned error: 502"
       ),
-      "Could not resolve host: renkulab.io"
+      "Could not resolve host: renkulab.io",
+      "Failed to connect to renkulab.io port 443: Host is unreachable"
     )
 
     recoverableFailureMessagesToCheck foreach { recoverableError =>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.10.0-SNAPSHOT"
+version in ThisBuild := "1.9.8-SNAPSHOT"


### PR DESCRIPTION
It looks like errors like this:
```
Failed to connect to renkulab.io port 443: Host is unreachable
```
happening during `git clone` operation on the triples-generator are classified as non-recoverable while they should be recoverable.