### PR TITLE
fix: commit sync processes to work with invalid access token

### DIFF
--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/categories/commitsync/eventgeneration/CommitsSynchronizer.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/categories/commitsync/eventgeneration/CommitsSynchronizer.scala
@@ -63,15 +63,15 @@ private[commitsync] class CommitsSynchronizerImpl[F[_]: MonadThrow: Logger](
   import executionTimeRecorder._
   import latestCommitFinder._
 
-  override def synchronizeEvents(event: CommitSyncEvent): F[Unit] = (for {
-    maybeAccessToken  <- findAccessToken(event.project.id)
-    maybeLatestCommit <- findLatestCommit(event.project.id, maybeAccessToken).value
-    _                 <- checkForSkippedEvent(maybeLatestCommit, event)(maybeAccessToken)
-  } yield ()) recoverWith loggingError(event)
+  override def synchronizeEvents(event: CommitSyncEvent): F[Unit] = {
+    findAccessToken(event.project.id) >>= { implicit maybeAccessToken =>
+      findLatestCommit(event.project.id) >>= (checkForSkippedEvent(_, event))
+    }
+  } recoverWith loggingError(event)
 
   private def checkForSkippedEvent(maybeLatestCommit: Option[CommitInfo], event: CommitSyncEvent)(implicit
       maybeAccessToken:                               Option[AccessToken]
-  ) = (maybeLatestCommit, event) match {
+  ): F[Unit] = (maybeLatestCommit, event) match {
     case (Some(commitInfo), FullCommitSyncEvent(id, _, _)) if commitInfo.id == id =>
       measureExecutionTime(Skipped.pure[F].widen[UpdateResult]) >>= logResult(event)
     case (Some(commitInfo), event) =>

--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/CommitsSynchronizer.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/CommitsSynchronizer.scala
@@ -68,7 +68,7 @@ private[globalcommitsync] class CommitsSynchronizerImpl[F[_]: Async: NonEmptyPar
   override def synchronizeEvents(event: GlobalCommitSyncEvent): F[Unit] = {
     findAccessToken(event.project.id) >>= { implicit maybeAccessToken =>
       fetchCommitStats(event.project.id) >>= {
-        case maybeStats if outOfSync(event, maybeStats) => createOrDeleteEvents(event)
+        case maybeStats if outOfSync(event)(maybeStats) => createOrDeleteEvents(event)
         case _ =>
           logSummary(event.project,
                      SynchronizationSummary().updated(UpdateResult.Skipped, event.commits.count.value.toInt)
@@ -80,13 +80,12 @@ private[globalcommitsync] class CommitsSynchronizerImpl[F[_]: Async: NonEmptyPar
       error.raiseError[F, Unit]
   }
 
-  private def outOfSync(event: GlobalCommitSyncEvent, maybeCommitStats: Option[ProjectCommitStats]) =
-    maybeCommitStats match {
-      case Some(commitStats) =>
-        event.commits.count != commitStats.commitsCount ||
-          !commitStats.maybeLatestCommit.contains(event.commits.latest)
-      case _ => true
-    }
+  private def outOfSync(event: GlobalCommitSyncEvent): Option[ProjectCommitStats] => Boolean = {
+    case Some(commitStats) =>
+      event.commits.count != commitStats.commitsCount ||
+        !(commitStats.maybeLatestCommit contains event.commits.latest)
+    case _ => true
+  }
 
   private def createOrDeleteEvents(
       event:                   GlobalCommitSyncEvent

--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitStatFetcher.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitStatFetcher.scala
@@ -71,19 +71,21 @@ private[globalcommitsync] class GitLabCommitStatFetcherImpl[F[_]: Async: Logger]
   }.value
 
   private def fetchCommitCount(projectId: projects.Id)(implicit maybeAccessToken: Option[AccessToken]) = for {
-    uri         <- validateUri(s"$gitLabApiUrl/projects/$projectId?statistics=true")
-    commitCount <- send(request(GET, uri, maybeAccessToken))(mapResponse)
-  } yield commitCount
+    uri              <- validateUri(s"$gitLabApiUrl/projects/$projectId?statistics=true")
+    maybeCommitCount <- send(request(GET, uri, maybeAccessToken))(mapResponse)
+  } yield maybeCommitCount
 
   private implicit lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Option[CommitsCount]]] = {
-    case (Ok, _, response)               => response.as[CommitsCount].map(_.some)
+    case (Ok, _, response)               => response.as[Option[CommitsCount]]
     case (NotFound | Unauthorized, _, _) => Option.empty[CommitsCount].pure[F]
   }
 
-  private implicit val commitCountDecoder: EntityDecoder[F, CommitsCount] = {
-    implicit val commitDecoder: Decoder[CommitsCount] =
-      _.downField("statistics").downField("commit_count").as(CommitsCount.decoder)
-    jsonOf[F, CommitsCount]
+  private implicit val commitCountDecoder: EntityDecoder[F, Option[CommitsCount]] = {
+    import io.circe.Decoder.decodeOption
+
+    implicit val commitDecoder: Decoder[Option[CommitsCount]] =
+      _.downField("statistics").downField("commit_count").as(decodeOption(CommitsCount.decoder))
+    jsonOf[F, Option[CommitsCount]]
   }
 }
 

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitFetcherSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitFetcherSpec.scala
@@ -29,13 +29,12 @@ import io.circe.literal._
 import io.renku.commiteventservice.events.categories.common.CommitInfo
 import io.renku.commiteventservice.events.categories.common.Generators.commitInfos
 import io.renku.commiteventservice.events.categories.globalcommitsync.eventgeneration.PageResult
-import io.renku.generators.CommonGraphGenerators.{oauthAccessTokens, pages, pagingRequests, personalAccessTokens}
+import io.renku.generators.CommonGraphGenerators.{accessTokens, pages, pagingRequests}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.EventsGenerators._
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.http.client.RestClient.ResponseMappingF
-import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.interpreters.TestLogger
 import io.renku.testtools.IOSpec
@@ -52,7 +51,7 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
 
   "fetchGitLabCommits" should {
 
-    "fetch commits from the given page" in new TestCase {
+    "fetch commits from the given page" in new AllCommitsEndpointTestCase {
 
       val expectation = pageResults().generateOne
 
@@ -68,61 +67,27 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
         .unsafeRunSync() shouldBe expectation
     }
 
-    "fetch commits using the given personal access token" in new TestCase {
-      val personalAccessToken = personalAccessTokens.generateOne
+    "return no commits if there aren't any" in new AllCommitsEndpointTestCase {
 
-      val expectation = pageResults().generateOne
-
-      (gitLabClient
-        .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
-          _: Option[AccessToken]
-        ))
-        .expects(GET, uri, endpointName, *, Some(personalAccessToken))
-        .returning(expectation.pure[IO])
-
-      gitLabCommitFetcher
-        .fetchGitLabCommits(projectId, pageRequest)(Some(personalAccessToken))
-        .unsafeRunSync() shouldBe expectation
-    }
-
-    "fetch commits using the given oauth token" in new TestCase {
-      val authAccessToken = oauthAccessTokens.generateOne
-
-      val expectation = pageResults().generateOne
-
-      (gitLabClient
-        .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
-          _: Option[AccessToken]
-        ))
-        .expects(GET, uri, endpointName, *, authAccessToken.some)
-        .returning(expectation.pure[IO])
-
-      gitLabCommitFetcher
-        .fetchGitLabCommits(projectId, pageRequest)(Some(authAccessToken))
-        .unsafeRunSync() shouldBe expectation
-    }
-
-    "return no commits if there aren't any" in new TestCase {
-
-      val expectation = PageResult(commits = Nil, maybeNextPage = None)
+      val pageResult = PageResult(commits = Nil, maybeNextPage = None)
 
       (gitLabClient
         .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
           _: Option[AccessToken]
         ))
         .expects(GET, uri, endpointName, *, maybeAccessToken)
-        .returning(expectation.pure[IO])
+        .returning(pageResult.pure[IO])
 
       gitLabCommitFetcher
         .fetchGitLabCommits(projectId, pageRequest)(maybeAccessToken)
-        .unsafeRunSync() shouldBe expectation
+        .unsafeRunSync() shouldBe pageResult
     }
 
-    "fetch commits from the given page - responseMapping OK" in new TestCase {
+    "fetch commits from the given page - response OK" in new AllCommitsEndpointTestCase {
 
       val maybeNextPage = pages.generateOption
 
-      multiCommitResponseMapping
+      responseMapping
         .value(
           (Status.Ok,
            Request[IO](),
@@ -134,44 +99,43 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
         .unsafeRunSync() shouldBe PageResult(commitInfoList.map(_.id), maybeNextPage)
     }
 
-    "fetch commits from the given page - responseMapping NotFound" in new TestCase {
+    "fetch commits from the given page - response NotFound" in new AllCommitsEndpointTestCase {
 
-      multiCommitResponseMapping
+      responseMapping
         .value(
           (Status.NotFound, Request[IO](), Response[IO]())
         )
         .unsafeRunSync() shouldBe PageResult.empty
     }
 
-    "fetch commits from the given page - responseMapping Unauthorized" in new TestCase {
+    "fallback to fetch commits without an access token for Unauthorized" in new AllCommitsEndpointTestCase {
 
-      intercept[UnauthorizedException] {
-        multiCommitResponseMapping
-          .value(
-            (Status.Unauthorized, Request[IO](), Response[IO]())
-          )
-          .unsafeRunSync()
-      }.getMessage should startWith(s"Unauthorized")
+      val pageResult = PageResult(commits = commitIds.generateFixedSizeList(1), maybeNextPage = None)
+
+      (gitLabClient
+        .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
+          _: Option[AccessToken]
+        ))
+        .expects(GET, uri, endpointName, *, Option.empty[AccessToken])
+        .returning(pageResult.pure[IO])
+
+      responseMapping
+        .value((Status.Unauthorized, Request[IO](), Response[IO]()))
+        .unsafeRunSync() shouldBe pageResult
     }
 
-    "return an Exception if remote client responds with status neither OK nor UNAUTHORIZED" in new TestCase {
-
+    "return an Exception if remote client responds with status neither OK nor UNAUTHORIZED" in new AllCommitsEndpointTestCase {
       intercept[Exception] {
-        multiCommitResponseMapping
-          .value(
-            (Status.BadRequest, Request[IO](), Response[IO]())
-          )
+        responseMapping
+          .value((Status.BadRequest, Request[IO](), Response[IO]()))
           .unsafeRunSync()
       }.getMessage should startWith(s"(400 Bad Request")
     }
 
-    "return an Exception if remote client responds with unexpected body" in new TestCase {
-
+    "return an Exception if remote client responds with unexpected body" in new AllCommitsEndpointTestCase {
       intercept[Exception] {
-        multiCommitResponseMapping
-          .value(
-            (Status.Ok, Request[IO](), Response[IO](body = EmptyBody))
-          )
+        responseMapping
+          .value((Status.Ok, Request[IO](), Response[IO](body = EmptyBody)))
           .unsafeRunSync()
       }
     }
@@ -179,32 +143,27 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
 
   "fetchLatestGitLabCommit" should {
 
-    "return a single commit" in new TestCase {
+    "return a single commit" in new LatestCommitsEndpointTestCase {
 
-      override val uri = uri"projects" / projectId.show / "repository" / "commits" withQueryParams Map(
-        "per_page" -> "1"
-      )
-
-      val expectation = pageResults().generateOne
+      val pageResult = pageResults().generateOne
 
       (gitLabClient
         .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
           _: Option[AccessToken]
         ))
         .expects(GET, uri, endpointName, *, maybeAccessToken)
-        .returning(expectation.pure[IO])
+        .returning(pageResult.pure[IO])
 
       gitLabCommitFetcher
         .fetchLatestGitLabCommit(projectId)(maybeAccessToken)
-        .unsafeRunSync() shouldBe expectation
-
+        .unsafeRunSync() shouldBe pageResult
     }
 
-    "fetch the latest commit from the given page - responseMapping OK" in new TestCase {
+    "fetch the latest commit from the given page - response OK" in new LatestCommitsEndpointTestCase {
 
       val maybeNextPage = pages.generateOption
 
-      singleCommitResponseMapping
+      responseMapping
         .value(
           (Status.Ok,
            Request[IO](),
@@ -213,55 +172,50 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
              .withHeaders(Header.Raw(ci"X-Next-Page", maybeNextPage.map(_.show).getOrElse("")))
           )
         )
-        .unsafeRunSync() shouldBe Some(commitInfoList.head.id)
+        .unsafeRunSync() shouldBe commitInfoList.head.id.some
     }
 
-    "fetch the latest commit from the given page - responseMapping NotFound" in new TestCase {
-
-      singleCommitResponseMapping
-        .value(
-          (Status.NotFound, Request[IO](), Response[IO]())
-        )
+    "fetch the latest commit from the given page - response NotFound" in new LatestCommitsEndpointTestCase {
+      responseMapping
+        .value((Status.NotFound, Request[IO](), Response[IO]()))
         .unsafeRunSync() shouldBe None
     }
 
-    "fetch the latest commit from the given page - responseMapping Unauthorized" in new TestCase {
+    "fallback to fetch latest commit without an access token for Unauthorized" in new LatestCommitsEndpointTestCase {
 
-      intercept[UnauthorizedException] {
+      val pageResult = pageResults().generateOne
 
-        singleCommitResponseMapping
-          .value(
-            (Status.Unauthorized, Request[IO](), Response[IO]())
-          )
-          .unsafeRunSync()
-      }.getMessage should startWith("Unauthorized")
+      (gitLabClient
+        .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
+          _: Option[AccessToken]
+        ))
+        .expects(GET, uri, endpointName, *, Option.empty[AccessToken])
+        .returning(pageResult.pure[IO])
+
+      responseMapping
+        .value((Status.Unauthorized, Request[IO](), Response[IO]()))
+        .unsafeRunSync() shouldBe pageResult
     }
 
-    "return an Exception if remote client responds with status neither OK nor UNAUTHORIZED" in new TestCase {
+    "return an Exception if remote client responds with status neither OK nor UNAUTHORIZED" in new LatestCommitsEndpointTestCase {
       intercept[Exception] {
-        singleCommitResponseMapping
-          .value(
-            (Status.BadRequest, Request[IO](), Response[IO]())
-          )
+        responseMapping
+          .value((Status.BadRequest, Request[IO](), Response[IO]()))
           .unsafeRunSync()
       }.getMessage should startWith(s"(400 Bad Request")
     }
 
-    "return an Exception if remote client responds with unexpected body" in new TestCase {
-
+    "return an Exception if remote client responds with unexpected body" in new LatestCommitsEndpointTestCase {
       intercept[Exception] {
-        singleCommitResponseMapping
-          .value(
-            (Status.Ok, Request[IO](), Response[IO](body = EmptyBody))
-          )
+        responseMapping
+          .value((Status.Ok, Request[IO](), Response[IO](body = EmptyBody)))
           .unsafeRunSync()
       }
     }
-
   }
 
   private trait TestCase {
-    implicit val maybeAccessToken: Option[AccessToken] = personalAccessTokens.generateSome
+    implicit val maybeAccessToken: Option[AccessToken] = accessTokens.generateSome
     val projectId      = projectIds.generateOne
     val pageRequest    = pagingRequests.generateOne
     val commitInfoList = commitInfos.generateNonEmptyList().toList
@@ -269,6 +223,9 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
     val gitLabClient = mock[GitLabClient[IO]]
     private implicit val logger: TestLogger[IO] = TestLogger()
     val gitLabCommitFetcher = new GitLabCommitFetcherImpl[IO](gitLabClient)
+  }
+
+  private trait AllCommitsEndpointTestCase extends TestCase {
 
     val uri = uri"projects" / projectId.show / "repository" / "commits" withQueryParams Map(
       "page"     -> pageRequest.page.show,
@@ -277,35 +234,48 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
 
     val endpointName: String Refined NonEmpty = "commits"
 
-    lazy val multiCommitResponseMapping = responseMapping(true)
-
-    lazy val singleCommitResponseMapping = responseMapping(false)
-
-    private def responseMapping(isMulti: Boolean) = {
+    val responseMapping = {
       val responseMapping = CaptureOne[ResponseMappingF[IO, PageResult]]()
 
-      val results = if (isMulti) pageResults().generateOne else pageResults(1).generateOne
-
+      val endpointName: String Refined NonEmpty = "commits"
       (gitLabClient
         .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
           _: Option[AccessToken]
         ))
-        .expects(*, *, *, capture(responseMapping), *)
-        .returning(results.pure[IO])
+        .expects(*, *, endpointName, capture(responseMapping), maybeAccessToken)
+        .returning(pageResults().generateOne.pure[IO])
 
-      if (isMulti) {
-        gitLabCommitFetcher
-          .fetchGitLabCommits(projectId, pageRequest)(None)
-          .unsafeRunSync()
-      } else {
-        gitLabCommitFetcher
-          .fetchLatestGitLabCommit(projectId)(None)
-          .unsafeRunSync()
-      }
+      gitLabCommitFetcher
+        .fetchGitLabCommits(projectId, pageRequest)(maybeAccessToken)
+        .unsafeRunSync()
 
       responseMapping
     }
+  }
 
+  private trait LatestCommitsEndpointTestCase extends TestCase {
+
+    val uri = uri"projects" / projectId.show / "repository" / "commits" withQueryParams Map("per_page" -> "1")
+
+    val endpointName: String Refined NonEmpty = "latest commit"
+
+    val responseMapping = {
+      val responseMapping = CaptureOne[ResponseMappingF[IO, PageResult]]()
+
+      val endpointName: String Refined NonEmpty = "latest commit"
+      (gitLabClient
+        .send(_: Method, _: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, PageResult])(
+          _: Option[AccessToken]
+        ))
+        .expects(*, *, endpointName, capture(responseMapping), maybeAccessToken)
+        .returning(pageResults(1).generateOne.pure[IO])
+
+      gitLabCommitFetcher
+        .fetchLatestGitLabCommit(projectId)(maybeAccessToken)
+        .unsafeRunSync()
+
+      responseMapping
+    }
   }
 
   private def pageResults(maxCommitCount: Int Refined Positive = positiveInts().generateOne) = for {
@@ -316,8 +286,7 @@ class GitLabCommitFetcherSpec extends AnyWordSpec with IOSpec with MockFactory w
   private def commitsJson(from: List[CommitInfo]) =
     Json.arr(from.map(commitJson): _*).noSpaces
 
-  private def commitJson(commitInfo: CommitInfo) =
-    json"""{
+  private def commitJson(commitInfo: CommitInfo) = json"""{
     "id":              ${commitInfo.id.value},
     "author_name":     ${commitInfo.author.name.value},
     "author_email":    ${commitInfo.author.emailToJson},

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitStatFetcherSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitStatFetcherSpec.scala
@@ -86,6 +86,21 @@ class GitLabCommitStatFetcherSpec
       gitLabCommitStatFetcher.fetchCommitStats(projectId).unsafeRunSync() shouldBe None
     }
 
+    "return None if the gitlab API returns no statistics" in new TestCase {
+      val maybeLatestCommit = commitIds.generateOption
+      (gitLabCommitFetcher
+        .fetchLatestGitLabCommit(_: projects.Id)(_: Option[AccessToken]))
+        .expects(projectId, maybeAccessToken)
+        .returning(maybeLatestCommit.pure[IO])
+
+      stubFor {
+        get(s"/api/v4/projects/$projectId?statistics=true")
+          .willReturn(okJson("{}"))
+      }
+
+      gitLabCommitStatFetcher.fetchCommitStats(projectId).unsafeRunSync() shouldBe None
+    }
+
     "return None if the gitlab API returns a Unauthorized" in new TestCase {
       val maybeLatestCommit = commitIds.generateOption
       (gitLabCommitFetcher

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitStatFetcherSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/events/categories/globalcommitsync/eventgeneration/gitlab/GitLabCommitStatFetcherSpec.scala
@@ -34,7 +34,6 @@ import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.graph.model.{GitLabUrl, projects}
 import io.renku.http.client.AccessToken
-import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.interpreters.TestLogger
 import io.renku.stubbing.ExternalServiceStubbing
 import io.renku.testtools.IOSpec
@@ -52,6 +51,7 @@ class GitLabCommitStatFetcherSpec
     with ScalaCheckPropertyChecks {
 
   "fetchCommitStats" should {
+
     "return a ProjectCommitStats with count of commits " in new TestCase {
       forAll(commitIds.toGeneratorOfOptions, commitsCounts) { (maybeLatestCommit, commitCount) =>
         (gitLabCommitFetcher
@@ -86,7 +86,7 @@ class GitLabCommitStatFetcherSpec
       gitLabCommitStatFetcher.fetchCommitStats(projectId).unsafeRunSync() shouldBe None
     }
 
-    "throw an UnauthorizedException if the gitlab API returns an UnauthorizedException" in new TestCase {
+    "return None if the gitlab API returns a Unauthorized" in new TestCase {
       val maybeLatestCommit = commitIds.generateOption
       (gitLabCommitFetcher
         .fetchLatestGitLabCommit(_: projects.Id)(_: Option[AccessToken]))
@@ -95,9 +95,7 @@ class GitLabCommitStatFetcherSpec
 
       stubFor(get(s"/api/v4/projects/$projectId?statistics=true").willReturn(unauthorized()))
 
-      intercept[Exception] {
-        gitLabCommitStatFetcher.fetchCommitStats(projectId).unsafeRunSync()
-      } shouldBe a[UnauthorizedException]
+      gitLabCommitStatFetcher.fetchCommitStats(projectId).unsafeRunSync() shouldBe None
     }
   }
 


### PR DESCRIPTION
It looks there are cases when we end up with some invalid access tokens for a project that is deleted. It looks it's safe for the sync processes to treat such cases as if the project is removed.

/deploy