### PR TITLE
fix: event fetcher to sort the projests int the queue

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
@@ -106,6 +106,7 @@ private class EventFetcherImpl(
             or (status = ${Processing: EventStatus} and execution_date < ${now() minus maxProcessingTime})
           )
       )
+      order by latest_event_date desc
       limit ${projectsFetchingLimit.value}  
       """ 
     }.query[(projects.Id, projects.Path, EventDate, Int)]

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.14.0-53fe185
+version: 1.13.3-53fe185

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.14.0-SNAPSHOT"
+version in ThisBuild := "1.13.3-SNAPSHOT"


### PR DESCRIPTION
It looks the sorting done in the view does not guarantee the projects waiting in the queue are fetched in the right order.