### PR TITLE
fix: Transformation to default to visibility public if not returned

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/projectinfo/ProjectFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/projectinfo/ProjectFinder.scala
@@ -106,7 +106,7 @@ private class ProjectFinderImpl[F[_]: Async: Logger](
         id               <- cursor.downField("id").as[projects.Id]
         path             <- cursor.downField("path_with_namespace").as[projects.Path]
         name             <- cursor.downField("name").as[projects.Name]
-        visibility       <- cursor.downField("visibility").as[projects.Visibility]
+        maybeVisibility  <- cursor.downField("visibility").as[Option[projects.Visibility]]
         dateCreated      <- cursor.downField("created_at").as[projects.DateCreated]
         maybeDescription <- cursor.downField("description").as[Option[projects.Description]]
         keywords         <- cursor.downField("tag_list").as[Set[Option[projects.Keyword]]].map(_.flatten)
@@ -114,16 +114,17 @@ private class ProjectFinderImpl[F[_]: Async: Logger](
         maybeParentPath <- cursor
                              .downField("forked_from_project")
                              .as[Option[projects.Path]](decodeOption(parentPathDecoder))
-      } yield GitLabProjectInfo(id,
-                                name,
-                                path,
-                                dateCreated,
-                                maybeDescription,
-                                maybeCreator = None,
-                                keywords,
-                                members = Set.empty,
-                                visibility,
-                                maybeParentPath
+      } yield GitLabProjectInfo(
+        id,
+        name,
+        path,
+        dateCreated,
+        maybeDescription,
+        maybeCreator = None,
+        keywords,
+        members = Set.empty,
+        maybeVisibility getOrElse projects.Visibility.Public,
+        maybeParentPath
       ) -> maybeCreatorId
 
     jsonOf[F, ProjectAndCreator]


### PR DESCRIPTION
It may happen that for public projects and invalid/no token in tokens-repository, the Transformation process will not get `visibility` back from the call to the Project Details GitLab API. It seems to be safe in such cases to default to `public` as if the project is non-public GitLab would respond with `404`.