### PR TITLE
fix: lineage query to work with diamond cases

### DIFF
--- a/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/model.scala
+++ b/knowledge-graph/src/main/scala/ch/datascience/knowledgegraph/lineage/model.scala
@@ -32,6 +32,7 @@ object model {
   private[lineage] final class RunDate private (val value: Instant) extends AnyVal with InstantTinyType
   private[lineage] implicit object RunDate extends TinyTypeFactory[RunDate](new RunDate(_))
   private[lineage] type FromAndToNodes = (Set[Node.Location], Set[Node.Location])
+  private[lineage] type EdgeMapEntry   = (RunInfo, FromAndToNodes)
   private[lineage] type EdgeMap        = Map[RunInfo, FromAndToNodes]
 
   final case class Lineage private (edges: Set[Edge], nodes: Set[Node]) extends LineageOps


### PR DESCRIPTION
@gavin-k-lee found an issue with the lineage query when multiple files are used as both inputs and outputs to different Run Plans.

As an example, if we have lineage like follows:
```
  m -- N -- o -- Q -- r
         \_ p _/
```
because of the issue we'd produce:
```
  m -- N -- o -- Q -- r
         \_ p
```

