### PR TITLE
fix: last sync date update

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/commitsyncrequest/CommitSyncForcer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/commitsyncrequest/CommitSyncForcer.scala
@@ -40,8 +40,7 @@ private trait CommitSyncForcer[Interpretation[_]] {
 
 private class CommitSyncForcerImpl[Interpretation[_]: BracketThrow](
     sessionResource:  SessionResource[Interpretation, EventLogDB],
-    queriesExecTimes: LabeledHistogram[Interpretation, SqlStatement.Name],
-    now:              () => Instant = () => Instant.now
+    queriesExecTimes: LabeledHistogram[Interpretation, SqlStatement.Name]
 ) extends DbClient(Some(queriesExecTimes))
     with CommitSyncForcer[Interpretation]
     with TypeSerializers
@@ -78,7 +77,7 @@ private class CommitSyncForcerImpl[Interpretation[_]: BracketThrow](
           ON CONFLICT (project_id)
           DO NOTHING
       """.command)
-      .arguments(projectId ~ projectPath ~ EventDate(now()))
+      .arguments(projectId ~ projectPath ~ EventDate(Instant.EPOCH))
       .build
   }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/commitsyncrequest/CommitSyncForcerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/commitsyncrequest/CommitSyncForcerSpec.scala
@@ -26,10 +26,12 @@ import ch.datascience.metrics.TestLabeledHistogram
 import eu.timepit.refined.auto._
 import io.renku.eventlog.EventContentGenerators.eventDates
 import io.renku.eventlog.subscriptions._
-import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
+import io.renku.eventlog.{EventDate, InMemoryEventLogDbSpec, TypeSerializers}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
 
 class CommitSyncForcerSpec
     extends AnyWordSpec
@@ -76,7 +78,7 @@ class CommitSyncForcerSpec
         forcer.forceCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
 
         findSyncTime(projectId, commitsync.categoryName) shouldBe None
-        findProjects.map(proj => proj._1 -> proj._2) shouldBe List(projectId -> projectPath)
+        findProjects                                     shouldBe List((projectId, projectPath, EventDate(Instant.EPOCH)))
 
         queriesExecTimes.verifyExecutionTimeMeasured("commit_sync_request - delete last_synced")
         queriesExecTimes.verifyExecutionTimeMeasured("commit_sync_request - insert project")

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/commitsync/CommitSyncEventFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/commitsync/CommitSyncEventFinderSpec.scala
@@ -181,7 +181,7 @@ class CommitSyncEventFinderSpec
       }
 
     "not return events for projects" +
-      "where event statuses are AWAITING_DELETION" in new TestCase {
+      "where event statuses are AWAITING_DELETION but still update the last sync date" in new TestCase {
 
         finder.popEvent().unsafeRunSync() shouldBe None
         val sharedProjectPath = projectPaths.generateOne
@@ -201,11 +201,13 @@ class CommitSyncEventFinderSpec
 
         finder.popEvent().unsafeRunSync() shouldBe None
 
-        val event2Id   = compoundEventIds.generateOne.copy(projectId = event0Id.projectId)
-        val event2Date = EventDate(event1Date.value.plus(1L, ChronoUnit.MINUTES))
-        addEvent(event2Id, event2Date, sharedProjectPath)
+        // This event should not be picked up as the last sync date was set to NOW()
+        addEvent(compoundEventIds.generateOne.copy(projectId = event0Id.projectId),
+                 eventDates.generateOne,
+                 sharedProjectPath
+        )
 
-        finder.popEvent().unsafeRunSync() shouldBe Some(FullCommitSyncEvent(event2Id, sharedProjectPath, lastSynced))
+        finder.popEvent().unsafeRunSync() shouldBe None
 
       }
   }


### PR DESCRIPTION
When picking up an AWAITING DELETION event, the last sync date will still be updated.