### PR TITLE
fix: always upsert project name during triples transformation

### DIFF
--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/WebhookCreationSpec.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/WebhookCreationSpec.scala
@@ -51,6 +51,7 @@ class WebhookCreationSpec
     Scenario("Graph Services hook is present on the project in GitLab") {
 
       val projectId = projectIds.generateOne
+
       implicit val accessToken: AccessToken = accessTokens.generateOne
       Given("api user is authenticated")
       `GET <gitlabApi>/user returning OK`()

--- a/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/stubs/GitLab.scala
+++ b/acceptance-tests/src/test/scala/ch/datascience/graph/acceptancetests/stubs/GitLab.scala
@@ -27,7 +27,7 @@ import ch.datascience.graph.acceptancetests.tooling.TestLogger
 import ch.datascience.graph.model.EventsGenerators._
 import ch.datascience.graph.model.GraphModelGenerators._
 import ch.datascience.graph.model.events.CommitId
-import ch.datascience.graph.model.projects.{Id, Path, Visibility}
+import ch.datascience.graph.model.projects.{Id, Name, Path, Visibility}
 import ch.datascience.graph.model.users
 import ch.datascience.http.client.AccessToken
 import ch.datascience.http.client.AccessToken.{OAuthAccessToken, PersonalAccessToken}
@@ -69,13 +69,15 @@ object GitLab {
 
   def `GET <gitlabApi>/projects/:id returning OK`(
       projectId:          Id,
+      projectName:        Name = projectNames.generateOne,
       projectVisibility:  Visibility
   )(implicit accessToken: AccessToken): Unit = {
     stubFor {
       get(s"/api/v4/projects/$projectId").withAccessTokenInHeader
         .willReturn(okJson(json"""{
           "id":                  ${projectId.value}, 
-          "visibility":          ${projectVisibility.value}, 
+          "visibility":          ${projectVisibility.value},
+          "name":                ${projectName.value},
           "path_with_namespace": ${projectPaths.generateOne.value}
         }""".noSpaces))
     }
@@ -159,16 +161,18 @@ object GitLab {
   def `GET <gitlabApi>/projects/:id returning OK with Project Path`(
       project:            Project
   )(implicit accessToken: AccessToken): Unit =
-    `GET <gitlabApi>/projects/:id returning OK with Project Path`(project.id, project.path)
+    `GET <gitlabApi>/projects/:id returning OK with Project Path`(project.id, project.path, project.name)
 
   def `GET <gitlabApi>/projects/:id returning OK with Project Path`(
       projectId:          Id,
-      projectPath:        Path
+      projectPath:        Path,
+      projectName:        Name = projectNames.generateOne
   )(implicit accessToken: AccessToken): Unit = {
     stubFor {
       get(s"/api/v4/projects/$projectId").withAccessTokenInHeader
         .willReturn(okJson(json"""{
           "id":                  ${projectId.value},
+          "name":                ${projectName.value},
           "path_with_namespace": ${projectPath.value}
         }""".noSpaces))
     }
@@ -239,6 +243,7 @@ object GitLab {
           okJson(
             json"""{
               "id":                   ${project.id.value},
+              "name":                 ${project.name.value},
               "description":          ${project.maybeDescription.map(_.value)},
               "visibility":           ${project.visibility.value},
               "path_with_namespace":  ${project.path.value},

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/GitLabInfoFinder.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/GitLabInfoFinder.scala
@@ -22,7 +22,7 @@ import cats.effect.{ContextShift, IO, Timer}
 import ch.datascience.config.GitLab
 import ch.datascience.control.Throttler
 import ch.datascience.graph.config.GitLabUrl
-import ch.datascience.graph.model.projects.{DateCreated, Path}
+import ch.datascience.graph.model.projects.{DateCreated, Name, Path}
 import ch.datascience.graph.model.{projects, users}
 import ch.datascience.graph.model.users.GitLabId
 import ch.datascience.http.client.{AccessToken, IORestClient}
@@ -96,13 +96,14 @@ private class IOGitLabInfoFinder(
     implicit val decoder: Decoder[ProjectAndCreatorId] = cursor =>
       for {
         path           <- cursor.downField("path_with_namespace").as[projects.Path]
+        name           <- cursor.downField("name").as[projects.Name]
         visibility     <- cursor.downField("visibility").as[projects.Visibility]
         dateCreated    <- cursor.downField("created_at").as[projects.DateCreated]
         maybeCreatorId <- cursor.downField("creator_id").as[Option[users.GitLabId]]
         maybeParentPath <- cursor
                              .downField("forked_from_project")
                              .as[Option[projects.Path]](decodeOption(parentPathDecoder))
-      } yield GitLabProject(path, visibility, dateCreated, maybeParentPath, maybeCreator = None) -> maybeCreatorId
+      } yield GitLabProject(path, name, visibility, dateCreated, maybeParentPath, maybeCreator = None) -> maybeCreatorId
 
     jsonOf[IO, ProjectAndCreatorId]
   }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/ProjectPropertiesRemover.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/ProjectPropertiesRemover.scala
@@ -35,7 +35,7 @@ private class ProjectPropertiesRemover extends (JsonLDTriples => JsonLDTriples) 
   private def toJsonWithoutCreatorDetails(json: Json): Json =
     root.`@type`.each.string.getAll(json) match {
       case types if types.contains("http://schema.org/Project") =>
-        json.remove(schema / "creator").remove(schema / "dateCreated")
+        json.remove(schema / "creator").remove(schema / "dateCreated").remove(schema / "name")
       case _ => json
     }
 }

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/UpdatesCreator.scala
@@ -80,32 +80,35 @@ private class UpdatesCreatorImpl(
 
   private object `when project has a creator` {
     def unapply(maybeProject: Option[GitLabProject]): Option[(GitLabCreator, GitLabProject)] = maybeProject match {
-      case Some(project @ GitLabProject(_, _, _, _, Some(creator))) => (creator -> project).some
-      case _                                                        => None
+      case Some(project @ GitLabProject(_, _, _, _, _, Some(creator))) => (creator -> project).some
+      case _                                                           => None
     }
   }
 
   private object `when project has no creator` {
     def unapply(maybeProject: Option[GitLabProject]): Option[GitLabProject] = maybeProject match {
-      case Some(project @ GitLabProject(_, _, _, _, None)) => project.some
-      case _                                               => None
+      case Some(project @ GitLabProject(_, _, _, _, _, None)) => project.some
+      case _                                                  => None
     }
   }
 
   private def updateProjectAndSwapCreator(gitLabProject: GitLabProject, existingUserResource: users.ResourceId) =
-    updateWasDerivedFrom(gitLabProject.path, gitLabProject.maybeParentPath) ++
+    upsertName(gitLabProject.path, gitLabProject.name) ++
+      updateWasDerivedFrom(gitLabProject.path, gitLabProject.maybeParentPath) ++
       swapCreator(gitLabProject.path, existingUserResource) ++
       updateDateCreated(gitLabProject.path, gitLabProject.dateCreated) ++
       upsertVisibility(gitLabProject.path, gitLabProject.visibility)
 
   private def updateProjectAndAddCreator(gitLabProject: GitLabProject, creator: GitLabCreator) =
-    updateWasDerivedFrom(gitLabProject.path, gitLabProject.maybeParentPath) ++
+    upsertName(gitLabProject.path, gitLabProject.name) ++
+      updateWasDerivedFrom(gitLabProject.path, gitLabProject.maybeParentPath) ++
       addNewCreator(gitLabProject.path, creator) ++
       updateDateCreated(gitLabProject.path, gitLabProject.dateCreated) ++
       upsertVisibility(gitLabProject.path, gitLabProject.visibility)
 
   private def updateProjectAndUnlinkCreator(gitLabProject: GitLabProject) =
-    updateWasDerivedFrom(gitLabProject.path, gitLabProject.maybeParentPath) ++
+    upsertName(gitLabProject.path, gitLabProject.name) ++
+      updateWasDerivedFrom(gitLabProject.path, gitLabProject.maybeParentPath) ++
       unlinkCreator(gitLabProject.path) ++
       updateDateCreated(gitLabProject.path, gitLabProject.dateCreated) ++
       upsertVisibility(gitLabProject.path, gitLabProject.visibility)

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/UpdatesQueryCreator.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/UpdatesQueryCreator.scala
@@ -163,7 +163,7 @@ private class UpdatesQueryCreator(renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitL
         s"""|DELETE { $rdfResource schema:name ?name }
             |INSERT { $rdfResource schema:name '$name' }
             |WHERE  {
-            |  OPTIONAL { $rdfResource schema:name schema:previousName }  # NOT SURE IF WE NEED THIS LINE
+            |  OPTIONAL { $rdfResource schema:name ?previousName }
             |  BIND (IF(BOUND(?previousName), ?previousName, "nonexisting") AS ?name)
             |}
             |""".stripMargin

--- a/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/model.scala
+++ b/triples-generator/src/main/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/model.scala
@@ -18,11 +18,12 @@
 
 package ch.datascience.triplesgenerator.events.categories.awaitinggeneration.triplescuration.projects
 
-import ch.datascience.graph.model.projects.{DateCreated, Path, Visibility}
+import ch.datascience.graph.model.projects.{DateCreated, Name, Path, Visibility}
 import ch.datascience.graph.model.users
 import ch.datascience.graph.model.users.{Email, GitLabId}
 
 private final case class GitLabProject(path:            Path,
+                                       name:            Name,
                                        visibility:      Visibility,
                                        dateCreated:     DateCreated,
                                        maybeParentPath: Option[Path],

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/GitLabInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/GitLabInfoFinderSpec.scala
@@ -103,6 +103,7 @@ class GitLabInfoFinderSpec
   private def projectJson(project: GitLabProject, maybeCreatorId: Option[users.GitLabId]): Json =
     json"""{
       "path_with_namespace": ${project.path.value},
+      "name":                ${project.name.value},
       "created_at":          ${project.dateCreated.value},
       "visibility":          ${project.visibility.value}
     }"""

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/ProjectPropertiesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/ProjectPropertiesRemoverSpec.scala
@@ -44,7 +44,7 @@ class ProjectPropertiesRemoverSpec extends AnyWordSpec with ScalaCheckPropertyCh
 
   "ProjectPropertiesRemover" should {
 
-    "remove schema:dateCreated, and schema:creator, and schema:alternateName properties from all the Project entities in the given JSON" in {
+    "remove schema:dateCreated, and schema:creator, and schema:name properties from all the Project entities in the given JSON" in {
       forAll { project: Project =>
         val triples = JsonLDTriples {
           JsonLD

--- a/triples-generator/src/test/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/package.scala
+++ b/triples-generator/src/test/scala/ch/datascience/triplesgenerator/events/categories/awaitinggeneration/triplescuration/projects/package.scala
@@ -22,7 +22,7 @@ import ch.datascience.generators.CommonGraphGenerators.{fusekiBaseUrls, gitLabUr
 import ch.datascience.generators.Generators.Implicits._
 import ch.datascience.graph.config.{GitLabApiUrl, RenkuBaseUrl}
 import ch.datascience.graph.model.GraphModelGenerators._
-import ch.datascience.graph.model.projects.{Path, Visibility}
+import ch.datascience.graph.model.projects.{Name, Path, Visibility}
 import ch.datascience.graph.model.users
 import ch.datascience.graph.model.users.Email
 import ch.datascience.rdfstore.FusekiBaseUrl
@@ -44,11 +44,12 @@ package object projects {
       maybeParentPaths: Gen[Option[Path]] = projectPaths.toGeneratorOfOptions
   ): Gen[GitLabProject] =
     for {
+      name            <- projectNames
       visibility      <- projectVisibilities
       maybeParentPath <- maybeParentPaths
       maybeCreator    <- gitLabCreator().toGeneratorOfOptions
       dateCreated     <- projectCreatedDates
-    } yield GitLabProject(projectPath, visibility, dateCreated, maybeParentPath, maybeCreator)
+    } yield GitLabProject(projectPath, name, visibility, dateCreated, maybeParentPath, maybeCreator)
 
   private[projects] def gitLabCreator(gitLabId: users.GitLabId = userGitLabIds.generateOne,
                                       name:     users.Name = userNames.generateOne
@@ -63,15 +64,15 @@ package object projects {
 
   implicit val entitiesProjects: Gen[Project] = entitiesProjects(
     maybeCreator = persons.generateOption,
-    maybeParentProject = entitiesProjects(persons.generateOption).generateOption
+    maybeParentProject = entitiesProjects(maybeCreator = persons.generateOption).generateOption
   )
 
-  def entitiesProjects(maybeCreator:       Option[Person] = persons.generateOption,
+  def entitiesProjects(name:               Name = projectNames.generateOne,
+                       maybeCreator:       Option[Person] = persons.generateOption,
                        maybeParentProject: Option[Project] = None,
                        maybeVisibility:    Option[Visibility] = None
   ): Gen[Project] = for {
     path        <- projectPaths
-    name        <- projectNames
     createdDate <- projectCreatedDates
     version     <- projectSchemaVersions
   } yield Project(path,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.27.0"
+version in ThisBuild := "1.27.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.27.3"
+version in ThisBuild := "1.27.4"


### PR DESCRIPTION
Signed-off-by: Travis Lee <travis.lee@sdsc.ethz.ch>

I called this a fix because this was kind of a bug I think. 

closes #607 