### PR TITLE
fix: mute logback status log entries

### DIFF
--- a/event-log/src/main/resources/logback.xml
+++ b/event-log/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/knowledge-graph/src/main/resources/logback.xml
+++ b/knowledge-graph/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/token-repository/src/main/resources/logback.xml
+++ b/token-repository/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/triples-generator/src/main/resources/logback.xml
+++ b/triples-generator/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.20.17"
+version in ThisBuild := "1.20.18"

--- a/webhook-service/src/main/resources/logback.xml
+++ b/webhook-service/src/main/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <charset>UTF-8</charset>


### PR DESCRIPTION
With the current set-up logback logs some status log entries on service start-up. This PR mutes that.

Example of logs to be muted:
```
15:02:36,161 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
15:02:36,162 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
15:02:36,162 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/Users/kuba/sdsc/code/renku-graph/webhook-service/target/scala-2.13/classes/logback.xml]
15:02:36,291 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - debug attribute not set
15:02:36,293 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
15:02:36,302 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [STDOUT]
15:02:36,310 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
15:02:36,348 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.classic.AsyncAppender]
15:02:36,350 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [ASYNC_STDOUT]
15:02:36,350 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [STDOUT] to ch.qos.logback.classic.AsyncAppender[ASYNC_STDOUT]
15:02:36,351 |-INFO in ch.qos.logback.classic.AsyncAppender[ASYNC_STDOUT] - Attaching appender named [STDOUT] to AsyncAppender.
15:02:36,351 |-INFO in ch.qos.logback.classic.AsyncAppender[ASYNC_STDOUT] - Setting discardingThreshold to 51
15:02:36,351 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.core.FileAppender]
15:02:36,355 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [FILE]
15:02:36,356 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
15:02:36,357 |-INFO in ch.qos.logback.core.FileAppender[FILE] - File property is set to [/tmp/microservice-access.log]
15:02:36,359 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [io.sentry.logback.SentryAppender]
15:02:36,431 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [SENTRY]
15:02:36,442 |-WARN in io.sentry.logback.SentryAppender[SENTRY] - Failed to init Sentry during appender initialization: DSN is required. Use empty string to disable SDK.
15:02:36,442 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - About to instantiate appender of type [ch.qos.logback.classic.AsyncAppender]
15:02:36,442 |-INFO in ch.qos.logback.core.joran.action.AppenderAction - Naming appender as [ASYNC_FILE]
15:02:36,442 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [FILE] to ch.qos.logback.classic.AsyncAppender[ASYNC_FILE]
15:02:36,442 |-INFO in ch.qos.logback.classic.AsyncAppender[ASYNC_FILE] - Attaching appender named [FILE] to AsyncAppender.
15:02:36,442 |-INFO in ch.qos.logback.classic.AsyncAppender[ASYNC_FILE] - Setting discardingThreshold to 51
15:02:36,443 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.http4s.blaze.channel.nio1.NIO1SocketServerGroup] to INFO
15:02:36,443 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting additivity of logger [org.http4s.blaze.channel.nio1.NIO1SocketServerGroup] to false
15:02:36,443 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [ASYNC_FILE] to Logger[org.http4s.blaze.channel.nio1.NIO1SocketServerGroup]
15:02:36,443 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [application] to INFO
15:02:36,443 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting additivity of logger [application] to false
15:02:36,443 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [ASYNC_STDOUT] to Logger[application]
15:02:36,443 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [SENTRY] to Logger[application]
15:02:36,443 |-INFO in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN
15:02:36,443 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [ASYNC_STDOUT] to Logger[ROOT]
15:02:36,443 |-INFO in ch.qos.logback.core.joran.action.AppenderRefAction - Attaching appender named [SENTRY] to Logger[ROOT]
15:02:36,443 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
15:02:36,444 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@27d4a09 - Registering current configuration as safe fallback point
```