### PR TITLE
Events timeouts extended

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
@@ -186,7 +186,7 @@ private class EventFetcherImpl(
 
 private object IOEventFetcher {
 
-  private val MaxProcessingTime:     Duration             = Duration.ofMinutes(120)
+  private val MaxProcessingTime:     Duration             = Duration.ofHours(5)
   private val ProjectsFetchingLimit: Int Refined Positive = 10
 
   def apply(

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.14.0-b2c7ac3
+version: 1.13.5-b2c7ac3

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -34,7 +34,7 @@ triplesGenerator:
     limits:
       memory: 5000Mi
   jvmXmx: 2g
-  renkuLogTimeout: 60 minutes
+  renkuLogTimeout: 180 minutes
   reProvisioningRemovalBatchSize: 1000
   gitlab:
     rateLimit: 30/sec

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -4,7 +4,7 @@ generation-processes-number = ${?GENERATION_PROCESSES_NUMBER}
 threads-number = 2
 threads-number = ${?THREADS_NUMBER}
 
-renku-log-timeout = 1 hour
+renku-log-timeout = 3 hours
 renku-log-timeout = ${?RENKU_LOG_TIMEOUT}
 
 re-provisioning-removal-batch-size = 1000

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.14.0-SNAPSHOT"
+version in ThisBuild := "1.13.5-SNAPSHOT"


### PR DESCRIPTION
It looks two timeouts are currently too short:
* `renku-log-timeout` set to one hour causes events to fail when they could succeed if allowed to run longer;
* `maxProcessingTime` causes same events to be processed several times in different TGs.

Both the values get extended as part of the PR.
