### PR TITLE
refactor: COMMIT_SYNC_REQUEST to be sent with EventSender

### DIFF
--- a/webhook-service/src/main/scala/io/renku/webhookservice/CommitSyncRequestSender.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/CommitSyncRequestSender.scala
@@ -18,70 +18,34 @@
 
 package io.renku.webhookservice
 
-import cats.Eval
+import cats.MonadThrow
 import cats.effect.Async
-import cats.effect.kernel.Temporal
 import cats.syntax.all._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.NonNegative
-import io.renku.control.Throttler
-import io.renku.graph.config.EventLogUrl
-import io.renku.http.client.RestClient
-import io.renku.http.client.RestClientError.{ClientException, ConnectivityException, UnexpectedResponseException}
+import io.renku.events.producers.EventSender
+import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.metrics.MetricsRegistry
 import io.renku.webhookservice.model.CommitSyncRequest
-import org.http4s.Status.{Accepted, BadGateway, GatewayTimeout, ServiceUnavailable}
-import org.http4s.{Status, Uri}
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration._
-
 private trait CommitSyncRequestSender[F[_]] {
-  def sendCommitSyncRequest(commitSyncRequest: CommitSyncRequest): F[Unit]
+  def sendCommitSyncRequest(commitSyncRequest: CommitSyncRequest, processName: String): F[Unit]
 }
 
-private class CommitSyncRequestSenderImpl[F[_]: Async: Temporal: Logger](
-    eventLogUrl:            EventLogUrl,
-    retryDelay:             FiniteDuration,
-    retryInterval:          FiniteDuration = RestClient.SleepAfterConnectionIssue,
-    maxRetries:             Int Refined NonNegative = RestClient.MaxRetriesAfterConnectionTimeout,
-    requestTimeoutOverride: Option[Duration] = None
-) extends RestClient[F, CommitSyncRequestSender[F]](
-      Throttler.noThrottling,
-      retryInterval = retryInterval,
-      maxRetries = maxRetries,
-      requestTimeoutOverride = requestTimeoutOverride
-    )
-    with CommitSyncRequestSender[F] {
+private class CommitSyncRequestSenderImpl[F[_]: MonadThrow: Logger](eventSender: EventSender[F])
+    extends CommitSyncRequestSender[F] {
 
+  import eventSender._
   import io.circe.Encoder
   import io.circe.literal._
   import io.circe.syntax._
-  import org.http4s.Method.POST
-  import org.http4s.{Request, Response}
 
-  def sendCommitSyncRequest(syncRequest: CommitSyncRequest): F[Unit] = for {
-    uri           <- validateUri(s"$eventLogUrl/events")
-    sendingResult <- send(prepareRequest(uri, syncRequest))(mapResponse) recoverWith retryDelivery(syncRequest)
-    _             <- logInfo(syncRequest)
-  } yield sendingResult
-
-  private def prepareRequest(uri: Uri, commitSyncRequest: CommitSyncRequest) =
-    request(POST, uri).withMultipartBuilder
-      .addPart("event", commitSyncRequest.asJson)
-      .build()
-
-  private def retryDelivery(commitSyncRequest: CommitSyncRequest): PartialFunction[Throwable, F[Unit]] = {
-    case UnexpectedResponseException(ServiceUnavailable | GatewayTimeout | BadGateway, message) =>
-      waitAndRetry(Eval.always(sendCommitSyncRequest(commitSyncRequest)), message)
-    case exception @ (_: ConnectivityException | _: ClientException) =>
-      waitAndRetry(Eval.always(sendCommitSyncRequest(commitSyncRequest)), exception.getMessage)
-  }
-
-  private def waitAndRetry(retry: Eval[F[Unit]], errorMessage: String) = for {
-    _      <- Logger[F].error(s"Sending commit sync request event failed - retrying in $retryDelay - $errorMessage")
-    _      <- Temporal[F] sleep retryDelay
-    result <- retry.value
-  } yield result
+  def sendCommitSyncRequest(syncRequest: CommitSyncRequest, processName: String): F[Unit] =
+    sendEvent(
+      EventRequestContent.NoPayload(syncRequest.asJson),
+      EventSender.EventContext(CategoryName("COMMIT_SYNC_REQUEST"),
+                               show"$processName - sending COMMIT_SYNC_REQUEST for ${syncRequest.project} failed"
+      )
+    ) >> logInfo(processName)(syncRequest)
 
   private implicit lazy val entityEncoder: Encoder[CommitSyncRequest] = Encoder.instance[CommitSyncRequest] { event =>
     json"""{
@@ -93,18 +57,13 @@ private class CommitSyncRequestSenderImpl[F[_]: Async: Temporal: Logger](
     }"""
   }
 
-  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Unit]] = { case (Accepted, _, _) =>
-    ().pure[F]
-  }
-
-  private lazy val logInfo: CommitSyncRequest => F[Unit] = { case CommitSyncRequest(project) =>
-    Logger[F].info(show"CommitSyncRequest sent for projectId = ${project.id}, projectPath = ${project.path}")
+  private def logInfo(processName: String): CommitSyncRequest => F[Unit] = { case CommitSyncRequest(project) =>
+    Logger[F].info(show"$processName - COMMIT_SYNC_REQUEST sent for $project")
   }
 }
 
 private object CommitSyncRequestSender {
-
-  def apply[F[_]: Async: Logger]: F[CommitSyncRequestSender[F]] = for {
-    eventLogUrl <- EventLogUrl[F]()
-  } yield new CommitSyncRequestSenderImpl(eventLogUrl, retryDelay = 30 seconds)
+  def apply[F[_]: Async: Logger: MetricsRegistry]: F[CommitSyncRequestSender[F]] = for {
+    eventSender <- EventSender[F]
+  } yield new CommitSyncRequestSenderImpl(eventSender)
 }

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreationEndpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreationEndpoint.scala
@@ -28,6 +28,7 @@ import io.renku.http.ErrorMessage._
 import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.http.server.security.model.AuthUser
 import io.renku.http.{ErrorMessage, InfoMessage}
