### PR TITLE
fix: zombie nodes to be removed irrespectively of the source

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/LongProcessingEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/LongProcessingEventFinder.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog.subscriptions.zombieevents
 
 import cats.data.Nested
-import cats.effect.{Bracket, ContextShift, IO}
+import cats.effect.{ContextShift, IO}
 import cats.free.Free
 import cats.syntax.all._
 import ch.datascience.db.{DbClient, DbTransactor, SqlQuery}
@@ -38,7 +38,7 @@ import java.time.{Duration, Instant}
 private class LongProcessingEventFinder(transactor:       DbTransactor[IO, EventLogDB],
                                         queriesExecTimes: LabeledHistogram[IO, SqlQuery.Name],
                                         now:              () => Instant = () => Instant.now
-)(implicit ME:                                            Bracket[IO, Throwable], contextShift: ContextShift[IO])
+)(implicit contextShift:                                  ContextShift[IO])
     extends DbClient(Some(queriesExecTimes))
     with EventFinder[IO, ZombieEvent]
     with ZombieEventSubProcess

--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/LostSubscriberEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/LostSubscriberEventFinder.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.subscriptions.zombieevents
 
-import cats.effect.{Bracket, ContextShift, IO}
+import cats.effect.{ContextShift, IO}
 import cats.free.Free
 import cats.syntax.all._
 import ch.datascience.db.{DbClient, DbTransactor, SqlQuery}
@@ -35,7 +35,7 @@ import java.time.Instant.now
 
 private class LostSubscriberEventFinder(transactor:       DbTransactor[IO, EventLogDB],
                                         queriesExecTimes: LabeledHistogram[IO, SqlQuery.Name]
-)(implicit ME:                                            Bracket[IO, Throwable], contextShift: ContextShift[IO])
+)(implicit contextShift:                                  ContextShift[IO])
     extends DbClient(Some(queriesExecTimes))
     with EventFinder[IO, ZombieEvent]
     with ZombieEventSubProcess

--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/LostZombieEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/LostZombieEventFinder.scala
@@ -18,18 +18,18 @@
 
 package io.renku.eventlog.subscriptions.zombieevents
 
-import cats.effect.{Bracket, ContextShift, IO}
-import cats.syntax.all._
+import cats.effect.{ContextShift, IO}
 import cats.free.Free
+import cats.syntax.all._
 import ch.datascience.db.{DbClient, DbTransactor, SqlQuery}
-import ch.datascience.graph.model.events.{CompoundEventId, EventProcessingTime, EventStatus}
 import ch.datascience.graph.model.events.EventStatus.{GeneratingTriples, TransformingTriples}
+import ch.datascience.graph.model.events.{CompoundEventId, EventProcessingTime, EventStatus}
 import ch.datascience.graph.model.projects
 import ch.datascience.metrics.LabeledHistogram
 import doobie.free.connection.ConnectionOp
 import eu.timepit.refined.api.Refined
-import io.renku.eventlog.{EventLogDB, TypeSerializers}
 import io.renku.eventlog.subscriptions.EventFinder
+import io.renku.eventlog.{EventLogDB, TypeSerializers}
 
 import java.time.Duration
 import java.time.Instant.now
@@ -37,7 +37,7 @@ import scala.language.postfixOps
 
 private class LostZombieEventFinder(transactor:       DbTransactor[IO, EventLogDB],
                                     queriesExecTimes: LabeledHistogram[IO, SqlQuery.Name]
-)(implicit ME:                                        Bracket[IO, Throwable], contextShift: ContextShift[IO])
+)(implicit contextShift:                              ContextShift[IO])
     extends DbClient(Some(queriesExecTimes))
     with EventFinder[IO, ZombieEvent]
     with ZombieEventSubProcess


### PR DESCRIPTION
**The problem**
It looks like it's possible that during deployment EL gets redeployed quicker than TGs get shut down. In such cases the old TGs, while still being up, can subscribe to the new EL and so they could never be removed from the `subscriber` table. As a consequence, events sent to such TGs would never be classified as zombies.

**Solution**
This PR changes the logic of the zombie subscription category so all rows from the `subscriber` table (including rows related to the active EL) get health tested and eventually removed.