### PR TITLE
refactor: event distributor to fetch event when subscriber is up

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/commitsync/CommitSyncEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/commitsync/CommitSyncEventFinder.scala
@@ -53,7 +53,13 @@ private class CommitSyncEventFinderImpl(transactor:       DbTransactor[IO, Event
   private def findEvent() = measureExecutionTime {
     SqlQuery(
       sql"""|SELECT
-            |  (SELECT evt.event_id FROM event evt WHERE evt.project_id = proj.project_id AND evt.event_date = proj.latest_event_date),
+            |  (SELECT evt.event_id 
+            |    FROM event evt 
+            |    WHERE evt.project_id = proj.project_id 
+            |      AND evt.event_date = proj.latest_event_date
+            |    ORDER BY created_date DESC
+            |    LIMIT 1
+            |  ),
             |  proj.project_id, 
             |  proj.project_path,
             |  sync_time.last_synced,

--- a/event-log/src/test/scala/io/renku/eventlog/EventLogDataProvisioning.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/EventLogDataProvisioning.scala
@@ -81,7 +81,9 @@ trait EventLogDataProvisioning {
             |project (project_id, project_path, latest_event_date)
             |VALUES (${compoundEventId.projectId}, $projectPath, $eventDate)
             |ON CONFLICT (project_id)
-            |DO UPDATE SET latest_event_date = excluded.latest_event_date WHERE excluded.latest_event_date > project.latest_event_date
+            |DO UPDATE 
+            |  SET latest_event_date = excluded.latest_event_date 
+            |  WHERE excluded.latest_event_date > project.latest_event_date
       """.stripMargin.update.run.void
     }
 

--- a/event-log/src/test/scala/io/renku/eventlog/metrics/StatsFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/metrics/StatsFinderSpec.scala
@@ -32,7 +32,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
 import io.renku.eventlog.EventContentGenerators._
 import io.renku.eventlog._
-import io.renku.eventlog.subscriptions.{LastSyncedDate, SubscriptionDataProvisioning}
+import io.renku.eventlog.subscriptions._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -48,40 +48,56 @@ class StatsFinderSpec
 
     "return info about number of events grouped by categoryName" in {
 
-      val projectPath0 = projectPaths.generateOne
-      val eventDate0   = eventDates.generateOne
-      upsertProject(compoundEventIds.generateOne, projectPath0, eventDate0)
+      // MEMBER_SYNC specific
+      val compoundId1 = compoundEventIds.generateOne
+      val eventDate1  = EventDate(generateInstant(lessThanAgo = Duration.ofMinutes(59)))
+      val lastSynced1 = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofSeconds(61)))
+      upsertProject(compoundId1, projectPaths.generateOne, eventDate1)
+      upsertLastSynced(compoundId1.projectId, membersync.categoryName, lastSynced1)
 
-      val compoundId1  = compoundEventIds.generateOne
-      val projectPath1 = projectPaths.generateOne
-      val eventDate1   = EventDate(generateInstant(lessThanAgo = Duration.ofMinutes(59)))
-      val lastSynced1  = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofSeconds(61)))
-      upsertProject(compoundId1, projectPath1, eventDate1)
-      upsertLastSynced(compoundId1.projectId, categoryName, lastSynced1)
+      val compoundId2 = compoundEventIds.generateOne
+      val eventDate2  = EventDate(generateInstant(lessThanAgo = Duration.ofHours(23)))
+      val lastSynced2 = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofMinutes(61)))
+      upsertProject(compoundId2, projectPaths.generateOne, eventDate2)
+      upsertLastSynced(compoundId2.projectId, membersync.categoryName, lastSynced2)
 
