### PR TITLE
fix: token removal error

### DIFF
--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/projectCleaner/ProjectWebhookAndTokenRemoverSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/statuschange/projectCleaner/ProjectWebhookAndTokenRemoverSpec.scala
@@ -65,14 +65,13 @@ class ProjectWebhookAndTokenRemoverSpec
       webhookAndTokenRemover.removeWebhookAndToken(project).unsafeRunSync() shouldBe ()
     }
 
-    "fail when the tokenFinder returns no token for the project" in new TestCase {
+    "do nothing when the tokenFinder returns no token for the project" in new TestCase {
       (accesTokenFinder
         .findAccessToken[projects.Id](_: projects.Id)(_: projects.Id => String))
         .expects(project.id, AccessTokenFinder.projectIdToPath)
         .returns(None.pure[IO])
-      intercept[Exception] {
-        webhookAndTokenRemover.removeWebhookAndToken(project).unsafeRunSync()
-      }.getMessage shouldBe s"No token found for project: ${project.show}"
+
+      webhookAndTokenRemover.removeWebhookAndToken(project).unsafeRunSync() shouldBe ()
     }
 
     "fail when the tokenFinder fails" in new TestCase {


### PR DESCRIPTION
When removing a project it could happened that the token is not found at this point we can consider the project already removed and not throw an error