### PR TITLE
fix: DS with multiple descriptions

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DatasetTransformer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DatasetTransformer.scala
@@ -40,6 +40,7 @@ private[transformation] class DatasetTransformerImpl[F[_]: MonadThrow](
     topmostSameAsUpdater:           TopmostSameAsUpdater[F],
     originalIdentifierUpdater:      OriginalIdentifierUpdater[F],
     dateCreatedUpdater:             DateCreatedUpdater[F],
+    descriptionUpdater:             DescriptionUpdater[F],
     personLinksUpdater:             PersonLinksUpdater[F],
     hierarchyOnInvalidationUpdater: HierarchyOnInvalidationUpdater[F],
     recoverableErrorsRecovery:      RecoverableErrorsRecovery = RecoverableErrorsRecovery
@@ -50,6 +51,7 @@ private[transformation] class DatasetTransformerImpl[F[_]: MonadThrow](
   import hierarchyOnInvalidationUpdater._
   import originalIdentifierUpdater._
   import personLinksUpdater._
+  import descriptionUpdater._
   import recoverableErrorsRecovery._
   import sameAsUpdater._
   import topmostSameAsUpdater._
@@ -64,6 +66,7 @@ private[transformation] class DatasetTransformerImpl[F[_]: MonadThrow](
         updateTopmostSameAs >>=
         updateOriginalIdentifiers >>=
         updateDateCreated >>=
+        updateDescriptions >>=
         updatePersonLinks >>=
         updateHierarchyOnInvalidation)
         .map(_.asRight[ProcessingRecoverableError])
@@ -80,11 +83,13 @@ private[transformation] object DatasetTransformer {
     hierarchyOnInvalidationUpdater <- HierarchyOnInvalidationUpdater[F]
     originalIdentifierUpdater      <- OriginalIdentifierUpdater[F]
     dateCreatedUpdater             <- DateCreatedUpdater[F]
+    descriptionUpdater             <- DescriptionUpdater[F]
   } yield new DatasetTransformerImpl[F](derivationHierarchyUpdater,
                                         sameAsUpdater,
                                         topmostSameAsUpdater,
                                         originalIdentifierUpdater,
                                         dateCreatedUpdater,
+                                        descriptionUpdater,
                                         personLinksUpdater,
                                         hierarchyOnInvalidationUpdater
   )

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DescriptionUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DescriptionUpdater.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.categories.triplesgenerated.transformation.datasets
+
+import cats.MonadThrow
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.model.entities.Project
+import io.renku.rdfstore.SparqlQueryTimeRecorder
+import io.renku.triplesgenerator.events.categories.triplesgenerated.TransformationStep.Queries
+import org.typelevel.log4cats.Logger
+
+private trait DescriptionUpdater[F[_]] {
+  def updateDescriptions: ((Project, Queries)) => F[(Project, Queries)]
+}
+
+private object DescriptionUpdater {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[DescriptionUpdater[F]] = for {
+    kgDatasetInfoFinder <- KGDatasetInfoFinder[F]
+  } yield new DescriptionUpdaterImpl[F](kgDatasetInfoFinder, UpdatesCreator)
+}
+
+private class DescriptionUpdaterImpl[F[_]: MonadThrow](
+    kgDatasetInfoFinder: KGDatasetInfoFinder[F],
+    updatesCreator:      UpdatesCreator
+) extends DescriptionUpdater[F] {
+  import kgDatasetInfoFinder._
+  import updatesCreator._
+
+  override def updateDescriptions: ((Project, Queries)) => F[(Project, Queries)] = { case (project, queries) =>
+    project.datasets
+      .map(ds => findDatasetDescriptions(ds.resourceId).map(removeOtherDescriptions(ds, _)))
+      .sequence
+      .map(_.flatten)
+      .map(quers => project -> (queries |+| Queries.preDataQueriesOnly(quers)))
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/Migrations.scala
@@ -48,6 +48,7 @@ private[tsmigrationrequest] object Migrations {
     multipleDSSameAs                  <- MultipleDSSameAs[F]
     multipleActivityAuthors           <- MultipleActivityAuthors[F]
     removeNotLinkedPersons            <- RemoveNotLinkedPersons[F]
+    multipleDSDescriptions            <- MultipleDSDescriptions[F]
     migrations <- validateNames(
                     reProvisioning,
                     malformedActivityIds,
@@ -62,7 +63,8 @@ private[tsmigrationrequest] object Migrations {
                     multipleDSDateCreated,
                     multipleDSSameAs,
                     multipleActivityAuthors,
-                    removeNotLinkedPersons
+                    removeNotLinkedPersons,
+                    multipleDSDescriptions
                   )
   } yield migrations
 
@@ -72,8 +74,7 @@ private[tsmigrationrequest] object Migrations {
       case (name, ms) if ms.size > 1 => name
     }
     if (problematicMigrations.nonEmpty) {
-      val error =
-        show"$categoryName: there are multiple migrations with the same name: ${problematicMigrations.mkString("; ")}"
+      val error = show"$categoryName: there are multiple migrations with name: ${problematicMigrations.mkString("; ")}"
       Logger[F]
         .error(error) >> new Exception(error).raiseError[F, List[Migration[F]]].map(_ => List.empty[Migration[F]])
     } else migrations.toList.pure[F]

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleDSDescriptions.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleDSDescriptions.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.Schemas.schema
+import io.renku.metrics.MetricsRegistry
+import io.renku.rdfstore.SparqlQuery.Prefixes
+import io.renku.rdfstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import io.renku.triplesgenerator.events.categories.tsmigrationrequest.Migration
+import org.typelevel.log4cats.Logger
+import tooling.UpdateQueryMigration
+
+private object MultipleDSDescriptions {
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    UpdateQueryMigration[F](name, query).widen
+
+  private lazy val name = Migration.Name("Multiple Descriptions on DS")
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of schema -> "schema",
+    s"""|DELETE { ?dsId schema:description ?desc }
+        |WHERE {
+        |  SELECT ?dsId ?desc
+        |  WHERE {
+        |    {
+        |      SELECT ?dsId (SAMPLE(?desc) as ?someDesc)
+        |      WHERE {
+        |        ?dsId a schema:Dataset;
+        |              schema:description ?desc.
+        |      }
+        |      GROUP BY ?dsId
+        |      HAVING (COUNT(?desc) > 1)
+        |    }
+        |    ?dsId schema:description ?desc.
+        |    FILTER ( ?desc != ?someDesc )
+        |  }
+        |}
+        |""".stripMargin
+  )
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DatasetTransformerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DatasetTransformerSpec.scala
@@ -64,19 +64,24 @@ class DatasetTransformerSpec extends AnyWordSpec with MockFactory with should.Ma
         .returning(transformation(in = step4Result, out = step5Result))
 
       val step6Result = generateProjAndQueries
-      (() => personLinksUpdater.updatePersonLinks)
+      (() => descriptionUpdater.updateDescriptions)
         .expects()
         .returning(transformation(in = step5Result, out = step6Result))
 
       val step7Result = generateProjAndQueries
-      (() => hierarchyOnInvalidationUpdater.updateHierarchyOnInvalidation)
+      (() => personLinksUpdater.updatePersonLinks)
         .expects()
         .returning(transformation(in = step6Result, out = step7Result))
+
+      val step8Result = generateProjAndQueries
+      (() => hierarchyOnInvalidationUpdater.updateHierarchyOnInvalidation)
+        .expects()
+        .returning(transformation(in = step7Result, out = step8Result))
 
       val step = transformer.createTransformationStep
       step.name.value shouldBe "Dataset Details Updates"
 
-      (step run initialProjectAndQueries._1).value shouldBe step7Result.asRight.pure[Try]
+      (step run initialProjectAndQueries._1).value shouldBe step8Result.asRight.pure[Try]
     }
 
     "return the ProcessingRecoverableFailure if one of the steps fails with a recoverable failure" in new TestCase {
@@ -100,6 +105,10 @@ class DatasetTransformerSpec extends AnyWordSpec with MockFactory with should.Ma
         .returning(transformation(in = generateProjAndQueries, out = generateProjAndQueries))
 
       (() => dateCreatedUpdater.updateDateCreated)
+        .expects()
+        .returning(transformation(in = generateProjAndQueries, out = generateProjAndQueries))
+
+      (() => descriptionUpdater.updateDescriptions)
         .expects()
         .returning(transformation(in = generateProjAndQueries, out = generateProjAndQueries))
 
@@ -142,6 +151,10 @@ class DatasetTransformerSpec extends AnyWordSpec with MockFactory with should.Ma
         .expects()
         .returning(transformation(in = generateProjAndQueries, out = generateProjAndQueries))
 
+      (() => descriptionUpdater.updateDescriptions)
+        .expects()
+        .returning(transformation(in = generateProjAndQueries, out = generateProjAndQueries))
+
       (() => personLinksUpdater.updatePersonLinks)
         .expects()
         .returning(transformation(in = generateProjAndQueries, out = generateProjAndQueries))
@@ -176,6 +189,7 @@ class DatasetTransformerSpec extends AnyWordSpec with MockFactory with should.Ma
     val topmostSameAsUpdater           = mock[TopmostSameAsUpdater[Try]]
     val originalIdentifierUpdater      = mock[OriginalIdentifierUpdater[Try]]
     val dateCreatedUpdater             = mock[DateCreatedUpdater[Try]]
+    val descriptionUpdater             = mock[DescriptionUpdater[Try]]
     val personLinksUpdater             = mock[PersonLinksUpdater[Try]]
     val hierarchyOnInvalidationUpdater = mock[HierarchyOnInvalidationUpdater[Try]]
     val transformer = new DatasetTransformerImpl[Try](derivationHierarchyUpdater,
@@ -183,6 +197,7 @@ class DatasetTransformerSpec extends AnyWordSpec with MockFactory with should.Ma
                                                       topmostSameAsUpdater,
                                                       originalIdentifierUpdater,
                                                       dateCreatedUpdater,
+                                                      descriptionUpdater,
                                                       personLinksUpdater,
                                                       hierarchyOnInvalidationUpdater
     )

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DescriptionUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/transformation/datasets/DescriptionUpdaterSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.categories.triplesgenerated.transformation
+package datasets
+
+import Generators.queriesGen
+import cats.syntax.all._
+import io.renku.generators.CommonGraphGenerators.sparqlQueries
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators.datasetDescriptions
+import io.renku.graph.model.datasets.Description
+import io.renku.graph.model.entities
+import io.renku.graph.model.testentities._
+import io.renku.rdfstore.SparqlQuery
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.{Success, Try}
+
+class DescriptionUpdaterSpec extends AnyWordSpec with MockFactory with should.Matchers {
+
+  "updateDescriptions" should {
+
+    "prepare updates for changes to description" in new TestCase {
+      val (_, project) = anyRenkuProjectEntities
+        .addDataset(datasetEntities(provenanceInternal).modify(replaceDSDesc(datasetDescriptions.generateSome)))
+        .generateOne
+        .bimap(identity, _.to[entities.Project])
+
+      val datasets = project.datasets
+
+      val allUpdateQueries = datasets.foldRight(List.empty[SparqlQuery]) { (ds, allQueries) =>
+        val updateQueries = sparqlQueries.generateList()
+        givenDescriptionsUpdates(ds, updateQueries = updateQueries)
+        updateQueries ::: allQueries
+      }
+
+      val Success(updatedProject -> queries) = updater.updateDescriptions(project -> initialQueries)
+
+      updatedProject                shouldBe project
+      queries.preDataUploadQueries  shouldBe initialQueries.preDataUploadQueries ::: allUpdateQueries
+      queries.postDataUploadQueries shouldBe initialQueries.postDataUploadQueries
+    }
+  }
+
+  private trait TestCase {
+    val initialQueries      = queriesGen.generateOne
+    val kgDatasetInfoFinder = mock[KGDatasetInfoFinder[Try]]
+    val updatesCreator      = mock[UpdatesCreator]
+    val updater             = new DescriptionUpdaterImpl[Try](kgDatasetInfoFinder, updatesCreator)
+
+    def givenDescriptionsUpdates(ds:                   entities.Dataset[entities.Dataset.Provenance],
+                                 existingDescriptions: Set[Description] = datasetDescriptions.generateSet(),
+                                 updateQueries:        List[SparqlQuery] = sparqlQueries.generateList()
+    ): Unit = {
+      (kgDatasetInfoFinder.findDatasetDescriptions _)
+        .expects(ds.resourceId)
+        .returning(existingDescriptions.pure[Try])
+      (updatesCreator.removeOtherDescriptions _)
+        .expects(ds, existingDescriptions)
+        .returning(updateQueries)
+      ()
+    }
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleDSDescriptionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleDSDescriptionsSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import GraphModelGenerators.datasetDescriptions
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.metrics.MetricsRegistry
+import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
+import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import tooling._
+
+class MultipleDSDescriptionsSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryRdfStore
+    with MockFactory {
+
+  "run" should {
+
+    "find DS records with multiple schema:description and remove the additional ones" in {
+      val (correctDS, correctProject) = renkuProjectEntities(anyVisibility)
+        .addDataset(datasetEntities(provenanceInternal).modify(replaceDSDesc(datasetDescriptions.generateSome)))
+        .generateOne
+
+      val brokenDSDesc1 = datasetDescriptions.generateOne
+      val (brokenDS, brokenProject) = renkuProjectEntities(anyVisibility)
+        .addDataset(datasetEntities(provenanceInternal).modify(replaceDSDesc(brokenDSDesc1.some)))
+        .generateOne
+
+      loadToStore(correctProject, brokenProject)
+
+      val brokenDSDesc2 = datasetDescriptions.generateOne
+      insertTriple(brokenDS.entityId, "schema:description", show"'$brokenDSDesc2'")
+
+      findDescriptions(brokenDS.identification.identifier) shouldBe Set(brokenDSDesc1, brokenDSDesc2)
+
+      runUpdate(MultipleDSDescriptions.query).unsafeRunSync() shouldBe ()
+
+      findDescriptions(brokenDS.identification.identifier)    should (be(Set(brokenDSDesc1)) or be(Set(brokenDSDesc2)))
+      findDescriptions(correctDS.identification.identifier) shouldBe correctDS.additionalInfo.maybeDescription.toSet
+    }
+  }
+
+  "apply" should {
+    "return an QueryBasedMigration" in {
+      implicit val logger:          TestLogger[IO]              = TestLogger[IO]()
+      implicit val timeRecorder:    SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
+      implicit val metricsRegistry: MetricsRegistry[IO]         = new MetricsRegistry.DisabledMetricsRegistry[IO]()
+      MultipleDSDescriptions[IO].unsafeRunSync().getClass shouldBe classOf[UpdateQueryMigration[IO]]
+    }
+  }
+
+  private def findDescriptions(id: datasets.Identifier): Set[datasets.Description] =
+    runQuery(s"""|SELECT ?desc 
+                 |WHERE { 
+                 |  ?id a schema:Dataset;
+                 |      schema:identifier '$id';
+                 |      schema:description ?desc
+                 |}""".stripMargin)
+      .unsafeRunSync()
+      .map(row => datasets.Description(row("desc")))
+      .toSet
+}


### PR DESCRIPTION
This PR adds a TS migration to remove multiple descriptions as well as changes the DS transformation flow to prevent from duplicating descriptions in the future.