### PR TITLE
Event fetcher bug

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
@@ -117,18 +117,15 @@ private class EventFetcherImpl(
 
   // format: off
   private def findOldestEvent(idAndPath: ProjectIdAndPath) = SqlQuery({
-      fr"""select el.event_id, el.project_id, el.event_body
-           from (
-             select project_id, min(event_date) as min_event_date
-             from event_log
-             where project_id = ${idAndPath.id}
-               and ((""" ++ `status IN`(New, RecoverableFailure) ++ fr""" and execution_date < ${now()})
-                 or (status = ${Processing: EventStatus} and execution_date < ${now() minus maxProcessingTime}))
-             group by project_id
-           ) oldest_event_date
-           join event_log el on oldest_event_date.project_id = el.project_id and oldest_event_date.min_event_date = el.event_date
-           limit 1
-           """
+    fr"""select event_log.event_id, event_log.project_id, event_log.event_body
+         from event_log
+         where project_id = ${idAndPath.id}
+           and (
+             (""" ++ `status IN`(New, RecoverableFailure) ++ fr""" and execution_date < ${now()})
+             or (status = ${Processing: EventStatus} and execution_date < ${now() minus maxProcessingTime})
+           )
+         order by event_date asc
+         limit 1"""
     }.query[EventIdAndBody].option,
     name = "pop event - oldest"
   )

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.14.0-00fe679
+version: 1.13.1-00fe679

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.14.0-SNAPSHOT"
+version in ThisBuild := "1.13.1-SNAPSHOT"


### PR DESCRIPTION
It looks like the new improved query for selecting the oldest non-processed event did not work with events having the same date created.