### PR TITLE
feat: TS migration to fix broken DS Image Resource IDs

### DIFF
--- a/renku-model/src/test/scala/io/renku/graph/model/GraphModelGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/GraphModelGenerators.scala
@@ -126,7 +126,7 @@ object GraphModelGenerators {
   implicit val filePaths: Gen[FilePath] = relativePaths() map FilePath.apply
 
   implicit val datasetIdentifiers: Gen[Identifier] = uuid
-    .map(_.toString)
+    .map(_.toString.replace("-", ""))
     .map(Identifier.apply)
 
   implicit val datasetInitialVersions: Gen[InitialVersion] = datasetIdentifiers map (id => InitialVersion(id.toString))

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
@@ -361,6 +361,6 @@ object Dataset {
   def entityId(identifier: DatasetIdentifier)(implicit renkuBaseUrl: RenkuBaseUrl): EntityId =
     EntityId of (renkuBaseUrl / "datasets" / identifier)
 
-  private def imageEntityId(datasetEntityId: EntityId, position: ImagePosition): UrlfiedEntityId =
+  def imageEntityId(datasetEntityId: EntityId, position: ImagePosition): UrlfiedEntityId =
     datasetEntityId.asUrlEntityId / "images" / position.toString
 }

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -31,7 +31,7 @@ RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py
     python3 -m pip install --ignore-installed packaging && \
     python3 -m pip install --upgrade 'pip==22.0.4' && \
     python3 -m pip install jinja2 && \
-    python3 -m pip install 'renku==1.2.2' 'sentry-sdk==1.5.5'  && \
+    python3 -m pip install 'renku==1.2.3' 'sentry-sdk==1.5.5'  && \
     chown -R daemon:daemon .
 
 COPY triples-generator/entrypoint.sh /entrypoint.sh

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -22,7 +22,7 @@ triples-generation = "renku-log"
 # *  ["0.16.1 -> 9", ...] as above
 # *  ["0.16.1 -> 9", "0.16.0 -> 9", ...] then the decision about re-provisioning is taken using the 9 schema version and 0.16.1 CLI version
 compatibility-matrix = [
-  "1.2.2  -> 9",
+  "1.2.3  -> 9",
   "0.16.2 -> 8"
 ]
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MalformedDSImageIds.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MalformedDSImageIds.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import io.renku.graph.model.Schemas.{renku, schema}
+import io.renku.metrics.MetricsRegistry
+import io.renku.rdfstore.SparqlQuery.Prefixes
+import io.renku.rdfstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import io.renku.triplesgenerator.events.categories.tsmigrationrequest.Migration
+import org.typelevel.log4cats.Logger
+import tooling.{CleanUpEventsProducer, QueryBasedMigration}
+
+private object MalformedDSImageIds {
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    QueryBasedMigration[F](name, query, CleanUpEventsProducer).widen
+
+  private lazy val name = Migration.Name("Malformed DS Image Ids")
+  private[migrations] lazy val query = SparqlQuery.of(
+    Refined.unsafeApply(name.show),
+    Prefixes.of(schema -> "schema", renku -> "renku"),
+    s"""|SELECT DISTINCT ?path
+        |WHERE {
+        |  ?id a schema:Dataset;
+        |      ^renku:hasDataset/renku:projectPath ?path;
+        |      schema:image ?imageId.
+        |  BIND (STR(?imageId) AS ?imageIdString)
+        |  FILTER REGEX(?imageIdString, '(.*/datasets/([a-zA-Z0-9]+[-]+[a-zA-Z0-9]+)+(/.*)*)')
+        |}
+        |""".stripMargin
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/Migrations.scala
@@ -39,11 +39,13 @@ private[tsmigrationrequest] object Migrations {
     malformedActivityIds      <- MalformedActivityIds[F]
     deDuplicatePersonNames    <- DeDuplicatePersonNames[F]
     deDuplicateModifiedDSData <- DeDuplicateModifiedDSData[F]
+    malformedDSImageIds       <- MalformedDSImageIds[F]
     migrations <- validateNames(reProvisioning,
                                 topMostDerivedFrom,
                                 malformedActivityIds,
                                 deDuplicatePersonNames,
-                                deDuplicateModifiedDSData
+                                deDuplicateModifiedDSData,
+                                malformedDSImageIds
                   )
   } yield migrations
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MalformedDSImageIdsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MalformedDSImageIdsSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations
+
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import GraphModelGenerators.datasetImageUris
+import io.renku.graph.model.datasets.{ImagePosition, ImageResourceId}
+import io.renku.graph.model.testentities._
+import io.renku.rdfstore.InMemoryRdfStore
+import io.renku.testtools.IOSpec
+import org.scalacheck.Gen
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class MalformedDSImageIdsSpec extends AnyWordSpec with should.Matchers with IOSpec with InMemoryRdfStore {
+
+  "query" should {
+
+    "find projects with at least one DS with an Image having a broken Resource Id" in {
+      val project1 = {
+        val p = renkuProjectEntities(anyVisibility)
+          .withDatasets(datasetEntities(provenanceInternal))
+          .withDatasets(datasetEntities(provenanceInternal))
+          .generateOne
+          .to[entities.RenkuProject.WithoutParent]
+        val ds1 :: ds2 :: Nil = p.datasets
+        p.copy(datasets = List(ds1, addImageWithBrokenId(ds2)))
+      }
+      val project2 = {
+        val p = renkuProjectEntities(anyVisibility)
+          .withDatasets(datasetEntities(provenanceInternal))
+          .generateOne
+          .to[entities.RenkuProject.WithoutParent]
+        p.copy(datasets = p.datasets map addImageWithBrokenId)
+      }
+      val project3 = renkuProjectEntities(anyVisibility)
+        .withDatasets(
+          datasetEntities(provenanceInternal).modify(ds =>
+            ds.copy(additionalInfo = ds.additionalInfo.copy(images = datasetImageUris.generateNonEmptyList().toList))
+          )
+        )
+        .generateOne
+        .to[entities.RenkuProject.WithoutParent]
+
+      loadToStore(
+        project1,
+        project2,
+        project3,
+        anyRenkuProjectEntities.generateOne.to[entities.RenkuProject]
+      )
+
+      runQuery(MalformedDSImageIds.query.toString)
+        .unsafeRunSync()
+        .map(row => projects.Path(row("path")))
+        .toSet shouldBe Set(project1.path, project2.path)
+    }
+  }
+
+  private def addImageWithBrokenId(
+      ds: entities.Dataset[entities.Dataset.Provenance]
+  ): entities.Dataset[entities.Dataset.Provenance] = {
+    val position = ImagePosition(0)
+    ds.copy(additionalInfo =
+      ds.additionalInfo.copy(images =
+        entities.Dataset
+          .Image(
+            malformedImageId(ds, position),
+            datasetImageUris.generateOne,
+            position
+          )
+          .some
+          .toList
+      )
+    )
+  }
+
+  private def malformedImageId(ds: entities.Dataset[entities.Dataset.Provenance], position: ImagePosition) = {
+    val identifier = ds.identification.identifier
+    val id = Dataset
+      .imageEntityId(Dataset.entityId(identifier), position)
+      .show
+    ImageResourceId(id.replace(identifier.show, Gen.uuid.generateOne.toString))
+  }
+}


### PR DESCRIPTION
This PR:
* upgrades CLI to version `1.2.3` on TG
* adds migration fixing broken DS Image Resource IDs