### PR TITLE
chore(ci): Update renku action to v0.5.0

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -31,7 +31,7 @@ jobs:
       persist: ${{ steps.deploy-comment.outputs.persist}}
     steps:
       - id: deploy-comment
-        uses: SwissDataScienceCenter/renku-actions/check-pr-description@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/check-pr-description@v0.5.0
         with:
           string: /deploy
           pr_ref: ${{ github.event.number }}
@@ -43,7 +43,7 @@ jobs:
       name: renku-ci-gr-${{ github.event.number }}
     steps:
       - name: deploy-pr
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.5.0
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -87,7 +87,7 @@ jobs:
     if: ${{ github.event.action != 'closed' && needs.check-deploy.outputs.pr-contains-string == 'true' && needs.check-deploy.outputs.test-enabled == 'true' }} 
     needs: [ check-deploy, deploy-pr ]
     steps:
-    - uses: SwissDataScienceCenter/renku-actions/test-renku@0.5.0
+    - uses: SwissDataScienceCenter/renku-actions/test-renku@v0.5.0
       with:
         renkubot-kubeconfig: ${{ secrets.RENKUBOT_DEV_KUBECONFIG }}
         renku-release: renku-ci-gr-${{ github.event.number }}
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: renku teardown
-        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/cleanup-renku-ci-deployments@v0.5.0
         env:
           HELM_RELEASE_REGEX: "^renku-ci-gr-${{ github.event.number }}$"
           GITLAB_TOKEN: ${{ secrets.DEV_GITLAB_TOKEN }}

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -98,7 +98,7 @@ jobs:
       name: renku-kg-dev
     steps:
       - name: deploy-development
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v0.5.0
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
@@ -136,7 +136,7 @@ jobs:
           helm test ${RENKU_RELEASE} --namespace ${RENKU_RELEASE} --timeout 140m --logs
       - name: Download artifact for packaging on failure
         if: failure()
-        uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/download-test-artifacts@v0.5.0
         env:
           RENKU_VALUES: ${{ secrets.CI_RENKU_VALUES }}
           TEST_ARTIFACTS_PATH: "tests-artifacts-${{ github.sha }}"

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -107,7 +107,7 @@ jobs:
           echo "GIT_USER=Renku Bot" >> $GITHUB_ENV
           echo "GIT_EMAIL=renku@datascience.ch" >> $GITHUB_ENV
       - name: Build and push chart and images
-        uses: SwissDataScienceCenter/renku-actions/publish-chart@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/publish-chart@v0.5.0
         env:
           CHART_PATH: helm-chart/renku-graph
           CHART_NAME: renku-graph
@@ -117,7 +117,7 @@ jobs:
       - name: Wait for chart to be available
         run: sleep 120
       - name: Update component version
-        uses: SwissDataScienceCenter/renku-actions/update-component-version@0.5.0
+        uses: SwissDataScienceCenter/renku-actions/update-component-version@v0.5.0
         env:
           CHART_NAME: renku-graph
           GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
So it seems there were renku actions published with the tag `0.5.0` which is missing the `v`. This caused the other automated PR to be automatically opened and then reviewed (where we missed the missing `v`) and merged.

This switches the actions back to using tags that contain `v` and a semver.