### PR TITLE
Memory leak on event-log

### DIFF
--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.10.0-f870200
+version: 1.9.9-f870200

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.10.0-SNAPSHOT"
+version in ThisBuild := "1.9.9-SNAPSHOT"


### PR DESCRIPTION
There's a tiny problem which causes huge memory leak on event-log. The SubscribersRegistry creates a new thread each time it checks if there are subscribers in the busy pool.