### PR TITLE
chore: use userid 1000 and k8s security context

### DIFF
--- a/commit-event-service/Dockerfile
+++ b/commit-event-service/Dockerfile
@@ -29,9 +29,9 @@ ENV TZ UTC
 RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
-ENV GID=90060
+ENV GID=1000
 RUN addgroup -g "$GID" -S cesgroup && \
-    adduser --disabled-password -g "$GID" -D -u 9006 cesuser && \
+    adduser --disabled-password -g "$GID" -D -u 1000 cesuser && \
     chmod 555 -R /opt/commit-event-service
 
 USER cesuser

--- a/commit-event-service/Dockerfile
+++ b/commit-event-service/Dockerfile
@@ -30,8 +30,7 @@ RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
 ENV GID=1000
-RUN addgroup -g "$GID" -S cesgroup && \
-    adduser --disabled-password -g "$GID" -D -u 1000 cesuser && \
+RUN adduser --disabled-password -g "$GID" -D -u 1000 cesuser && \
     chmod 555 -R /opt/commit-event-service
 
 USER cesuser

--- a/event-log/Dockerfile
+++ b/event-log/Dockerfile
@@ -29,9 +29,9 @@ ENV TZ UTC
 RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
-ENV GID=90050
+ENV GID=1000
 RUN addgroup -g "$GID" -S elgroup && \
-    adduser --disabled-password -g "$GID" -D -u 9005 eluser && \
+    adduser --disabled-password -g "$GID" -D -u 1000 eluser && \
     chmod 555 -R /opt/event-log
 
 USER eluser

--- a/event-log/Dockerfile
+++ b/event-log/Dockerfile
@@ -30,8 +30,7 @@ RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
 ENV GID=1000
-RUN addgroup -g "$GID" -S elgroup && \
-    adduser --disabled-password -g "$GID" -D -u 1000 eluser && \
+RUN adduser --disabled-password -g "$GID" -D -u 1000 eluser && \
     chmod 555 -R /opt/event-log
 
 USER eluser

