### PR TITLE
charts: triples generator to accept number of replicas

### DIFF
--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.triplesGenerator.replicas }}
   strategy:
     type: Recreate
   selector:

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -23,6 +23,7 @@ tokenRepository:
     secret:
 
 triplesGenerator:
+  replicas: 1
   image:
     repository: renku/triples-generator
     tag: 'latest'


### PR DESCRIPTION
Noticed that this was missing on the TG charts, useful for Renkulab.
@jachro we might want to update the Chart version but I leave that to you.

/deploy