### PR TITLE
refactor: improved readability of the renkuBaseUrl class

### DIFF
--- a/acceptance-tests/src/test/resources/application.conf
+++ b/acceptance-tests/src/test/resources/application.conf
@@ -34,7 +34,7 @@ services {
   }
   renku {
     url = "https://dev.renku.ch"
-    resources-url = "http://localhost:9004/knowledge-graph"
+    api-url = "http://localhost:9004/knowledge-graph"
   }
 }
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/package.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/package.scala
@@ -33,8 +33,8 @@ import java.time.Instant.now
 
 package object data extends RdfStoreData {
 
-  implicit val cliVersion: CliVersion         = currentVersionPair.cliVersion
-  val renkuResourcesUrl:   renku.ResourcesUrl = renku.ResourcesUrl("http://localhost:9004/knowledge-graph")
+  implicit val cliVersion: CliVersion   = currentVersionPair.cliVersion
+  val renkuApiUrl:         renku.ApiUrl = renku.ApiUrl("http://localhost:9004/knowledge-graph")
 
   def dataProjects(
       projectGen:   Gen[testentities.RenkuProject],

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
@@ -472,8 +472,8 @@ trait DatasetsResources {
     }"""
       .deepMerge(
         _links(
-          Rel("details")         -> Href(renkuResourcesUrl / "datasets" / dataset.identification.identifier),
-          Rel("initial-version") -> Href(renkuResourcesUrl / "datasets" / dataset.provenance.originalIdentifier)
+          Rel("details")         -> Href(renkuApiUrl / "datasets" / dataset.identification.identifier),
+          Rel("initial-version") -> Href(renkuApiUrl / "datasets" / dataset.provenance.originalIdentifier)
         )
       )
       .deepMerge(provenanceEncoder(dataset.provenance))
@@ -512,7 +512,7 @@ trait DatasetsResources {
       .addIfDefined("description" -> dataset.additionalInfo.maybeDescription)
       .deepMerge {
         _links(
-          Rel("details") -> Href(renkuResourcesUrl / "datasets" / actualIdentifier)
+          Rel("details") -> Href(renkuApiUrl / "datasets" / actualIdentifier)
         )
       }
   }

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
@@ -52,8 +52,8 @@ package object knowledgegraph {
     "version": ${project.entitiesProject.version.value}
   }""" deepMerge {
     _links(
-      Link(Rel.Self        -> Href(renkuResourcesUrl / "projects" / project.path)),
-      Link(Rel("datasets") -> Href(renkuResourcesUrl / "projects" / project.path / "datasets"))
+      Link(Rel.Self        -> Href(renkuApiUrl / "projects" / project.path)),
+      Link(Rel("datasets") -> Href(renkuApiUrl / "projects" / project.path / "datasets"))
     )
   } deepMerge {
     project.entitiesProject.maybeDescription

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
@@ -41,7 +41,7 @@ trait RemoteTriplesGenerator {
   def `GET <triples-generator>/projects/:id/commits/:id returning OK with some triples`(
       project:             data.Project,
       commitId:            CommitId
-  )(implicit gitLabApiUrl: GitLabApiUrl, renkuBaseUrl: RenkuBaseUrl): Unit =
+  )(implicit gitLabApiUrl: GitLabApiUrl, renkuUrl: RenkuUrl): Unit =
     `GET <triples-generator>/projects/:id/commits/:id returning OK`(
       project,
       commitId,

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/tooling/GraphServices.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/tooling/GraphServices.scala
@@ -25,8 +25,8 @@ import io.renku.graph.acceptancetests.db.{EventLog, TokenRepository}
 import io.renku.graph.acceptancetests.stubs.{GitLab, RemoteTriplesGenerator}
 import io.renku.graph.acceptancetests.tooling.KnowledgeGraphClient.KnowledgeGraphClient
 import io.renku.graph.acceptancetests.tooling.WebhookServiceClient.WebhookServiceClient
-import io.renku.graph.config.RenkuBaseUrlLoader
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
 import io.renku.rdfstore.FusekiBaseUrl
 import io.renku.testtools.IOSpec
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -38,7 +38,7 @@ trait GraphServices extends GitLab with RemoteTriplesGenerator with IOSpec with 
   self: Suite =>
 
   protected implicit val fusekiBaseUrl: FusekiBaseUrl = RDFStore.fusekiBaseUrl
-  implicit val renkuBaseUrl:            RenkuBaseUrl  = RenkuBaseUrlLoader[Try]().fold(throw _, identity)
+  implicit val renkuUrl:                RenkuUrl      = RenkuUrlLoader[Try]().fold(throw _, identity)
   implicit lazy val logger:             Logger[IO]    = TestLogger()
 
   val restClient:               RestClientImpl                = new RestClientImpl()

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/tooling/RDFStore.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/tooling/RDFStore.scala
@@ -26,7 +26,7 @@ import io.renku.graph.acceptancetests.data.RdfStoreData
 import RdfStoreData.currentVersionPair
 import io.renku.graph.model.RenkuVersionPair
 import io.renku.graph.model.Schemas._
-import io.renku.graph.model.testentities.renkuBaseUrl
+import io.renku.graph.model.testentities.renkuUrl
 import io.renku.jsonld.EntityId
 import io.renku.rdfstore.FusekiBaseUrl
 import org.apache.jena.fuseki.main.FusekiServer
@@ -107,7 +107,7 @@ object RDFStore {
     _ = maybeVersionPair.map { currentVersionPair =>
           newJena.connection.update(s"""
           INSERT DATA{
-            <${EntityId.of((renkuBaseUrl / "version-pair").toString)}> a <${renku / "VersionPair"}> ;
+            <${EntityId.of((renkuUrl / "version-pair").toString)}> a <${renku / "VersionPair"}> ;
                             <${renku / "cliVersion"}> '${currentVersionPair.cliVersion}' ;
                             <${renku / "schemaVersion"}> '${currentVersionPair.schemaVersion}'}""")
         }

--- a/graph-commons/src/main/scala/io/renku/config/renku.scala
+++ b/graph-commons/src/main/scala/io/renku/config/renku.scala
@@ -24,19 +24,16 @@ import io.renku.tinytypes.{TinyTypeFactory, UrlTinyType}
 
 object renku {
 
-  class ResourcesUrl private (val value: String) extends AnyVal with UrlTinyType
-  object ResourcesUrl
-      extends TinyTypeFactory[ResourcesUrl](new ResourcesUrl(_))
-      with Url[ResourcesUrl]
-      with BaseUrl[ResourcesUrl, ResourceUrl] {
+  class ApiUrl private (val value: String) extends AnyVal with UrlTinyType
+  object ApiUrl extends TinyTypeFactory[ApiUrl](new ApiUrl(_)) with Url[ApiUrl] with BaseUrl[ApiUrl, ResourceUrl] {
     import ConfigLoader._
     import com.typesafe.config.{Config, ConfigFactory}
     import pureconfig.ConfigReader
 
-    private implicit val configReader: ConfigReader[ResourcesUrl] = urlTinyTypeReader(this)
+    private implicit val configReader: ConfigReader[ApiUrl] = urlTinyTypeReader(this)
 
-    def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[ResourcesUrl] =
-      find[F, ResourcesUrl]("services.renku.resources-url", config)
+    def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[ApiUrl] =
+      find[F, ApiUrl]("services.renku.api-url", config)
   }
 
   class ResourceUrl private (val value: String) extends AnyVal with UrlTinyType

--- a/graph-commons/src/main/scala/io/renku/graph/config/RenkuUrlLoader.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/config/RenkuUrlLoader.scala
@@ -20,17 +20,16 @@ package io.renku.graph.config
 
 import cats.MonadThrow
 import io.renku.config.ConfigLoader
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 
-object RenkuBaseUrlLoader {
+object RenkuUrlLoader {
 
   import ConfigLoader._
   import com.typesafe.config.{Config, ConfigFactory}
   import pureconfig.ConfigReader
 
-  private implicit val renkuBaseUrlReader: ConfigReader[RenkuBaseUrl] = urlTinyTypeReader(RenkuBaseUrl)
+  private implicit val renkuUrlReader: ConfigReader[RenkuUrl] = urlTinyTypeReader(RenkuUrl)
 
-  def apply[F[_]: MonadThrow](
-      config: Config = ConfigFactory.load()
-  ): F[RenkuBaseUrl] = find[F, RenkuBaseUrl]("services.renku.url", config)
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[RenkuUrl] =
+    find[F, RenkuUrl]("services.renku.url", config)
 }

--- a/graph-commons/src/test/scala/io/renku/config/ApiUrlSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/config/ApiUrlSpec.scala
@@ -20,7 +20,7 @@ package io.renku.config
 
 import com.typesafe.config.ConfigFactory
 import io.renku.config.ConfigLoader.ConfigLoadingException
-import io.renku.config.renku.{ResourceUrl, ResourcesUrl}
+import io.renku.config.renku.{ApiUrl, ResourceUrl}
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
@@ -31,7 +31,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-class ResourcesUrlSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
+class ApiUrlSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
 
   "apply" should {
 
@@ -41,17 +41,17 @@ class ResourcesUrlSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
           Map(
             "services" -> Map(
               "renku" -> Map(
-                "resources-url" -> url
+                "api-url" -> url
               ).asJava
             ).asJava
           ).asJava
         )
-        ResourcesUrl[Try](config) shouldBe Success(ResourcesUrl(url))
+        ApiUrl[Try](config) shouldBe Success(ApiUrl(url))
       }
     }
 
     "fail if there's no value for the 'services.renku.url'" in {
-      val Failure(exception) = ResourcesUrl[Try](ConfigFactory.empty())
+      val Failure(exception) = ApiUrl[Try](ConfigFactory.empty())
       exception shouldBe an[ConfigLoadingException]
     }
 
@@ -60,13 +60,13 @@ class ResourcesUrlSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
         Map(
           "services" -> Map(
             "renku" -> Map(
-              "resources-url" -> "abcd"
+              "api-url" -> "abcd"
             ).asJava
           ).asJava
         ).asJava
       )
 
-      val Failure(exception) = ResourcesUrl[Try](config)
+      val Failure(exception) = ApiUrl[Try](config)
 
       exception shouldBe an[ConfigLoadingException]
     }
@@ -75,7 +75,7 @@ class ResourcesUrlSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
   "/" should {
 
     "produce a ResourceUrl" in {
-      val resourcesUrl = renkuResourcesUrls.generateOne
+      val resourcesUrl = renkuApiUrls.generateOne
       val segment      = relativePaths(maxSegments = 1).generateOne
 
       val resourceUrl = resourcesUrl / segment

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -124,16 +124,13 @@ object CommonGraphGenerators {
     commitPart    <- shas.toGeneratorOfOptions.map(_.map(_.take(8)).map(sha => s"-$commitsNumber-g$sha").getOrElse(""))
   } yield ServiceVersion(s"$version$commitPart")
 
-  implicit val renkuResourcesUrls: Gen[renku.ResourcesUrl] = for {
+  implicit val renkuApiUrls: Gen[renku.ApiUrl] = for {
     url  <- httpUrls()
     path <- relativePaths(maxSegments = 1)
-  } yield renku.ResourcesUrl(s"$url/$path")
+  } yield renku.ApiUrl(s"$url/$path")
 
-  def renkuResourceUrls(
-      renkuResourcesUrl: renku.ResourcesUrl = renkuResourcesUrls.generateOne
-  ): Gen[renku.ResourceUrl] = for {
-    path <- relativePaths(maxSegments = 1)
-  } yield renkuResourcesUrl / path
+  def renkuResourceUrls(renkuApiUrl: renku.ApiUrl = renkuApiUrls.generateOne): Gen[renku.ResourceUrl] =
+    relativePaths(maxSegments = 1) map (path => renkuApiUrl / path)
 
   private implicit val sentryDsns: Gen[Dsn] = for {
     url         <- httpUrls()

--- a/graph-commons/src/test/scala/io/renku/graph/config/RenkuUrlLoaderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/config/RenkuUrlLoaderSpec.scala
@@ -23,7 +23,7 @@ import io.renku.config.ConfigLoader.ConfigLoadingException
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators._
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.views.{RdfResource, SparqlValueEncoder}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -32,11 +32,11 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-class RenkuBaseUrlLoaderSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
+class RenkuUrlLoaderSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
 
   "apply" should {
 
-    "return a RenkuBaseUrl if there's a value for 'services.renku.url'" in {
+    "return a renkuUrl if there's a value for 'services.renku.url'" in {
       forAll(httpUrls()) { url =>
         val config = ConfigFactory.parseMap(
           Map(
@@ -48,12 +48,12 @@ class RenkuBaseUrlLoaderSpec extends AnyWordSpec with ScalaCheckPropertyChecks w
           ).asJava
         )
 
-        RenkuBaseUrlLoader[Try](config) shouldBe Success(RenkuBaseUrl(url))
+        RenkuUrlLoader[Try](config) shouldBe Success(RenkuUrl(url))
       }
     }
 
     "fail if there's no value for the 'services.renku.url'" in {
-      val Failure(exception) = RenkuBaseUrlLoader[Try](ConfigFactory.empty())
+      val Failure(exception) = RenkuUrlLoader[Try](ConfigFactory.empty())
       exception shouldBe an[ConfigLoadingException]
     }
 
@@ -68,7 +68,7 @@ class RenkuBaseUrlLoaderSpec extends AnyWordSpec with ScalaCheckPropertyChecks w
         ).asJava
       )
 
-      val Failure(exception) = RenkuBaseUrlLoader[Try](config)
+      val Failure(exception) = RenkuUrlLoader[Try](config)
 
       exception shouldBe an[ConfigLoadingException]
     }
@@ -76,9 +76,9 @@ class RenkuBaseUrlLoaderSpec extends AnyWordSpec with ScalaCheckPropertyChecks w
 
   "showAs[RdfResource]" should {
 
-    "wrap the RenkuBaseUrl in <>" in {
+    "wrap the renkuUrl in <>" in {
       import SparqlValueEncoder.sparqlEncode
-      forAll { url: RenkuBaseUrl =>
+      forAll { url: RenkuUrl =>
         url.showAs[RdfResource] shouldBe s"<${sparqlEncode(url.value)}>"
       }
     }

--- a/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
+++ b/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
@@ -37,7 +37,7 @@ spec:
                 secretKeyRef:
                   name: client-certificate-secret
                   key: client-certificate
-            - name: RENKU_BASE_URL
+            - name: RENKU_URL
               value: https://{{ .Values.global.renku.domain }}
             - name: RENKU_API_URL
               value: https://{{ .Values.global.renku.domain }}{{ .Values.knowledgeGraph.services.renku.resourcesPath }}

--- a/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
+++ b/helm-chart/renku-graph/templates/knowledge-graph-deployment.yaml
@@ -39,7 +39,7 @@ spec:
                   key: client-certificate
             - name: RENKU_BASE_URL
               value: https://{{ .Values.global.renku.domain }}
-            - name: RENKU_RESOURCES_URL
+            - name: RENKU_API_URL
               value: https://{{ .Values.global.renku.domain }}{{ .Values.knowledgeGraph.services.renku.resourcesPath }}
             - name: JENA_DATASET_NAME
               {{- if .Values.global.graph.jena.dataset }}

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
                   key: client-certificate
             - name: RENKU_DOMAIN
               value: {{ .Values.global.renku.domain }}
-            - name: RENKU_BASE_URL
+            - name: RENKU_URL
               value: https://{{ .Values.global.renku.domain }}
             - name: EVENT_LOG_BASE_URL
               value: "http://{{ template "eventLog.fullname" . }}:{{ .Values.eventLog.service.port }}"

--- a/knowledge-graph/src/main/resources/application.conf
+++ b/knowledge-graph/src/main/resources/application.conf
@@ -18,7 +18,7 @@ services {
 
   renku {
     url = ${?RENKU_BASE_URL}
-    resources-url = ${?RENKU_RESOURCES_URL}
+    api-url = ${?RENKU_API_URL}
   }
 
   token-repository {

--- a/knowledge-graph/src/main/resources/application.conf
+++ b/knowledge-graph/src/main/resources/application.conf
@@ -17,7 +17,7 @@ services {
   }
 
   renku {
-    url = ${?RENKU_BASE_URL}
+    url = ${?RENKU_URL}
     api-url = ${?RENKU_API_URL}
   }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/rest/DatasetEndpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/rest/DatasetEndpoint.scala
@@ -48,7 +48,7 @@ trait DatasetEndpoint[F[_]] {
 
 class DatasetEndpointImpl[F[_]: MonadThrow: Logger](
     datasetFinder:         DatasetFinder[F],
-    renkuResourcesUrl:     renku.ResourcesUrl,
+    renkuApiUrl:           renku.ApiUrl,
     gitLabUrl:             GitLabUrl,
     executionTimeRecorder: ExecutionTimeRecorder[F]
 ) extends Http4sDsl[F]
@@ -111,8 +111,8 @@ class DatasetEndpointImpl[F[_]: MonadThrow: Logger](
         ("images" -> (dataset.images, dataset.project).asJson).some
       ).flatten: _*
     ) deepMerge _links(
-      Rel.Self -> DatasetEndpoint.href(renkuResourcesUrl, dataset.id),
-      Rel("initial-version") -> DatasetEndpoint.href(renkuResourcesUrl, dataset.versions.initial.value)
+      Rel.Self -> DatasetEndpoint.href(renkuApiUrl, dataset.id),
+      Rel("initial-version") -> DatasetEndpoint.href(renkuApiUrl, dataset.versions.initial.value)
     )
   }
   // format: on
@@ -147,7 +147,7 @@ class DatasetEndpointImpl[F[_]: MonadThrow: Logger](
     json"""{
       "path": ${project.path},
       "name": ${project.name}
-    }""" deepMerge _links(Link(Rel("project-details") -> ProjectEndpoint.href(renkuResourcesUrl, project.path)))
+    }""" deepMerge _links(Link(Rel("project-details") -> ProjectEndpoint.href(renkuApiUrl, project.path)))
   }
 
   private implicit lazy val versionsEncoder: Encoder[DatasetVersions] = Encoder.instance[DatasetVersions] { versions =>
@@ -179,11 +179,11 @@ object DatasetEndpoint {
 
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[DatasetEndpoint[F]] = for {
     datasetFinder         <- DatasetFinder[F]
-    renkuResourceUrl      <- renku.ResourcesUrl[F]()
+    renkuApiUrl           <- renku.ApiUrl[F]()
     gitLabUrl             <- GitLabUrlLoader[F]()
     executionTimeRecorder <- ExecutionTimeRecorder[F]()
-  } yield new DatasetEndpointImpl[F](datasetFinder, renkuResourceUrl, gitLabUrl, executionTimeRecorder)
+  } yield new DatasetEndpointImpl[F](datasetFinder, renkuApiUrl, gitLabUrl, executionTimeRecorder)
 
-  def href(renkuResourcesUrl: renku.ResourcesUrl, identifier: Identifier): Href =
-    Href(renkuResourcesUrl / "datasets" / identifier)
+  def href(renkuApiUrl: renku.ApiUrl, identifier: Identifier): Href =
+    Href(renkuApiUrl / "datasets" / identifier)
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/rest/ProjectDatasetsEndpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/rest/ProjectDatasetsEndpoint.scala
@@ -46,7 +46,7 @@ trait ProjectDatasetsEndpoint[F[_]] {
 
 class ProjectDatasetsEndpointImpl[F[_]: MonadCancelThrow: Logger](
     projectDatasetsFinder: ProjectDatasetsFinder[F],
-    renkuResourcesUrl:     renku.ResourcesUrl,
+    renkuApiUrl:           renku.ApiUrl,
     gitLabUrl:             GitLabUrl,
     executionTimeRecorder: ExecutionTimeRecorder[F]
 ) extends Http4sDsl[F]
@@ -97,8 +97,8 @@ class ProjectDatasetsEndpointImpl[F[_]: MonadCancelThrow: Logger](
         .deepMerge(sameAsOrDerived.asJson)
         .deepMerge(
           _links(
-            Rel("details")         -> Href(renkuResourcesUrl / "datasets" / id),
-            Rel("initial-version") -> Href(renkuResourcesUrl / "datasets" / originalId)
+            Rel("details")         -> Href(renkuApiUrl / "datasets" / id),
+            Rel("initial-version") -> Href(renkuApiUrl / "datasets" / originalId)
           )
         )
     }
@@ -127,7 +127,7 @@ object ProjectDatasetsEndpoint {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectDatasetsEndpoint[F]] = for {
     rdfStoreConfig        <- RdfStoreConfig[F]()
     gitLabUrl             <- GitLabUrlLoader[F]()
-    renkuResourceUrl      <- renku.ResourcesUrl[F]()
+    renkuResourceUrl      <- renku.ApiUrl[F]()
     executionTimeRecorder <- ExecutionTimeRecorder[F]()
     projectDatasetFinder  <- ProjectDatasetsFinder(rdfStoreConfig)
   } yield new ProjectDatasetsEndpointImpl[F](
@@ -137,6 +137,6 @@ object ProjectDatasetsEndpoint {
     executionTimeRecorder
   )
 
-  def href(renkuResourcesUrl: renku.ResourcesUrl, projectPath: projects.Path): Href =
-    Href(renkuResourcesUrl / "projects" / projectPath / "datasets")
+  def href(renkuApiUrl: renku.ApiUrl, projectPath: projects.Path): Href =
+    Href(renkuApiUrl / "projects" / projectPath / "datasets")
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/Endpoint.scala
@@ -182,17 +182,17 @@ object Endpoint {
   private def parsingFailure(paramName: String) = ParseFailure(s"'$paramName' parameter with invalid value", "")
 
   def apply[F[_]: Async: NonEmptyParallel: Logger: SparqlQueryTimeRecorder]: F[Endpoint[F]] = for {
-    entitiesFinder    <- EntitiesFinder[F]
-    renkuUrl          <- RenkuUrlLoader()
-    renkuResourcesUrl <- renku.ResourcesUrl()
-    gitLabUrl         <- GitLabUrlLoader[F]()
-  } yield new EndpointImpl(entitiesFinder, renkuUrl, renkuResourcesUrl, gitLabUrl)
+    entitiesFinder <- EntitiesFinder[F]
+    renkuUrl       <- RenkuUrlLoader()
+    renkuApiUrl    <- renku.ApiUrl()
+    gitLabUrl      <- GitLabUrlLoader[F]()
+  } yield new EndpointImpl(entitiesFinder, renkuUrl, renkuApiUrl, gitLabUrl)
 }
 
 private class EndpointImpl[F[_]: Async: Logger](finder: EntitiesFinder[F],
-                                                renkuUrl:          RenkuUrl,
-                                                renkuResourcesUrl: renku.ResourcesUrl,
-                                                gitLabUrl:         GitLabUrl
+                                                renkuUrl:    RenkuUrl,
+                                                renkuApiUrl: renku.ApiUrl,
+                                                gitLabUrl:   GitLabUrl
 ) extends Http4sDsl[F]
     with Endpoint[F] {
 
@@ -235,7 +235,7 @@ private class EndpointImpl[F[_]: Async: Logger](finder: EntitiesFinder[F],
           .addIfDefined("description" -> project.maybeDescription)
           .deepMerge(
             _links(
-              Link(Rel("details") -> ProjectEndpoint.href(renkuResourcesUrl, project.path))
+              Link(Rel("details") -> ProjectEndpoint.href(renkuApiUrl, project.path))
             )
           )
       case ds: model.Entity.Dataset =>
@@ -252,7 +252,7 @@ private class EndpointImpl[F[_]: Async: Logger](finder: EntitiesFinder[F],
           .addIfDefined("description" -> ds.maybeDescription)
           .deepMerge(
             _links(
-              Link(Rel("details") -> DatasetEndpoint.href(renkuResourcesUrl, ds.identifier))
+              Link(Rel("details") -> DatasetEndpoint.href(renkuApiUrl, ds.identifier))
             )
           )
       case workflow: model.Entity.Workflow =>

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/rest/ProjectEndpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/rest/ProjectEndpoint.scala
@@ -46,7 +46,7 @@ trait ProjectEndpoint[F[_]] {
 
 class ProjectEndpointImpl[F[_]: MonadThrow: Logger](
     projectFinder:         ProjectFinder[F],
-    renkuResourcesUrl:     renku.ResourcesUrl,
+    renkuApiUrl:           renku.ApiUrl,
     executionTimeRecorder: ExecutionTimeRecorder[F]
 ) extends Http4sDsl[F]
     with ProjectEndpoint[F] {
@@ -97,8 +97,8 @@ class ProjectEndpointImpl[F[_]: MonadThrow: Logger](
       "permissions":${project.permissions},
       "statistics": ${project.statistics}
     }""" deepMerge _links(
-      Link(Rel.Self        -> ProjectEndpoint.href(renkuResourcesUrl, project.path)),
-      Link(Rel("datasets") -> ProjectDatasetsEndpoint.href(renkuResourcesUrl, project.path))
+      Link(Rel.Self        -> ProjectEndpoint.href(renkuApiUrl, project.path)),
+      Link(Rel("datasets") -> ProjectDatasetsEndpoint.href(renkuApiUrl, project.path))
     ).addIfDefined("description" -> project.maybeDescription)
       .addIfDefined("version" -> project.maybeVersion)
   }
@@ -176,7 +176,7 @@ object ProjectEndpoint {
       gitLabClient: GitLabClient[F]
   ): F[ProjectEndpoint[F]] = for {
     projectFinder         <- ProjectFinder[F](gitLabClient)
-    renkuResourceUrl      <- renku.ResourcesUrl[F]()
+    renkuResourceUrl      <- renku.ApiUrl[F]()
     executionTimeRecorder <- ExecutionTimeRecorder[F]()
   } yield new ProjectEndpointImpl[F](
     projectFinder,
@@ -184,6 +184,6 @@ object ProjectEndpoint {
     executionTimeRecorder
   )
 
-  def href(renkuResourcesUrl: renku.ResourcesUrl, projectPath: projects.Path): Href =
-    Href(renkuResourcesUrl / "projects" / projectPath)
+  def href(renkuApiUrl: renku.ApiUrl, projectPath: projects.Path): Href =
+    Href(renkuApiUrl / "projects" / projectPath)
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/BaseDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/BaseDetailsFinderSpec.scala
@@ -24,7 +24,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.datasets.ResourceId
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.{RenkuBaseUrl, datasets, testentities}
+import io.renku.graph.model.{RenkuUrl, datasets, testentities}
 import io.renku.jsonld.syntax._
 import io.renku.knowledgegraph.datasets.model
 import io.renku.tinytypes.json.TinyTypeEncoders
@@ -101,7 +101,7 @@ class BaseDetailsFinderSpec
   private def nonModifiedToResultSet(project:     testentities.RenkuProject,
                                      dataset:     testentities.Dataset[testentities.Dataset.Provenance.NonModified],
                                      description: String
-  )(implicit renkuBaseUrl:                        RenkuBaseUrl) = {
+  )(implicit renkuUrl:                            RenkuUrl) = {
     val binding = json"""{
       "datasetId":      {"value": ${ResourceId(dataset.asEntityId.show)}},
       "identifier":     {"value": ${dataset.identifier}},

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
@@ -33,7 +33,7 @@ import io.renku.graph.model.datasets._
 import io.renku.graph.model.projects.Path
 import io.renku.graph.model.testentities._
 import io.renku.graph.model.persons.{Affiliation, Email, Name => UserName}
-import io.renku.graph.model.{RenkuBaseUrl, projects}
+import io.renku.graph.model.{RenkuUrl, projects}
 import io.renku.http.InfoMessage._
 import io.renku.http.rest.Links
 import io.renku.http.rest.Links.Rel.Self
@@ -178,7 +178,7 @@ class DatasetEndpointSpec
   }
 
   private trait TestCase {
-    implicit val renkuBaseUrl: RenkuBaseUrl = renkuBaseUrls.generateOne
+    implicit val renkuUrl: RenkuUrl = renkuUrls.generateOne
     val gitLabUrl = gitLabUrls.generateOne
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetEndpointSpec.scala
@@ -24,7 +24,7 @@ import cats.syntax.all._
 import io.circe.Decoder._
 import io.circe.syntax._
 import io.circe.{Decoder, DecodingFailure, Json}
-import io.renku.generators.CommonGraphGenerators.{authContexts, renkuResourcesUrls}
+import io.renku.generators.CommonGraphGenerators.{authContexts, renkuApiUrls}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.http.server.security.Authorizer.AuthContext
@@ -92,8 +92,8 @@ class DatasetEndpointSpec
         response.as[model.Dataset].unsafeRunSync() shouldBe dataset
         response.as[Json].unsafeRunSync()._links shouldBe Links
           .of(
-            Self                   -> Href(renkuResourcesUrl / "datasets" / dataset.id),
-            Rel("initial-version") -> Href(renkuResourcesUrl / "datasets" / dataset.versions.initial)
+            Self                   -> Href(renkuApiUrl / "datasets" / dataset.id),
+            Rel("initial-version") -> Href(renkuApiUrl / "datasets" / dataset.versions.initial)
           )
           .asRight
 
@@ -102,7 +102,7 @@ class DatasetEndpointSpec
         val Right(mainProject) = responseCursor.downField("project").as[Json]
         (mainProject.hcursor.downField("path").as[Path], mainProject._links)
           .mapN { case (path, links) =>
-            links shouldBe Links.of(Rel("project-details") -> Href(renkuResourcesUrl / "projects" / path))
+            links shouldBe Links.of(Rel("project-details") -> Href(renkuApiUrl / "projects" / path))
           }
           .getOrElse(fail("No 'path' or 'project-details' links on the 'project' element"))
 
@@ -111,7 +111,7 @@ class DatasetEndpointSpec
         usedInJsons.foreach { json =>
           (json.hcursor.downField("path").as[Path], json._links)
             .mapN { case (path, links) =>
-              links shouldBe Links.of(Rel("project-details") -> Href(renkuResourcesUrl / "projects" / path))
+              links shouldBe Links.of(Rel("project-details") -> Href(renkuApiUrl / "projects" / path))
             }
             .getOrElse(fail("No 'path' or 'project-details' links on the 'usedIn' elements"))
         }
@@ -183,9 +183,9 @@ class DatasetEndpointSpec
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val datasetsFinder        = mock[DatasetFinder[IO]]
-    val renkuResourcesUrl     = renkuResourcesUrls.generateOne
+    val renkuApiUrl           = renkuApiUrls.generateOne
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
-    val endpoint = new DatasetEndpointImpl[IO](datasetsFinder, renkuResourcesUrl, gitLabUrl, executionTimeRecorder)
+    val endpoint = new DatasetEndpointImpl[IO](datasetsFinder, renkuApiUrl, gitLabUrl, executionTimeRecorder)
   }
 
   private implicit val datasetEntityDecoder: EntityDecoder[IO, model.Dataset] = jsonOf[IO, model.Dataset]

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetFinderSpec.scala
@@ -24,7 +24,7 @@ import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.http.server.security.Authorizer.AuthContext
 import io.renku.graph.model.GraphModelGenerators._
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.datasets.SameAs
 import io.renku.graph.model.testentities._
 import io.renku.interpreters.TestLogger
@@ -630,7 +630,7 @@ class DatasetFinderSpec
   }
 
   private trait TestCase {
-    implicit val renkuBaseUrl:         RenkuBaseUrl                = renkuBaseUrls.generateOne
+    implicit val renkuUrl:             RenkuUrl                    = renkuUrls.generateOne
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     val datasetFinder = new DatasetFinderImpl[IO](

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetsSearchEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetsSearchEndpointSpec.scala
@@ -147,15 +147,15 @@ class DatasetsSearchEndpointSpec
 
     val maybeAuthUser = authUsers.generateOption
 
-    private val renkuResourcesUrl = renkuResourcesUrls.generateOne
+    private val renkuApiUrl = renkuApiUrls.generateOne
     implicit val renkuResourceUrl: renku.ResourceUrl =
-      (renkuResourcesUrl / "datasets") ? (page.parameterName -> pagingRequest.page) & (perPage.parameterName -> pagingRequest.perPage) & (Sort.sort.parameterName -> sort) && (query.parameterName -> maybePhrase)
+      (renkuApiUrl / "datasets") ? (page.parameterName -> pagingRequest.page) & (perPage.parameterName -> pagingRequest.perPage) & (Sort.sort.parameterName -> sort) && (query.parameterName -> maybePhrase)
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val datasetsFinder        = mock[DatasetsFinder[IO]]
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
     val endpoint =
-      new DatasetsSearchEndpointImpl[IO](datasetsFinder, renkuResourcesUrl, gitLabUrl, executionTimeRecorder)
+      new DatasetsSearchEndpointImpl[IO](datasetsFinder, renkuApiUrl, gitLabUrl, executionTimeRecorder)
 
     lazy val toJson: DatasetSearchResult => Json = {
       case DatasetSearchResult(id,
@@ -180,7 +180,7 @@ class DatasetsSearchEndpointSpec
           "images": ${images -> exemplarProjectPath},
           "_links": [{
             "rel": "details",
-            "href": ${(renkuResourcesUrl / "datasets" / id).value}
+            "href": ${(renkuApiUrl / "datasets" / id).value}
           }]
         }""" addIfDefined "description" -> maybeDescription
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/ProjectDatasetsEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/ProjectDatasetsEndpointSpec.scala
@@ -121,12 +121,12 @@ class ProjectDatasetsEndpointSpec
     val projectPath = projectPaths.generateOne
 
     val projectDatasetsFinder = mock[ProjectDatasetsFinder[IO]]
-    val renkuResourcesUrl     = renkuResourcesUrls.generateOne
+    val renkuApiUrl           = renkuApiUrls.generateOne
     val gitLabUrl             = gitLabUrls.generateOne
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
     val endpoint =
-      new ProjectDatasetsEndpointImpl[IO](projectDatasetsFinder, renkuResourcesUrl, gitLabUrl, executionTimeRecorder)
+      new ProjectDatasetsEndpointImpl[IO](projectDatasetsFinder, renkuApiUrl, gitLabUrl, executionTimeRecorder)
 
     lazy val toJson: ((Identifier, OriginalIdentifier, Title, Name, SameAsOrDerived, List[ImageUri])) => Json = {
       case (id, originalId, title, name, Left(sameAs), images) =>
@@ -141,10 +141,10 @@ class ProjectDatasetsEndpointSpec
           "images": $images,
           "_links": [{
             "rel": "details",
-            "href": ${renkuResourcesUrl / "datasets" / id}
+            "href": ${renkuApiUrl / "datasets" / id}
           }, {
             "rel": "initial-version",
-            "href": ${renkuResourcesUrl / "datasets" / originalId}
+            "href": ${renkuApiUrl / "datasets" / originalId}
           }]
         }"""
       case (id, originalId, title, name, Right(derivedFrom), images) =>
@@ -159,10 +159,10 @@ class ProjectDatasetsEndpointSpec
           "images": $images,
           "_links": [{
             "rel": "details",
-            "href": ${renkuResourcesUrl / "datasets" / id}
+            "href": ${renkuApiUrl / "datasets" / id}
           }, {
             "rel": "initial-version",
-            "href": ${renkuResourcesUrl / "datasets" / originalId}
+            "href": ${renkuApiUrl / "datasets" / originalId}
           }]
         }"""
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/package.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/package.scala
@@ -24,7 +24,7 @@ import io.renku.generators.CommonGraphGenerators.sortBys
 import io.renku.generators.Generators._
 import io.renku.graph.model.datasets._
 import io.renku.graph.model.testentities.{Dataset, HavingInvalidationTime, Person, RenkuProject}
-import io.renku.graph.model.{RenkuBaseUrl, testentities}
+import io.renku.graph.model.{RenkuUrl, testentities}
 import io.renku.jsonld.syntax._
 import io.renku.knowledgegraph.datasets.model._
 import io.renku.knowledgegraph.datasets.rest.DatasetsSearchEndpoint.Query.Phrase
@@ -41,7 +41,7 @@ package object rest {
     project => DatasetProject(project.path, project.name)
 
   def internalToNonModified(dataset: Dataset[Dataset.Provenance.Internal], project: RenkuProject)(implicit
-      renkuBaseUrl:                  RenkuBaseUrl
+      renkuUrl:                      RenkuUrl
   ): NonModifiedDataset = NonModifiedDataset(
     ResourceId(dataset.asEntityId.show),
     dataset.identification.identifier,
@@ -60,7 +60,7 @@ package object rest {
   )
 
   def importedExternalToNonModified(dataset: Dataset[Dataset.Provenance.ImportedExternal], project: RenkuProject)(
-      implicit renkuBaseUrl:                 RenkuBaseUrl
+      implicit renkuUrl:                     RenkuUrl
   ): NonModifiedDataset = NonModifiedDataset(
     ResourceId(dataset.asEntityId.show),
     dataset.identification.identifier,
@@ -79,7 +79,7 @@ package object rest {
   )
 
   def importedInternalToNonModified(dataset: Dataset[Dataset.Provenance.ImportedInternal], project: RenkuProject)(
-      implicit renkuBaseUrl:                 RenkuBaseUrl
+      implicit renkuUrl:                     RenkuUrl
   ): NonModifiedDataset = NonModifiedDataset(
     ResourceId(dataset.asEntityId.show),
     dataset.identification.identifier,
@@ -98,7 +98,7 @@ package object rest {
   )
 
   def modifiedToModified(dataset: Dataset[Dataset.Provenance.Modified], project: RenkuProject)(implicit
-      renkuBaseUrl:               RenkuBaseUrl
+      renkuUrl:                   RenkuUrl
   ): ModifiedDataset = ModifiedDataset(
     ResourceId(dataset.asEntityId.show),
     dataset.identifier,

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
@@ -28,7 +28,7 @@ import io.renku.config.renku.ResourceUrl
 import io.renku.generators.CommonGraphGenerators.{authUsers, pagingRequests, pagingResponses, sortBys}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
-import io.renku.graph.model.GraphModelGenerators.{gitLabUrls, renkuBaseUrls}
+import io.renku.graph.model.GraphModelGenerators.{gitLabUrls, renkuUrls}
 import io.renku.graph.model._
 import io.renku.http.ErrorMessage
 import io.renku.http.ErrorMessage._
@@ -115,19 +115,19 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
     }
   }
 
-  private lazy val renkuBaseUrl = renkuBaseUrls.generateOne
+  private lazy val renkuUrl = renkuUrls.generateOne
   private lazy val renkuResourcesUrl =
-    renku.ResourcesUrl(s"$renkuBaseUrl/${relativePaths(maxSegments = 1).generateOne}")
+    renku.ResourcesUrl(s"$renkuUrl/${relativePaths(maxSegments = 1).generateOne}")
 
   private trait TestCase {
     val criteria = criterias.generateOne
     val request  = Request[IO](GET, Uri.fromString(s"/${relativePaths().generateOne}").fold(throw _, identity))
 
-    implicit val renkuResourceUrl: renku.ResourceUrl = renku.ResourceUrl(show"$renkuBaseUrl${request.uri}")
+    implicit val renkuResourceUrl: renku.ResourceUrl = renku.ResourceUrl(show"$renkuUrl${request.uri}")
     implicit val logger:           TestLogger[IO]    = TestLogger[IO]()
     implicit val gitLabUrl:        GitLabUrl         = gitLabUrls.generateOne
     val finder   = mock[EntitiesFinder[IO]]
-    val endpoint = new EndpointImpl[IO](finder, renkuBaseUrl, renkuResourcesUrl, gitLabUrl)
+    val endpoint = new EndpointImpl[IO](finder, renkuUrl, renkuResourcesUrl, gitLabUrl)
   }
 
   private lazy val criterias: Gen[Criteria] = for {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/package.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/package.scala
@@ -23,7 +23,7 @@ import eu.timepit.refined.auto._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{localDatesNotInTheFuture, nonBlankStrings}
 import io.renku.graph.model.testentities.{Entity => _, _}
-import io.renku.graph.model.{RenkuBaseUrl, testentities}
+import io.renku.graph.model.{RenkuUrl, testentities}
 import org.scalacheck.Gen
 import org.scalacheck.Gen.choose
 
@@ -78,7 +78,7 @@ package object entities {
 
   private[entities] implicit class ProjectDatasetOps[PROV <: testentities.Dataset.Provenance,
                                                      +P <: testentities.Project
-  ](datasetAndProject: (testentities.Dataset[PROV], P))(implicit renkuBaseUrl: RenkuBaseUrl) {
+  ](datasetAndProject: (testentities.Dataset[PROV], P))(implicit renkuUrl: RenkuUrl) {
     def to[T](implicit convert: ((testentities.Dataset[PROV], P)) => T): T = convert(datasetAndProject)
   }
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/EdgesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/EdgesFinderSpec.scala
@@ -239,7 +239,7 @@ class EdgesFinderSpec
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] =
       TestSparqlQueryTimeRecorder[IO](executionTimeRecorder)
-    val edgesFinder = new EdgesFinderImpl[IO](rdfStoreConfig, renkuBaseUrl)
+    val edgesFinder = new EdgesFinderImpl[IO](rdfStoreConfig, renkuUrl)
   }
 
   private implicit class NodeDefOps(nodeDef: NodeDef) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/NodeDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/NodeDetailsFinderSpec.scala
@@ -259,7 +259,7 @@ class NodeDetailsFinderSpec
   private trait TestCase {
     implicit val logger:               TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val nodeDetailsFinder = new NodeDetailsFinderImpl[IO](rdfStoreConfig, renkuBaseUrl)
+    val nodeDetailsFinder = new NodeDetailsFinderImpl[IO](rdfStoreConfig, renkuUrl)
   }
 
   private implicit class NodeDefOps(nodeDef: NodeDef) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/rest/ProjectEndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/rest/ProjectEndpointSpec.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import io.circe.syntax._
 import io.circe.{Decoder, DecodingFailure, Json}
-import io.renku.generators.CommonGraphGenerators.{authUsers, renkuResourcesUrls}
+import io.renku.generators.CommonGraphGenerators.{authUsers, renkuApiUrls}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators._
@@ -80,8 +80,8 @@ class ProjectEndpointSpec
         response.as[Project].unsafeRunSync() shouldBe project
         response.as[Json].unsafeRunSync()._links shouldBe Right(
           Links.of(
-            Rel.Self        -> Href(renkuResourcesUrl / "projects" / project.path),
-            Rel("datasets") -> Href(renkuResourcesUrl / "projects" / project.path / "datasets")
+            Rel.Self        -> Href(renkuApiUrl / "projects" / project.path),
+            Rel("datasets") -> Href(renkuApiUrl / "projects" / project.path / "datasets")
           )
         )
 
@@ -136,9 +136,9 @@ class ProjectEndpointSpec
   private trait TestCase {
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val projectFinder         = mock[ProjectFinder[IO]]
-    val renkuResourcesUrl     = renkuResourcesUrls.generateOne
+    val renkuApiUrl           = renkuApiUrls.generateOne
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
-    val endpoint              = new ProjectEndpointImpl[IO](projectFinder, renkuResourcesUrl, executionTimeRecorder)
+    val endpoint              = new ProjectEndpointImpl[IO](projectFinder, renkuApiUrl, executionTimeRecorder)
   }
 
   private implicit val projectEntityDecoder: EntityDecoder[IO, Project] = jsonOf[IO, Project]

--- a/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
@@ -214,7 +214,7 @@ object datasets {
       with constraints.Url[SameAs]
       with UrlResourceRenderer[SameAs] {
 
-    final def internal(value: RenkuBaseUrl): Either[IllegalArgumentException, InternalSameAs] =
+    final def internal(value: RenkuUrl): Either[IllegalArgumentException, InternalSameAs] =
       from(value.value) map (sameAs => new InternalSameAs(sameAs.value))
 
     final def external(value: String Refined string.Url): Either[IllegalArgumentException, ExternalSameAs] =

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Activity.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Activity.scala
@@ -21,7 +21,7 @@ package io.renku.graph.model.entities
 import cats.data.{Validated, ValidatedNel}
 import cats.syntax.all._
 import io.circe.DecodingFailure
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.activities.{EndTime, ResourceId, StartTime}
 import io.renku.graph.model.entities.ParameterValue.{CommandInputValue, CommandOutputValue}
 
@@ -97,7 +97,7 @@ object Activity {
     case (result, _) => result
   }
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[Activity] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[Activity] =
     JsonLDEncoder.instance { activity =>
       JsonLD.entity(
         activity.resourceId.asEntityId,
@@ -112,7 +112,7 @@ object Activity {
       )
     }
 
-  implicit def decoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[Activity] =
+  implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Activity] =
     JsonLDDecoder.entity(entityTypes) { cursor =>
       import io.renku.jsonld.JsonLDDecoder.decodeList
 

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Association.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Association.scala
@@ -20,7 +20,7 @@ package io.renku.graph.model.entities
 
 import cats.syntax.all._
 import io.circe.DecodingFailure
-import io.renku.graph.model.{GitLabApiUrl, RenkuBaseUrl}
+import io.renku.graph.model.{GitLabApiUrl, RenkuUrl}
 import io.renku.graph.model.Schemas.prov
 import io.renku.graph.model.associations.ResourceId
 import io.renku.jsonld._
@@ -61,7 +61,7 @@ object Association {
       )
   }
 
-  implicit def decoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[Association] =
+  implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Association] =
     JsonLDDecoder.entity(entityTypes) { implicit cursor =>
       for {
         resourceId <- cursor.downEntityId.as[ResourceId]
@@ -73,11 +73,9 @@ object Association {
       } yield association
     }
 
-  private def tryAsPersonAgent(resourceId: ResourceId, plan: Plan)(implicit
-      cursor:                              Cursor,
-      renkuBaseUrl:                        RenkuBaseUrl
-  ) = cursor.downField(prov / "agent").as[Option[Person]] >>= {
-    case Some(agent) => Association.WithPersonAgent(resourceId, agent, plan).asRight
-    case None        => DecodingFailure(show"Association $resourceId without a valid ${prov / "agent"}", Nil).asLeft
-  }
+  private def tryAsPersonAgent(resourceId: ResourceId, plan: Plan)(implicit cursor: Cursor, renkuUrl: RenkuUrl) =
+    cursor.downField(prov / "agent").as[Option[Person]] >>= {
+      case Some(agent) => Association.WithPersonAgent(resourceId, agent, plan).asRight
+      case None        => DecodingFailure(show"Association $resourceId without a valid ${prov / "agent"}", Nil).asLeft
+    }
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Dataset.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Dataset.scala
@@ -24,7 +24,7 @@ import io.circe.DecodingFailure
 import io.renku.graph.model.datasets._
 import io.renku.graph.model.entities.Dataset.Provenance._
 import io.renku.graph.model.entities.Dataset._
-import io.renku.graph.model.{GitLabApiUrl, InvalidationTime, RenkuBaseUrl}
+import io.renku.graph.model.{GitLabApiUrl, InvalidationTime, RenkuUrl}
 
 import java.time.Instant
 
@@ -217,7 +217,7 @@ object Dataset {
     }
 
     private[Dataset] implicit def encoder(implicit
-        renkuBaseUrl: RenkuBaseUrl,
+        renkuUrl:     RenkuUrl,
         gitLabApiUrl: GitLabApiUrl
     ): Provenance => Map[Property, JsonLD] = {
       case provenance @ Internal(_, _, date, creators) =>
@@ -275,8 +275,8 @@ object Dataset {
     }
 
     private[Dataset] def decoder(
-        identification:      Identification
-    )(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[(Provenance, Option[FixableFailure])] =
+        identification:  Identification
+    )(implicit renkuUrl: RenkuUrl): JsonLDDecoder[(Provenance, Option[FixableFailure])] =
       JsonLDDecoder.entity(entityTypes) { cursor =>
         import io.renku.graph.model.views.StringTinyTypeJsonLDDecoders._
 
@@ -455,7 +455,7 @@ object Dataset {
   val entityTypes: EntityTypes = EntityTypes of (schema / "Dataset", prov / "Entity")
 
   implicit def encoder[P <: Provenance](implicit
-      renkuBaseUrl: RenkuBaseUrl,
+      renkuUrl:     RenkuUrl,
       gitLabApiUrl: GitLabApiUrl
   ): JsonLDEncoder[Dataset[P]] = {
     implicit class SerializationOps[T](obj: T) {
@@ -477,7 +477,7 @@ object Dataset {
     }
   }
 
-  implicit def decoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[Dataset[Provenance]] =
+  implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Dataset[Provenance]] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       import Dataset.Provenance.FixableFailure
       import Dataset.Provenance.FixableFailure.MissingDerivedFrom

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Person.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Person.scala
@@ -22,7 +22,7 @@ import cats.data.ValidatedNel
 import cats.syntax.all._
 import io.circe.DecodingFailure
 import io.renku.graph.model.persons.{Affiliation, Email, GitLabId, Name, OrcidId, ResourceId}
-import io.renku.graph.model.{GitLabApiUrl, RenkuBaseUrl}
+import io.renku.graph.model.{GitLabApiUrl, RenkuUrl}
 import io.renku.jsonld.JsonLDDecoder.{Result, decodeList}
 import io.renku.jsonld._
 
@@ -36,7 +36,7 @@ sealed trait Person extends PersonAlgebra with Product with Serializable {
 }
 
 sealed trait PersonAlgebra {
-  def add(gitLabId: GitLabId)(implicit renkuBaseUrl: RenkuBaseUrl): Person.WithGitLabId
+  def add(gitLabId: GitLabId)(implicit renkuUrl: RenkuUrl): Person.WithGitLabId
 }
 
 object Person {
@@ -52,7 +52,7 @@ object Person {
 
     override type Id = ResourceId.GitLabIdBased
 
-    override def add(gitLabId: GitLabId)(implicit renkuBaseUrl: RenkuBaseUrl): WithGitLabId =
+    override def add(gitLabId: GitLabId)(implicit renkuUrl: RenkuUrl): WithGitLabId =
       copy(resourceId = ResourceId(gitLabId), gitLabId = gitLabId)
   }
 
@@ -67,7 +67,7 @@ object Person {
 
     val maybeEmail: Option[Email] = Some(email)
 
-    override def add(gitLabId: GitLabId)(implicit renkuBaseUrl: RenkuBaseUrl): WithGitLabId =
+    override def add(gitLabId: GitLabId)(implicit renkuUrl: RenkuUrl): WithGitLabId =
       Person.WithGitLabId(ResourceId(gitLabId), gitLabId, name, email.some, maybeOrcidId, maybeAffiliation)
   }
 
@@ -81,7 +81,7 @@ object Person {
 
     val maybeEmail: Option[Email] = None
 
-    override def add(gitLabId: GitLabId)(implicit renkuBaseUrl: RenkuBaseUrl): WithGitLabId =
+    override def add(gitLabId: GitLabId)(implicit renkuUrl: RenkuUrl): WithGitLabId =
       Person.WithGitLabId(ResourceId(gitLabId), gitLabId, name, maybeEmail = None, maybeOrcidId, maybeAffiliation)
   }
 
@@ -171,7 +171,7 @@ object Person {
     )
   }
 
-  implicit def decoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[Person] =
+  implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Person] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       import io.renku.graph.model.views.StringTinyTypeJsonLDDecoders._
 

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Project.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Project.scala
@@ -334,7 +334,7 @@ object Project {
   val entityTypes: EntityTypes = EntityTypes.of(prov / "Location", schema / "Project")
 
   implicit def encoder[P <: Project](implicit
-      renkuBaseUrl: RenkuBaseUrl,
+      renkuUrl:     RenkuUrl,
       gitLabApiUrl: GitLabApiUrl
   ): JsonLDEncoder[P] = JsonLDEncoder.instance {
     case project: RenkuProject =>
@@ -387,7 +387,7 @@ object Project {
       }
   }
 
-  def decoder(gitLabInfo: GitLabProjectInfo)(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[Project] =
+  def decoder(gitLabInfo: GitLabProjectInfo)(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Project] =
     ProjectJsonLDDecoder(gitLabInfo)
 
   final case class GitLabProjectInfo(id:               Id,

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ProjectJsonLDDecoder.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ProjectJsonLDDecoder.scala
@@ -31,7 +31,7 @@ import io.renku.jsonld.{Cursor, JsonLDDecoder}
 
 object ProjectJsonLDDecoder {
 
-  def apply(gitLabInfo: GitLabProjectInfo)(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDDecoder[Project] =
+  def apply(gitLabInfo: GitLabProjectInfo)(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Project] =
     JsonLDDecoder.entity(entityTypes) { implicit cursor =>
       val maybeDescriptionR = cursor
         .downField(schema / "description")
@@ -67,7 +67,7 @@ object ProjectJsonLDDecoder {
       } yield project
     }
 
-  private def findAllPersons(gitLabInfo: GitLabProjectInfo)(implicit cursor: Cursor, renkuBaseUrl: RenkuBaseUrl) =
+  private def findAllPersons(gitLabInfo: GitLabProjectInfo)(implicit cursor: Cursor, renkuUrl: RenkuUrl) =
     cursor.focusTop
       .as[List[Person]]
       .map(_.toSet)
@@ -85,7 +85,7 @@ object ProjectJsonLDDecoder {
                          allJsonLdPersons: Set[Person],
                          activities:       List[Activity],
                          datasets:         List[Dataset[Dataset.Provenance]]
-  )(implicit renkuBaseUrl:                 RenkuBaseUrl): Either[DecodingFailure, Project] = {
+  )(implicit renkuUrl:                     RenkuUrl): Either[DecodingFailure, Project] = {
     (maybeAgent, maybeVersion, gitLabInfo.maybeParentPath) match {
       case (Some(agent), Some(version), Some(parentPath)) =>
         RenkuProject.WithParent
@@ -168,7 +168,7 @@ object ProjectJsonLDDecoder {
 
   private def maybeCreator(
       allJsonLdPersons: Set[Person]
-  )(gitLabInfo:         GitLabProjectInfo)(implicit renkuBaseUrl: RenkuBaseUrl): Option[Person] =
+  )(gitLabInfo:         GitLabProjectInfo)(implicit renkuUrl: RenkuUrl): Option[Person] =
     gitLabInfo.maybeCreator.map { creator =>
       allJsonLdPersons
         .find(byEmailOrUsername(creator))
@@ -178,7 +178,7 @@ object ProjectJsonLDDecoder {
 
   private def members(
       allJsonLdPersons: Set[Person]
-  )(gitLabInfo:         GitLabProjectInfo)(implicit renkuBaseUrl: RenkuBaseUrl): Set[Person] =
+  )(gitLabInfo:         GitLabProjectInfo)(implicit renkuUrl: RenkuUrl): Set[Person] =
     gitLabInfo.members.map(member =>
       allJsonLdPersons
         .find(byEmailOrUsername(member))
@@ -196,7 +196,7 @@ object ProjectJsonLDDecoder {
     case member: ProjectMemberNoEmail => person => person.name.value == member.username.value
   }
 
-  private def merge(member: Project.ProjectMember)(implicit renkuBaseUrl: RenkuBaseUrl): Person => Person =
+  private def merge(member: Project.ProjectMember)(implicit renkuUrl: RenkuUrl): Person => Person =
     member match {
       case ProjectMemberWithEmail(name, _, gitLabId, email) =>
         _.add(gitLabId).copy(name = name, maybeEmail = email.some)
@@ -204,7 +204,7 @@ object ProjectJsonLDDecoder {
         _.add(gitLabId).copy(name = name)
     }
 
-  private def toPerson(projectMember: ProjectMember)(implicit renkuBaseUrl: RenkuBaseUrl): Person =
+  private def toPerson(projectMember: ProjectMember)(implicit renkuUrl: RenkuUrl): Person =
     projectMember match {
       case ProjectMemberNoEmail(name, _, gitLabId) =>
         Person.WithGitLabId(persons.ResourceId(gitLabId),

--- a/renku-model/src/main/scala/io/renku/graph/model/infra.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/infra.scala
@@ -25,12 +25,12 @@ import io.renku.tinytypes.constraints.{NonBlank, Url, UrlOps}
 import io.renku.tinytypes.json.TinyTypeDecoders
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory, UrlTinyType}
 
-final class RenkuBaseUrl private (val value: String) extends AnyVal with UrlTinyType
-object RenkuBaseUrl
-    extends TinyTypeFactory[RenkuBaseUrl](new RenkuBaseUrl(_))
-    with Url[RenkuBaseUrl]
-    with UrlOps[RenkuBaseUrl]
-    with UrlResourceRenderer[RenkuBaseUrl]
+final class RenkuUrl private (val value: String) extends AnyVal with UrlTinyType
+object RenkuUrl
+    extends TinyTypeFactory[RenkuUrl](new RenkuUrl(_))
+    with Url[RenkuUrl]
+    with UrlOps[RenkuUrl]
+    with UrlResourceRenderer[RenkuUrl]
 
 final class GitLabUrl private (val value: String) extends AnyVal with UrlTinyType {
   def apiV4: GitLabApiUrl = GitLabApiUrl(this)

--- a/renku-model/src/main/scala/io/renku/graph/model/persons.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/persons.scala
@@ -93,16 +93,16 @@ object persons {
       )
     }
 
-    def apply(gitLabId: GitLabId)(implicit renkuBaseUrl: RenkuBaseUrl): GitLabIdBased =
-      new GitLabIdBased((renkuBaseUrl / "persons" / gitLabId).show)
+    def apply(gitLabId: GitLabId)(implicit renkuUrl: RenkuUrl): GitLabIdBased =
+      new GitLabIdBased((renkuUrl / "persons" / gitLabId).show)
 
-    def apply(orcidId: OrcidId)(implicit renkuBaseUrl: RenkuBaseUrl, ev: OrcidId.type): OrcidIdBased =
-      new OrcidIdBased((renkuBaseUrl / "persons" / "orcid" / orcidId.id).show)
+    def apply(orcidId: OrcidId)(implicit renkuUrl: RenkuUrl, ev: OrcidId.type): OrcidIdBased =
+      new OrcidIdBased((renkuUrl / "persons" / "orcid" / orcidId.id).show)
 
     def apply(email: Email): EmailBased = new EmailBased(show"mailto:$email")
 
-    def apply(name: Name)(implicit renkuBaseUrl: RenkuBaseUrl): NameBased =
-      new NameBased((renkuBaseUrl / "persons" / name).show)
+    def apply(name: Name)(implicit renkuUrl: RenkuUrl): NameBased =
+      new NameBased((renkuUrl / "persons" / name).show)
 
     implicit object UsersResourceIdRdfResourceRenderer extends Renderer[RdfResource, ResourceId] {
       private val localPartExtractor = "^mailto:(.*)@.*$".r

--- a/renku-model/src/main/scala/io/renku/graph/model/plans.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/plans.scala
@@ -34,8 +34,8 @@ object plans {
       with Url[ResourceId]
       with EntityIdJsonLdOps[ResourceId] {
 
-    def apply(identifier: Identifier)(implicit renkuBaseUrl: RenkuBaseUrl): ResourceId =
-      ResourceId((renkuBaseUrl / "plans" / identifier).value)
+    def apply(identifier: Identifier)(implicit renkuUrl: RenkuUrl): ResourceId =
+      ResourceId((renkuUrl / "plans" / identifier).value)
 
     private val identifierExtractor = "^.*\\/plans\\/(.*)$".r
     implicit lazy val toIdentifier: TinyTypeConverter[ResourceId, Identifier] = {

--- a/renku-model/src/main/scala/io/renku/graph/model/projects.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/projects.scala
@@ -70,8 +70,8 @@ object projects {
       message = (value: String) => s"'$value' is not a valid $typeName"
     )
 
-    def apply(projectPath: Path)(implicit renkuBaseUrl: RenkuBaseUrl): ResourceId =
-      ResourceId((renkuBaseUrl / "projects" / projectPath).value)
+    def apply(projectPath: Path)(implicit renkuUrl: RenkuUrl): ResourceId =
+      ResourceId((renkuUrl / "projects" / projectPath).value)
 
     def apply(id: EntityId): ResourceId = ResourceId(id.value.toString)
 

--- a/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
@@ -107,7 +107,7 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     }
 
     "allow to construct InternalSameAs using the internal factory" in {
-      forAll(renkuBaseUrls) { url =>
+      forAll(renkuUrls) { url =>
         val Right(sameAs) = SameAs.internal(url)
         sameAs         should (be(a[SameAs]) and be(a[InternalSameAs]))
         sameAs.value shouldBe url.value
@@ -119,8 +119,8 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
 
     "return true for two SameAs having equal value regardless of the type - case of InternalSameAs" in {
       forAll { sameAs: InternalSameAs =>
-        SameAs.internal(RenkuBaseUrl(sameAs.value)) shouldBe SameAs.from(sameAs.value)
-        SameAs.from(sameAs.value)                   shouldBe SameAs.internal(RenkuBaseUrl(sameAs.value))
+        SameAs.internal(RenkuUrl(sameAs.value)) shouldBe SameAs.from(sameAs.value)
+        SameAs.from(sameAs.value)               shouldBe SameAs.internal(RenkuUrl(sameAs.value))
       }
     }
 
@@ -136,7 +136,7 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
 
     "return same values for two SameAs having equal value regardless of the type" in {
       forAll(datasetSameAs) { sameAs =>
-        SameAs.internal(RenkuBaseUrl(sameAs.value)).map(_.hashCode()) shouldBe SameAs
+        SameAs.internal(RenkuUrl(sameAs.value)).map(_.hashCode()) shouldBe SameAs
           .external(Refined.unsafeApply(sameAs.value))
           .map(_.hashCode())
       }
@@ -148,7 +148,7 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     "return an instance of InternalSameAs" in {
       val sameAs = datasetInternalSameAs.generateOne
 
-      val Right(instance) = SameAs.internal(RenkuBaseUrl(sameAs.value))
+      val Right(instance) = SameAs.internal(RenkuUrl(sameAs.value))
 
       instance       shouldBe an[InternalSameAs]
       instance.value shouldBe sameAs.value

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
@@ -87,7 +87,7 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
         val updateGenerations = activity.generations.map { generation =>
           val updatedEntity = generation.entity.copy(generationResourceIds =
             generation.entity.generationResourceIds ::: generations.ResourceId(
-              (renkuBaseUrl / Generation.Id.generate).show
+              (renkuUrl / Generation.Id.generate).show
             ) :: Nil
           )
           generation.copy(entity = updatedEntity)

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/Generators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/Generators.scala
@@ -116,8 +116,8 @@ private object Generators {
     (plan: Plan) => ImplicitCommandOutput(name, maybePrefix, defaultValue, folderCreation, maybeEncodingFormat, plan)
 
   implicit val ioStreamOuts: Gen[IOStream.Out] = Gen.oneOf(
-    IOStream.StdOut(IOStream.ResourceId((renkuBaseUrl / nonEmptyStrings().generateOne).show)),
-    IOStream.StdErr(IOStream.ResourceId((renkuBaseUrl / nonEmptyStrings().generateOne).show))
+    IOStream.StdOut(IOStream.ResourceId((renkuUrl / nonEmptyStrings().generateOne).show)),
+    IOStream.StdErr(IOStream.ResourceId((renkuUrl / nonEmptyStrings().generateOne).show))
   )
 
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -848,7 +848,7 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
   private def datasetWith(
       creators: NonEmptyList[entities.Person]
   ): projects.DateCreated => entities.Dataset[entities.Dataset.Provenance] = dateCreated => {
-    val ds = datasetEntities(provenanceNonModified)(renkuBaseUrl)(dateCreated).generateOne
+    val ds = datasetEntities(provenanceNonModified)(renkuUrl)(dateCreated).generateOne
       .to[entities.Dataset[entities.Dataset.Provenance]]
     ds.copy(provenance = ds.provenance match {
       case p: entities.Dataset.Provenance.Internal                         => p.copy(creators = creators.sortBy(_.name))

--- a/renku-model/src/test/scala/io/renku/graph/model/personsSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/personsSpec.scala
@@ -96,19 +96,19 @@ class EmailSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Ma
 }
 
 class PersonResourceIdSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
-  private implicit val renkuBaseUrl: RenkuBaseUrl = renkuBaseUrls.generateOne
+  private implicit val renkuUrl: RenkuUrl = renkuUrls.generateOne
 
   "apply(GitLabId)" should {
-    "generate 'renkuBaseUrl/persons/gitLabId' ResourceId" in {
+    "generate 'renkuUrl/persons/gitLabId' ResourceId" in {
       val gitLabId = personGitLabIds.generateOne
-      ResourceId(gitLabId).show shouldBe (renkuBaseUrl / "persons" / gitLabId).show
+      ResourceId(gitLabId).show shouldBe (renkuUrl / "persons" / gitLabId).show
     }
   }
 
   "apply(OrcidId)" should {
-    "generate 'renkuBaseUrl/persons/orcid/xxxx-xxxx-xxxx-xxxx' ResourceId" in {
+    "generate 'renkuUrl/persons/orcid/xxxx-xxxx-xxxx-xxxx' ResourceId" in {
       val orcid = personOrcidIds.generateOne
-      ResourceId(orcid).show shouldBe (renkuBaseUrl / "persons" / "orcid" / orcid.id).show
+      ResourceId(orcid).show shouldBe (renkuUrl / "persons" / "orcid" / orcid.id).show
     }
   }
 
@@ -120,9 +120,9 @@ class PersonResourceIdSpec extends AnyWordSpec with ScalaCheckPropertyChecks wit
   }
 
   "apply(Name)" should {
-    "generate 'renkuBaseUrl/persons/name' ResourceId" in {
+    "generate 'renkuUrl/persons/name' ResourceId" in {
       val name = personNames.generateOne
-      ResourceId(name).show shouldBe (renkuBaseUrl / "persons" / name).show
+      ResourceId(name).show shouldBe (renkuUrl / "persons" / name).show
     }
   }
 
@@ -131,7 +131,7 @@ class PersonResourceIdSpec extends AnyWordSpec with ScalaCheckPropertyChecks wit
       val resourceId = personGitLabResourceId.generateOne
       ResourceId.from(resourceId.show) shouldBe resourceId.asRight
     }
-    "return ResourceId.OrcidIdBased for strings matching the renku orcid based id like 'renkuBaseUrl/persons/orcid/xxxx-xxxx-xxxx-xxxx'" in {
+    "return ResourceId.OrcidIdBased for strings matching the renku orcid based id like 'renkuUrl/persons/orcid/xxxx-xxxx-xxxx-xxxx'" in {
       val resourceId = personOrcidResourceId.generateOne
       ResourceId.from(resourceId.show) shouldBe resourceId.asRight
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/projectsSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/projectsSpec.scala
@@ -175,8 +175,8 @@ class ProjectResourceIdSpec extends AnyWordSpec with ScalaCheckPropertyChecks wi
   "toProjectPath converter" should {
 
     "convert any Project Resource to ProjectPath" in {
-      forAll { (renkuBaseUrl: RenkuBaseUrl, projectPath: Path) =>
-        ResourceId(projectPath)(renkuBaseUrl).as[Try, Path] shouldBe projectPath.pure[Try]
+      forAll { (renkuUrl: RenkuUrl, projectPath: Path) =>
+        ResourceId(projectPath)(renkuUrl).as[Try, Path] shouldBe projectPath.pure[Try]
       }
     }
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
@@ -86,7 +86,7 @@ object Activity {
   import io.renku.jsonld._
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesActivity(implicit renkuBaseUrl: RenkuBaseUrl): Activity => entities.Activity = activity =>
+  implicit def toEntitiesActivity(implicit renkuUrl: RenkuUrl): Activity => entities.Activity = activity =>
     entities.Activity(
       activities.ResourceId(activity.asEntityId.show),
       activity.startTime,
@@ -99,9 +99,9 @@ object Activity {
       activity.parameters.map(_.to[entities.ParameterValue])
     )
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[Activity] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[Activity] =
     JsonLDEncoder.instance(activity => activity.to[entities.Activity].asJsonLD)
 
-  implicit def entityIdEncoder(implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[Activity] =
-    EntityIdEncoder.instance(entity => EntityId of renkuBaseUrl / "activities" / entity.id)
+  implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[Activity] =
+    EntityIdEncoder.instance(entity => EntityId of renkuUrl / "activities" / entity.id)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
@@ -19,7 +19,7 @@
 package io.renku.graph.model.testentities
 
 import cats.syntax.all._
-import io.renku.graph.model.{RenkuBaseUrl, associations, entities}
+import io.renku.graph.model.{RenkuUrl, associations, entities}
 import io.renku.jsonld._
 
 sealed trait Association {
@@ -42,7 +42,7 @@ object Association {
 
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesAssociation(implicit renkuBaseUrl: RenkuBaseUrl): Association => entities.Association = {
+  implicit def toEntitiesAssociation(implicit renkuUrl: RenkuUrl): Association => entities.Association = {
     case a @ Association.WithRenkuAgent(_, agent, plan) =>
       entities.Association.WithRenkuAgent(associations.ResourceId(a.asEntityId.show),
                                           agent.to[entities.Agent],
@@ -55,9 +55,9 @@ object Association {
       )
   }
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[Association] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[Association] =
     JsonLDEncoder.instance(association => association.to[entities.Association].asJsonLD)
 
-  implicit def entityIdEncoder[A <: Association](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[A] =
+  implicit def entityIdEncoder[A <: Association](implicit renkuUrl: RenkuUrl): EntityIdEncoder[A] =
     EntityIdEncoder.instance(entity => entity.activity.asEntityId.asUrlEntityId / "association")
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/CommandParameterBase.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/CommandParameterBase.scala
@@ -23,7 +23,7 @@ import eu.timepit.refined.auto._
 import io.renku.graph.model.commandParameters.IOStream.{StdErr, StdIn, StdOut}
 import io.renku.graph.model.commandParameters._
 import io.renku.graph.model.entityModel.Location
-import io.renku.graph.model.{RenkuBaseUrl, commandParameters, entities}
+import io.renku.graph.model.{RenkuUrl, commandParameters, entities}
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 
@@ -69,7 +69,7 @@ object CommandParameterBase {
           )
 
     implicit def toEntitiesCommandParameter(implicit
-        renkuBaseUrl: RenkuBaseUrl
+        renkuUrl: RenkuUrl
     ): CommandParameter => entities.CommandParameterBase.CommandParameter =
       parameter =>
         entities.CommandParameterBase.CommandParameter(
@@ -81,10 +81,10 @@ object CommandParameterBase {
           parameter.defaultValue
         )
 
-    implicit def commandParameterEncoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[CommandParameter] =
+    implicit def commandParameterEncoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[CommandParameter] =
       JsonLDEncoder.instance(_.to[entities.CommandParameterBase.CommandParameter].asJsonLD)
 
-    implicit def entityIdEncoder(implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[CommandParameter] =
+    implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[CommandParameter] =
       EntityIdEncoder.instance(parameter => parameter.plan.asEntityId.asUrlEntityId / "parameters" / parameter.position)
   }
 
@@ -146,10 +146,10 @@ object CommandParameterBase {
                                         defaultValue:        InputDefaultValue,
                                         maybeEncodingFormat: Option[EncodingFormat],
                                         plan:                Plan
-    )(implicit renkuBaseUrl:                                 RenkuBaseUrl)
+    )(implicit renkuUrl:                                     RenkuUrl)
         extends CommandInput
         with ExplicitCommandParameter {
-      val mappedTo: IOStream.In = IOStream.StdIn(IOStream.ResourceId((renkuBaseUrl / "iostreams" / StdIn.name).value))
+      val mappedTo: IOStream.In = IOStream.StdIn(IOStream.ResourceId((renkuUrl / "iostreams" / StdIn.name).value))
     }
 
     final case class ImplicitCommandInput(
@@ -161,7 +161,7 @@ object CommandParameterBase {
     ) extends CommandInput
 
     implicit def toEntitiesCommandInput(implicit
-        renkuBaseUrl: RenkuBaseUrl
+        renkuUrl: RenkuUrl
     ): CommandInput => entities.CommandParameterBase.CommandInput = {
       case parameter: LocationCommandInput =>
         entities.CommandParameterBase.LocationCommandInput(
@@ -194,10 +194,10 @@ object CommandParameterBase {
         )
     }
 
-    implicit def commandInputEncoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[CommandInput] =
+    implicit def commandInputEncoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[CommandInput] =
       JsonLDEncoder.instance(_.to[entities.CommandParameterBase.CommandInput].asJsonLD)
 
-    implicit def entityIdEncoder[I <: CommandInput](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[I] =
+    implicit def entityIdEncoder[I <: CommandInput](implicit renkuUrl: RenkuUrl): EntityIdEncoder[I] =
       EntityIdEncoder.instance(input => input.plan.asEntityId.asUrlEntityId / "inputs" / input.name)
   }
 
@@ -229,11 +229,11 @@ object CommandParameterBase {
     def streamedFromLocation(defaultValue: Location, stream: IOStream.Out): Position => Plan => MappedCommandOutput =
       streamedFrom(OutputDefaultValue(defaultValue), stream)
 
-    def stdOut(implicit renkuBaseUrl: RenkuBaseUrl): IOStream.StdOut =
-      IOStream.StdOut(IOStream.ResourceId((renkuBaseUrl / "iostreams" / StdOut.name).value))
+    def stdOut(implicit renkuUrl: RenkuUrl): IOStream.StdOut =
+      IOStream.StdOut(IOStream.ResourceId((renkuUrl / "iostreams" / StdOut.name).value))
 
-    def stdErr(implicit renkuBaseUrl: RenkuBaseUrl): IOStream.StdErr =
-      IOStream.StdErr(IOStream.ResourceId((renkuBaseUrl / "iostreams" / StdErr.name).value))
+    def stdErr(implicit renkuUrl: RenkuUrl): IOStream.StdErr =
+      IOStream.StdErr(IOStream.ResourceId((renkuUrl / "iostreams" / StdErr.name).value))
 
     def streamedFrom(defaultValue: OutputDefaultValue, stream: IOStream.Out): Position => Plan => MappedCommandOutput =
       position =>
@@ -283,7 +283,7 @@ object CommandParameterBase {
     ) extends CommandOutput
 
     implicit def toEntitiesCommandOutput(implicit
-        renkuBaseUrl: RenkuBaseUrl
+        renkuUrl: RenkuUrl
     ): CommandOutput => entities.CommandParameterBase.CommandOutput = {
       case parameter: LocationCommandOutput =>
         entities.CommandParameterBase.LocationCommandOutput(
@@ -319,10 +319,10 @@ object CommandParameterBase {
         )
     }
 
-    implicit def commandOutputEncoder[O <: CommandOutput](implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[O] =
+    implicit def commandOutputEncoder[O <: CommandOutput](implicit renkuUrl: RenkuUrl): JsonLDEncoder[O] =
       JsonLDEncoder.instance(_.to[entities.CommandParameterBase.CommandOutput].asJsonLD)
 
-    implicit def entityIdEncoder[O <: CommandOutput](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[O] =
+    implicit def entityIdEncoder[O <: CommandOutput](implicit renkuUrl: RenkuUrl): EntityIdEncoder[O] =
       EntityIdEncoder.instance(output => output.plan.asEntityId.asUrlEntityId / "outputs" / output.name)
   }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/DatasetPart.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/DatasetPart.scala
@@ -32,11 +32,11 @@ case class DatasetPart(
 
 object DatasetPart {
 
-  import io.renku.graph.model.RenkuBaseUrl
+  import io.renku.graph.model.RenkuUrl
   import io.renku.jsonld._
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesDatasetPart(implicit renkuBaseUrl: RenkuBaseUrl): DatasetPart => entities.DatasetPart = {
+  implicit def toEntitiesDatasetPart(implicit renkuUrl: RenkuUrl): DatasetPart => entities.DatasetPart = {
     case datasetPart: DatasetPart with HavingInvalidationTime =>
       entities.DatasetPart(
         datasets.PartResourceId(datasetPart.asEntityId.show),
@@ -57,9 +57,9 @@ object DatasetPart {
       )
   }
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[DatasetPart] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[DatasetPart] =
     JsonLDEncoder.instance(_.to[entities.DatasetPart].asJsonLD)
 
-  implicit def entityIdEncoder[D <: DatasetPart](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[D] =
-    EntityIdEncoder.instance(part => renkuBaseUrl / "dataset-files" / part.id / part.entity.location)
+  implicit def entityIdEncoder[D <: DatasetPart](implicit renkuUrl: RenkuUrl): EntityIdEncoder[D] =
+    EntityIdEncoder.instance(part => renkuUrl / "dataset-files" / part.id / part.entity.location)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Entity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Entity.scala
@@ -40,16 +40,16 @@ object Entity {
       (generation: Generation) => OutputEntity(location, entityChecksums.generateOne, generation)
   }
 
-  implicit def toEntity(implicit renkuBaseUrl: RenkuBaseUrl): Entity => entities.Entity = {
-    case e: InputEntity  => toInputEntity(renkuBaseUrl)(e)
-    case e: OutputEntity => toOutputEntity(renkuBaseUrl)(e)
+  implicit def toEntity(implicit renkuUrl: RenkuUrl): Entity => entities.Entity = {
+    case e: InputEntity  => toInputEntity(renkuUrl)(e)
+    case e: OutputEntity => toOutputEntity(renkuUrl)(e)
   }
 
-  implicit def toInputEntity(implicit renkuBaseUrl: RenkuBaseUrl): InputEntity => entities.Entity.InputEntity =
+  implicit def toInputEntity(implicit renkuUrl: RenkuUrl): InputEntity => entities.Entity.InputEntity =
     entity =>
       entities.Entity.InputEntity(entityModel.ResourceId(entity.asEntityId.show), entity.location, entity.checksum)
 
-  implicit def toOutputEntity(implicit renkuBaseUrl: RenkuBaseUrl): OutputEntity => entities.Entity.OutputEntity =
+  implicit def toOutputEntity(implicit renkuUrl: RenkuUrl): OutputEntity => entities.Entity.OutputEntity =
     entity =>
       entities.Entity.OutputEntity(entityModel.ResourceId(entity.asEntityId.show),
                                    entity.location,
@@ -57,9 +57,9 @@ object Entity {
                                    List(generations.ResourceId(entity.generation.asEntityId.show))
       )
 
-  implicit def encoder[E <: Entity](implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[E] =
+  implicit def encoder[E <: Entity](implicit renkuUrl: RenkuUrl): JsonLDEncoder[E] =
     JsonLDEncoder.instance(_.to[entities.Entity].asJsonLD)
 
-  implicit def entityIdEncoder[E <: Entity](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[E] =
-    EntityIdEncoder.instance(entity => EntityId of renkuBaseUrl / "blob" / entity.checksum / entity.location)
+  implicit def entityIdEncoder[E <: Entity](implicit renkuUrl: RenkuUrl): EntityIdEncoder[E] =
+    EntityIdEncoder.instance(entity => EntityId of renkuUrl / "blob" / entity.checksum / entity.location)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Generation.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Generation.scala
@@ -37,11 +37,11 @@ object Generation {
     def generate: Id = generationIds.generateOne
   }
 
-  import io.renku.graph.model.RenkuBaseUrl
+  import io.renku.graph.model.RenkuUrl
   import io.renku.jsonld._
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesGeneration(implicit renkuBaseUrl: RenkuBaseUrl): Generation => entities.Generation =
+  implicit def toEntitiesGeneration(implicit renkuUrl: RenkuUrl): Generation => entities.Generation =
     generation =>
       entities.Generation(
         generations.ResourceId(generation.asEntityId.show),
@@ -52,10 +52,10 @@ object Generation {
   def factory(entityFactory: Generation => OutputEntity): Activity => Generation =
     activity => Generation(Id.generate, activity, entityFactory)
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[Generation] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[Generation] =
     JsonLDEncoder.instance(_.to[entities.Generation].asJsonLD)
 
-  implicit def entityIdEncoder(implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[Generation] =
+  implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[Generation] =
     EntityIdEncoder.instance { case generation @ Generation(id, activity, _) =>
       activity.asEntityId.asUrlEntityId / "generation" / id / generation.entity.checksum / generation.entity.location
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
@@ -56,8 +56,8 @@ object LineageExemplarData {
   )
 
   def apply(
-      project: RenkuProject = renkuProjectEntities(visibilityPublic, forksCountGen = anyForksCount).generateOne
-  )(implicit renkuBaseUrl: RenkuBaseUrl): ExemplarData = {
+      project:         RenkuProject = renkuProjectEntities(visibilityPublic, forksCountGen = anyForksCount).generateOne
+  )(implicit renkuUrl: RenkuUrl): ExemplarData = {
 
     val zhbikesFolder = Location.Folder("data/zhbikes")
     val velo2018      = Location.File(zhbikesFolder, "2018velo.csv")
@@ -178,7 +178,7 @@ final case class NodeDef(location: String, label: String, types: Set[String])
 
 object NodeDef {
 
-  def apply(activity: Activity, location: Location)(implicit renkuBaseUrl: RenkuBaseUrl): NodeDef =
+  def apply(activity: Activity, location: Location)(implicit renkuUrl: RenkuUrl): NodeDef =
     activity
       .findEntity(location)
       .map { entity =>
@@ -194,7 +194,7 @@ object NodeDef {
         )
       )
 
-  def apply(activity: Activity)(implicit renkuBaseUrl: RenkuBaseUrl): NodeDef = NodeDef(
+  def apply(activity: Activity)(implicit renkuUrl: RenkuUrl): NodeDef = NodeDef(
     activity.asJsonLD.entityId.getOrElse(throw new Exception("Non entity id found for Activity")).show,
     activity.show,
     activity.asJsonLD.entityTypes.getOrElse(throw new Exception("No entityTypes found")).toList.map(_.show).toSet

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
@@ -46,30 +46,30 @@ trait ModelOps extends Dataset.ProvenanceOps {
   }
 
   implicit class ProjectOps(project: Project)(implicit
-      renkuBaseUrl:                  RenkuBaseUrl
+      renkuUrl:                      RenkuUrl
   ) extends AbstractProjectOps[Project](project)
 
   abstract class AbstractProjectOps[P <: Project](project: P)(implicit
-      renkuBaseUrl:                                        RenkuBaseUrl
+      renkuUrl:                                            RenkuUrl
   ) {
 
     def to[T](implicit convert: P => T): T = convert(project)
   }
 
   implicit class RenkuProjectWithParentOps(project: RenkuProject.WithParent)(implicit
-      renkuBaseUrl:                                 RenkuBaseUrl
+      renkuUrl:                                     RenkuUrl
   ) extends AbstractRenkuProjectOps[RenkuProject.WithParent](project)
 
   implicit class RenkuProjectWithoutParentOps(project: RenkuProject.WithoutParent)(implicit
-      renkuBaseUrl:                                    RenkuBaseUrl
+      renkuUrl:                                        RenkuUrl
   ) extends AbstractRenkuProjectOps[RenkuProject.WithoutParent](project)
 
   implicit class RenkuProjectOps(project: RenkuProject)(implicit
-      renkuBaseUrl:                       RenkuBaseUrl
+      renkuUrl:                           RenkuUrl
   ) extends AbstractRenkuProjectOps[RenkuProject](project)
 
   abstract class AbstractRenkuProjectOps[P <: RenkuProject](project: P)(implicit
-      renkuBaseUrl:                                                  RenkuBaseUrl
+      renkuUrl:                                                      RenkuUrl
   ) {
 
     lazy val resourceId: projects.ResourceId = projects.ResourceId(project.asEntityId)
@@ -133,19 +133,19 @@ trait ModelOps extends Dataset.ProvenanceOps {
   }
 
   implicit class NonRenkuProjectWithParentOps(project: NonRenkuProject.WithParent)(implicit
-      renkuBaseUrl:                                    RenkuBaseUrl
+      renkuUrl:                                        RenkuUrl
   ) extends AbstractNonRenkuProjectOps[NonRenkuProject.WithParent](project)
 
   implicit class NonRenkuProjectWithoutParentOps(project: NonRenkuProject.WithoutParent)(implicit
-      renkuBaseUrl:                                       RenkuBaseUrl
+      renkuUrl:                                           RenkuUrl
   ) extends AbstractNonRenkuProjectOps[NonRenkuProject.WithoutParent](project)
 
   implicit class NonRenkuProjectOps(project: NonRenkuProject)(implicit
-      renkuBaseUrl:                          RenkuBaseUrl
+      renkuUrl:                              RenkuUrl
   ) extends AbstractNonRenkuProjectOps[NonRenkuProject](project)
 
   abstract class AbstractNonRenkuProjectOps[P <: NonRenkuProject](project: P)(implicit
-      renkuBaseUrl:                                                        RenkuBaseUrl
+      renkuUrl:                                                            RenkuUrl
   ) {
 
     def to[T](implicit convert: P => T): T = convert(project)
@@ -186,7 +186,7 @@ trait ModelOps extends Dataset.ProvenanceOps {
       )
   }
 
-  implicit class DatasetOps[P <: Dataset.Provenance](dataset: Dataset[P])(implicit renkuBaseUrl: RenkuBaseUrl) {
+  implicit class DatasetOps[P <: Dataset.Provenance](dataset: Dataset[P])(implicit renkuUrl: RenkuUrl) {
 
     lazy val identifier: datasets.Identifier = dataset.identification.identifier
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/NonRenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/NonRenkuProject.scala
@@ -55,15 +55,13 @@ object NonRenkuProject {
     override type ProjectType = NonRenkuProject.WithParent
   }
 
-  implicit def toEntitiesNonRenkuProject(implicit
-      renkuBaseUrl: RenkuBaseUrl
-  ): NonRenkuProject => entities.NonRenkuProject = {
-    case p: NonRenkuProject.WithParent    => toEntitiesNonRenkuProjectWithParent(renkuBaseUrl)(p)
-    case p: NonRenkuProject.WithoutParent => toEntitiesNonRenkuProjectWithoutParent(renkuBaseUrl)(p)
+  implicit def toEntitiesNonRenkuProject(implicit renkuUrl: RenkuUrl): NonRenkuProject => entities.NonRenkuProject = {
+    case p: NonRenkuProject.WithParent    => toEntitiesNonRenkuProjectWithParent(renkuUrl)(p)
+    case p: NonRenkuProject.WithoutParent => toEntitiesNonRenkuProjectWithoutParent(renkuUrl)(p)
   }
 
   implicit def toEntitiesNonRenkuProjectWithoutParent(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): NonRenkuProject.WithoutParent => entities.NonRenkuProject.WithoutParent =
     project =>
       entities.NonRenkuProject.WithoutParent(
@@ -79,7 +77,7 @@ object NonRenkuProject {
       )
 
   implicit def toEntitiesNonRenkuProjectWithParent(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): NonRenkuProject.WithParent => entities.NonRenkuProject.WithParent =
     project =>
       entities.NonRenkuProject.WithParent(
@@ -96,7 +94,7 @@ object NonRenkuProject {
       )
 
   implicit def encoder[P <: NonRenkuProject](implicit
-      renkuBaseUrl: RenkuBaseUrl,
+      renkuUrl:     RenkuUrl,
       gitLabApiUrl: GitLabApiUrl
   ): JsonLDEncoder[P] = JsonLDEncoder.instance {
     case project: NonRenkuProject.WithParent    => project.to[entities.NonRenkuProject.WithParent].asJsonLD

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterValue.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterValue.scala
@@ -26,7 +26,7 @@ import io.renku.graph.model.parameterValues.ValueOverride
 import io.renku.graph.model.testentities.CommandParameterBase._
 import io.renku.graph.model.testentities.ParameterValue.LocationParameterValue.{CommandInputValue, CommandOutputValue}
 import io.renku.graph.model.testentities.ParameterValue._
-import io.renku.graph.model.{RenkuBaseUrl, entities, parameterValues}
+import io.renku.graph.model.{RenkuUrl, entities, parameterValues}
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 import io.renku.tinytypes.constraints.UUID
@@ -49,9 +49,7 @@ object ParameterValue {
     override type Value = LocationLike
   }
 
-  implicit def toEntitiesParameterValue(implicit
-      renkuBaseUrl: RenkuBaseUrl
-  ): ParameterValue => entities.ParameterValue = {
+  implicit def toEntitiesParameterValue(implicit renkuUrl: RenkuUrl): ParameterValue => entities.ParameterValue = {
     case p: CommandParameterValue =>
       entities.ParameterValue.CommandParameterValue(parameterValues.ResourceId(p.asEntityId.show),
                                                     p.value,
@@ -103,10 +101,10 @@ object ParameterValue {
       CommandParameterValue(Id.generate, value, valueReference, _)
   }
 
-  implicit def encoder[PV <: ParameterValue](implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[PV] =
+  implicit def encoder[PV <: ParameterValue](implicit renkuUrl: RenkuUrl): JsonLDEncoder[PV] =
     JsonLDEncoder.instance(_.to[entities.ParameterValue].asJsonLD)
 
-  implicit def entityIdEncoder[PV <: ParameterValue](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[PV] =
+  implicit def entityIdEncoder[PV <: ParameterValue](implicit renkuUrl: RenkuUrl): EntityIdEncoder[PV] =
     EntityIdEncoder.instance(value => value.activity.asEntityId.asUrlEntityId / "parameter" / value.id)
 
   final class Id private (val value: String) extends AnyVal with StringTinyType

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Person.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Person.scala
@@ -37,7 +37,7 @@ object Person {
   import io.renku.jsonld._
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesPerson(implicit renkuBaseUrl: RenkuBaseUrl): Person => entities.Person = {
+  implicit def toEntitiesPerson(implicit renkuUrl: RenkuUrl): Person => entities.Person = {
     case Person(name, maybeEmail, Some(gitLabId), maybeOrcidId, maybeAffiliation) =>
       entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
                                    gitLabId,
@@ -62,7 +62,7 @@ object Person {
   }
 
   implicit def toMaybeEntitiesPersonWithGitLabId(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): Person => Option[entities.Person.WithGitLabId] = {
     case Person(name, maybeEmail, Some(gitLabId), maybeOrcidId, maybeAffiliation) =>
       entities.Person
@@ -78,16 +78,16 @@ object Person {
   }
 
   implicit def toMaybeEntitiesPersonWithName(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): Person => Option[entities.Person.WithNameOnly] = {
     case Person(name, None, None, maybeOrcidId, maybeAffiliation) =>
       entities.Person.WithNameOnly(persons.ResourceId(name), name, maybeOrcidId, maybeAffiliation).some
     case _ => None
   }
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[Person] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[Person] =
     JsonLDEncoder.instance(_.to[entities.Person].asJsonLD)
 
-  implicit def entityIdEncoder(implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[Person] =
+  implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[Person] =
     EntityIdEncoder.instance(person => EntityId.of(person.to[entities.Person].resourceId.value))
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
@@ -75,7 +75,7 @@ object Plan {
     def of(parameters: CommandParameterFactory*): List[CommandParameterFactory] = parameters.toList
   }
 
-  implicit def toEntitiesPlan(implicit renkuBaseUrl: RenkuBaseUrl): Plan => entities.Plan =
+  implicit def toEntitiesPlan(implicit renkuUrl: RenkuUrl): Plan => entities.Plan =
     plan => {
       val maybeInvalidationTime = plan match {
         case plan: Plan with HavingInvalidationTime => plan.invalidationTime.some
@@ -98,9 +98,9 @@ object Plan {
       )
     }
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[Plan] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[Plan] =
     JsonLDEncoder.instance(_.to[entities.Plan].asJsonLD)
 
-  implicit def entityIdEncoder[R <: Plan](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[R] =
+  implicit def entityIdEncoder[R <: Plan](implicit renkuUrl: RenkuUrl): EntityIdEncoder[R] =
     EntityIdEncoder.instance(plan => ResourceId(plan.id).asEntityId)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Project.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Project.scala
@@ -21,7 +21,7 @@ package io.renku.graph.model.testentities
 import io.renku.graph.model.projects.{DateCreated, Description, ForksCount, Keyword, Name, Path, Visibility}
 import io.renku.graph.model.testentities.NonRenkuProject._
 import io.renku.graph.model.testentities.RenkuProject._
-import io.renku.graph.model.{GitLabApiUrl, RenkuBaseUrl, entities}
+import io.renku.graph.model.{GitLabApiUrl, RenkuUrl, entities}
 import io.renku.jsonld.{EntityIdEncoder, JsonLDEncoder}
 
 trait Project extends Product with Serializable {
@@ -47,23 +47,19 @@ object Project {
 
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesProject(implicit
-      renkuBaseUrl: RenkuBaseUrl
-  ): Project => entities.Project = {
-    case p: RenkuProject.WithParent       => toEntitiesRenkuProject(renkuBaseUrl)(p)
-    case p: RenkuProject.WithoutParent    => toEntitiesRenkuProjectWithoutParent(renkuBaseUrl)(p)
-    case p: NonRenkuProject.WithParent    => toEntitiesNonRenkuProjectWithParent(renkuBaseUrl)(p)
-    case p: NonRenkuProject.WithoutParent => toEntitiesNonRenkuProjectWithoutParent(renkuBaseUrl)(p)
+  implicit def toEntitiesProject(implicit renkuUrl: RenkuUrl): Project => entities.Project = {
+    case p: RenkuProject.WithParent       => toEntitiesRenkuProject(renkuUrl)(p)
+    case p: RenkuProject.WithoutParent    => toEntitiesRenkuProjectWithoutParent(renkuUrl)(p)
+    case p: NonRenkuProject.WithParent    => toEntitiesNonRenkuProjectWithParent(renkuUrl)(p)
+    case p: NonRenkuProject.WithoutParent => toEntitiesNonRenkuProjectWithoutParent(renkuUrl)(p)
   }
 
-  implicit def encoder[P <: Project](implicit
-      renkuBaseUrl: RenkuBaseUrl,
-      gitLabApiUrl: GitLabApiUrl
-  ): JsonLDEncoder[P] = JsonLDEncoder.instance {
-    case project: RenkuProject    => project.to[entities.RenkuProject].asJsonLD
-    case project: NonRenkuProject => project.to[entities.NonRenkuProject].asJsonLD
-  }
+  implicit def encoder[P <: Project](implicit renkuUrl: RenkuUrl, gitLabApiUrl: GitLabApiUrl): JsonLDEncoder[P] =
+    JsonLDEncoder.instance {
+      case project: RenkuProject    => project.to[entities.RenkuProject].asJsonLD
+      case project: NonRenkuProject => project.to[entities.NonRenkuProject].asJsonLD
+    }
 
-  implicit def entityIdEncoder[P <: Project](implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[P] =
-    EntityIdEncoder.instance(project => renkuBaseUrl / "projects" / project.path)
+  implicit def entityIdEncoder[P <: Project](implicit renkuUrl: RenkuUrl): EntityIdEncoder[P] =
+    EntityIdEncoder.instance(project => renkuUrl / "projects" / project.path)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/PublicationEvent.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/PublicationEvent.scala
@@ -35,20 +35,20 @@ object PublicationEvent {
   import io.renku.jsonld.syntax._
 
   implicit def toEntitiesPublicationEvent(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): PublicationEvent => entities.PublicationEvent = publicationEvent =>
     entities.PublicationEvent(
       publicationEvents.ResourceId(publicationEvent.asEntityId.show),
-      About((renkuBaseUrl / "urls" / "datasets" / publicationEvent.dataset.identifier).show),
+      About((renkuUrl / "urls" / "datasets" / publicationEvent.dataset.identifier).show),
       datasets.ResourceId(publicationEvent.dataset.asEntityId.show),
       publicationEvent.maybeDescription,
       publicationEvent.name,
       publicationEvent.startDate
     )
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[PublicationEvent] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[PublicationEvent] =
     JsonLDEncoder.instance(_.to[entities.PublicationEvent].asJsonLD)
 
-  implicit def entityIdEncoder(implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[PublicationEvent] =
-    EntityIdEncoder.instance(event => renkuBaseUrl / "datasettags" / s"${event.name}@${event.dataset.asEntityId.show}")
+  implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[PublicationEvent] =
+    EntityIdEncoder.instance(event => renkuUrl / "datasettags" / s"${event.name}@${event.dataset.asEntityId.show}")
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
@@ -158,15 +158,13 @@ object RenkuProject {
     def addDataset[P <: Dataset.Provenance](toAdd: DatasetGenFactory[P]): (Dataset[P], ProjectType)
   }
 
-  implicit def toEntitiesRenkuProject(implicit
-      renkuBaseUrl: RenkuBaseUrl
-  ): RenkuProject => entities.RenkuProject = {
-    case p: RenkuProject.WithParent    => toEntitiesRenkuProjectWithParent(renkuBaseUrl)(p)
-    case p: RenkuProject.WithoutParent => toEntitiesRenkuProjectWithoutParent(renkuBaseUrl)(p)
+  implicit def toEntitiesRenkuProject(implicit renkuUrl: RenkuUrl): RenkuProject => entities.RenkuProject = {
+    case p: RenkuProject.WithParent    => toEntitiesRenkuProjectWithParent(renkuUrl)(p)
+    case p: RenkuProject.WithoutParent => toEntitiesRenkuProjectWithoutParent(renkuUrl)(p)
   }
 
   implicit def toEntitiesRenkuProjectWithoutParent(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): RenkuProject.WithoutParent => entities.RenkuProject.WithoutParent =
     project =>
       entities.RenkuProject.WithoutParent
@@ -188,7 +186,7 @@ object RenkuProject {
         .fold(errors => throw new IllegalStateException(errors.intercalate("; ")), identity)
 
   implicit def toEntitiesRenkuProjectWithParent(implicit
-      renkuBaseUrl: RenkuBaseUrl
+      renkuUrl: RenkuUrl
   ): RenkuProject.WithParent => entities.RenkuProject.WithParent =
     project =>
       entities.RenkuProject.WithParent
@@ -211,7 +209,7 @@ object RenkuProject {
         .fold(errors => throw new IllegalStateException(errors.intercalate("; ")), identity)
 
   implicit def encoder[P <: RenkuProject](implicit
-      renkuBaseUrl: RenkuBaseUrl,
+      renkuUrl:     RenkuUrl,
       gitLabApiUrl: GitLabApiUrl
   ): JsonLDEncoder[P] = JsonLDEncoder.instance {
     case project: RenkuProject.WithParent    => project.to[entities.RenkuProject.WithParent].asJsonLD

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Usage.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Usage.scala
@@ -22,7 +22,7 @@ import Usage.Id
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.noDashUuid
-import io.renku.graph.model.{RenkuBaseUrl, entities, usages}
+import io.renku.graph.model.{RenkuUrl, entities, usages}
 import io.renku.tinytypes.constraints.UUID
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 
@@ -41,13 +41,13 @@ object Usage {
   import io.renku.jsonld._
   import io.renku.jsonld.syntax._
 
-  implicit def toEntitiesUsage(implicit renkuBaseUrl: RenkuBaseUrl): Usage => entities.Usage = usage =>
+  implicit def toEntitiesUsage(implicit renkuUrl: RenkuUrl): Usage => entities.Usage = usage =>
     entities.Usage(usages.ResourceId(usage.asEntityId.show), usage.entity.to[entities.Entity])
 
-  implicit def encoder(implicit renkuBaseUrl: RenkuBaseUrl): JsonLDEncoder[Usage] =
+  implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[Usage] =
     JsonLDEncoder.instance(_.to[entities.Usage].asJsonLD)
 
-  implicit def entityIdEncoder(implicit renkuBaseUrl: RenkuBaseUrl): EntityIdEncoder[Usage] =
+  implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[Usage] =
     EntityIdEncoder.instance { case Usage(id, activity, entity) =>
       activity.asEntityId.asUrlEntityId / "usage" / id / entity.checksum / entity.location
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/EntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/EntitiesGenerators.scala
@@ -36,7 +36,7 @@ object EntitiesGenerators extends EntitiesGenerators {
 }
 
 private object Instances {
-  implicit val renkuBaseUrl: RenkuBaseUrl = renkuBaseUrls.generateOne
+  implicit val renkuUrl:     RenkuUrl     = renkuUrls.generateOne
   implicit val gitLabUrl:    GitLabUrl    = gitLabUrls.generateOne
   implicit val gitLabApiUrl: GitLabApiUrl = gitLabUrl.apiV4
 }
@@ -48,7 +48,7 @@ trait EntitiesGenerators
     with ActivityGenerators
     with DatasetEntitiesGenerators {
 
-  implicit val renkuBaseUrl: RenkuBaseUrl = Instances.renkuBaseUrl
+  implicit val renkuUrl:     RenkuUrl     = Instances.renkuUrl
   implicit val gitLabUrl:    GitLabUrl    = Instances.gitLabUrl
   implicit val gitLabApiUrl: GitLabApiUrl = Instances.gitLabApiUrl
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -30,7 +30,7 @@ import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail
 import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
 import io.renku.graph.model.projects.{ForksCount, Visibility}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{ActivityGenFactory, DatasetGenFactory}
-import io.renku.graph.model.{RenkuBaseUrl, projects}
+import io.renku.graph.model.{RenkuUrl, projects}
 import org.scalacheck.Gen
 
 import java.time.Instant
@@ -147,7 +147,7 @@ trait RenkuProjectEntitiesGenerators {
   }
 
   implicit class RenkuProjectGenFactoryOps[FC <: ForksCount](projectGen: Gen[RenkuProject])(implicit
-      renkuBaseUrl:                                                      RenkuBaseUrl
+      renkuUrl:                                                          RenkuUrl
   ) {
 
     def withDatasets[P <: Dataset.Provenance](factories: DatasetGenFactory[P]*): Gen[RenkuProject] = for {
@@ -212,7 +212,7 @@ trait RenkuProjectEntitiesGenerators {
     def forkOnce(): Gen[(RenkuProject, RenkuProject.WithParent)] = projectGen.map(_.forkOnce())
   }
 
-  implicit class DatasetAndProjectOps[T](tupleGen: Gen[(T, RenkuProject)])(implicit renkuBaseUrl: RenkuBaseUrl) {
+  implicit class DatasetAndProjectOps[T](tupleGen: Gen[(T, RenkuProject)])(implicit renkuUrl: RenkuUrl) {
 
     def addDataset[P <: Dataset.Provenance](
         factory: DatasetGenFactory[P]

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/package.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/package.scala
@@ -31,7 +31,7 @@ package object testentities extends Schemas with EntitiesGenerators with ModelOp
     def unapply[A, B](t: A ::~ B): Some[A ::~ B] = Some(t)
   }
 
-  implicit val renkuBaseUrlToEntityId: RenkuBaseUrl => EntityId = url => EntityId of url.value
+  implicit val renkuUrlToEntityId: RenkuUrl => EntityId = url => EntityId of url.value
 
   private implicit lazy val sameAsToPathSegment: SameAs => List[PathSegment] = sameAs => List(PathSegment(sameAs.value))
 

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -58,7 +58,7 @@ services {
   }
 
   renku {
-    url = ${?RENKU_BASE_URL}
+    url = ${?RENKU_URL}
   }
 
   sentry {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/awaitinggeneration/triplesgeneration/renkulog/RenkuLogTriplesGenerator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/awaitinggeneration/triplesgeneration/renkulog/RenkuLogTriplesGenerator.scala
@@ -24,8 +24,8 @@ import cats.data.EitherT._
 import cats.effect.Async
 import cats.effect.implicits._
 import cats.syntax.all._
-import io.renku.graph.config.{GitLabUrlLoader, RenkuBaseUrlLoader}
-import io.renku.graph.model.{RenkuBaseUrl, entities, projects}
+import io.renku.graph.config.{GitLabUrlLoader, RenkuUrlLoader}
+import io.renku.graph.model.{RenkuUrl, entities, projects}
 import io.renku.http.client.AccessToken
 import io.renku.jsonld.{JsonLD, Property}
 import io.renku.triplesgenerator.events.categories.awaitinggeneration.triplesgeneration.TriplesGenerator
@@ -38,12 +38,12 @@ import java.security.SecureRandom
 import scala.util.control.NonFatal
 
 private[awaitinggeneration] class RenkuLogTriplesGenerator[F[_]: Async] private[renkulog] (
-    gitRepoUrlFinder:    GitLabRepoUrlFinder[F],
-    renku:               Commands.Renku[F],
-    file:                Commands.File[F],
-    git:                 Commands.Git[F],
-    randomLong:          () => Long
-)(implicit renkuBaseUrl: RenkuBaseUrl)
+    gitRepoUrlFinder: GitLabRepoUrlFinder[F],
+    renku:            Commands.Renku[F],
+    file:             Commands.File[F],
+    git:              Commands.Git[F],
+    randomLong:       () => Long
+)(implicit renkuUrl:  RenkuUrl)
     extends TriplesGenerator[F] {
 
   import ammonite.ops.{Path, root}
@@ -164,10 +164,10 @@ private[awaitinggeneration] class RenkuLogTriplesGenerator[F[_]: Async] private[
 private[events] object RenkuLogTriplesGenerator {
 
   def apply[F[_]: Async: Logger](): F[TriplesGenerator[F]] = for {
-    gitLabUrl    <- GitLabUrlLoader[F]()
-    renkuBaseUrl <- RenkuBaseUrlLoader[F]()
+    gitLabUrl <- GitLabUrlLoader[F]()
+    renkuUrl  <- RenkuUrlLoader[F]()
   } yield {
-    implicit val baseUrl: RenkuBaseUrl = renkuBaseUrl
+    implicit val baseUrl: RenkuUrl = renkuUrl
     new RenkuLogTriplesGenerator(
       new GitLabRepoUrlFinderImpl[F](gitLabUrl),
       Commands.Renku[F],

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/cleanup/ProjectTriplesRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/cleanup/ProjectTriplesRemover.scala
@@ -25,7 +25,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.NonNegative
 import io.renku.graph.config._
 import io.renku.graph.model.views.RdfResource
-import io.renku.graph.model.{RenkuBaseUrl, projects}
+import io.renku.graph.model.{RenkuUrl, projects}
 import io.renku.http.client.RestClient.{MaxRetriesAfterConnectionTimeout, SleepAfterConnectionIssue}
 import io.renku.rdfstore.SparqlQuery.Prefixes
 import io.renku.rdfstore._
@@ -45,9 +45,9 @@ private object ProjectTriplesRemover {
       requestTimeout: Duration = 15 minutes
   ): F[ProjectTriplesRemover[F]] = for {
     rdfStoreConfig <- RdfStoreConfig[F]()
-    renkuBaseUrl   <- RenkuBaseUrlLoader[F]()
+    renkuUrl       <- RenkuUrlLoader[F]()
   } yield new ProjectTriplesRemoverImpl[F](rdfStoreConfig,
-                                           renkuBaseUrl,
+                                           renkuUrl,
                                            retryInterval,
                                            maxRetries,
                                            idleTimeout,
@@ -57,7 +57,7 @@ private object ProjectTriplesRemover {
 
 private class ProjectTriplesRemoverImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     rdfStoreConfig: RdfStoreConfig,
-    renkuBaseUrl:   RenkuBaseUrl,
+    renkuUrl:       RenkuUrl,
     retryInterval:  FiniteDuration = SleepAfterConnectionIssue,
     maxRetries:     Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeout:    Duration = 16 minutes,
@@ -72,7 +72,7 @@ private class ProjectTriplesRemoverImpl[F[_]: Async: Logger: SparqlQueryTimeReco
   import SameAsHierarchyFixer._
   import io.renku.graph.model.Schemas._
 
-  private implicit val baseUrl:     RenkuBaseUrl   = renkuBaseUrl
+  private implicit val baseUrl:     RenkuUrl       = renkuUrl
   private implicit val storeConfig: RdfStoreConfig = rdfStoreConfig
 
   override def removeTriples(projectPath: projects.Path): F[Unit] = for {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/membersync/KGProjectMembersFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/membersync/KGProjectMembersFinder.scala
@@ -20,12 +20,12 @@ package io.renku.triplesgenerator.events.categories.membersync
 
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.graph.config.RenkuBaseUrlLoader
+import io.renku.graph.config.RenkuUrlLoader
 import io.renku.graph.model.Schemas.schema
 import io.renku.graph.model.persons.GitLabId
 import io.renku.graph.model.projects.{Path, ResourceId}
 import io.renku.graph.model.views.RdfResource
-import io.renku.graph.model.{RenkuBaseUrl, persons, projects}
+import io.renku.graph.model.{RenkuUrl, persons, projects}
 import io.renku.rdfstore.SparqlQuery.Prefixes
 import io.renku.rdfstore._
 import org.typelevel.log4cats.Logger
@@ -36,7 +36,7 @@ private trait KGProjectMembersFinder[F[_]] {
 
 private class KGProjectMembersFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     rdfStoreConfig: RdfStoreConfig,
-    renkuBaseUrl:   RenkuBaseUrl
+    renkuUrl:       RenkuUrl
 ) extends RdfStoreClientImpl(rdfStoreConfig)
     with KGProjectMembersFinder[F] {
 
@@ -58,7 +58,7 @@ private class KGProjectMembersFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRec
     Prefixes of schema -> "schema",
     s"""|SELECT DISTINCT ?memberId ?gitLabId
         |WHERE {
-        |  ${ResourceId(path)(renkuBaseUrl).showAs[RdfResource]} a schema:Project;
+        |  ${ResourceId(path)(renkuUrl).showAs[RdfResource]} a schema:Project;
         |                                                        schema:member ?memberId.                                                     
         |  ?sameAsId  schema:additionalType  'GitLab';
         |             schema:identifier      ?gitLabId ;
@@ -71,8 +71,8 @@ private class KGProjectMembersFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRec
 private object KGProjectMembersFinder {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[KGProjectMembersFinder[F]] = for {
     rdfStoreConfig <- RdfStoreConfig[F]()
-    renkuBaseUrl   <- RenkuBaseUrlLoader[F]()
-  } yield new KGProjectMembersFinderImpl(rdfStoreConfig, renkuBaseUrl)
+    renkuUrl       <- RenkuUrlLoader[F]()
+  } yield new KGProjectMembersFinderImpl(rdfStoreConfig, renkuUrl)
 }
 
 private final case class KGProjectMember(resourceId: persons.ResourceId, gitLabId: persons.GitLabId)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/membersync/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/membersync/UpdatesCreator.scala
@@ -21,7 +21,7 @@ package io.renku.triplesgenerator.events.categories.membersync
 import cats.MonadThrow
 import cats.syntax.all._
 import eu.timepit.refined.auto._
-import io.renku.graph.config.{GitLabUrlLoader, RenkuBaseUrlLoader}
+import io.renku.graph.config.{GitLabUrlLoader, RenkuUrlLoader}
 import io.renku.graph.model.Schemas.schema
 import io.renku.graph.model._
 import io.renku.graph.model.projects.ResourceId
@@ -31,7 +31,7 @@ import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
 import io.renku.rdfstore.SparqlQuery
 import io.renku.rdfstore.SparqlQuery.Prefixes
 
-private class UpdatesCreator(renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApiUrl) {
+private class UpdatesCreator(renkuUrl: RenkuUrl, gitLabApiUrl: GitLabApiUrl) {
 
   def insertion(projectPath: projects.Path,
                 members:     Set[(GitLabProjectMember, Option[persons.ResourceId])]
@@ -89,7 +89,7 @@ private class UpdatesCreator(renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApi
   }
 
   private def generateResourceId(gitLabId: GitLabId): persons.ResourceId =
-    persons.ResourceId(gitLabId)(renkuBaseUrl)
+    persons.ResourceId(gitLabId)(renkuUrl)
 
   private def createMemberLinks(projectPath:        projects.Path,
                                 membersAlreadyInKG: List[(GitLabProjectMember, persons.ResourceId)]
@@ -106,7 +106,7 @@ private class UpdatesCreator(renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApi
     }
 
   private def generateLinkTriple(projectPath: projects.Path, memberResourceId: persons.ResourceId) =
-    s"${ResourceId(projectPath)(renkuBaseUrl).showAs[RdfResource]} schema:member ${memberResourceId.showAs[RdfResource]}."
+    s"${ResourceId(projectPath)(renkuUrl).showAs[RdfResource]} schema:member ${memberResourceId.showAs[RdfResource]}."
 
   private lazy val generatePersonTriples: ((persons.ResourceId, GitLabProjectMember)) => String = {
     case (resourceId, member) =>
@@ -131,7 +131,7 @@ private class UpdatesCreator(renkuBaseUrl: RenkuBaseUrl, gitLabApiUrl: GitLabApi
 
 private object UpdatesCreator {
   def apply[F[_]: MonadThrow]: F[UpdatesCreator] = for {
-    renkuBaseUrl <- RenkuBaseUrlLoader[F]()
-    gitLabUrl    <- GitLabUrlLoader[F]()
-  } yield new UpdatesCreator(renkuBaseUrl, gitLabUrl.apiV4)
+    renkuUrl  <- RenkuUrlLoader[F]()
+    gitLabUrl <- GitLabUrlLoader[F]()
+  } yield new UpdatesCreator(renkuUrl, gitLabUrl.apiV4)
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/JsonLDDeserializer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/JsonLDDeserializer.scala
@@ -23,8 +23,8 @@ import cats.effect.Async
 import cats.syntax.all._
 import cats.{Applicative, MonadThrow, NonEmptyParallel, Parallel}
 import io.circe.DecodingFailure
-import io.renku.graph.config.RenkuBaseUrlLoader
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.entities.Project.GitLabProjectInfo
 import io.renku.graph.model.entities._
 import io.renku.http.client.{AccessToken, GitLabClient}
@@ -41,11 +41,11 @@ private trait JsonLDDeserializer[F[_]] {
 
 private class JsonLDDeserializerImpl[F[_]: MonadThrow](
     projectInfoFinder: ProjectInfoFinder[F],
-    renkuBaseUrl:      RenkuBaseUrl
+    renkuUrl:          RenkuUrl
 ) extends JsonLDDeserializer[F] {
 
-  private implicit val renkuUrl: RenkuBaseUrl   = renkuBaseUrl
-  private val applicative:       Applicative[F] = Applicative[F]
+  private implicit val renkuUrlImplicit: RenkuUrl       = renkuUrl
+  private val applicative:               Applicative[F] = Applicative[F]
 
   import applicative._
   import projectInfoFinder._
@@ -101,7 +101,7 @@ private object JsonLDDeserializer {
   def apply[F[_]: Async: NonEmptyParallel: Parallel: Logger](
       gitLabClient: GitLabClient[F]
   ): F[JsonLDDeserializer[F]] = for {
-    renkuBaseUrl      <- RenkuBaseUrlLoader[F]()
+    renkuUrl          <- RenkuUrlLoader[F]()
     projectInfoFinder <- ProjectInfoFinder(gitLabClient)
-  } yield new JsonLDDeserializerImpl[F](projectInfoFinder, renkuBaseUrl)
+  } yield new JsonLDDeserializerImpl[F](projectInfoFinder, renkuUrl)
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/triplesuploading/TransformationStepsRunnerImpl.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/triplesuploading/TransformationStepsRunnerImpl.scala
@@ -22,9 +22,9 @@ import cats.MonadThrow
 import cats.data.EitherT
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.graph.config.{GitLabUrlLoader, RenkuBaseUrlLoader}
+import io.renku.graph.config.{GitLabUrlLoader, RenkuUrlLoader}
 import io.renku.graph.model.entities.Project
-import io.renku.graph.model.{GitLabApiUrl, GitLabUrl, RenkuBaseUrl}
+import io.renku.graph.model.{GitLabApiUrl, GitLabUrl, RenkuUrl}
 import io.renku.rdfstore.{RdfStoreConfig, SparqlQuery, SparqlQueryTimeRecorder}
 import io.renku.triplesgenerator.events.categories.ProcessingRecoverableError
 import io.renku.triplesgenerator.events.categories.triplesgenerated.TransformationStep
@@ -40,12 +40,12 @@ private[triplesgenerated] trait TransformationStepsRunner[F[_]] {
 private[triplesgenerated] class TransformationStepsRunnerImpl[F[_]: MonadThrow](
     triplesUploader: TriplesUploader[F],
     updatesUploader: UpdatesUploader[F],
-    renkuBaseUrl:    RenkuBaseUrl,
+    renkuUrl:        RenkuUrl,
     gitLabUrl:       GitLabUrl
 ) extends TransformationStepsRunner[F] {
 
-  private implicit val gitLabApiUrl: GitLabApiUrl = gitLabUrl.apiV4
-  private implicit val renkuUrl:     RenkuBaseUrl = renkuBaseUrl
+  private implicit val gitLabApiUrl:     GitLabApiUrl = gitLabUrl.apiV4
+  private implicit val renkuUrlImplicit: RenkuUrl     = renkuUrl
 
   import TriplesUploadResult._
   import io.renku.jsonld.syntax._
@@ -110,11 +110,11 @@ private[triplesgenerated] object TransformationStepsRunner {
 
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[TransformationStepsRunnerImpl[F]] = for {
     rdfStoreConfig <- RdfStoreConfig[F]()
-    renkuBaseUrl   <- RenkuBaseUrlLoader[F]()
+    renkuUrl       <- RenkuUrlLoader[F]()
     gitlabUrl      <- GitLabUrlLoader[F]()
   } yield new TransformationStepsRunnerImpl[F](new TriplesUploaderImpl[F](rdfStoreConfig),
                                                new UpdatesUploaderImpl(rdfStoreConfig),
-                                               renkuBaseUrl,
+                                               renkuUrl,
                                                gitlabUrl
   )
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisionJudge.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisionJudge.scala
@@ -38,7 +38,7 @@ private object ReProvisionJudge {
                                                           reProvisioningStatus:      ReProvisioningStatus[F],
                                                           microserviceUrlFinder:     MicroserviceUrlFinder[F],
                                                           versionCompatibilityPairs: NonEmptyList[RenkuVersionPair]
-  )(implicit renkuBaseUrl:                                                           RenkuBaseUrl) = for {
+  )(implicit renkuUrl:                                                               RenkuUrl) = for {
     renkuVersionPairFinder <- RenkuVersionPairFinder(rdfStoreConfig)
     serviceHealthChecker   <- ServiceHealthChecker[F]
   } yield new ReProvisionJudgeImpl[F](renkuVersionPairFinder,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningInfo.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningInfo.scala
@@ -18,7 +18,7 @@
 
 package io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations.reprovisioning
 
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.jsonld._
@@ -49,14 +49,13 @@ private object ReProvisioningInfo {
 
   import io.renku.jsonld.syntax._
 
-  implicit def jsonLDEncoder(implicit
-      renkuBaseUrl: RenkuBaseUrl
-  ): JsonLDEncoder[ReProvisioningInfo] = JsonLDEncoder.instance { entity =>
-    JsonLD.entity(
-      EntityId.of((renkuBaseUrl / "re-provisioning").toString),
-      EntityTypes of renku / "ReProvisioning",
-      renku / "status"        -> entity.status.asInstanceOf[Status].asJsonLD,
-      renku / "controllerUrl" -> entity.controllerUrl.asJsonLD
-    )
+  implicit def jsonLDEncoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[ReProvisioningInfo] = JsonLDEncoder.instance {
+    entity =>
+      JsonLD.entity(
+        EntityId.of((renkuUrl / "re-provisioning").toString),
+        EntityTypes of renku / "ReProvisioning",
+        renku / "status"        -> entity.status.asInstanceOf[Status].asJsonLD,
+        renku / "controllerUrl" -> entity.controllerUrl.asJsonLD
+      )
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatus.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatus.scala
@@ -26,8 +26,8 @@ import io.circe.Decoder
 import io.circe.Decoder.decodeList
 import io.renku.events.consumers.EventHandler
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
-import io.renku.graph.config.RenkuBaseUrlLoader
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.Schemas.renku
 import io.renku.microservices.MicroserviceBaseUrl
 import io.renku.rdfstore.SparqlQuery.Prefixes
@@ -49,7 +49,7 @@ private class ReProvisioningStatusImpl[F[_]: Async: Parallel: Logger: SparqlQuer
     statusRefreshInterval: FiniteDuration,
     cacheRefreshInterval:  FiniteDuration,
     lastCacheCheckTimeRef: Ref[F, Long]
-)(implicit renkuBaseUrl:   RenkuBaseUrl)
+)(implicit renkuUrl:       RenkuUrl)
     extends RdfStoreClientImpl(rdfStoreConfig)
     with ReProvisioningStatus[F] {
 
@@ -171,10 +171,10 @@ object ReProvisioningStatus {
       subscriptionFactories: (EventHandler[F], SubscriptionMechanism[F])*
   ): F[ReProvisioningStatus[F]] = for {
     rdfStoreConfig        <- RdfStoreConfig[F]()
-    renkuBaseUrl          <- RenkuBaseUrlLoader[F]()
+    renkuUrl              <- RenkuUrlLoader[F]()
     lastCacheCheckTimeRef <- Ref.of[F, Long](0)
   } yield {
-    implicit val baseUrl: RenkuBaseUrl = renkuBaseUrl
+    implicit val baseUrl: RenkuUrl = renkuUrl
     new ReProvisioningStatusImpl(subscriptionFactories.map(_._2).toList,
                                  rdfStoreConfig,
                                  StatusRefreshInterval,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinder.scala
@@ -23,7 +23,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.graph.model.Schemas.renku
-import io.renku.graph.model.{RenkuBaseUrl, RenkuVersionPair}
+import io.renku.graph.model.{RenkuUrl, RenkuVersionPair}
 import io.renku.rdfstore.SparqlQuery.Prefixes
 import io.renku.rdfstore._
 import org.typelevel.log4cats.Logger
@@ -33,8 +33,8 @@ trait RenkuVersionPairFinder[F[_]] {
 }
 
 private class RenkuVersionPairFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    rdfStoreConfig:      RdfStoreConfig
-)(implicit renkuBaseUrl: RenkuBaseUrl)
+    rdfStoreConfig:  RdfStoreConfig
+)(implicit renkuUrl: RenkuUrl)
     extends RdfStoreClientImpl[F](rdfStoreConfig)
     with RenkuVersionPairFinder[F] {
 
@@ -61,8 +61,8 @@ private class RenkuVersionPairFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRec
 
 private object RenkuVersionPairFinder {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-      rdfStoreConfig:      RdfStoreConfig
-  )(implicit renkuBaseUrl: RenkuBaseUrl): F[RenkuVersionPairFinderImpl[F]] = MonadThrow[F].catchNonFatal {
+      rdfStoreConfig:  RdfStoreConfig
+  )(implicit renkuUrl: RenkuUrl): F[RenkuVersionPairFinderImpl[F]] = MonadThrow[F].catchNonFatal {
     new RenkuVersionPairFinderImpl[F](rdfStoreConfig)
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
@@ -22,7 +22,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.graph.model.Schemas._
-import io.renku.graph.model.{RenkuBaseUrl, RenkuVersionPair}
+import io.renku.graph.model.{RenkuUrl, RenkuVersionPair}
 import io.renku.jsonld.syntax._
 import io.renku.rdfstore.SparqlQuery.Prefixes
 import io.renku.rdfstore._
@@ -33,8 +33,8 @@ trait RenkuVersionPairUpdater[F[_]] {
 }
 
 private class RenkuVersionPairUpdaterImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    rdfStoreConfig:      RdfStoreConfig
-)(implicit renkuBaseUrl: RenkuBaseUrl)
+    rdfStoreConfig:  RdfStoreConfig
+)(implicit renkuUrl: RenkuUrl)
     extends RdfStoreClientImpl(rdfStoreConfig)
     with RenkuVersionPairUpdater[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/package.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/package.scala
@@ -21,7 +21,7 @@ package migrations
 
 import cats.syntax.all._
 import io.renku.graph.model.Schemas.renku
-import io.renku.graph.model.{RenkuBaseUrl, RenkuVersionPair}
+import io.renku.graph.model.{RenkuUrl, RenkuVersionPair}
 import io.renku.jsonld.syntax._
 import io.renku.jsonld.{EntityId, EntityTypes}
 
@@ -33,14 +33,13 @@ package object reprovisioning {
 
   import io.renku.jsonld.{JsonLD, JsonLDEncoder}
 
-  private[reprovisioning] implicit def jsonLDEncoder(implicit
-      renkuBaseUrl: RenkuBaseUrl
-  ): JsonLDEncoder[RenkuVersionPair] = JsonLDEncoder.instance { entity =>
-    JsonLD.entity(
-      EntityId.of((renkuBaseUrl / "version-pair").toString),
-      EntityTypes of renku / "VersionPair",
-      renku / "schemaVersion" -> entity.schemaVersion.asJsonLD,
-      renku / "cliVersion"    -> entity.cliVersion.asJsonLD
-    )
-  }
+  private[reprovisioning] implicit def jsonLDEncoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[RenkuVersionPair] =
+    JsonLDEncoder.instance { entity =>
+      JsonLD.entity(
+        EntityId.of((renkuUrl / "version-pair").toString),
+        EntityTypes of renku / "VersionPair",
+        renku / "schemaVersion" -> entity.schemaVersion.asJsonLD,
+        renku / "cliVersion"    -> entity.cliVersion.asJsonLD
+      )
+    }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/awaitinggeneration/GenerationProcessesNumberSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/awaitinggeneration/GenerationProcessesNumberSpec.scala
@@ -23,7 +23,7 @@ import com.typesafe.config.ConfigFactory
 import io.renku.config.ConfigLoader.ConfigLoadingException
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{nonBlankStrings, positiveInts}
-import io.renku.graph.config.RenkuBaseUrlLoader
+import io.renku.graph.config.RenkuUrlLoader
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -55,7 +55,7 @@ class GenerationProcessesNumberSpec extends AnyWordSpec with ScalaCheckPropertyC
         Map("generation-processes-number" -> nonBlankStrings().generateOne.value).asJava
       )
 
-      val Failure(exception) = RenkuBaseUrlLoader[Try](config)
+      val Failure(exception) = RenkuUrlLoader[Try](config)
 
       exception shouldBe an[ConfigLoadingException]
     }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/awaitinggeneration/triplesgeneration/renkulog/RenkuLogTriplesGeneratorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/awaitinggeneration/triplesgeneration/renkulog/RenkuLogTriplesGeneratorSpec.scala
@@ -31,9 +31,9 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.generators.jsonld.JsonLDGenerators.jsonLDEntities
 import io.renku.graph.model.EventsGenerators._
-import io.renku.graph.model.GraphModelGenerators.{projectIds, renkuBaseUrls}
+import io.renku.graph.model.GraphModelGenerators.{projectIds, renkuUrls}
 import io.renku.graph.model.events.{CommitId, EventId}
-import io.renku.graph.model.{RenkuBaseUrl, entities, projects}
+import io.renku.graph.model.{RenkuUrl, entities, projects}
 import io.renku.http.client.AccessToken
 import io.renku.jsonld.syntax._
 import io.renku.jsonld.{JsonLD, Property}
@@ -854,7 +854,7 @@ class RenkuLogTriplesGeneratorSpec extends AnyWordSpec with IOSpec with MockFact
 
   private trait TestCase {
     implicit lazy val maybeAccessToken: Option[AccessToken] = Gen.option(accessTokens).generateOne
-    implicit lazy val renkuBaseUrl:     RenkuBaseUrl        = renkuBaseUrls.generateOne
+    implicit lazy val renkuUrl:         RenkuUrl            = renkuUrls.generateOne
     lazy val repositoryName = nonEmptyStrings().generateOne
     lazy val projectPath    = projects.Path(s"user/$repositoryName")
     lazy val gitRepositoryUrl = serviceUrls.generateOne / maybeAccessToken

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/cleanup/ProjectTriplesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/cleanup/ProjectTriplesRemoverSpec.scala
@@ -433,7 +433,7 @@ class ProjectTriplesRemoverSpec
   private def findProject(projectPath: projects.Path) = runQuery(
     s"""SELECT ?p ?o 
         WHERE { 
-          <$renkuBaseUrl/projects/$projectPath> ?p ?o .
+          <$renkuUrl/projects/$projectPath> ?p ?o .
         } """
   ).map(_.map(_.values.toList))
 
@@ -461,7 +461,7 @@ class ProjectTriplesRemoverSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val projectTriplesRemover = new ProjectTriplesRemoverImpl[IO](rdfStoreConfig, renkuBaseUrl)
+    val projectTriplesRemover = new ProjectTriplesRemoverImpl[IO](rdfStoreConfig, renkuUrl)
   }
 
   private def findOutNewlyNominatedTopDS(ds1: Dataset[Dataset.Provenance], ds2: Dataset[Dataset.Provenance]): EntityId =

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/Generators.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/Generators.scala
@@ -19,7 +19,7 @@
 package io.renku.triplesgenerator.events.categories.membersync
 
 import io.renku.graph.model.GraphModelGenerators.{personGitLabIds, personNames, personResourceIds}
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 import org.scalacheck.Gen
 
 private object Generators {
@@ -29,7 +29,7 @@ private object Generators {
     name <- personNames
   } yield GitLabProjectMember(id, name)
 
-  implicit def kgProjectMembers(implicit renkuBaseUrl: RenkuBaseUrl): Gen[KGProjectMember] = for {
+  implicit def kgProjectMembers(implicit renkuUrl: RenkuUrl): Gen[KGProjectMember] = for {
     memberId <- personResourceIds
     gitLabId <- personGitLabIds
   } yield KGProjectMember(memberId, gitLabId)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/KGProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/KGProjectMembersFinderSpec.scala
@@ -59,6 +59,6 @@ class KGProjectMembersFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new KGProjectMembersFinderImpl[IO](rdfStoreConfig, renkuBaseUrl)
+    val finder = new KGProjectMembersFinderImpl[IO](rdfStoreConfig, renkuUrl)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/MembersSynchronizerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/MembersSynchronizerSpec.scala
@@ -23,7 +23,7 @@ import io.renku.generators.CommonGraphGenerators.{accessTokens, sparqlQueries}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators._
-import io.renku.graph.model.{RenkuBaseUrl, projects}
+import io.renku.graph.model.{RenkuUrl, projects}
 import io.renku.graph.model.projects.Path
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.graph.tokenrepository.AccessTokenFinder.projectPathToPath
@@ -124,7 +124,7 @@ class MembersSynchronizerSpec extends AnyWordSpec with MockFactory with should.M
   }
 
   private trait TestCase {
-    implicit val renkuBaseUrl: RenkuBaseUrl = renkuBaseUrls.generateOne
+    implicit val renkuUrl: RenkuUrl = renkuUrls.generateOne
     val projectPath = projectPaths.generateOne
 
     implicit val logger: TestLogger[Try] = TestLogger[Try]()

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/UpdatesCreatorSpec.scala
@@ -171,7 +171,7 @@ class UpdatesCreatorSpec extends AnyWordSpec with IOSpec with InMemoryRdfStore w
       - links are created regardless of the project exists in KG
    */
 
-  private lazy val updatesCreator = new UpdatesCreator(renkuBaseUrl, gitLabApiUrl)
+  private lazy val updatesCreator = new UpdatesCreator(renkuUrl, gitLabApiUrl)
 
   private def findMembers(path: projects.Path): Set[GitLabId] =
     runQuery(

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/JsonLDDeserializerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/JsonLDDeserializerSpec.scala
@@ -262,7 +262,7 @@ class JsonLDDeserializerSpec extends AnyWordSpec with MockFactory with should.Ma
     )
 
     val projectInfoFinder = mock[ProjectInfoFinder[Try]]
-    val deserializer      = new JsonLDDeserializerImpl[Try](projectInfoFinder, renkuBaseUrl)
+    val deserializer      = new JsonLDDeserializerImpl[Try](projectInfoFinder, renkuUrl)
 
     private implicit lazy val toProjectMember: Person => ProjectMember = person => {
       val member = ProjectMember(person.name,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/ProjectFunctionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/ProjectFunctionsSpec.scala
@@ -174,7 +174,7 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
 
       val dataset1 :: dataset2Old :: Nil = project.datasets
 
-      val dataset2New = datasetEntities(provenanceNonModified)(renkuBaseUrl)(project.dateCreated).generateOne
+      val dataset2New = datasetEntities(provenanceNonModified)(renkuUrl)(project.dateCreated).generateOne
         .to[entities.Dataset[entities.Dataset.Provenance]]
 
       update(dataset2Old, dataset2New)(project).datasets shouldBe List(dataset1, dataset2New)
@@ -195,7 +195,7 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
             .generateOne
 
         val originalImportedInternal =
-          datasetEntities(provenanceImportedInternalAncestorInternal())(renkuBaseUrl)(project.dateCreated).generateOne
+          datasetEntities(provenanceImportedInternalAncestorInternal())(renkuUrl)(project.dateCreated).generateOne
         val projectWithAllDatasets =
           project.addDatasets(originalImportedInternal, originalImportedInternal.invalidateNow).to[entities.Project]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/triplesuploading/TransformationStepsRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/triplesgenerated/triplesuploading/TransformationStepsRunnerSpec.scala
@@ -287,6 +287,6 @@ class TransformationStepsRunnerSpec extends AnyWordSpec with MockFactory with sh
   private trait TestCase {
     val triplesUploader = mock[TriplesUploader[Try]]
     val updatesUploader = mock[UpdatesUploader[Try]]
-    val uploader = new TransformationStepsRunnerImpl[Try](triplesUploader, updatesUploader, renkuBaseUrl, gitLabUrl)
+    val uploader        = new TransformationStepsRunnerImpl[Try](triplesUploader, updatesUploader, renkuUrl, gitLabUrl)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MalformedActivityIdsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MalformedActivityIdsSpec.scala
@@ -69,5 +69,5 @@ class MalformedActivityIdsSpec extends AnyWordSpec with should.Matchers with IOS
   private def makeResourceIdBroken(activity: entities.Activity): entities.Activity =
     activity.copy(resourceId = activities.ResourceId(activity.resourceId.value.replace("/activities/", "")))
 
-  implicit val renkuBaseUrl: RenkuBaseUrl = RenkuBaseUrl(s"http://${nonEmptyStrings().generateOne}")
+  implicit val renkuUrl: RenkuUrl = RenkuUrl(s"http://${nonEmptyStrings().generateOne}")
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatusSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatusSpec.scala
@@ -25,8 +25,8 @@ import eu.timepit.refined.auto._
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.generators.CommonGraphGenerators.microserviceBaseUrls
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.GraphModelGenerators.renkuBaseUrls
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.GraphModelGenerators.renkuUrls
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.Schemas._
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
@@ -151,7 +151,7 @@ class ReProvisioningStatusSpec
     val statusRefreshInterval = 1 second
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    private implicit val renkuBaseUrl: RenkuBaseUrl                = renkuBaseUrls.generateOne
+    private implicit val renkuUrl:     RenkuUrl                    = renkuUrls.generateOne
     private val statusCacheCheckTimeRef = Ref.unsafe[IO, Long](0L)
     private val subscriptions           = List(mock[SubscriptionMechanism[IO]], mock[SubscriptionMechanism[IO]])
     val reProvisioningStatus = new ReProvisioningStatusImpl[IO](subscriptions,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinderSpec.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators._
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.RenkuUrl
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Warn
 import io.renku.logging.{TestExecutionTimeRecorder, TestSparqlQueryTimeRecorder}
@@ -35,7 +35,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class RenkuVersionPairFinderSpec extends AnyWordSpec with IOSpec with InMemoryRdfStore with should.Matchers {
 
-  private implicit lazy val renkuBaseUrl: RenkuBaseUrl = renkuBaseUrls.generateOne
+  private implicit lazy val renkuUrl: RenkuUrl = renkuUrls.generateOne
 
   "find" should {
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdaterSpec.scala
@@ -50,7 +50,7 @@ class RenkuVersionPairUpdaterSpec extends AnyWordSpec with IOSpec with InMemoryR
     val currentRenkuVersionPair      = renkuVersionPairs.generateOne
     val newVersionCompatibilityPairs = renkuVersionPairs.generateOne
 
-    private implicit val renkuBaseUrl: RenkuBaseUrl                = renkuBaseUrls.generateOne
+    private implicit val renkuUrl:     RenkuUrl                    = renkuUrls.generateOne
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     val renkuVersionPairUpdater = new RenkuVersionPairUpdaterImpl[IO](rdfStoreConfig)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/MigrationExecutionRegisterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/MigrationExecutionRegisterSpec.scala
@@ -25,8 +25,8 @@ import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators.serviceVersions
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.GraphModelGenerators.renkuBaseUrls
-import io.renku.graph.model.RenkuBaseUrl
+import io.renku.graph.model.GraphModelGenerators.renkuUrls
+import io.renku.graph.model.RenkuUrl
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
@@ -53,7 +53,7 @@ class MigrationExecutionRegisterSpec extends AnyWordSpec with IOSpec with InMemo
     val migrationName  = migrationNames.generateOne
     val serviceVersion = serviceVersions.generateOne
 
-    private implicit val renkuBaseUrl: RenkuBaseUrl                = renkuBaseUrls.generateOne
+    private implicit val renkuUrl:     RenkuUrl                    = renkuUrls.generateOne
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     val register = new MigrationExecutionRegisterImpl[IO](serviceVersion, migrationsStoreConfig)


### PR DESCRIPTION
It's simple but extensive rename of `RenkuBaseUrl` to `RenkuUrl`