+import io.renku.metrics.MetricsRegistry
 import io.renku.webhookservice.crypto.HookTokenCrypto
 import io.renku.webhookservice.hookcreation
 import io.renku.webhookservice.hookcreation.HookCreator.CreationResult
@@ -73,7 +74,7 @@ class HookCreationEndpointImpl[F[_]: MonadThrow: Logger](
 }
 
 object HookCreationEndpoint {
-  def apply[F[_]: Async: Logger](
+  def apply[F[_]: Async: Logger: MetricsRegistry](
       projectHookUrl:  ProjectHookUrl,
       gitLabThrottler: Throttler[F, GitLab],
       hookTokenCrypto: HookTokenCrypto[F]

--- a/webhook-service/src/main/scala/io/renku/webhookservice/model.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/model.scala
@@ -18,8 +18,8 @@
 
 package io.renku.webhookservice
 
-import cats.MonadThrow
 import cats.syntax.all._
+import cats.{MonadThrow, Show}
 import com.typesafe.config.{Config, ConfigFactory}
 import io.renku.config.ConfigLoader.{find, urlTinyTypeReader}
 import io.renku.graph.model.projects
@@ -34,6 +34,11 @@ object model {
   final case class CommitSyncRequest(project: Project)
 
   final case class Project(id: projects.Id, path: projects.Path)
+  object Project {
+    implicit lazy val show: Show[Project] = Show.show { case Project(id, path) =>
+      s"projectId = $id, projectPath = $path"
+    }
+  }
 
   final class ProjectHookUrl private (val value: String) extends AnyVal with StringTinyType
 

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventprocessing/HookEventEndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventprocessing/HookEventEndpointSpec.scala
@@ -55,8 +55,8 @@ class HookEventEndpointSpec extends AnyWordSpec with MockFactory with should.Mat
     "return ACCEPTED for valid push event payload which are accepted" in new TestCase {
 
       (commitSyncRequestSender
-        .sendCommitSyncRequest(_: CommitSyncRequest))
-        .expects(syncRequest)
+        .sendCommitSyncRequest(_: CommitSyncRequest, _: String))
+        .expects(syncRequest, "HookEvent")
         .returning(().pure[IO])
 
       expectDecryptionOf(serializedHookToken, returning = HookToken(syncRequest.project.id))

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -74,7 +74,7 @@ class HookCreatorSpec extends AnyWordSpec with MockFactory with should.Matchers 
         .returning(IO.unit)
 
       (commitSyncRequestSender.sendCommitSyncRequest _)
-        .expects(CommitSyncRequest(Project(projectInfo.id, projectInfo.path)))
+        .expects(CommitSyncRequest(Project(projectInfo.id, projectInfo.path)), "HookCreation")
         .returning(().pure[IO])
 
       hookCreation.createHook(projectId, accessToken).unsafeRunSync() shouldBe HookCreated
@@ -247,7 +247,7 @@ class HookCreatorSpec extends AnyWordSpec with MockFactory with should.Matchers 
         .returning(IO.unit)
 
       (commitSyncRequestSender.sendCommitSyncRequest _)
-        .expects(CommitSyncRequest(Project(projectInfo.id, projectInfo.path)))
+        .expects(CommitSyncRequest(Project(projectInfo.id, projectInfo.path)), "HookCreation")
         .returning(exceptions.generateOne.raiseError[IO, Unit])
 
       hookCreation.createHook(projectId, accessToken).unsafeRunSync() shouldBe HookCreated


### PR DESCRIPTION
The `COMMIT_SYNC_REQUEST` events were probably the last ones that were not going through the `EventSender` and so the `sent_events_count` metric was not collecting data for it. This PR fixes this.