### PR TITLE
fix: global commit sync to be set in 5 mins on forcing

### DIFF
--- a/event-log/src/main/resources/application.conf
+++ b/event-log/src/main/resources/application.conf
@@ -3,6 +3,8 @@ service-name = "event-log"
 client-certificate = ""
 client-certificate = ${?RENKU_CLIENT_CERTIFICATE}
 
+global-commit-sync-frequency = 7 days
+
 event-log {
   db-host = "localhost"
   db-host = ${?EVENT_LOG_POSTGRES_HOST}

--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/EventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/EventHandler.scala
@@ -47,7 +47,7 @@ private class EventHandler[F[_]: Concurrent: Logger](
       fromEither[F](
         request.event.as[(projects.Id, projects.Path)].leftMap(_ => BadRequest).leftWiden[EventSchedulingResult]
       )
-    result <- forceGlobalCommitSync(event._1, event._2).toRightT
+    result <- moveGlobalCommitSync(event._1, event._2).toRightT
                 .map(_ => Accepted)
                 .semiflatTap(Logger[F].log(event))
                 .leftSemiflatTap(Logger[F].log(event))

--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/GlobalCommitSyncForcer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/GlobalCommitSyncForcer.scala
@@ -18,60 +18,64 @@
 
 package io.renku.eventlog.events.categories.globalcommitsyncrequest
 
-import cats.MonadThrow
 import cats.data.Kleisli
 import cats.effect.MonadCancelThrow
+import cats.syntax.all._
+import com.typesafe.config.{Config, ConfigFactory}
 import eu.timepit.refined.api.Refined
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.subscriptions.{SubscriptionTypeSerializers, globalcommitsync}
 import io.renku.eventlog.{EventDate, TypeSerializers}
-import io.renku.events.CategoryName
+import io.renku.graph.model.events.LastSyncedDate
 import io.renku.graph.model.projects
 import io.renku.metrics.LabeledHistogram
 import skunk._
 import skunk.data.Completion
 import skunk.implicits._
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 private trait GlobalCommitSyncForcer[F[_]] {
-  def forceGlobalCommitSync(projectId: projects.Id, projectPath: projects.Path): F[Unit]
+  def moveGlobalCommitSync(projectId: projects.Id, projectPath: projects.Path): F[Unit]
 }
 
-private class GlobalCommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F])
-    extends DbClient(Some(queriesExecTimes))
+private class GlobalCommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F],
+                                                                                  syncFrequency: Duration,
+                                                                                  now: () => Instant = () => Instant.now
+) extends DbClient(Some(queriesExecTimes))
     with GlobalCommitSyncForcer[F]
     with TypeSerializers
     with SubscriptionTypeSerializers {
 
-  override def forceGlobalCommitSync(projectId: projects.Id, projectPath: projects.Path): F[Unit] =
+  override def moveGlobalCommitSync(projectId: projects.Id, projectPath: projects.Path): F[Unit] =
     SessionResource[F].useK {
-      deleteLastSyncedDate(projectId) flatMap {
+      scheduleGlobalSync(projectId, in = Duration ofMinutes 5) >>= {
         case true  => upsertProject(projectId, projectPath)
         case false => Kleisli.pure(())
       }
     }
 
-  private def deleteLastSyncedDate(projectId: projects.Id) = measureExecutionTime {
-    SqlStatement(name = Refined.unsafeApply(s"${categoryName.value.toLowerCase} - delete last_synced"))
-      .command[projects.Id ~ CategoryName](sql"""
-            DELETE FROM subscription_category_sync_time
-            WHERE project_id = $projectIdEncoder AND category_name = $categoryNameEncoder
+  private def scheduleGlobalSync(projectId: projects.Id, in: Duration) =
+    measureExecutionTime {
+      SqlStatement(name = Refined.unsafeApply(s"${categoryName.value.toLowerCase} - move last_synced"))
+        .command[LastSyncedDate ~ projects.Id](sql"""
+            UPDATE subscription_category_sync_time
+            SET last_synced = $lastSyncedDateEncoder
+            WHERE project_id = $projectIdEncoder AND category_name = '#${globalcommitsync.categoryName.show}'
           """.command)
-      .arguments(projectId ~ globalcommitsync.categoryName)
-      .build
-      .mapResult {
-        case Completion.Delete(0) => true
-        case _                    => false
-      }
-  }
+        .arguments(LastSyncedDate(now().minus(syncFrequency).plus(in)), projectId)
+        .build
+        .mapResult {
+          case Completion.Update(0) => true
+          case _                    => false
+        }
+    }
 
   private def upsertProject(projectId: projects.Id, projectPath: projects.Path) = measureExecutionTime {
     SqlStatement(name = Refined.unsafeApply(s"${categoryName.value.toLowerCase} - insert project"))
       .command[projects.Id ~ projects.Path ~ EventDate](sql"""
-          INSERT INTO
-          project (project_id, project_path, latest_event_date)
+          INSERT INTO project (project_id, project_path, latest_event_date)
           VALUES ($projectIdEncoder, $projectPathEncoder, $eventDateEncoder)
           ON CONFLICT (project_id)
           DO NOTHING
@@ -83,10 +87,15 @@ private class GlobalCommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource
 }
 
 private object GlobalCommitSyncForcer {
+  import io.renku.config.ConfigLoader._
+
+  import scala.concurrent.duration.FiniteDuration
 
   def apply[F[_]: MonadCancelThrow: SessionResource](
-      queriesExecTimes: LabeledHistogram[F]
-  ): F[GlobalCommitSyncForcer[F]] = MonadThrow[F].catchNonFatal {
-    new GlobalCommitSyncForcerImpl(queriesExecTimes)
-  }
+      queriesExecTimes: LabeledHistogram[F],
+      config:           Config = ConfigFactory.load()
+  ): F[GlobalCommitSyncForcer[F]] = for {
+    configFrequency <- find[F, FiniteDuration]("global-commit-sync-frequency", config)
+    syncFrequency   <- Duration.ofDays(configFrequency.toDays).pure[F]
+  } yield new GlobalCommitSyncForcerImpl(queriesExecTimes, syncFrequency)
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/EventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/EventHandlerSpec.scala
@@ -54,7 +54,7 @@ class EventHandlerSpec
         val projectId   = projectIds.generateOne
         val projectPath = projectPaths.generateOne
 
-        (globalCommitSyncForcer.forceGlobalCommitSync _)
+        (globalCommitSyncForcer.moveGlobalCommitSync _)
           .expects(projectId, projectPath)
           .returning(().pure[IO])
 
@@ -82,7 +82,7 @@ class EventHandlerSpec
       val projectPath = projectPaths.generateOne
 
       val exception = exceptions.generateOne
-      (globalCommitSyncForcer.forceGlobalCommitSync _)
+      (globalCommitSyncForcer.moveGlobalCommitSync _)
         .expects(projectId, projectPath)
         .returning(exception.raiseError[IO, Unit])
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/GlobalCommitSyncForcerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/categories/globalcommitsyncrequest/GlobalCommitSyncForcerSpec.scala
@@ -18,22 +18,24 @@
 
 package io.renku.eventlog.events.categories.globalcommitsyncrequest
 
-import eu.timepit.refined.auto._
+import cats.syntax.all._
 import io.renku.db.SqlStatement
 import io.renku.eventlog.EventContentGenerators.eventDates
 import io.renku.eventlog.subscriptions._
 import io.renku.eventlog.{EventDate, InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.Generators.categoryNames
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestampsNotInTheFuture
 import io.renku.graph.model.EventsGenerators._
 import io.renku.graph.model.GraphModelGenerators._
+import io.renku.graph.model.events.LastSyncedDate
 import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.time.Instant
+import java.time.{Duration, Instant}
 
 class GlobalCommitSyncForcerSpec
     extends AnyWordSpec
@@ -44,29 +46,34 @@ class GlobalCommitSyncForcerSpec
     with TypeSerializers
     with should.Matchers {
 
-  "forceGlobalCommitSync" should {
+  "moveGlobalCommitSync" should {
 
-    "remove row for the given project id and GLOBAL_COMMIT_SYNC category " +
-      "from the subscription_category_sync_time " +
-      "if it exists" in new TestCase {
+    "schedule the next the GLOBAL_COMMIT_SYNC event for the project " +
+      "in 5 minutes (7 days - 5 mins) " +
+      "if the row in the subscription_category_sync_time exists" in new TestCase {
 
         val projectId   = projectIds.generateOne
         val projectPath = projectPaths.generateOne
         upsertProject(projectId, projectPath, eventDates.generateOne)
 
         val otherCategoryName = categoryNames.generateOne
-        upsertLastSynced(projectId, globalcommitsync.categoryName, lastSyncedDates.generateOne)
-        upsertLastSynced(projectId, otherCategoryName, lastSyncedDates.generateOne)
+        val globalSyncSyncDate =
+          timestampsNotInTheFuture(butYoungerThan = now.minus(syncFrequency minusDays 1)).generateAs(LastSyncedDate)
+        upsertLastSynced(projectId, globalcommitsync.categoryName, globalSyncSyncDate)
+        val otherCategorySyncDate = lastSyncedDates.generateOne
+        upsertLastSynced(projectId, otherCategoryName, otherCategorySyncDate)
 
-        findSyncTime(projectId, globalcommitsync.categoryName) shouldBe a[Some[_]]
-        findSyncTime(projectId, otherCategoryName)             shouldBe a[Some[_]]
+        findSyncTime(projectId, globalcommitsync.categoryName) shouldBe globalSyncSyncDate.some
+        findSyncTime(projectId, otherCategoryName)             shouldBe otherCategorySyncDate.some
 
-        forcer.forceGlobalCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
+        forcer.moveGlobalCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
 
-        findSyncTime(projectId, globalcommitsync.categoryName) shouldBe None
-        findSyncTime(projectId, otherCategoryName)             shouldBe a[Some[_]]
+        findSyncTime(projectId, globalcommitsync.categoryName) shouldBe LastSyncedDate(
+          now.minus(syncFrequency).plus(Duration ofMinutes 5)
+        ).some
+        findSyncTime(projectId, otherCategoryName) shouldBe otherCategorySyncDate.some
 
-        queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - delete last_synced")
+        queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - move last_synced")
       }
 
     "upsert a new project " +
@@ -78,17 +85,17 @@ class GlobalCommitSyncForcerSpec
 
         findSyncTime(projectId, globalcommitsync.categoryName) shouldBe None
 
-        forcer.forceGlobalCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
+        forcer.moveGlobalCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
 
         findSyncTime(projectId, globalcommitsync.categoryName) shouldBe None
         findProjects shouldBe List((projectId, projectPath, EventDate(Instant.EPOCH)))
 
-        queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - delete last_synced")
+        queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - move last_synced")
         queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - insert project")
       }
 
     "do nothing " +
-      "if there's no row the given project id and category in the subscription_category_sync_time" +
+      "if there's no row for the given project id and category in the subscription_category_sync_time" +
       "but the project exists in the project table" in new TestCase {
 
         val projectId   = projectIds.generateOne
@@ -99,17 +106,21 @@ class GlobalCommitSyncForcerSpec
 
         findSyncTime(projectId, globalcommitsync.categoryName) shouldBe None
 
-        forcer.forceGlobalCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
+        forcer.moveGlobalCommitSync(projectId, projectPath).unsafeRunSync() shouldBe ()
 
         findSyncTime(projectId, globalcommitsync.categoryName) shouldBe None
         findProjects.map(proj => proj._1 -> proj._2)           shouldBe List(projectId -> projectPath)
 
-        queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - delete last_synced")
+        queriesExecTimes.verifyExecutionTimeMeasured("global_commit_sync_request - move last_synced")
       }
   }
 
   private trait TestCase {
+    val syncFrequency = Duration ofDays 7
+    val currentTime   = mockFunction[Instant]
+    val now           = Instant.now()
+    currentTime.expects().returning(now)
     val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
-    val forcer           = new GlobalCommitSyncForcerImpl(queriesExecTimes)
+    val forcer           = new GlobalCommitSyncForcerImpl(queriesExecTimes, syncFrequency, currentTime)
   }
 }


### PR DESCRIPTION
It looks like global commit sync does not work correctly for big projects being updated often. That's due to `statistics.commits_count` returned by the call to the single project GitLab API does not get updated instantly after a new commit is pushed. This PR changes the global commit sync request logic so instead of issuing the `global_commit_sync` event instantly, the event is scheduled in 5 mins.