### PR TITLE
fix: zombie nodes finder not to ping own service

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/ZombieNodesCleaner.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/zombieevents/ZombieNodesCleaner.scala
@@ -48,8 +48,6 @@ private class ZombieNodesCleanerImpl[Interpretation[_]: Async: Parallel: Bracket
     with ZombieNodesCleaner[Interpretation]
     with TypeSerializers {
 
-  import serviceHealthChecker._
-
   override def removeZombieNodes(): Interpretation[Unit] = sessionResource.useK {
     for {
       maybeZombieRecords <- findPotentialZombieRecords
@@ -77,14 +75,18 @@ private class ZombieNodesCleanerImpl[Interpretation[_]: Async: Parallel: Bracket
     case (sourceUrl, subscriberUrl) =>
       for {
         subscriberAsBaseUrl <- subscriberUrl.as[Interpretation, MicroserviceBaseUrl]
-        subscriberHealthy   <- ping(subscriberAsBaseUrl)
-        sourceHealthy       <- ping(sourceUrl)
+        subscriberHealthy   <- ping(subscriberAsBaseUrl, ifNot = microserviceBaseUrl)
+        sourceHealthy       <- ping(sourceUrl, ifNot = microserviceBaseUrl)
       } yield sourceHealthy -> subscriberHealthy match {
         case (true, true)  => NoAction
         case (false, true) => Upsert(sourceUrl, subscriberUrl)
         case (_, false)    => Delete(sourceUrl, subscriberUrl)
       }
   }
+
+  private def ping(url: MicroserviceBaseUrl, ifNot: MicroserviceBaseUrl) =
+    if (url == ifNot) true.pure[Interpretation]
+    else serviceHealthChecker.ping(url)
 
   private lazy val toQuery: Action => Kleisli[Interpretation, Session[Interpretation], Completion] = {
     case Delete(sourceUrl, subscriberUrl, _) =>

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/zombieevents/ZombieNodesCleanerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/zombieevents/ZombieNodesCleanerSpec.scala
@@ -48,11 +48,6 @@ class ZombieNodesCleanerSpec extends AnyWordSpec with InMemoryEventLogDbSpec wit
 
     "do nothing if all sources and subscribers listed in the subscriber table are up" in new TestCase {
 
-      (serviceHealthChecker.ping _)
-        .expects(microserviceBaseUrl)
-        .returning(true.pure[IO])
-        .atLeastOnce()
-
       val subscriber1Id  = subscriberIds.generateOne
       val subscriber1Url = subscriberUrls.generateOne
       (serviceHealthChecker.ping _)
@@ -85,11 +80,6 @@ class ZombieNodesCleanerSpec extends AnyWordSpec with InMemoryEventLogDbSpec wit
 
     "remove rows from the subscriber table if both the sources and the deliveries are inactive " +
       "but move active subscribers on inactive source to the current source" in new TestCase {
-
-        (serviceHealthChecker.ping _)
-          .expects(microserviceBaseUrl)
-          .returning(true.pure[IO])
-          .atLeastOnce()
 
         val activeSubscriberId  = subscriberIds.generateOne
         val activeSubscriberUrl = subscriberUrls.generateOne
@@ -140,11 +130,6 @@ class ZombieNodesCleanerSpec extends AnyWordSpec with InMemoryEventLogDbSpec wit
       }
 
     "remove rows from the subscriber table if there are inactive subscriber on the current source" in new TestCase {
-
-      (serviceHealthChecker.ping _)
-        .expects(microserviceBaseUrl)
-        .returning(true.pure[IO])
-        .atLeastOnce()
 
       val activeSubscriberId  = subscriberIds.generateOne
       val activeSubscriberUrl = subscriberUrls.generateOne


### PR DESCRIPTION
**The problem**
After recent changes to the zombie nodes finding algorithm, some unnecessary ping calls to the EL service where the zombie finding exists were introduced. This is obviously not needed.

This PR checks if the given URL is the same as the service where the zombie finding process runs and skips pinging the service;