### PR TITLE
fix: Sentry initialization via the new API

### DIFF
--- a/commit-event-service/src/main/resources/application.conf
+++ b/commit-event-service/src/main/resources/application.conf
@@ -18,10 +18,9 @@ services {
   sentry {
     enabled = false
     enabled = ${?SENTRY_ENABLED}
-    url = ${?SENTRY_BASE_URL}
-    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
-    service-name = "commit-event-service"
-    stacktrace-package = "io.renku.commiteventservice"
+    dsn = ${?SENTRY_DSN}
+    environment = ${?SENTRY_ENVIRONMENT}
+    service = "commit-event-service"
   }
 
   token-repository {

--- a/event-log/src/main/resources/application.conf
+++ b/event-log/src/main/resources/application.conf
@@ -39,9 +39,8 @@ services {
   sentry {
     enabled = false
     enabled = ${?SENTRY_ENABLED}
-    url = ${?SENTRY_BASE_URL}
-    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
+    dsn = ${?SENTRY_DSN}
+    environment = ${?SENTRY_ENVIRONMENT}
     service-name = "event-log"
-    stacktrace-package = "io.renku.eventlog"
   }
 }

--- a/graph-commons/src/main/scala/io/renku/config/sentry/SentryConfig.scala
+++ b/graph-commons/src/main/scala/io/renku/config/sentry/SentryConfig.scala
@@ -25,53 +25,29 @@ import io.renku.config.sentry.SentryConfig._
 import io.renku.tinytypes.constraints.{NonBlank, Url, UrlOps}
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory, UrlTinyType}
 
-import scala.util.control.NonFatal
-
-final case class SentryConfig(baseUrl:           SentryBaseUrl,
-                              environmentName:   EnvironmentName,
-                              serviceName:       ServiceName,
-                              stackTracePackage: SentryStackTracePackage
-)
+final case class SentryConfig(baseUrl: Dsn, environmentName: Environment, serviceName: Service)
 
 object SentryConfig {
 
   import io.renku.config.ConfigLoader._
 
-  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[Option[SentryConfig]] = {
-    lazy val emptyString: PartialFunction[Throwable, F[SentryStackTracePackage]] = { case NonFatal(_) =>
-      SentryStackTracePackage.empty.pure[F]
-    }
-
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[Option[SentryConfig]] =
     find[F, Boolean]("services.sentry.enabled", config) flatMap {
       case false => MonadThrow[F].pure(None)
       case true =>
         for {
-          url         <- find[F, SentryBaseUrl]("services.sentry.url", config)
-          environment <- find[F, EnvironmentName]("services.sentry.environment-name", config)
-          serviceName <- find[F, ServiceName]("services.sentry.service-name", config)
-          stackTracePackage <-
-            find[F, SentryStackTracePackage]("services.sentry.stacktrace-package", config) recoverWith emptyString
-        } yield Some(
-          SentryConfig(url, environment, serviceName, stackTracePackage)
-        )
+          url         <- find[F, Dsn]("services.sentry.dsn", config)
+          environment <- find[F, Environment]("services.sentry.environment", config)
+          serviceName <- find[F, Service]("services.sentry.service", config)
+        } yield SentryConfig(url, environment, serviceName).some
     }
-  }
 
-  class SentryBaseUrl private (val value: String) extends AnyVal with UrlTinyType
-  implicit object SentryBaseUrl
-      extends TinyTypeFactory[SentryBaseUrl](new SentryBaseUrl(_))
-      with Url
-      with UrlOps[SentryBaseUrl]
+  class Dsn private (val value: String) extends AnyVal with UrlTinyType
+  implicit object Dsn                   extends TinyTypeFactory[Dsn](new Dsn(_)) with Url with UrlOps[Dsn]
 
-  class ServiceName private (val value: String) extends AnyVal with StringTinyType
-  implicit object ServiceName                   extends TinyTypeFactory[ServiceName](new ServiceName(_)) with NonBlank
+  class Service private (val value: String) extends AnyVal with StringTinyType
+  implicit object Service                   extends TinyTypeFactory[Service](new Service(_)) with NonBlank
 
-  class SentryStackTracePackage private (val value: String) extends AnyVal with StringTinyType
-  implicit object SentryStackTracePackage
-      extends TinyTypeFactory[SentryStackTracePackage](new SentryStackTracePackage(_)) {
-    lazy val empty: SentryStackTracePackage = SentryStackTracePackage("")
-  }
-
-  class EnvironmentName private (val value: String) extends AnyVal with StringTinyType
-  implicit object EnvironmentName extends TinyTypeFactory[EnvironmentName](new EnvironmentName(_)) with NonBlank
+  class Environment private (val value: String) extends AnyVal with StringTinyType
+  implicit object Environment                   extends TinyTypeFactory[Environment](new Environment(_)) with NonBlank
 }

