### PR TITLE
fix: triples-generator to wait for re-provisioning

### DIFF
--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/Microservice.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/Microservice.scala
@@ -18,7 +18,8 @@
 
 package io.renku.commiteventservice
 
-import cats.effect.{ExitCode, IO}
+import cats.effect.{ExitCode, IO, Spawn}
+import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
@@ -31,7 +32,7 @@ import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.http.server.HttpServer
 import io.renku.logging.{ApplicationLogger, ExecutionTimeRecorder}
 import io.renku.metrics.{MetricsRegistry, RoutesMetrics}
-import io.renku.microservices.IOMicroservice
+import io.renku.microservices.{IOMicroservice, ServiceReadinessChecker}
 import org.typelevel.log4cats.Logger
 
 object Microservice extends IOMicroservice {
@@ -49,31 +50,32 @@ object Microservice extends IOMicroservice {
       events.categories.commitsync.SubscriptionFactory(gitLabThrottler, executionTimeRecorder)
     globalCommitSyncCategory <-
       events.categories.globalcommitsync.SubscriptionFactory(gitLabThrottler, executionTimeRecorder)
-    eventConsumersRegistry <- consumers.EventConsumersRegistry(commitSyncCategory, globalCommitSyncCategory)
-    metricsRegistry        <- MetricsRegistry[IO]()
-    microserviceRoutes     <- MicroserviceRoutes(eventConsumersRegistry, new RoutesMetrics[IO](metricsRegistry))
+    eventConsumersRegistry  <- consumers.EventConsumersRegistry(commitSyncCategory, globalCommitSyncCategory)
+    metricsRegistry         <- MetricsRegistry[IO]()
+    serviceReadinessChecker <- ServiceReadinessChecker[IO](ServicePort)
+    microserviceRoutes      <- MicroserviceRoutes(eventConsumersRegistry, new RoutesMetrics[IO](metricsRegistry))
     exitcode <- microserviceRoutes.routes.use { routes =>
-                  new MicroserviceRunner(
-                    certificateLoader,
-                    sentryInitializer,
-                    eventConsumersRegistry,
-                    HttpServer[IO](serverPort = ServicePort.value, routes)
+                  new MicroserviceRunner[IO](serviceReadinessChecker,
+                                             certificateLoader,
+                                             sentryInitializer,
+                                             eventConsumersRegistry,
+                                             HttpServer[IO](serverPort = ServicePort.value, routes)
                   ).run()
                 }
   } yield exitcode
 }
 
-class MicroserviceRunner(certificateLoader:      CertificateLoader[IO],
-                         sentryInitializer:      SentryInitializer[IO],
-                         eventConsumersRegistry: EventConsumersRegistry[IO],
-                         httpServer:             HttpServer[IO]
+class MicroserviceRunner[F[_]: Spawn: Logger](serviceReadinessChecker: ServiceReadinessChecker[F],
+                                              certificateLoader:      CertificateLoader[F],
+                                              sentryInitializer:      SentryInitializer[F],
+                                              eventConsumersRegistry: EventConsumersRegistry[F],
+                                              httpServer:             HttpServer[F]
 ) {
 
-  def run(): IO[ExitCode] = for {
+  def run(): F[ExitCode] = for {
     _      <- certificateLoader.run()
     _      <- sentryInitializer.run()
-    _      <- eventConsumersRegistry.run().start
+    _      <- Spawn[F].start(serviceReadinessChecker.waitIfNotUp >> eventConsumersRegistry.run())
     result <- httpServer.run()
   } yield result
-
 }

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/MicroserviceRunnerSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/MicroserviceRunnerSpec.scala
@@ -19,12 +19,15 @@
 package io.renku.commiteventservice
 
 import cats.effect._
+import cats.syntax.all._
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
 import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.http.server.HttpServer
+import io.renku.interpreters.TestLogger
+import io.renku.microservices.ServiceReadinessChecker
 import io.renku.testtools.{IOSpec, MockedRunnableCollaborators}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
@@ -45,6 +48,7 @@ class MicroserviceRunnerSpec
 
         given(certificateLoader).succeeds(returning = ())
         given(sentryInitializer).succeeds(returning = ())
+        (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
         given(eventConsumersRegistry).succeeds(returning = ())
         given(httpServer).succeeds(returning = ExitCode.Success)
 
@@ -76,19 +80,19 @@ class MicroserviceRunnerSpec
 
       given(certificateLoader).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
+      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       given(eventConsumersRegistry).succeeds(returning = ())
       val exception = exceptions.generateOne
       given(httpServer).fails(becauseOf = exception)
 
-      intercept[Exception] {
-        runner.run().unsafeRunSync()
-      } shouldBe exception
+      intercept[Exception](runner.run().unsafeRunSync()) shouldBe exception
     }
 
     "return Success ExitCode even if Event Consumers Registry initialisation fails" in new TestCase {
 
       given(certificateLoader).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
+      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       given(eventConsumersRegistry).fails(becauseOf = exceptions.generateOne)
       given(httpServer).succeeds(returning = ExitCode.Success)
 
@@ -97,15 +101,17 @@ class MicroserviceRunnerSpec
   }
 
   private trait TestCase {
-    val certificateLoader      = mock[CertificateLoader[IO]]
-    val sentryInitializer      = mock[SentryInitializer[IO]]
-    val eventConsumersRegistry = mock[EventConsumersRegistry[IO]]
-    val httpServer             = mock[HttpServer[IO]]
-    val runner = new MicroserviceRunner(
-      certificateLoader,
-      sentryInitializer,
-      eventConsumersRegistry,
-      httpServer
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val serviceReadinessChecker = mock[ServiceReadinessChecker[IO]]
+    val certificateLoader       = mock[CertificateLoader[IO]]
+    val sentryInitializer       = mock[SentryInitializer[IO]]
+    val eventConsumersRegistry  = mock[EventConsumersRegistry[IO]]
+    val httpServer              = mock[HttpServer[IO]]
+    val runner = new MicroserviceRunner(serviceReadinessChecker,
+                                        certificateLoader,
+                                        sentryInitializer,
+                                        eventConsumersRegistry,
+                                        httpServer
     )
   }
 }

--- a/event-log/src/main/scala/io/renku/eventlog/Microservice.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/Microservice.scala
@@ -20,6 +20,7 @@ package io.renku.eventlog
 
 import cats.effect._
 import cats.effect.kernel.Ref
+import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Positive
@@ -38,7 +39,7 @@ import io.renku.graph.model.projects
 import io.renku.http.server.HttpServer
 import io.renku.logging.ApplicationLogger
 import io.renku.metrics._
-import io.renku.microservices.IOMicroservice
+import io.renku.microservices.{IOMicroservice, ServiceReadinessChecker}
 import natchez.Trace.Implicits.noop
 import org.typelevel.log4cats.Logger
 
@@ -103,6 +104,7 @@ object Microservice extends IOMicroservice {
                                     commitSyncRequestSubscription,
                                     statusChangeEventSubscription
                                   )
+        serviceReadinessChecker  <- ServiceReadinessChecker[IO](ServicePort)
         eventEndpoint            <- EventEndpoint(eventConsumersRegistry)
         processingStatusEndpoint <- ProcessingStatusEndpoint(sessionResource, queriesExecTimes)
         eventProducersRegistry <- EventProducersRegistry(
@@ -126,43 +128,45 @@ object Microservice extends IOMicroservice {
                                isMigrating
                              ).routes
         exitCode <- microserviceRoutes.use { routes =>
-                      new MicroserviceRunner(
-                        certificateLoader,
-                        sentryInitializer,
-                        dbInitializer,
-                        eventLogMetrics,
-                        eventProducersRegistry,
-                        eventConsumersRegistry,
-                        metricsResetScheduler,
-                        HttpServer[IO](serverPort = ServicePort.value, routes)
+                      new MicroserviceRunner(serviceReadinessChecker,
+                                             certificateLoader,
+                                             sentryInitializer,
+                                             dbInitializer,
+                                             eventLogMetrics,
+                                             eventProducersRegistry,
+                                             eventConsumersRegistry,
+                                             metricsResetScheduler,
+                                             HttpServer[IO](serverPort = ServicePort.value, routes)
                       ).run()
                     }
       } yield exitCode
     }
 }
 
-private class MicroserviceRunner(
-    certificateLoader:      CertificateLoader[IO],
-    sentryInitializer:      SentryInitializer[IO],
-    dbInitializer:          DbInitializer[IO],
-    metrics:                EventLogMetrics[IO],
-    eventProducersRegistry: EventProducersRegistry[IO],
-    eventConsumersRegistry: EventConsumersRegistry[IO],
-    gaugeScheduler:         GaugeResetScheduler[IO],
-    httpServer:             HttpServer[IO]
+private class MicroserviceRunner[F[_]: Spawn: Logger](
+    serviceReadinessChecker: ServiceReadinessChecker[F],
+    certificateLoader:       CertificateLoader[F],
+    sentryInitializer:       SentryInitializer[F],
+    dbInitializer:           DbInitializer[F],
+    metrics:                 EventLogMetrics[F],
+    eventProducersRegistry:  EventProducersRegistry[F],
+    eventConsumersRegistry:  EventConsumersRegistry[F],
+    gaugeScheduler:          GaugeResetScheduler[F],
+    httpServer:              HttpServer[F]
 ) {
 
-  def run(): IO[ExitCode] = for {
+  def run(): F[ExitCode] = for {
     _      <- certificateLoader.run()
     _      <- sentryInitializer.run()
-    _      <- (dbInitializer.run() >> startDBDependentProcesses()).start
-    _      <- eventProducersRegistry.run().start
-    _      <- eventConsumersRegistry.run().start
+    _      <- Spawn[F].start(dbInitializer.run() >> startDBDependentProcesses())
     result <- httpServer.run()
   } yield result
 
   private def startDBDependentProcesses() = for {
-    _ <- metrics.run().start
+    _ <- Spawn[F].start(metrics.run())
+    _ <- serviceReadinessChecker.waitIfNotUp
+    _ <- Spawn[F].start(eventProducersRegistry.run())
+    _ <- Spawn[F].start(eventConsumersRegistry.run())
     _ <- gaugeScheduler.run()
   } yield ()
 }

--- a/graph-commons/src/main/scala/io/renku/events/consumers/EventConsumersRegistry.scala
+++ b/graph-commons/src/main/scala/io/renku/events/consumers/EventConsumersRegistry.scala
@@ -18,7 +18,6 @@
 
 package io.renku.events.consumers
 
-import cats.effect.IO
 import cats.syntax.all._
 import cats.{MonadThrow, Parallel}
 import io.renku.events.EventRequestContent
@@ -67,8 +66,9 @@ class EventConsumersRegistryImpl[F[_]: MonadThrow: Parallel](
 }
 
 object EventConsumersRegistry {
-  def apply(subscriptionFactories: (EventHandler[IO], SubscriptionMechanism[IO])*): IO[EventConsumersRegistry[IO]] =
-    IO {
-      new EventConsumersRegistryImpl[IO](subscriptionFactories.toList.map(_._1), subscriptionFactories.toList.map(_._2))
-    }
+  def apply[F[_]: MonadThrow: Parallel](
+      subscriptionFactories: (EventHandler[F], SubscriptionMechanism[F])*
+  ): F[EventConsumersRegistry[F]] = MonadThrow[F].catchNonFatal {
+    new EventConsumersRegistryImpl[F](subscriptionFactories.toList.map(_._1), subscriptionFactories.toList.map(_._2))
+  }
 }

--- a/graph-commons/src/main/scala/io/renku/microservices/ServiceReadinessChecker.scala
+++ b/graph-commons/src/main/scala/io/renku/microservices/ServiceReadinessChecker.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.microservices
+
+import cats.effect.{Async, Temporal}
+import cats.syntax.all._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
+import io.renku.http.client.ServiceHealthChecker
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
+
+trait ServiceReadinessChecker[F[_]] {
+  def waitIfNotUp: F[Unit]
+}
+
+object ServiceReadinessChecker {
+  def apply[F[_]: Async: Logger](microservicePort: Int Refined Positive): F[ServiceReadinessChecker[F]] = for {
+    urlFinder     <- MicroserviceUrlFinder[F](microservicePort)
+    healthChecker <- ServiceHealthChecker[F]
+  } yield new ServiceReadinessCheckerImpl(urlFinder, healthChecker)
+}
+
+class ServiceReadinessCheckerImpl[F[_]: Async: Logger](
+    urlFinder:     MicroserviceUrlFinder[F],
+    healthChecker: ServiceHealthChecker[F]
+) extends ServiceReadinessChecker[F] {
+
+  import healthChecker._
+
+  override def waitIfNotUp: F[Unit] = urlFinder.findBaseUrl() >>= checkAndWait
+
+  private def checkAndWait(url: MicroserviceBaseUrl): F[Unit] =
+    ping(url) >>= {
+      case true  => ().pure[F]
+      case false => Temporal[F].delayBy(Logger[F].info("Service not ready") >> checkAndWait(url), 1 second)
+    }
+}

--- a/graph-commons/src/test/scala/io/renku/microservices/MicroserviceUrlFinderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/MicroserviceUrlFinderSpec.scala
@@ -16,12 +16,11 @@
  * limitations under the License.
  */
 
-package io.renku.microservice
+package io.renku.microservices
 
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.positiveInts
-import io.renku.microservices.{MicroserviceBaseUrl, MicroserviceUrlFinderImpl}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/graph-commons/src/test/scala/io/renku/microservices/ServiceReadinessCheckerSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/ServiceReadinessCheckerSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.microservices
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.generators.CommonGraphGenerators.microserviceBaseUrls
+import io.renku.generators.Generators.Implicits._
+import io.renku.http.client.ServiceHealthChecker
+import io.renku.interpreters.TestLogger
+import io.renku.interpreters.TestLogger.Level.Info
+import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class ServiceReadinessCheckerSpec extends AnyWordSpec with IOSpec with should.Matchers with MockFactory {
+
+  "waitIfNotUp" should {
+    "block until the health check returns true" in new TestCase {
+      (urlFinder.findBaseUrl _).expects().returning(microserviceUrl.pure[IO])
+
+      (healthChecker.ping _).expects(microserviceUrl).returning(false.pure[IO])
+      (healthChecker.ping _).expects(microserviceUrl).returning(true.pure[IO])
+
+      readinessChecker.waitIfNotUp.unsafeRunSync() shouldBe ()
+
+      logger.loggedOnly(Info("Service not ready"))
+    }
+  }
+
+  private trait TestCase {
+    val microserviceUrl = microserviceBaseUrls.generateOne
+
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val urlFinder        = mock[MicroserviceUrlFinder[IO]]
+    val healthChecker    = mock[ServiceHealthChecker[IO]]
+    val readinessChecker = new ServiceReadinessCheckerImpl[IO](urlFinder, healthChecker)
+  }
+}

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -61,8 +61,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "jena.fullname" . }}
                   key: jena-renku-password
-            - name: RENKU_LOG_TIMEOUT
-              value: "{{ .Values.triplesGenerator.renkuLogTimeout }}"
             - name: RENKU_DISABLE_VERSION_CHECK
               value: "true"
             - name: RE_PROVISIONING_REMOVAL_BATCH_SIZE

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -62,7 +62,6 @@ triplesGenerator:
       memory: 5000Mi
       cpu: "10"
   jvmXmx: 2g
-  renkuLogTimeout: 180 minutes
   reProvisioningRemovalBatchSize: 1000
   gitlab:
     rateLimit: 30/sec

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -20,9 +20,9 @@ triples-generation = "renku-log"
 # *  ["0.16.1 -> 9", ...] as above
 # *  ["0.16.1 -> 9", "0.16.0 -> 9", ...] then the decision about re-provisioning is taken using the 9 schema version and 0.16.1 CLI version
 compatibility-matrix = [
-  "1.0.1.dev1+g594d0ad  -> 9",
-  "1.0.0.dev10+gb6f2217 -> 9",
-  "0.14.1               -> 8"
+  "1.0.1.dev2+g4b594bf -> 9",
+  "1.0.1.dev1+g594d0ad -> 9",
+  "0.14.1              -> 8"
 ]
 
 renku-python-dev-version = ${?RENKU_PYTHON_DEV_VERSION}

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -7,9 +7,6 @@ transformation-processes-number = ${?TRANSFORMATION_PROCESSES_NUMBER}
 client-certificate = ""
 client-certificate = ${?RENKU_CLIENT_CERTIFICATE}
 
-renku-log-timeout = 3 hours
-renku-log-timeout = ${?RENKU_LOG_TIMEOUT}
-
 re-provisioning-retry-delay = 1 minute
 re-provisioning-removal-batch-size = 1000
 re-provisioning-removal-batch-size = ${?RE_PROVISIONING_REMOVAL_BATCH_SIZE}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -111,13 +111,12 @@ private class MicroserviceRunner[F[_]: Spawn: Logger](
 
   def run(): F[ExitCode] = {
     for {
-      _           <- certificateLoader.run()
-      _           <- gitCertificateInstaller.run()
-      _           <- sentryInitializer.run()
-      _           <- cliVersionCompatibilityVerifier.run()
-      serverFiber <- Spawn[F].start(httpServer.run())
-      _ <- serviceReadinessChecker.waitIfNotUp >> reProvisioning.run() >> Spawn[F].start(eventConsumersRegistry.run())
-      exitCode <- serverFiber.joinWith(new Exception("Http server canceled").raiseError)
+      _ <- certificateLoader.run()
+      _ <- gitCertificateInstaller.run()
+      _ <- sentryInitializer.run()
+      _ <- cliVersionCompatibilityVerifier.run()
+      _ <- Spawn[F].start(serviceReadinessChecker.waitIfNotUp >> reProvisioning.run() >> eventConsumersRegistry.run())
+      exitCode <- httpServer.run()
     } yield exitCode
   } recoverWith logAndThrow
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -33,7 +33,7 @@ import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.http.server.HttpServer
 import io.renku.logging.ApplicationLogger
 import io.renku.metrics.{MetricsRegistry, RoutesMetrics}
-import io.renku.microservices.IOMicroservice
+import io.renku.microservices.{IOMicroservice, ServiceReadinessChecker}
 import io.renku.rdfstore.SparqlQueryTimeRecorder
 import io.renku.triplesgenerator.config.certificates.GitCertificateInstaller
 import io.renku.triplesgenerator.config.{TriplesGeneration, VersionCompatibilityConfig}
@@ -80,10 +80,12 @@ object Microservice extends IOMicroservice {
     reProvisioningStatus    <- ReProvisioningStatus(eventConsumersRegistry, sparqlTimeRecorder)
     reProvisioning          <- ReProvisioning(reProvisioningStatus, renkuVersionPairs, sparqlTimeRecorder)
     eventProcessingEndpoint <- EventEndpoint(eventConsumersRegistry, reProvisioningStatus)
+    serviceReadinessChecker <- ServiceReadinessChecker[IO](ServicePort)
     microserviceRoutes =
       new MicroserviceRoutes[IO](eventProcessingEndpoint, new RoutesMetrics[IO](metricsRegistry), config.some).routes
     exitCode <- microserviceRoutes.use { routes =>
                   new MicroserviceRunner[IO](
+                    serviceReadinessChecker,
                     certificateLoader,
                     gitCertificateInstaller,
                     sentryInitializer,
@@ -97,6 +99,7 @@ object Microservice extends IOMicroservice {
 }
 
 private class MicroserviceRunner[F[_]: Spawn: Logger](
+    serviceReadinessChecker:         ServiceReadinessChecker[F],
     certificateLoader:               CertificateLoader[F],
     gitCertificateInstaller:         GitCertificateInstaller[F],
     sentryInitializer:               SentryInitializer[F],
@@ -108,13 +111,13 @@ private class MicroserviceRunner[F[_]: Spawn: Logger](
 
   def run(): F[ExitCode] = {
     for {
-      _        <- certificateLoader.run()
-      _        <- gitCertificateInstaller.run()
-      _        <- sentryInitializer.run()
-      _        <- cliVersionCompatibilityVerifier.run()
-      _        <- Spawn[F].start(eventConsumersRegistry.run())
-      _        <- Spawn[F].start(reProvisioning.run())
-      exitCode <- httpServer.run()
+      _           <- certificateLoader.run()
+      _           <- gitCertificateInstaller.run()
+      _           <- sentryInitializer.run()
+      _           <- cliVersionCompatibilityVerifier.run()
+      serverFiber <- Spawn[F].start(httpServer.run())
+      _ <- serviceReadinessChecker.waitIfNotUp >> reProvisioning.run() >> Spawn[F].start(eventConsumersRegistry.run())
+      exitCode <- serverFiber.joinWith(new Exception("Http server canceled").raiseError)
     } yield exitCode
   } recoverWith logAndThrow
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/EventsReScheduler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/EventsReScheduler.scala
@@ -39,16 +39,14 @@ private class EventsReSchedulerImpl[F[_]: Async: Logger](
   import org.http4s.Status.Accepted
   import org.http4s.{Request, Response, Status}
 
-  override def triggerEventsReScheduling(): F[Unit] =
-    for {
-      uri <- validateUri(s"$eventLogUrl/events")
-      sendingResult <-
-        send(
-          request(POST, uri).withMultipartBuilder
-            .addPart("event", json"""{"categoryName": "EVENTS_STATUS_CHANGE", "newStatus": "NEW"}""")
-            .build()
-        )(mapResponse)
-    } yield sendingResult
+  override def triggerEventsReScheduling(): F[Unit] = for {
+    uri <- validateUri(s"$eventLogUrl/events")
+    result <- send(
+                request(POST, uri).withMultipartBuilder
+                  .addPart("event", json"""{"categoryName": "EVENTS_STATUS_CHANGE", "newStatus": "NEW"}""")
+                  .build()
+              )(mapResponse)
+  } yield result
 
   private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Unit]] = { case (Accepted, _, _) =>
     ().pure[F]

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/ReProvisioning.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/ReProvisioning.scala
@@ -64,7 +64,7 @@ class ReProvisioningImpl[F[_]: Temporal: Logger](
 
   private def triggerReProvisioning = measureExecutionTime {
     for {
-      _ <- Logger[F].info("Triples Store is not on the required schema version - kicking-off re-provisioning")
+      _ <- Logger[F].info("Kicking-off re-provisioning")
       _ <- setRunningStatusInTS()
       _ <- versionPairUpdater
              .update(versionCompatibilityPairs.head)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/ReProvisioningStatus.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/ReProvisioningStatus.scala
@@ -95,8 +95,8 @@ private class ReProvisioningStatusImpl[F[_]: Async: Logger](
       Prefixes of renku -> "renku",
       s"""|DELETE { ?s ?p ?o }
           |WHERE {
-          | ?s ?p ?o;
-          |    a renku:ReProvisioning.
+          | ?s a renku:ReProvisioning;
+          |    ?p ?o.
           |}
           |""".stripMargin
     )

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/RenkuVersionPairFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/RenkuVersionPairFinder.scala
@@ -55,7 +55,7 @@ private class RenkuVersionPairFinderImpl[F[_]: Async: Logger](
     case Nil         => Option.empty[RenkuVersionPair].pure[F]
     case head :: Nil => head.some.pure[F]
     case versionPairs =>
-      new IllegalStateException(s"Too many Version pair found: $versionPairs")
+      new IllegalStateException(s"Too many Version pairs found: $versionPairs")
         .raiseError[F, Option[RenkuVersionPair]]
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/RenkuVersionPairUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/reprovisioning/RenkuVersionPairUpdater.scala
@@ -48,8 +48,8 @@ private class RenkuVersionPairUpdaterImpl[F[_]: Async: Logger](
       Prefixes of renku -> "renku",
       s"""|DELETE { ?s ?p ?o }
           |WHERE {
-          | ?s ?p ?o;
-          |    a renku:VersionPair.
+          | ?s a renku:VersionPair;
+          |    ?p ?o;
           |}
           |""".stripMargin
     )

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
@@ -144,7 +144,7 @@ class MicroserviceRunnerSpec
       )
     }
 
-    "fail if starting re-provisioning process fails" in new TestCase {
+    "return Success ExitCode even when starting re-provisioning process fails" in new TestCase {
 
       (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       given(certificateLoader).succeeds(returning = ())
@@ -155,16 +155,10 @@ class MicroserviceRunnerSpec
       given(reProvisioning).fails(becauseOf = exception)
       given(httpServer).succeeds(returning = ExitCode.Success)
 
-      intercept[Exception] {
-        runner.run().unsafeRunSync()
-      } shouldBe exception
-
-      logger.loggedOnly(
-        Error(exception.getMessage, exception)
-      )
+      runner.run().unsafeRunSync() shouldBe ExitCode.Success
     }
 
-    "return Success ExitCode even if running subscriptionMechanismRegistry fails" in new TestCase {
+    "return Success ExitCode even when running eventConsumersRegistry fails" in new TestCase {
 
       (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       given(certificateLoader).succeeds(returning = ())

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
@@ -174,6 +174,7 @@ class MicroserviceRunnerSpec
   }
 
   private trait TestCase {
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val serviceReadinessChecker = mock[ServiceReadinessChecker[IO]]
     val certificateLoader       = mock[CertificateLoader[IO]]
     val gitCertificateInstaller = mock[GitCertificateInstaller[IO]]
@@ -182,17 +183,15 @@ class MicroserviceRunnerSpec
     val eventConsumersRegistry  = mock[EventConsumersRegistry[IO]]
     val reProvisioning          = mock[ReProvisioning[IO]]
     val httpServer              = mock[HttpServer[IO]]
-    implicit val logger: TestLogger[IO] = TestLogger[IO]()
 
-    val runner = new MicroserviceRunner(
-      serviceReadinessChecker,
-      certificateLoader,
-      gitCertificateInstaller,
-      sentryInitializer,
-      cliVersionCompatChecker,
-      eventConsumersRegistry,
-      reProvisioning,
-      httpServer
+    val runner = new MicroserviceRunner(serviceReadinessChecker,
+                                        certificateLoader,
+                                        gitCertificateInstaller,
+                                        sentryInitializer,
+                                        cliVersionCompatChecker,
+                                        eventConsumersRegistry,
+                                        reProvisioning,
+                                        httpServer
     )
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.triplesgenerator
 
 import cats.effect._
+import cats.syntax.all._
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
 import io.renku.events.consumers.EventConsumersRegistry
@@ -27,6 +28,7 @@ import io.renku.generators.Generators._
 import io.renku.http.server.HttpServer
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
+import io.renku.microservices.ServiceReadinessChecker
 import io.renku.testtools.{IOSpec, MockedRunnableCollaborators}
 import io.renku.triplesgenerator.config.certificates.GitCertificateInstaller
 import io.renku.triplesgenerator.init.CliVersionCompatibilityVerifier
@@ -48,6 +50,7 @@ class MicroserviceRunnerSpec
       "Sentry and RDF dataset initialisation are fine " +
       "and subscription, re-provisioning and the http server start up" in new TestCase {
 
+        (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
         given(certificateLoader).succeeds(returning = ())
         given(gitCertificateInstaller).succeeds(returning = ())
         given(sentryInitializer).succeeds(returning = ())
@@ -122,6 +125,7 @@ class MicroserviceRunnerSpec
 
     "fail if starting the Http Server fails" in new TestCase {
 
+      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       given(certificateLoader).succeeds(returning = ())
       given(gitCertificateInstaller).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
@@ -140,8 +144,29 @@ class MicroserviceRunnerSpec
       )
     }
 
+    "fail if starting re-provisioning process fails" in new TestCase {
+
+      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
+      given(certificateLoader).succeeds(returning = ())
+      given(gitCertificateInstaller).succeeds(returning = ())
+      given(sentryInitializer).succeeds(returning = ())
+      given(cliVersionCompatChecker).succeeds(returning = ())
+      val exception = exceptions.generateOne
+      given(reProvisioning).fails(becauseOf = exception)
+      given(httpServer).succeeds(returning = ExitCode.Success)
+
+      intercept[Exception] {
+        runner.run().unsafeRunSync()
+      } shouldBe exception
+
+      logger.loggedOnly(
+        Error(exception.getMessage, exception)
+      )
+    }
+
     "return Success ExitCode even if running subscriptionMechanismRegistry fails" in new TestCase {
 
+      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       given(certificateLoader).succeeds(returning = ())
       given(gitCertificateInstaller).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
@@ -152,23 +177,10 @@ class MicroserviceRunnerSpec
 
       runner.run().unsafeRunSync() shouldBe ExitCode.Success
     }
-
-    "return Success ExitCode even if starting re-provisioning process fails" in new TestCase {
-
-      given(certificateLoader).succeeds(returning = ())
-      given(gitCertificateInstaller).succeeds(returning = ())
-      given(sentryInitializer).succeeds(returning = ())
-      given(cliVersionCompatChecker).succeeds(returning = ())
-      given(eventConsumersRegistry).succeeds(returning = ())
-      given(reProvisioning).fails(becauseOf = exceptions.generateOne)
-      given(httpServer).succeeds(returning = ExitCode.Success)
-
-      runner.run().unsafeRunSync() shouldBe ExitCode.Success
-    }
-
   }
 
   private trait TestCase {
+    val serviceReadinessChecker = mock[ServiceReadinessChecker[IO]]
     val certificateLoader       = mock[CertificateLoader[IO]]
     val gitCertificateInstaller = mock[GitCertificateInstaller[IO]]
     val sentryInitializer       = mock[SentryInitializer[IO]]
@@ -179,6 +191,7 @@ class MicroserviceRunnerSpec
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
 
     val runner = new MicroserviceRunner(
+      serviceReadinessChecker,
       certificateLoader,
       gitCertificateInstaller,
       sentryInitializer,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/reprovisioning/ReProvisioningSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/reprovisioning/ReProvisioningSpec.scala
@@ -62,7 +62,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
       )
     }
@@ -121,7 +121,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Error("Re-provisioning failure", exception),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
       )
@@ -151,7 +151,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Error("Re-provisioning failure", exception),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
       )
@@ -183,7 +183,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Error("Re-provisioning failure", exception),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
       )
@@ -214,7 +214,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Error("Re-provisioning failure", exception),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
       )
@@ -248,7 +248,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Error("Re-provisioning failure", exception1),
         Error("Re-provisioning failure", exception2),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
@@ -279,7 +279,7 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
       reProvisioning.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
-        Info("Triples Store is not on the required schema version - kicking-off re-provisioning"),
+        Info("Kicking-off re-provisioning"),
         Error("Re-provisioning failure", exception),
         Info(s"Clearing DB finished in ${executionTimeRecorder.elapsedTime}ms - re-processing all the events")
       )
@@ -290,15 +290,14 @@ class ReProvisioningSpec extends AnyWordSpec with IOSpec with MockFactory with s
     val controller = microserviceBaseUrls.generateOne
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
-    val configuredRenkuVersionPairs  = renkuVersionPairs.generateNonEmptyList(2)
-    val maybeCurrentRenkuVersionPair = renkuVersionPairs.generateOption
-    val reprovisionJudge             = mock[ReProvisionJudge[IO]]
-    val triplesRemover               = mock[TriplesRemover[IO]]
-    val eventsReScheduler            = mock[EventsReScheduler[IO]]
-    val renkuVersionPairUpdater      = mock[RenkuVersionPairUpdater[IO]]
-    val microserviceUrlFinder        = mock[MicroserviceUrlFinder[IO]]
-    val reProvisioningStatus         = mock[ReProvisioningStatus[IO]]
-    val executionTimeRecorder        = TestExecutionTimeRecorder[IO]()
+    val configuredRenkuVersionPairs = renkuVersionPairs.generateNonEmptyList(2)
+    val reprovisionJudge            = mock[ReProvisionJudge[IO]]
+    val triplesRemover              = mock[TriplesRemover[IO]]
+    val eventsReScheduler           = mock[EventsReScheduler[IO]]
+    val renkuVersionPairUpdater     = mock[RenkuVersionPairUpdater[IO]]
+    val microserviceUrlFinder       = mock[MicroserviceUrlFinder[IO]]
+    val reProvisioningStatus        = mock[ReProvisioningStatus[IO]]
+    val executionTimeRecorder       = TestExecutionTimeRecorder[IO]()
     val reProvisioning = new ReProvisioningImpl[IO](
       configuredRenkuVersionPairs,
       reprovisionJudge,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/reprovisioning/RenkuVersionPairFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/reprovisioning/RenkuVersionPairFinderSpec.scala
@@ -60,7 +60,7 @@ class RenkuVersionPairFinderSpec extends AnyWordSpec with IOSpec with InMemoryRd
 
       intercept[IllegalStateException] {
         versionPairFinder.find().unsafeRunSync()
-      }.getMessage should startWith("Too many Version pair found:")
+      }.getMessage should startWith("Too many Version pairs found:")
     }
   }
 


### PR DESCRIPTION
Starting re-provisioning process in a separate thread is causing issues when there are multiple triples-generator instances running. This PR changes the behaviour so TG is not fully up until re-provisioning is not finished.