### PR TITLE
fix: member-sync process to deal with 401s

### DIFF
--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/projectinfo/ProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/projectinfo/ProjectMembersFinderSpec.scala
@@ -86,7 +86,7 @@ class ProjectMembersFinderSpec
       finder.findProjectMembers(projectPath).value.unsafeRunSync() shouldBe allMembers.toSet.asRight
     }
 
-    "return an empty list if one of the endpoints responds with NOT_FOUND" in new TestCase {
+    "return members even if one of the endpoints responds with NOT_FOUND" in new TestCase {
       val members = projectMembersNoEmail.generateSet()
       if (Random.nextBoolean()) {
         `/api/v4/project/users`(projectPath) returning notFound()
@@ -99,7 +99,7 @@ class ProjectMembersFinderSpec
       finder.findProjectMembers(projectPath).value.unsafeRunSync() shouldBe members.asRight
     }
 
-    "return an empty list if one of the endpoints returns an empty list" in new TestCase {
+    "return an empty set if one of the endpoints returns an empty list" in new TestCase {
       val members = projectMembersNoEmail.generateSet()
       if (Random.nextBoolean()) {
         `/api/v4/project/users`(projectPath) returning okJson(Json.arr().noSpaces)


### PR DESCRIPTION
It looks that the `401`s in the `MEMBERS_SYNC` flow causes two problems:
* they do not remove project members in KG of a project we cannot reason about (potentially some/all members of the projects are removed but as we cannot refresh the list, we keep the old one)
* create some noise in the logs

This PR applies a similar approach as in the other places to call the `/users` and `/members` endpoints without an access token. If that does not help, the process removes all the members from the TS.

If a project owner would like to bring the members back to the TS, it simply needs to log in to the UI and wait for the `MEMBERS_SYNC` process to refresh the list.