### PR TITLE
fix: MEMBER_SYNC events finder to work when project removed

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/membersync/SubscriptionCategory.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/membersync/SubscriptionCategory.scala
@@ -35,12 +35,12 @@ private[subscriptions] object SubscriptionCategory {
       subscriberTracker: SubscriberTracker[F]
   ): F[subscriptions.SubscriptionCategory[F]] = for {
     subscribers      <- Subscribers(categoryName, subscriberTracker)
-    eventsFinder     <- MemberSyncEventFinder(queriesExecTimes)
+    eventFinder      <- EventFinder(queriesExecTimes)
     dispatchRecovery <- LoggingDispatchRecovery[F, MemberSyncEvent](categoryName)
     eventDelivery    <- EventDelivery.noOp[F, MemberSyncEvent]
     eventsDistributor <- EventsDistributor(categoryName,
                                            subscribers,
-                                           eventsFinder,
+                                           eventFinder,
                                            eventDelivery,
                                            EventEncoder(encodeEvent),
                                            dispatchRecovery

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/membersync/EventFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/membersync/EventFinderSpec.scala
@@ -19,7 +19,6 @@
 package io.renku.eventlog.subscriptions
 package membersync
 
-import eu.timepit.refined.auto._
 import io.renku.db.SqlStatement
 import io.renku.eventlog.EventContentGenerators._
 import io.renku.eventlog.{EventDate, InMemoryEventLogDbSpec}
@@ -36,7 +35,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import java.time.Duration
 
-class MemberSyncEventFinderSpec
+class EventFinderSpec
     extends AnyWordSpec
     with IOSpec
     with InMemoryEventLogDbSpec
@@ -148,6 +147,6 @@ class MemberSyncEventFinderSpec
 
   private trait TestCase {
     val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
-    val finder           = new MemberSyncEventFinderImpl(queriesExecTimes)
+    val finder           = new EventFinderImpl(queriesExecTimes)
   }
 }


### PR DESCRIPTION
closes #935 

This PR makes the finder not to fail in the case when the data for the MEMBER_SYNC event has started and in the meantime the project got removed.