--- a/graph-commons/src/test/scala/io/renku/config/sentry/SentryConfigSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/config/sentry/SentryConfigSpec.scala
@@ -20,7 +20,6 @@ package io.renku.config.sentry
 
 import com.typesafe.config.ConfigFactory
 import io.renku.config.ConfigLoader.ConfigLoadingException
-import io.renku.config.sentry.SentryConfig.SentryStackTracePackage
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import org.scalatest.matchers.should
@@ -49,17 +48,16 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
     }
 
     "return a SentryConfig if 'services.sentry.enabled' is 'true' and all " +
-      "'services.sentry.url', 'services.sentry.service-name', 'services.sentry.environment-name' and 'services.sentry.stacktrace-package' are set" in {
+      "'services.sentry.url', 'services.sentry.service' and 'services.sentry.environment' are set" in {
         forAll { sentryConfig: SentryConfig =>
           val config = ConfigFactory.parseMap(
             Map(
               "services" -> Map(
                 "sentry" -> Map(
-                  "enabled"            -> "true",
-                  "url"                -> sentryConfig.baseUrl.value,
-                  "service-name"       -> sentryConfig.serviceName.value,
-                  "environment-name"   -> sentryConfig.environmentName.value,
-                  "stacktrace-package" -> sentryConfig.stackTracePackage.value
+                  "enabled"     -> "true",
+                  "dsn"         -> sentryConfig.baseUrl.value,
+                  "service"     -> sentryConfig.serviceName.value,
+                  "environment" -> sentryConfig.environmentName.value
                 ).asJava
               ).asJava
             ).asJava
@@ -69,38 +67,16 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
         }
       }
 
-    "return a SentryConfig if 'services.sentry.enabled' is 'true' but 'services.sentry.stacktrace-package' is invalid and replace it with an empty string" in {
-
+    "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.dsn' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
             "sentry" -> Map(
-              "enabled"          -> "true",
-              "url"              -> sentryConfig.baseUrl.value,
-              "service-name"     -> sentryConfig.serviceName.value,
-              "environment-name" -> sentryConfig.environmentName.value
-            ).asJava
-          ).asJava
-        ).asJava
-      )
-
-      SentryConfig[Try](config) shouldBe Success(
-        Some(sentryConfig.copy(stackTracePackage = SentryStackTracePackage.empty))
-      )
-    }
-
-    "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.url' is invalid" in {
-      val sentryConfig = sentryConfigs.generateOne
-      val config = ConfigFactory.parseMap(
-        Map(
-          "services" -> Map(
-            "sentry" -> Map(
-              "enabled"            -> "true",
-              "url"                -> "",
-              "service-name"       -> sentryConfig.serviceName.value,
-              "environment-name"   -> sentryConfig.environmentName.value,
-              "stacktrace-package" -> sentryConfig.stackTracePackage.value
+              "enabled"     -> "true",
+              "dsn"         -> "",
+              "service"     -> sentryConfig.serviceName.value,
+              "environment" -> sentryConfig.environmentName.value
             ).asJava
           ).asJava
         ).asJava
@@ -111,17 +87,16 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
       exception shouldBe a[ConfigLoadingException]
     }
 
-    "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.service-name' is invalid" in {
+    "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.service' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
             "sentry" -> Map(
-              "enabled"            -> "true",
-              "url"                -> sentryConfig.baseUrl.value,
-              "service-name"       -> "",
-              "environment-name"   -> sentryConfig.environmentName.value,
-              "stacktrace-package" -> sentryConfig.stackTracePackage.value
+              "enabled"     -> "true",
+              "dsn"         -> sentryConfig.baseUrl.value,
+              "service"     -> "",
+              "environment" -> sentryConfig.environmentName.value
             ).asJava
           ).asJava
         ).asJava