-      val compoundId2  = compoundEventIds.generateOne
-      val projectPath2 = projectPaths.generateOne
-      val eventDate2   = EventDate(generateInstant(lessThanAgo = Duration.ofHours(23)))
-      val lastSynced2  = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofMinutes(61)))
-      upsertProject(compoundId2, projectPath2, eventDate2)
-      upsertLastSynced(compoundId2.projectId, categoryName, lastSynced2)
+      val compoundId3 = compoundEventIds.generateOne
+      val eventDate3  = EventDate(generateInstant(moreThanAgo = Duration.ofHours(25)))
+      val lastSynced3 = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofHours(25)))
+      upsertProject(compoundId3, projectPaths.generateOne, eventDate3)
+      upsertLastSynced(compoundId3.projectId, membersync.categoryName, lastSynced3)
 
-      val compoundId3  = compoundEventIds.generateOne
-      val projectPath3 = projectPaths.generateOne
-      val eventDate3   = EventDate(generateInstant(moreThanAgo = Duration.ofHours(25)))
-      val lastSynced3  = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofHours(25)))
-      upsertProject(compoundId3, projectPath3, eventDate3)
-      upsertLastSynced(compoundId3.projectId, categoryName, lastSynced3)
+      // MEMBER_SYNC should not see this one
+      val compoundId4 = compoundEventIds.generateOne
+      val eventDate4  = EventDate(generateInstant(moreThanAgo = Duration.ofHours(25)))
+      val lastSynced4 = LastSyncedDate(generateInstant(lessThanAgo = Duration.ofHours(23)))
+      upsertProject(compoundId4, projectPaths.generateOne, eventDate4)
+      upsertLastSynced(compoundId4.projectId, membersync.categoryName, lastSynced4)
 
-      // doesn't need an update
-      val compoundId4  = compoundEventIds.generateOne
-      val projectPath4 = projectPaths.generateOne
-      val eventDate4   = EventDate(generateInstant(moreThanAgo = Duration.ofHours(25)))
-      val lastSynced4  = LastSyncedDate(generateInstant(lessThanAgo = Duration.ofHours(23)))
-      upsertProject(compoundId4, projectPath4, eventDate4)
-      upsertLastSynced(compoundId4.projectId, categoryName, lastSynced4)
+      // COMMIT_SYNC specific
+      val compoundId5   = compoundEventIds.generateOne
+      val eventDate5    = EventDate(generateInstant(lessThanAgo = Duration.ofDays(7)))
+      val lastSyncDate5 = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofMinutes(61)))
+      upsertProject(compoundId5, projectPaths.generateOne, eventDate5)
+      upsertLastSynced(compoundId5.projectId, commitsync.categoryName, lastSyncDate5)
 
-      stats.countEventsByCategoryName().unsafeRunSync() shouldBe Map(categoryName -> 4L)
+      val compoundId6   = compoundEventIds.generateOne
+      val eventDate6    = EventDate(generateInstant(moreThanAgo = Duration.ofHours(7 * 24 + 1)))
+      val lastSyncDate6 = LastSyncedDate(generateInstant(moreThanAgo = Duration.ofMinutes(25)))
+      upsertProject(compoundId6, projectPaths.generateOne, eventDate6)
+      upsertLastSynced(compoundId6.projectId, commitsync.categoryName, lastSyncDate6)
+
+      // COMMIT_SYNC should not see this one
+      val compoundId7   = compoundEventIds.generateOne
+      val eventDate7    = EventDate(generateInstant(moreThanAgo = Duration.ofHours(7 * 24 + 1)))
+      val lastSyncDate7 = LastSyncedDate(generateInstant(lessThanAgo = Duration.ofHours(23)))
+      upsertProject(compoundId7, projectPaths.generateOne, eventDate7)
+      upsertLastSynced(compoundId7.projectId, commitsync.categoryName, lastSyncDate7)
+
+      stats.countEventsByCategoryName().unsafeRunSync() shouldBe Map(
+        membersync.categoryName -> 6L,
+        commitsync.categoryName -> 6L
+      )
     }
   }
 
@@ -159,13 +175,8 @@ class StatsFinderSpec
     }
   }
 
-  private lazy val categoryName     = io.renku.eventlog.subscriptions.membersync.categoryName
   private lazy val queriesExecTimes = TestLabeledHistogram[SqlQuery.Name]("query_id")
