### PR TITLE
fix: member email finder not to traverse all project events if many

### DIFF
--- a/generators/src/main/scala/io/renku/generators/Generators.scala
+++ b/generators/src/main/scala/io/renku/generators/Generators.scala
@@ -138,6 +138,8 @@ object Generators {
   def positiveInts(max: Int = 1000): Gen[Int Refined Positive] =
     choose(1, max) map Refined.unsafeApply
 
+  def ints(min: Int = Int.MinValue, max: Int = Int.MaxValue): Gen[Int] = choose(min, max)
+
   def positiveLongs(max: Long = 1000): Gen[Long Refined Positive] =
     choose(1L, max) map Refined.unsafeApply
 

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -21,7 +21,6 @@ triples-generation = "renku-log"
 # *  ["0.16.1 -> 9", "0.16.0 -> 9", ...] then the decision about re-provisioning is taken using the 9 schema version and 0.16.1 CLI version
 compatibility-matrix = [
   "1.0.4  -> 9",
-  "1.0.3  -> 9",
   "0.16.2 -> 8"
 ]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/generators/ErrorGenerators.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/generators/ErrorGenerators.scala
@@ -28,7 +28,7 @@ object ErrorGenerators {
   lazy val logWorthyRecoverableErrors: Gen[LogWorthyRecoverableError] = for {
     message    <- nonEmptyStrings()
     maybeCause <- exceptions.toGeneratorOfOptions
-  } yield LogWorthyRecoverableError(message, maybeCause.getOrElse(null))
+  } yield LogWorthyRecoverableError(message, maybeCause.orNull)
 
   lazy val authRecoverableErrors: Gen[AuthRecoverableError] = for {
     message <- nonEmptyStrings()


### PR DESCRIPTION
It looks like the project's events GitLab API is pretty costly to call on projects with hundreds of events. The member email finding process tries to go through all the events causing a huge load on Postgres. This PR changes the logic so only first, middle and last 20 events will be checked.