@@ -132,17 +107,16 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
       exception shouldBe a[ConfigLoadingException]
     }
 
-    "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.environment-name' is invalid" in {
+    "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.environment' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
             "sentry" -> Map(
-              "enabled"            -> "true",
-              "url"                -> sentryConfig.baseUrl.value,
-              "service-name"       -> sentryConfig.serviceName.value,
-              "environment-name"   -> "",
-              "stacktrace-package" -> sentryConfig.stackTracePackage.value
+              "enabled"     -> "true",
+              "dsn"         -> sentryConfig.baseUrl.value,
+              "service"     -> sentryConfig.serviceName.value,
+              "environment" -> ""
             ).asJava
           ).asJava
         ).asJava

--- a/helm-chart/renku-graph/templates/commit-event-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/commit-event-service-deployment.yaml
@@ -44,9 +44,9 @@ spec:
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
-            - name: SENTRY_BASE_URL
+            - name: SENTRY_DSN
               value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENVIRONMENT_NAME
+            - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS

--- a/helm-chart/renku-graph/templates/commit-event-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/commit-event-service-deployment.yaml
@@ -45,9 +45,9 @@ spec:
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_BASE_URL
-              value: {{ .Values.sentry.url }}
+              value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT_NAME
-              value: {{ .Values.sentry.environmentName }}
+              value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS
               value: -Xmx{{ .Values.commitEventService.jvmXmx }} -XX:+UseG1GC

--- a/helm-chart/renku-graph/templates/event-log-deployment.yaml
+++ b/helm-chart/renku-graph/templates/event-log-deployment.yaml
@@ -56,9 +56,9 @@ spec:
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_BASE_URL
-              value: {{ .Values.sentry.url }}
+              value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT_NAME
-              value: {{ .Values.sentry.environmentName }}
+              value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: WEBHOOK_SERVICE_BASE_URL
               value: "http://{{ template "webhookService.fullname" . }}:{{ .Values.webhookService.service.port }}"

--- a/helm-chart/renku-graph/templates/event-log-deployment.yaml
+++ b/helm-chart/renku-graph/templates/event-log-deployment.yaml
@@ -55,9 +55,9 @@ spec:
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
-            - name: SENTRY_BASE_URL
+            - name: SENTRY_DSN
               value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENVIRONMENT_NAME
+            - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: WEBHOOK_SERVICE_BASE_URL

--- a/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
+++ b/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
@@ -60,9 +60,9 @@ spec:
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_BASE_URL
-              value: {{ .Values.sentry.url }}
+              value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT_NAME
-              value: {{ .Values.sentry.environmentName }}
+              value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS
               value: -Xmx{{ .Values.knowledgeGraph.jvmXmx }} -XX:+UseG1GC

--- a/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
+++ b/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
@@ -59,9 +59,9 @@ spec:
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
-            - name: SENTRY_BASE_URL
+            - name: SENTRY_DSN
               value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENVIRONMENT_NAME
+            - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS

--- a/helm-chart/renku-graph/templates/token-repository-deployment.yaml
+++ b/helm-chart/renku-graph/templates/token-repository-deployment.yaml
@@ -62,9 +62,9 @@ spec:
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
-            - name: SENTRY_BASE_URL
+            - name: SENTRY_DSN
               value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENVIRONMENT_NAME
+            - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS

--- a/helm-chart/renku-graph/templates/token-repository-deployment.yaml
+++ b/helm-chart/renku-graph/templates/token-repository-deployment.yaml
@@ -63,9 +63,9 @@ spec:
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_BASE_URL
-              value: {{ .Values.sentry.url }}
+              value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT_NAME
-              value: {{ .Values.sentry.environmentName }}
+              value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS
               value: -Xmx{{ .Values.tokenRepository.jvmXmx }} -XX:+UseG1GC

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -70,9 +70,9 @@ spec:
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
-            - name: SENTRY_BASE_URL
+            - name: SENTRY_DSN
               value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENVIRONMENT_NAME
