### PR TITLE
fix: adding twice the same delivery id should not throw an error

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/eventdelivery/EventDelivery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/eventdelivery/EventDelivery.scala
@@ -78,7 +78,7 @@ private class EventDeliveryImpl[F[_]: MonadCancelThrow, CategoryEvent](
                 SELECT  $projectIdEncoder, delivery_id, $eventTypeIdEncoder
                 FROM subscriber
                 WHERE delivery_url = $subscriberUrlEncoder AND source_url = $microserviceBaseUrlEncoder
-                ON CONFLICT (event_id, project_id)
+                ON CONFLICT (project_id, event_type_id)
                 DO NOTHING
             """.command
             )

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/eventdelivery/EventDeliverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/eventdelivery/EventDeliverySpec.scala
@@ -93,6 +93,19 @@ class EventDeliverySpec
 
       findAllProjectDeliveries shouldBe List((event.compoundEventId.projectId, subscriberId, DeletingProjectTypeId))
     }
+
+    "do nothing if the same event is delivered twice with a DeletingProjectTypeId" in new DeletingProjectTestCase {
+      addEvent(event.compoundEventId)
+      upsertSubscriber(subscriberId, subscriberUrl, sourceUrl)
+
+      delivery.registerSending(event, subscriberUrl).unsafeRunSync() shouldBe ()
+
+      findAllProjectDeliveries shouldBe List((event.compoundEventId.projectId, subscriberId, DeletingProjectTypeId))
+
+      delivery.registerSending(event, subscriberUrl).unsafeRunSync() shouldBe ()
+
+      findAllProjectDeliveries shouldBe List((event.compoundEventId.projectId, subscriberId, DeletingProjectTypeId))
+    }
   }
 
   private trait CommonTestCase {


### PR DESCRIPTION
fix: adding twice the same delivery id should not throw an error