### PR TITLE
fix: lucene indices to be deleted on each restart

### DIFF
--- a/helm-chart/renku-graph/charts/jena/templates/fuseki-server.yaml
+++ b/helm-chart/renku-graph/charts/jena/templates/fuseki-server.yaml
@@ -37,6 +37,7 @@ data:
     killall -9 java
     rm $FUSEKI_BASE/databases/{{ .Values.global.graph.jena.dataset }}/tdb.lock
     rm $FUSEKI_BASE/system/tdb.lock
+    rm -rf $FUSEKI_BASE/databases/{{ .Values.global.graph.jena.dataset }}/lucene_index
 
     echo Rebuilding Lucene indices...
     DATASET_CONFIG=$FUSEKI_BASE/configuration/{{ .Values.global.graph.jena.dataset }}.ttl

--- a/helm-chart/renku-graph/charts/jena/templates/statefulset.yaml
+++ b/helm-chart/renku-graph/charts/jena/templates/statefulset.yaml
@@ -50,9 +50,9 @@ spec:
               path: /$/ping
               port: jena
             initialDelaySeconds: 30
-            periodSeconds: 60
+            periodSeconds: 120
             successThreshold: 1
-            failureThreshold: 6
+            failureThreshold: 10
           volumeMounts:
             - name: lucene-config
               mountPath: /fuseki/configuration/{{ .Values.global.graph.jena.dataset }}.ttl


### PR DESCRIPTION
It looks like Lucene indices in Jena get stale and so they don't return correct results. This PR removes them each time jena is restarted.