### PR TITLE
chore: webhook memory and maxProcessingTime increased

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/EventFetcher.scala
@@ -186,7 +186,7 @@ private class EventFetcherImpl(
 
 private object IOEventFetcher {
 
-  private val MaxProcessingTime:     Duration             = Duration.ofHours(5)
+  private val MaxProcessingTime:     Duration             = Duration ofHours 12
   private val ProjectsFetchingLimit: Int Refined Positive = 10
 
   def apply(

--- a/helm-chart/renku-graph/Chart.yaml
+++ b/helm-chart/renku-graph/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for renku graph services
 name: renku-graph
-version: 1.19.0-ee2630c
+version: 1.18.1-ee2630c

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -54,7 +54,7 @@ webhookService:
     port: 80
   resources:
     limits:
-      memory: 2100Mi
+      memory: 2500Mi
   jvmXmx: 300M
   eventsSynchronization:
     initialDelay: 2 minutes

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.19.0-SNAPSHOT"
+version in ThisBuild := "1.18.1-SNAPSHOT"


### PR DESCRIPTION
This PR contains two tiny tweaks:
* memory limit raised for webhook-service to 2500Mi to prevent from unnecessary kube restarts
* MaxProcessingTime raised to 12 hours to prevent from same events being processed multiple times