### PR TITLE
fix: member email finding algorithm to check up to 30 pages of project events

### DIFF
--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -29,7 +29,7 @@ ENV TZ UTC
 RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py3-pip py3-wheel openssl-dev libffi-dev linux-headers gcc g++ make libxml2-dev libxslt-dev libc-dev yaml-dev 'rust>1.41.0' cargo tini && \
     python3 -m pip install --upgrade 'pip==21.3.1' && \
     python3 -m pip install jinja2 && \
-    python3 -m pip install 'renku==1.0.4' 'sentry-sdk==0.18.0'  && \
+    python3 -m pip install 'renku==1.0.5' 'sentry-sdk==0.18.0'  && \
     chown -R daemon:daemon .
 
 COPY triples-generator/entrypoint.sh /entrypoint.sh

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -20,6 +20,7 @@ triples-generation = "renku-log"
 # *  ["0.16.1 -> 9", ...] as above
 # *  ["0.16.1 -> 9", "0.16.0 -> 9", ...] then the decision about re-provisioning is taken using the 9 schema version and 0.16.1 CLI version
 compatibility-matrix = [
+  "1.0.5  -> 9",
   "1.0.4  -> 9",
   "0.16.2 -> 8"
 ]


### PR DESCRIPTION
This PR reduces the number of costly project's events endpoint on GitLab