### PR TITLE
fix: GET projects/:path to work with any valid token if public project

### DIFF
--- a/graph-commons/src/main/scala/io/renku/graph/http/server/security/DatasetIdRecordsFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/http/server/security/DatasetIdRecordsFinder.scala
@@ -32,9 +32,8 @@ import org.typelevel.log4cats.Logger
 object DatasetIdRecordsFinder {
   def apply[F[_]: Async: Logger](
       timeRecorder: SparqlQueryTimeRecorder[F]
-  ): F[SecurityRecordFinder[F, datasets.Identifier]] = for {
-    config <- RdfStoreConfig[F]()
-  } yield new DatasetIdRecordsFinderImpl(config, timeRecorder)
+  ): F[SecurityRecordFinder[F, datasets.Identifier]] =
+    RdfStoreConfig[F]().map(new DatasetIdRecordsFinderImpl(_, timeRecorder))
 }
 
 private class DatasetIdRecordsFinderImpl[F[_]: Async: Logger](

--- a/graph-commons/src/main/scala/io/renku/graph/http/server/security/ProjectPathRecordsFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/http/server/security/ProjectPathRecordsFinder.scala
@@ -32,9 +32,7 @@ import org.typelevel.log4cats.Logger
 
 object ProjectPathRecordsFinder {
   def apply[F[_]: Async: Logger](timeRecorder: SparqlQueryTimeRecorder[F]): F[SecurityRecordFinder[F, projects.Path]] =
-    for {
-      config <- RdfStoreConfig[F]()
-    } yield new ProjectPathRecordsFinderImpl(config, timeRecorder)
+    RdfStoreConfig[F]().map(new ProjectPathRecordsFinderImpl[F](_, timeRecorder))
 }
 
 private class ProjectPathRecordsFinderImpl[F[_]: Async: Logger](
@@ -51,7 +49,7 @@ private class ProjectPathRecordsFinderImpl[F[_]: Async: Logger](
 
   private def query(path: projects.Path) = SparqlQuery.of(
     name = "authorise - project path",
-    Prefixes.of(schema -> "schema", renku -> "renku"),
+    Prefixes of (schema -> "schema", renku -> "renku"),
     s"""|SELECT DISTINCT ?projectId ?visibility (GROUP_CONCAT(?maybeMemberGitLabId; separator=',') AS ?memberGitLabIds)
         |WHERE {
         |  ?projectId a schema:Project;

--- a/graph-commons/src/main/scala/io/renku/rdfstore/RdfStoreConfig.scala
+++ b/graph-commons/src/main/scala/io/renku/rdfstore/RdfStoreConfig.scala
@@ -38,15 +38,12 @@ object RdfStoreConfig {
   import io.renku.config.ConfigLoader._
   import io.renku.http.client.BasicAuthConfigReaders._
 
-  def apply[F[_]: MonadThrow](
-      config: Config = ConfigFactory.load()
-  ): F[RdfStoreConfig] =
-    for {
-      url         <- find[F, FusekiBaseUrl]("services.fuseki.url", config)
-      datasetName <- find[F, DatasetName]("services.fuseki.dataset-name", config)
-      username    <- find[F, BasicAuthUsername]("services.fuseki.renku.username", config)
-      password    <- find[F, BasicAuthPassword]("services.fuseki.renku.password", config)
-    } yield RdfStoreConfig(url, datasetName, BasicAuthCredentials(username, password))
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[RdfStoreConfig] = for {
+    url         <- find[F, FusekiBaseUrl]("services.fuseki.url", config)
+    datasetName <- find[F, DatasetName]("services.fuseki.dataset-name", config)
+    username    <- find[F, BasicAuthUsername]("services.fuseki.renku.username", config)
+    password    <- find[F, BasicAuthPassword]("services.fuseki.renku.password", config)
+  } yield RdfStoreConfig(url, datasetName, BasicAuthCredentials(username, password))
 }
 
 class FusekiBaseUrl private (val value: String) extends AnyVal with UrlTinyType

--- a/graph-commons/src/test/scala/io/renku/graph/http/server/security/AuthorizerSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/http/server/security/AuthorizerSpec.scala
@@ -64,6 +64,19 @@ class AuthorizerSpec extends AnyWordSpec with MockFactory with should.Matchers {
       )
     }
 
+    "succeed if found SecurityRecord is for a public project and the user has no explicit rights to the project" in new TestCase {
+      val projectPath = projectPaths.generateOne
+      val authUser    = authUsers.generateOne
+
+      securityRecordsFinder
+        .expects(key)
+        .returning(List((Visibility.Public, projectPath, userGitLabIds.generateSet())).pure[Try])
+
+      authorizer.authorize(key, authUser.some) shouldBe EitherT.rightT[Try, EndpointSecurityException](
+        AuthContext[Key](Some(authUser), key, Set(projectPath))
+      )
+    }
+
     "succeed if found SecurityRecord is for a non-public project but the user has rights to the project" in new TestCase {
       val projectPath = projectPaths.generateOne
       val authUser    = authUsers.generateOne

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/rest/ProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/rest/ProjectFinder.scala
@@ -50,12 +50,10 @@ private class ProjectFinderImpl[F[_]: MonadThrow: Parallel](
   import kgProjectFinder.{findProject => findInKG}
 
   def findProject(path: Path, maybeAuthUser: Option[AuthUser]): F[Option[Project]] =
-    ((OptionT(findInKG(path, maybeAuthUser)), findInGitLab(path, maybeAuthUser)) parMapN (merge(path, _, _))).value
+    ((OptionT(findInKG(path, maybeAuthUser)), findInGitLab(path)) parMapN (merge(path, _, _))).value
 
-  private def findInGitLab(path: Path, maybeAuthUser: Option[AuthUser]) = for {
-    accessToken   <- OptionT.fromOption[F](maybeAuthUser.map(_.accessToken)) orElseF findAccessToken(path)
-    gitLabProject <- findProjectInGitLab(path, Some(accessToken))
-  } yield gitLabProject
+  private def findInGitLab(path: Path) =
+    OptionT(findAccessToken(path)) >>= { implicit accessToken => findProjectInGitLab(path) }
 
   private def merge(path: Path, kgProject: KGProject, gitLabProject: GitLabProject) = Project(
     id = gitLabProject.id,


### PR DESCRIPTION
Currently, the `GET projects/:path` returns `500` if called with a valid access token although not for the project. Conversely, the resource works fine if you call it with no token at all. This PR makes both cases work the same.