### PR TITLE
fix: AWAITING_GENERATION Event Finder hold event when one in progress

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/subscriptions/cleanup/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/subscriptions/cleanup/EventFinder.scala
@@ -133,7 +133,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: Logger](
   ): PartialFunction[Throwable, Kleisli[F, Session[F], Option[(CleanUpEvent, Int)]]] = {
     case SqlState.DeadlockDetected(_) =>
       liftF[F, Session[F], Unit](
-        Logger[F].warn(show"$categoryName: deadlock happened while popping $project; retrying")
+        Logger[F].info(show"$categoryName: deadlock happened while popping $project; retrying")
       ) >> markEventsDeleting()(project.some)
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/subscriptions/awaitinggeneration/EventFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/subscriptions/awaitinggeneration/EventFinderSpec.scala
@@ -203,12 +203,12 @@ private class EventFinderSpec
         }
     }
 
-    Set(GeneratingTriples,
-        TriplesGenerated,
-        TransformationRecoverableFailure,
-        TriplesStore,
-        AwaitingDeletion,
-        Deleting
+    List(GeneratingTriples,
+         TriplesGenerated,
+         TransformationRecoverableFailure,
+         TriplesStore,
+         AwaitingDeletion,
+         Deleting
     ) foreach { latestEventStatus =>
       s"find no event when there are older statuses in status $New or $GenerationRecoverableFailure " +
         s"but the latest event is $latestEventStatus" in new TestCase {


### PR DESCRIPTION
This fixes a problem when multiple `AWAITING_GENERATION` events are issued for a single repo.