### PR TITLE
chore: switching to RENKUBOT_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.RENKUBOT_GITHUB_TOKEN }}"
   check-deploy:
     runs-on: ubuntu-20.04
     outputs:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.RENKUBOT_GITHUB_TOKEN }}"
   conventional-commits:
     name: Commit message check
     runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v1.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.RENKUBOT_GITHUB_TOKEN }}"
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
         env:
           CHART_PATH: helm-chart/renku-graph
           CHART_NAME: renku-graph
-          GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Wait for chart to be available
@@ -120,4 +120,4 @@ jobs:
         uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.2.0
         env:
           CHART_NAME: renku-graph
-          GITHUB_TOKEN: ${{ secrets.RENKU_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
It was identified that various GitHub different tokens (at least having different names) are used within the renku-graph repo. This PR removes usage of all the tokens except `RENKUBOT_GITHUB_TOKEN`.