### PR TITLE
fix: events with the same date should be processed independently

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesGeneratedUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesGeneratedUpdater.scala
@@ -130,7 +130,7 @@ private class ToTriplesGeneratedUpdater[F[_]: Async](
                 FROM event
                 WHERE project_id = $projectIdEncoder
                   AND #${`status IN`(Set(New, GeneratingTriples, GenerationRecoverableFailure, AwaitingDeletion))}
-                  AND event_date <= (
+                  AND event_date < (
                     SELECT event_date
                     FROM event
                     WHERE project_id = $projectIdEncoder

--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesStoreUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/statuschange/ToTriplesStoreUpdater.scala
@@ -118,7 +118,7 @@ private class ToTriplesStoreUpdater[F[_]: MonadCancelThrow: Async](
                 FROM event
                 WHERE project_id = $projectIdEncoder
                   AND #${`status IN`(statusesToUpdate)}
-                  AND event_date <= (
+                  AND event_date < (
                     SELECT event_date
                     FROM event
                     WHERE project_id = $projectIdEncoder


### PR DESCRIPTION
It was found that in the case when there are two or more the most recent events that have the same date, one of them, not necessarily the latest event in terms of history, is picked up for processing. Thus, it's possible that the latest event is not processed at all but an assumption that it's one of the older events is taken. Obviously, in such case, the metadata in the KG is not complete.