+            - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: GENERATION_PROCESSES_NUMBER

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -67,15 +67,13 @@ spec:
               value: "true"
             - name: RE_PROVISIONING_REMOVAL_BATCH_SIZE
               value: "{{ .Values.triplesGenerator.reProvisioningRemovalBatchSize }}"
-            - name: SENTRY_DSN
-              value: {{ .Values.sentry.sentryDsnRenkuPython }}
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_BASE_URL
-              value: {{ .Values.sentry.url }}
+              value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT_NAME
-              value: {{ .Values.sentry.environmentName }}
+              value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: GENERATION_PROCESSES_NUMBER
               value: "{{ .Values.triplesGenerator.generationProcessesNumber }}"

--- a/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
@@ -59,9 +59,9 @@ spec:
             - name: SENTRY_ENABLED
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
-            - name: SENTRY_BASE_URL
+            - name: SENTRY_DSN
               value: {{ .Values.sentry.dsn }}
-            - name: SENTRY_ENVIRONMENT_NAME
+            - name: SENTRY_ENVIRONMENT
               value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS

--- a/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
@@ -60,9 +60,9 @@ spec:
               value: "{{ .Values.sentry.enabled }}"
               {{- if .Values.sentry.enabled }}
             - name: SENTRY_BASE_URL
-              value: {{ .Values.sentry.url }}
+              value: {{ .Values.sentry.dsn }}
             - name: SENTRY_ENVIRONMENT_NAME
-              value: {{ .Values.sentry.environmentName }}
+              value: {{ .Values.sentry.environment }}
               {{- end }}
             - name: JAVA_OPTS
               value: -Xmx{{ .Values.webhookService.jvmXmx }} -XX:+UseG1GC

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -128,9 +128,8 @@ commitEventService:
 
 sentry:
   enabled: false
-  url: '' # Sentry url
-  environmentName: '' # Environment name e.g. renkulabio
-  sentryDsnRenkuPython: ''
+  dsn: '' # Sentry dsn
+  environment: '' # Environment name e.g. renkulabio
 
 nameOverride: ''
 fullnameOverride: ''

--- a/knowledge-graph/src/main/resources/application.conf
+++ b/knowledge-graph/src/main/resources/application.conf
@@ -27,10 +27,9 @@ services {
   sentry {
     enabled = false
     enabled = ${?SENTRY_ENABLED}
-    url = ${?SENTRY_BASE_URL}
-    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
+    dsn = ${?SENTRY_DSN}
+    environment = ${?SENTRY_ENVIRONMENT}
     service-name = "knowledge-graph"
-    stacktrace-package = "io.renku.knowledgegraph"
   }
 
   gitlab {

--- a/token-repository/src/main/resources/application.conf
+++ b/token-repository/src/main/resources/application.conf
@@ -23,10 +23,9 @@ services {
   sentry {
     enabled = false
     enabled = ${?SENTRY_ENABLED}
-    url = ${?SENTRY_BASE_URL}
-    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
+    dsn = ${?SENTRY_DSN}
+    environment = ${?SENTRY_ENVIRONMENT}
     service-name = "token-repository"
-    stacktrace-package = "io.renku.tokenrepository"
   }
 
   gitlab {

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -63,10 +63,9 @@ services {
   sentry {
     enabled = false
     enabled = ${?SENTRY_ENABLED}
-    url = ${?SENTRY_BASE_URL}
-    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
+    dsn = ${?SENTRY_DSN}
+    environment = ${?SENTRY_ENVIRONMENT}
     service-name = "triples-generator"
-    stacktrace-package = "io.renku.triplesgenerator"
   }
 
   token-repository {

--- a/webhook-service/src/main/resources/application.conf
+++ b/webhook-service/src/main/resources/application.conf
@@ -23,10 +23,9 @@ services {
   sentry {
     enabled = false
     enabled = ${?SENTRY_ENABLED}
-    url = ${?SENTRY_BASE_URL}
-    environment-name = ${?SENTRY_ENVIRONMENT_NAME}
+    dsn = ${?SENTRY_DSN}
+    environment = ${?SENTRY_ENVIRONMENT}
     service-name = "webhook-service"
-    stacktrace-package = "io.renku.webhookservice"
   }
 
   token-repository {


### PR DESCRIPTION
Apparently, the Sentry API has changed in some version and things like environment and service stopped to work. This PR fixes this.