-  private lazy val stats = new StatsFinderImpl(
-    transactor,
-    queriesExecTimes,
-    categoryNames = Refined.unsafeApply(Set(categoryName))
-  )
+  private lazy val stats            = new StatsFinderImpl(transactor, queriesExecTimes)
 
   private def store: ((Path, EventId, EventStatus, EventDate)) => Unit = {
     case (projectPath, eventId, status, eventDate) =>

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/EventsDistributorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/EventsDistributorSpec.scala
@@ -58,14 +58,14 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
 
       inSequence {
 
-        givenEventFinder(returns = Some(event))
         givenThereIs(freeSubscriber = subscriber)
+        givenEventFinder(returns = Some(event))
         givenSending(event, to = subscriber, got = Delivered)
         givenDispatchRecoveryExists(subscriber, event)
         expectSendingRegistered(event, subscriber)
 
-        givenEventFinder(returns = Some(otherEvent))
         givenThereIs(freeSubscriber = otherSubscriber)
+        givenEventFinder(returns = Some(otherEvent))
         givenSending(otherEvent, to = otherSubscriber, got = Delivered)
         givenDispatchRecoveryExists(otherSubscriber, otherEvent)
         expectSendingRegistered(otherEvent, otherSubscriber)
@@ -91,8 +91,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
         val otherSubscriber = subscriberUrls.generateOne
 
         inSequence {
-          givenEventFinder(returns = Some(event))
           givenThereIs(freeSubscriber = subscriber)
+          givenEventFinder(returns = Some(event))
           givenSending(event, to = subscriber, got = ServiceBusy)
           givenDispatchRecoveryExists(subscriber, event)
           expectMarkedBusy(subscriber)
@@ -123,8 +123,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
         val yetAnotherSubscriber = subscriberUrls.generateOne
 
         inSequence {
-          givenEventFinder(returns = Some(event))
           givenThereIs(freeSubscriber = subscriber)
+          givenEventFinder(returns = Some(event))
           givenSending(event, to = subscriber, got = Misdelivered)
           givenDispatchRecoveryExists(subscriber, event)
           expectRemoval(subscriber)
@@ -164,8 +164,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
         val event        = testCategoryEvents.generateOne
 
         inSequence {
-          givenEventFinder(returns = Some(failingEvent))
           givenThereIs(freeSubscriber = subscriber)
+          givenEventFinder(returns = Some(failingEvent))
 
           (eventsSender.sendEvent _)
             .expects(subscriber, failingEvent)
@@ -176,8 +176,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
             .expects(exception)
             .returning(IO.unit)
 
-          givenEventFinder(returns = Some(event))
           givenThereIs(freeSubscriber = subscriber)
+          givenEventFinder(returns = Some(event))
           givenSending(event, to = subscriber, got = Delivered)
           givenDispatchRecoveryExists(subscriber, event)
           expectSendingRegistered(event, subscriber)
@@ -201,13 +201,12 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
       val subscriber = subscriberUrls.generateOne
 
       inSequence {
-        givenEventFinder(returns = Some(event))
-
         (subscribers.runOnSubscriber _)
           .expects(*)
           .returning(exception.raiseError[IO, Unit])
 
         givenThereIs(freeSubscriber = subscriber)
+        givenEventFinder(returns = Some(event))
         givenSending(event, to = subscriber, got = Delivered)
         givenDispatchRecoveryExists(subscriber, event)
         expectSendingRegistered(event, subscriber)
@@ -219,7 +218,7 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
 
       eventually {
         logger.loggedOnly(
-          Error(s"$categoryName: Dispatching an event failed", exception),
+          Error(s"$categoryName: executing event distribution on a subscriber failed", exception),
           Info(s"$categoryName: $event, url = $subscriber -> $Delivered")
         )
       }
@@ -232,17 +231,18 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
       val subscriber = subscriberUrls.generateOne
 
       inSequence {
-        (eventsFinder.popEvent _)
-          .expects()
-          .returning(exception.raiseError[IO, Option[TestCategoryEvent]])
-
-        (eventsFinder.popEvent _)
-          .expects()
-          .returning(exception.raiseError[IO, Option[TestCategoryEvent]])
-
-        // retry fetching some new event
-        givenEventFinder(returns = Some(event))
         givenThereIs(freeSubscriber = subscriber)
+
+        (eventsFinder.popEvent _)
+          .expects()
+          .returning(exception.raiseError[IO, Option[TestCategoryEvent]])
+
+        (eventsFinder.popEvent _)
+          .expects()
+          .returning(exception.raiseError[IO, Option[TestCategoryEvent]])
+
+        givenEventFinder(returns = Some(event))
+
         givenSending(event, to = subscriber, got = Delivered)
         givenDispatchRecoveryExists(subscriber, event)
         expectSendingRegistered(event, subscriber)
@@ -254,8 +254,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
 
       eventually {
         logger.loggedOnly(
-          Error(s"$categoryName: Finding events to dispatch failed", exception),
-          Error(s"$categoryName: Finding events to dispatch failed", exception),
+          Error(s"$categoryName: finding events to dispatch failed", exception),
+          Error(s"$categoryName: finding events to dispatch failed", exception),
           Info(s"$categoryName: $event, url = $subscriber -> $Delivered")
         )
       }
@@ -269,16 +269,16 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
       val subscriber = subscriberUrls.generateOne
 
       inSequence {
-        givenEventFinder(returns = Some(event))
         givenThereIs(freeSubscriber = subscriber)
+        givenEventFinder(returns = Some(event))
         givenSending(event, to = subscriber, got = Delivered)
         givenDispatchRecoveryExists(subscriber, event)
         (eventDelivery.registerSending _)
           .expects(event, subscriber)
           .returning(exception.raiseError[IO, Unit])
 
-        givenEventFinder(returns = Some(otherEvent))
         givenThereIs(freeSubscriber = subscriber)
+        givenEventFinder(returns = Some(otherEvent))
         givenSending(otherEvent, to = subscriber, got = Delivered)
         givenDispatchRecoveryExists(subscriber, otherEvent)
         expectSendingRegistered(otherEvent, subscriber)
@@ -304,9 +304,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
       val subscriber = subscriberUrls.generateOne
 
       inSequence {
-        givenEventFinder(returns = Some(event))
-
         givenThereIs(freeSubscriber = subscriber)
+        givenEventFinder(returns = Some(event))
         givenSending(event, to = subscriber, got = ServiceBusy)
         givenDispatchRecoveryExists(subscriber, event)
 
@@ -339,9 +338,8 @@ class EventsDistributorSpec extends AnyWordSpec with MockFactory with Eventually
       val otherSubscriber = subscriberUrls.generateOne
 
       inSequence {
-        givenEventFinder(returns = Some(event))
-
         givenThereIs(freeSubscriber = subscriber)
+        givenEventFinder(returns = Some(event))
         givenSending(event, to = subscriber, got = Misdelivered)
         givenDispatchRecoveryExists(subscriber, event)
 

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/SubscriptionDataProvisioning.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/SubscriptionDataProvisioning.scala
@@ -18,6 +18,7 @@
 
 package io.renku.eventlog.subscriptions
 
+import cats.syntax.all._
 import ch.datascience.graph.model.events.CategoryName
 import ch.datascience.graph.model.projects
 import doobie.implicits._
@@ -32,7 +33,7 @@ trait SubscriptionDataProvisioning extends EventLogDataProvisioning with Subscri
             |subscription_category_sync_time (project_id, category_name, last_synced)
             |VALUES ($projectId, $categoryName, $lastSynced)
             |ON CONFLICT (project_id, category_name)
-            |DO UPDATE SET  last_synced = excluded.last_synced 
-      """.stripMargin.update.run.map(_ => ())
+            |DO UPDATE SET last_synced = excluded.last_synced 
+      """.stripMargin.update.run.void
     }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.34.2"
+version in ThisBuild := "1.34.3"


### PR DESCRIPTION
This PR fixes the order of finding an event, marking it as taken and sending it to some subscriber so the event finding step happens only when there's a subscriber ready to accept an event.