### PR TITLE
fix: failures for the status change event to log more details

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/DBUpdateResults.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/DBUpdateResults.scala
@@ -27,7 +27,10 @@ private sealed trait DBUpdateResults
 
 private object DBUpdateResults {
 
-  final case class ForProjects(statusCounts: Set[(projects.Path, Map[EventStatus, Int])]) extends DBUpdateResults
+  final case class ForProjects(statusCounts: Set[(projects.Path, Map[EventStatus, Int])]) extends DBUpdateResults {
+    def apply(project: projects.Path): Map[EventStatus, Int] =
+      statusCounts.find(_._1 == project).map(_._2).getOrElse(Map.empty)
+  }
 
   object ForProjects {
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToAwaitingDeletionUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToAwaitingDeletionUpdater.scala
@@ -66,7 +66,7 @@ private class ToAwaitingDeletionUpdater[F[_]: MonadCancelThrow](
             .pure[F]
             .widen[DBUpdateResults]
         case _ =>
-          new Exception(s"Could not update event ${event.eventId} to status $AwaitingDeletion")
+          new Exception(s"Could not update event ${event.eventId} to status $AwaitingDeletion: event not found")
             .raiseError[F, DBUpdateResults]
       }
   }

--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToFailureUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToFailureUpdater.scala
@@ -81,8 +81,8 @@ private class ToFailureUpdater[F[_]: MonadCancelThrow: Async](
           DBUpdateResults
             .ForProjects(event.projectPath, Map(event.currentStatus -> -1, event.newStatus -> 1))
             .pure[F]
-        case _ =>
-          new Exception(s"Could not update event ${event.eventId} to status ${event.newStatus}")
+        case completion =>
+          new Exception(s"Could not update event ${event.eventId} to status ${event.newStatus}: $completion")
             .raiseError[F, DBUpdateResults.ForProjects]
       }
   }

--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesStoreUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesStoreUpdater.scala
@@ -79,8 +79,8 @@ private class ToTriplesStoreUpdater[F[_]: MonadCancelThrow: Async](
           DBUpdateResults
             .ForProjects(event.projectPath, Map(TransformingTriples -> -1, TriplesStore -> 1))
             .pure[F]
-        case _ =>
-          new Exception(s"Could not update event ${event.eventId} to status ${EventStatus.TriplesStore}")
+        case completion =>
+          new Exception(s"Could not update event ${event.eventId} to status ${EventStatus.TriplesStore}: $completion")
             .raiseError[F, DBUpdateResults.ForProjects]
       }
   }

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/DBUpdateResultsSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/DBUpdateResultsSpec.scala
@@ -28,7 +28,9 @@ import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
 class DBUpdateResultsSpec extends AnyWordSpec with should.Matchers {
+
   "combine" should {
+
     "merge status count for each project" in {
       val project1         = projectPaths.generateOne
       val project1Count    = EventStatus.all.map(_ -> Gen.choose(-200, 200).generateOne).toMap
@@ -40,6 +42,24 @@ class DBUpdateResultsSpec extends AnyWordSpec with should.Matchers {
       uniqueProject.combine(multipleProjects) shouldBe ForProjects(
         Set(project1 -> project1Count.combine(project1Count), project2 -> project2Count)
       )
+    }
+  }
+
+  "DBUpdateResults.ForProjects.apply" should {
+
+    "return the statuses count for the given project" in {
+      val project1      = projectPaths.generateOne
+      val project1Count = EventStatus.all.map(_ -> Gen.choose(-200, 200).generateOne).toMap
+      val project2      = projectPaths.generateOne
+      val project2Count = EventStatus.all.map(_ -> Gen.choose(-200, 200).generateOne).toMap
+
+      val updateResults = ForProjects(Set(project1 -> project1Count, project2 -> project2Count))
+
+      updateResults(project2) shouldBe project2Count
+    }
+
+    "return no statuses count if the given project does not exists in the results" in {
+      ForProjects.empty(projectPaths.generateOne) shouldBe Map.empty
     }
   }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/ToAwaitingDeletionUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/ToAwaitingDeletionUpdaterSpec.scala
@@ -70,7 +70,7 @@ class ToAwaitingDeletionUpdaterSpec
         sessionResource
           .useK(dbUpdater updateDB ToAwaitingDeletion(eventId, projectPaths.generateOne))
           .unsafeRunSync()
-      }.getMessage shouldBe s"Could not update event $eventId to status $AwaitingDeletion"
+      }.getMessage shouldBe s"Could not update event $eventId to status $AwaitingDeletion: event not found"
     }
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/ToFailureUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/ToFailureUpdaterSpec.scala
@@ -37,6 +37,7 @@ import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+import skunk.data.Completion
 
 import java.time.{Duration, Instant}
 
@@ -144,7 +145,8 @@ class ToFailureUpdaterSpec
 
           intercept[Exception] {
             sessionResource.useK(dbUpdater.updateDB(statusChangeEvent)).unsafeRunSync()
-          }.getMessage shouldBe s"Could not update event $eventId to status ${statusChangeEvent.newStatus}"
+          }.getMessage shouldBe s"Could not update event $eventId to status ${statusChangeEvent.newStatus}: ${Completion
+            .Update(0)}"
 
           findEvent(eventId).map(_._2) shouldBe Some(invalidStatus)
         }

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesStoreUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesStoreUpdaterSpec.scala
@@ -121,9 +121,7 @@ class ToTriplesStoreUpdaterSpec
 
       (deliveryInfoRemover.deleteDelivery _).expects(event.eventId).returning(Kleisli.pure(()))
 
-      sessionResource
-        .useK(dbUpdater onRollback event)
-        .unsafeRunSync() shouldBe ()
+      sessionResource.useK(dbUpdater onRollback event).unsafeRunSync() shouldBe ()
     }
   }
 


### PR DESCRIPTION
It looks like there are quite a few failures for the `EVENT_STATUS_CHANGE` events during re-provisioning. It would be good to the exceptions contains some more context. This PR adds the completion to the message.