### PR TITLE
fix: single location path segment on the project file lineage

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/LineageResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/LineageResourcesSpec.scala
@@ -36,6 +36,7 @@ import io.renku.graph.model.testentities.LineageExemplarData.ExemplarData
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{personEntities, renkuProjectEntities, visibilityPublic}
 import io.renku.graph.model.testentities.{LineageExemplarData, NodeDef}
 import io.renku.http.client.AccessToken
+import io.renku.http.client.UrlEncoder.urlEncode
 import io.renku.jsonld.syntax._
 import org.http4s.Status.{NotFound, Ok}
 import org.scalatest.GivenWhenThen
@@ -85,7 +86,7 @@ class LineageResourcesSpec
 
       When("user calls the lineage endpoint")
       val response =
-        knowledgeGraphClient GET s"knowledge-graph/projects/${project.path}/files/${exemplarData.`grid_plot entity`.location}/lineage"
+        knowledgeGraphClient GET s"knowledge-graph/projects/${project.path}/files/${urlEncode(exemplarData.`grid_plot entity`.location)}/lineage"
 
       Then("they should get Ok response with project lineage in Json")
       response.status shouldBe Ok
@@ -121,7 +122,7 @@ class LineageResourcesSpec
       When("user fetches the lineage of the project he is a member of")
 
       val response =
-        knowledgeGraphClient GET (s"knowledge-graph/projects/${project.path}/files/${accessibleExemplarData.`grid_plot entity`.location}/lineage", user.accessToken)
+        knowledgeGraphClient GET (s"knowledge-graph/projects/${project.path}/files/${urlEncode(accessibleExemplarData.`grid_plot entity`.location)}/lineage", user.accessToken)
 
       Then("he should get OK response with project lineage in Json")
       response.status shouldBe Ok
@@ -150,7 +151,7 @@ class LineageResourcesSpec
       When("user posts a graphql query to fetch lineage of the project he is not a member of")
       val response =
         knowledgeGraphClient.GET(
-          s"knowledge-graph/projects/${project.path}/files/${privateExemplarData.`grid_plot entity`.location}/lineage"
+          s"knowledge-graph/projects/${project.path}/files/${urlEncode(privateExemplarData.`grid_plot entity`.location)}/lineage"
         )
 
       Then("he should get a NotFound response without lineage")

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -652,7 +652,7 @@ Response body example:
 
 #### GET /knowledge-graph/projects/:namespace/:name/files/:location/lineage
 
-Fetches lineage for a given project `namespace`/`name` and file `location` (relative path). This endpoint is intended to replace the graphql endpoint.
+Fetches lineage for a given project `namespace`/`name` and file `location` (URL-encoded relative path to the file). This endpoint is intended to replace the graphql endpoint.
 
 | Status                     | Description                                                       |
 |----------------------------|-------------------------------------------------------------------|

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
@@ -23,6 +23,7 @@ import cats.data.{Kleisli, OptionT}
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import eu.timepit.refined.auto._
+import io.renku.http.client.UrlEncoder.urlEncode
 import io.circe.Json
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
@@ -244,9 +245,10 @@ class MicroserviceRoutesSpec
       response.body[ErrorMessage] shouldBe InfoMessage(AuthorizationFailure.getMessage)
     }
   }
+
   "GET /knowledge-graph/projects/:projectId/files/:location/lineage" should {
     def lineageUri(projectPath: ProjectPath, location: Location) =
-      Uri.unsafeFromString(s"knowledge-graph/projects/${projectPath.value}/files/${location.value}/lineage")
+      Uri.unsafeFromString(s"knowledge-graph/projects/${projectPath.show}/files/${urlEncode(location.show)}/lineage")
 
     s"return $Ok when the lineage is found" in new TestCase {
       val projectPath   = projectPaths.generateOne


### PR DESCRIPTION
This PR fixes the `location` path segment parameter so it's passed as a one piece of URL-encoded path instead of expanded segments