--- a/helm-chart/renku-graph/templates/commit-event-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/commit-event-service-deployment.yaml
@@ -21,12 +21,16 @@ spec:
         app: {{ include "commitEventService.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: commit-event-service
           image: "{{ .Values.commitEventService.image.repository }}:{{ .Values.commitEventService.image.tag }}"
           imagePullPolicy: {{ .Values.commitEventService.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: RENKU_CLIENT_CERTIFICATE
               valueFrom:

--- a/helm-chart/renku-graph/templates/event-log-deployment.yaml
+++ b/helm-chart/renku-graph/templates/event-log-deployment.yaml
@@ -21,12 +21,16 @@ spec:
         app: {{ include "eventLog.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: event-log
           image: "{{ .Values.eventLog.image.repository }}:{{ .Values.eventLog.image.tag }}"
           imagePullPolicy: {{ .Values.eventLog.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: RENKU_CLIENT_CERTIFICATE
               valueFrom:

--- a/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
+++ b/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
@@ -21,12 +21,16 @@ spec:
         app: {{ include "knowledgeGraph.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: knowledge-graph
           image: "{{ .Values.knowledgeGraph.image.repository }}:{{ .Values.knowledgeGraph.image.tag }}"
           imagePullPolicy: {{ .Values.knowledgeGraph.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: RENKU_CLIENT_CERTIFICATE
               valueFrom:

--- a/helm-chart/renku-graph/templates/token-repository-deployment.yaml
+++ b/helm-chart/renku-graph/templates/token-repository-deployment.yaml
@@ -21,12 +21,16 @@ spec:
         app: {{ include "tokenRepository.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: token-repository
           image: "{{ .Values.tokenRepository.image.repository }}:{{ .Values.tokenRepository.image.tag }}"
           imagePullPolicy: {{ .Values.tokenRepository.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: RENKU_CLIENT_CERTIFICATE
               valueFrom:

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -21,12 +21,16 @@ spec:
         app: {{ include "triplesGenerator.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: triples-generator
           image: "{{ .Values.triplesGenerator.image.repository }}:{{ .Values.triplesGenerator.image.tag }}"
           imagePullPolicy: {{ .Values.triplesGenerator.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: RENKU_CLIENT_CERTIFICATE
               valueFrom:

--- a/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
@@ -21,12 +21,16 @@ spec:
         app: {{ include "webhookService.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: webhook-service
           image: "{{ .Values.webhookService.image.repository }}:{{ .Values.webhookService.image.tag }}"
           imagePullPolicy: {{ .Values.webhookService.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
             - name: RENKU_CLIENT_CERTIFICATE
               valueFrom:

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -160,3 +160,4 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
+  runAsNonRoot: true

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -157,7 +157,7 @@ podSecurityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
+  runAsNonRoot: true
 
 securityContext:
   allowPrivilegeEscalation: false
-  runAsNonRoot: true

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -152,3 +152,11 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -153,12 +153,10 @@ tolerations: []
 
 affinity: {}
 
-podSecurityContext:
-  # Please note that the certificates init container needs to run as root
-  allowPrivilegeEscalation: false
+podSecurityContext: {}
 
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
-  fsGroup: 1000
+  allowPrivilegeEscalation: false
   runAsNonRoot: true

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -154,10 +154,11 @@ tolerations: []
 affinity: {}
 
 podSecurityContext:
+  # Please note that the certificates init container needs to run as root
+  allowPrivilegeEscalation: false
+
+securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
   runAsNonRoot: true
-
-securityContext:
-  allowPrivilegeEscalation: false

--- a/knowledge-graph/Dockerfile
+++ b/knowledge-graph/Dockerfile
@@ -29,9 +29,9 @@ ENV TZ UTC
 RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
-ENV GID=90040
+ENV GID=1000
 RUN addgroup -g "$GID" -S kggroup && \
-    adduser --disabled-password -g "$GID" -D -u 9004 kguser && \
+    adduser --disabled-password -g "$GID" -D -u 1000 kguser && \
     chmod 555 -R /opt/knowledge-graph
 
 USER kguser

--- a/knowledge-graph/Dockerfile
+++ b/knowledge-graph/Dockerfile
@@ -30,8 +30,7 @@ RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
 ENV GID=1000
-RUN addgroup -g "$GID" -S kggroup && \
-    adduser --disabled-password -g "$GID" -D -u 1000 kguser && \
+RUN adduser --disabled-password -g "$GID" -D -u 1000 kguser && \
     chmod 555 -R /opt/knowledge-graph
 
 USER kguser

--- a/token-repository/Dockerfile
+++ b/token-repository/Dockerfile
@@ -29,9 +29,9 @@ ENV TZ UTC
 RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
-ENV GID=90030
+ENV GID=1000
 RUN addgroup -g "$GID" -S trgroup && \
-    adduser --disabled-password -g "$GID" -D -u 9003 truser && \
+    adduser --disabled-password -g "$GID" -D -u 1000 truser && \
     chmod 555 -R /opt/token-repository
 
 USER truser

--- a/token-repository/Dockerfile
+++ b/token-repository/Dockerfile
@@ -30,8 +30,7 @@ RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
 ENV GID=1000
-RUN addgroup -g "$GID" -S trgroup && \
-    adduser --disabled-password -g "$GID" -D -u 1000 truser && \
+RUN adduser --disabled-password -g "$GID" -D -u 1000 truser && \
     chmod 555 -R /opt/token-repository
 
 USER truser

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -37,8 +37,7 @@ RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py
 COPY triples-generator/entrypoint.sh /entrypoint.sh
 
 ENV GID=1000
-RUN addgroup -g "$GID" -S tggroup && \
-    adduser --disabled-password -g "$GID" -D -u 1000 tguser && \
+RUN adduser --disabled-password -g "$GID" -D -u 1000 tguser && \
     chmod 555 -R /opt/triples-generator && \
     chmod 555 -R /entrypoint.sh
 

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -36,9 +36,9 @@ RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py
 
 COPY triples-generator/entrypoint.sh /entrypoint.sh
 
-ENV GID=90020
+ENV GID=1000
 RUN addgroup -g "$GID" -S tggroup && \
-    adduser --disabled-password -g "$GID" -D -u 9002 tguser && \
+    adduser --disabled-password -g "$GID" -D -u 1000 tguser && \
     chmod 555 -R /opt/triples-generator && \
     chmod 555 -R /entrypoint.sh
 

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -30,8 +30,7 @@ RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
 ENV GID=1000
-RUN addgroup -g "$GID" -S wsgroup && \
-    adduser --disabled-password -g "$GID" -D -u 1000 wsuser && \
+RUN adduser --disabled-password -g "$GID" -D -u 1000 wsuser && \
     chmod 555 -R /opt/webhook-service
 
 USER wsuser

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -29,9 +29,9 @@ ENV TZ UTC
 RUN apk add --no-cache tzdata curl bash tini && \
     chown -R daemon:daemon .
 
-ENV GID=90010
+ENV GID=1000
 RUN addgroup -g "$GID" -S wsgroup && \
-    adduser --disabled-password -g "$GID" -D -u 9001 wsuser && \
+    adduser --disabled-password -g "$GID" -D -u 1000 wsuser && \
     chmod 555 -R /opt/webhook-service
 
 USER wsuser


### PR DESCRIPTION
It is great that things were already setup to run as non-root. I just wanted to standardize all the Renku services to use the same user and group id of 1000. I already opened a bunch of PRs with 1000 and it was already used elsewhere. So I will go with 1000 here too.

Also adding the security context is useful because it prevents changes or switching to a higher permissions group or user when the container is running. 

/deploy #persist

closes https://github.com/swissdatasciencecenter/renku-notebooks/issues/1000