### PR TITLE
refactor: re-provisioninig process data to be stored in migrations DS

### DIFF
--- a/graph-commons/src/test/scala/io/renku/graph/http/server/security/DatasetIdRecordsFinderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/http/server/security/DatasetIdRecordsFinderSpec.scala
@@ -85,6 +85,6 @@ class DatasetIdRecordsFinderSpec extends AnyWordSpec with IOSpec with InMemoryRd
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val recordsFinder = new DatasetIdRecordsFinderImpl[IO](rdfStoreConfig)
+    val recordsFinder = new DatasetIdRecordsFinderImpl[IO](renkuStoreConfig)
   }
 }

--- a/graph-commons/src/test/scala/io/renku/graph/http/server/security/ProjectPathRecordsFinderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/http/server/security/ProjectPathRecordsFinderSpec.scala
@@ -64,6 +64,6 @@ class ProjectPathRecordsFinderSpec extends AnyWordSpec with IOSpec with InMemory
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val recordsFinder = new ProjectPathRecordsFinderImpl[IO](rdfStoreConfig)
+    val recordsFinder = new ProjectPathRecordsFinderImpl[IO](renkuStoreConfig)
   }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetFinderSpec.scala
@@ -634,10 +634,10 @@ class DatasetFinderSpec
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     val datasetFinder = new DatasetFinderImpl[IO](
-      new BaseDetailsFinderImpl[IO](rdfStoreConfig),
-      new CreatorsFinderImpl[IO](rdfStoreConfig),
-      new PartsFinderImpl[IO](rdfStoreConfig),
-      new ProjectsFinderImpl[IO](rdfStoreConfig)
+      new BaseDetailsFinderImpl[IO](renkuStoreConfig),
+      new CreatorsFinderImpl[IO](renkuStoreConfig),
+      new PartsFinderImpl[IO](renkuStoreConfig),
+      new ProjectsFinderImpl[IO](renkuStoreConfig)
     )
   }
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/DatasetsFinderSpec.scala
@@ -904,7 +904,7 @@ class DatasetsFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val datasetsFinder = new DatasetsFinderImpl[IO](rdfStoreConfig, new CreatorsFinderImpl[IO](rdfStoreConfig))
+    val datasetsFinder = new DatasetsFinderImpl[IO](renkuStoreConfig, new CreatorsFinderImpl[IO](renkuStoreConfig))
   }
 
   private lazy val publicProjectEntities: Gen[RenkuProject.WithoutParent] = renkuProjectEntities(visibilityPublic)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/ProjectDatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/rest/ProjectDatasetsFinderSpec.scala
@@ -157,6 +157,6 @@ class ProjectDatasetsFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val datasetsFinder = new ProjectDatasetsFinderImpl[IO](rdfStoreConfig)
+    val datasetsFinder = new ProjectDatasetsFinderImpl[IO](renkuStoreConfig)
   }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
@@ -39,7 +39,7 @@ trait FinderSpecOps {
   protected[finder] trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new EntitiesFinderImpl[IO](rdfStoreConfig)
+    val finder = new EntitiesFinderImpl[IO](renkuStoreConfig)
   }
 
   protected implicit class PagingResponseOps(response: PagingResponse[model.Entity]) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/EdgesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/EdgesFinderSpec.scala
@@ -239,7 +239,7 @@ class EdgesFinderSpec
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] =
       TestSparqlQueryTimeRecorder[IO](executionTimeRecorder)
-    val edgesFinder = new EdgesFinderImpl[IO](rdfStoreConfig, renkuUrl)
+    val edgesFinder = new EdgesFinderImpl[IO](renkuStoreConfig, renkuUrl)
   }
 
   private implicit class NodeDefOps(nodeDef: NodeDef) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/NodeDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/lineage/NodeDetailsFinderSpec.scala
@@ -259,7 +259,7 @@ class NodeDetailsFinderSpec
   private trait TestCase {
     implicit val logger:               TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val nodeDetailsFinder = new NodeDetailsFinderImpl[IO](rdfStoreConfig, renkuUrl)
+    val nodeDetailsFinder = new NodeDetailsFinderImpl[IO](renkuStoreConfig, renkuUrl)
   }
 
   private implicit class NodeDefOps(nodeDef: NodeDef) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/StatsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/StatsFinderSpec.scala
@@ -80,7 +80,7 @@ class StatsFinderSpec
   private trait TestCase {
     implicit val logger:               TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val stats = new StatsFinderImpl[IO](rdfStoreConfig)
+    val stats = new StatsFinderImpl[IO](renkuStoreConfig)
   }
 
   private implicit class MapOps(entitiesByType: Map[EntityLabel, Count]) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/rest/KGProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/rest/KGProjectFinderSpec.scala
@@ -113,7 +113,7 @@ class KGProjectFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val kgProjectFinder = new KGProjectFinderImpl[IO](rdfStoreConfig)
+    val kgProjectFinder = new KGProjectFinderImpl[IO](renkuStoreConfig)
   }
 
   private def replaceMembers(members: Set[Person]): Project => Project = {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisionJudge.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisionJudge.scala
@@ -26,7 +26,7 @@ import cats.{MonadThrow, Show}
 import io.renku.graph.model._
 import io.renku.http.client.ServiceHealthChecker
 import io.renku.microservices.MicroserviceUrlFinder
-import io.renku.rdfstore.{RdfStoreConfig, SparqlQueryTimeRecorder}
+import io.renku.rdfstore.{MigrationsStoreConfig, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 
 private trait ReProvisionJudge[F[_]] {
@@ -34,12 +34,12 @@ private trait ReProvisionJudge[F[_]] {
 }
 
 private object ReProvisionJudge {
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](rdfStoreConfig: RdfStoreConfig,
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](storeConfig: MigrationsStoreConfig,
                                                           reProvisioningStatus:      ReProvisioningStatus[F],
                                                           microserviceUrlFinder:     MicroserviceUrlFinder[F],
                                                           versionCompatibilityPairs: NonEmptyList[RenkuVersionPair]
   )(implicit renkuUrl:                                                               RenkuUrl) = for {
-    renkuVersionPairFinder <- RenkuVersionPairFinder(rdfStoreConfig)
+    renkuVersionPairFinder <- RenkuVersionPairFinder(storeConfig)
     serviceHealthChecker   <- ServiceHealthChecker[F]
   } yield new ReProvisionJudgeImpl[F](renkuVersionPairFinder,
                                       reProvisioningStatus,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatus.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatus.scala
@@ -45,12 +45,12 @@ trait ReProvisioningStatus[F[_]] {
 
 private class ReProvisioningStatusImpl[F[_]: Async: Parallel: Logger: SparqlQueryTimeRecorder](
     subscriptions:         List[SubscriptionMechanism[F]],
-    rdfStoreConfig:        RdfStoreConfig,
+    storeConfig:           MigrationsStoreConfig,
     statusRefreshInterval: FiniteDuration,
     cacheRefreshInterval:  FiniteDuration,
     lastCacheCheckTimeRef: Ref[F, Long]
 )(implicit renkuUrl:       RenkuUrl)
-    extends RdfStoreClientImpl(rdfStoreConfig)
+    extends RdfStoreClientImpl(storeConfig)
     with ReProvisioningStatus[F] {
 
   import io.renku.jsonld.syntax._
@@ -170,13 +170,13 @@ object ReProvisioningStatus {
   def apply[F[_]: Async: Parallel: Logger: SparqlQueryTimeRecorder](
       subscriptionFactories: (EventHandler[F], SubscriptionMechanism[F])*
   ): F[ReProvisioningStatus[F]] = for {
-    rdfStoreConfig        <- RdfStoreConfig[F]()
+    storeConfig           <- MigrationsStoreConfig[F]()
     renkuUrl              <- RenkuUrlLoader[F]()
     lastCacheCheckTimeRef <- Ref.of[F, Long](0)
   } yield {
     implicit val baseUrl: RenkuUrl = renkuUrl
     new ReProvisioningStatusImpl(subscriptionFactories.map(_._2).toList,
-                                 rdfStoreConfig,
+                                 storeConfig,
                                  StatusRefreshInterval,
                                  CacheRefreshInterval,
                                  lastCacheCheckTimeRef

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinder.scala
@@ -33,9 +33,9 @@ trait RenkuVersionPairFinder[F[_]] {
 }
 
 private class RenkuVersionPairFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    rdfStoreConfig:  RdfStoreConfig
+    storeConfig:     MigrationsStoreConfig
 )(implicit renkuUrl: RenkuUrl)
-    extends RdfStoreClientImpl[F](rdfStoreConfig)
+    extends RdfStoreClientImpl[F](storeConfig)
     with RenkuVersionPairFinder[F] {
 
   override def find(): F[Option[RenkuVersionPair]] = queryExpecting[List[RenkuVersionPair]] {
@@ -61,8 +61,8 @@ private class RenkuVersionPairFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRec
 
 private object RenkuVersionPairFinder {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-      rdfStoreConfig:  RdfStoreConfig
+      storeConfig:     MigrationsStoreConfig
   )(implicit renkuUrl: RenkuUrl): F[RenkuVersionPairFinderImpl[F]] = MonadThrow[F].catchNonFatal {
-    new RenkuVersionPairFinderImpl[F](rdfStoreConfig)
+    new RenkuVersionPairFinderImpl[F](storeConfig)
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
@@ -33,9 +33,9 @@ trait RenkuVersionPairUpdater[F[_]] {
 }
 
 private class RenkuVersionPairUpdaterImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    rdfStoreConfig:  RdfStoreConfig
+    storeConfig:     MigrationsStoreConfig
 )(implicit renkuUrl: RenkuUrl)
-    extends RdfStoreClientImpl(rdfStoreConfig)
+    extends RdfStoreClientImpl(storeConfig)
     with RenkuVersionPairUpdater[F] {
 
   override def update(versionPair: RenkuVersionPair): F[Unit] =

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/cleanup/ProjectTriplesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/cleanup/ProjectTriplesRemoverSpec.scala
@@ -461,7 +461,7 @@ class ProjectTriplesRemoverSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val projectTriplesRemover = new ProjectTriplesRemoverImpl[IO](rdfStoreConfig, renkuUrl)
+    val projectTriplesRemover = new ProjectTriplesRemoverImpl[IO](renkuStoreConfig, renkuUrl)
   }
 
   private def findOutNewlyNominatedTopDS(ds1: Dataset[Dataset.Provenance], ds2: Dataset[Dataset.Provenance]): EntityId =

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/KGPersonFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/KGPersonFinderSpec.scala
@@ -59,6 +59,6 @@ class KGPersonFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new KGPersonFinderImpl[IO](rdfStoreConfig)
+    val finder = new KGPersonFinderImpl[IO](renkuStoreConfig)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/KGProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/membersync/KGProjectMembersFinderSpec.scala
@@ -59,6 +59,6 @@ class KGProjectMembersFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new KGProjectMembersFinderImpl[IO](rdfStoreConfig, renkuUrl)
+    val finder = new KGProjectMembersFinderImpl[IO](renkuStoreConfig, renkuUrl)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleOriginalIdentifiersSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleOriginalIdentifiersSpec.scala
@@ -84,8 +84,8 @@ class MultipleOriginalIdentifiersSpec
     implicit val timeRecorder:    SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     implicit val metricsRegistry: MetricsRegistry[IO]         = new MetricsRegistry.DisabledMetricsRegistry[IO]()
     val executionRegister = mock[MigrationExecutionRegister[IO]]
-    val recordsFinder     = RecordsFinder[IO](rdfStoreConfig)
-    val updateRunner      = UpdateQueryRunner[IO](rdfStoreConfig)
+    val recordsFinder     = RecordsFinder[IO](renkuStoreConfig)
+    val updateRunner      = UpdateQueryRunner[IO](renkuStoreConfig)
     val migration         = new MultipleOriginalIdentifiers[IO](executionRegister, recordsFinder, updateRunner)
 
     lazy val satisfyMocks = {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleProjectAgentsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleProjectAgentsSpec.scala
@@ -76,8 +76,8 @@ class MultipleProjectAgentsSpec
     implicit val timeRecorder:    SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     implicit val metricsRegistry: MetricsRegistry[IO]         = new MetricsRegistry.DisabledMetricsRegistry[IO]()
     val executionRegister = mock[MigrationExecutionRegister[IO]]
-    val recordsFinder     = RecordsFinder[IO](rdfStoreConfig)
-    val updateRunner      = UpdateQueryRunner[IO](rdfStoreConfig)
+    val recordsFinder     = RecordsFinder[IO](renkuStoreConfig)
+    val updateRunner      = UpdateQueryRunner[IO](renkuStoreConfig)
     val migration         = new MultipleProjectAgents[IO](executionRegister, recordsFinder, updateRunner)
 
     lazy val satisfyMocks = {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleTopmostDerivedFromsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/MultipleTopmostDerivedFromsSpec.scala
@@ -89,8 +89,8 @@ class MultipleTopmostDerivedFromsSpec
     implicit val timeRecorder:    SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
     implicit val metricsRegistry: MetricsRegistry[IO]         = new MetricsRegistry.DisabledMetricsRegistry[IO]()
     val executionRegister = mock[MigrationExecutionRegister[IO]]
-    val recordsFinder     = RecordsFinder[IO](rdfStoreConfig)
-    val updateRunner      = UpdateQueryRunner[IO](rdfStoreConfig)
+    val recordsFinder     = RecordsFinder[IO](renkuStoreConfig)
+    val updateRunner      = UpdateQueryRunner[IO](renkuStoreConfig)
     val migration         = new MultipleTopmostDerivedFroms[IO](executionRegister, recordsFinder, updateRunner)
 
     lazy val satisfyMocks = {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatusSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatusSpec.scala
@@ -31,7 +31,7 @@ import io.renku.graph.model.Schemas._
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.rdfstore.SparqlQuery.Prefixes
-import io.renku.rdfstore.{InMemoryRdfStore, SparqlQuery, SparqlQueryTimeRecorder}
+import io.renku.rdfstore._
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations.reprovisioning.ReProvisioningInfo.Status.Running
 import org.scalamock.scalatest.MockFactory
@@ -146,6 +146,8 @@ class ReProvisioningStatusSpec
     }
   }
 
+  override lazy val storeConfig: TriplesStoreConfig = migrationsStoreConfig
+
   private trait TestCase {
     val cacheRefreshInterval  = 1 second
     val statusRefreshInterval = 1 second
@@ -155,7 +157,7 @@ class ReProvisioningStatusSpec
     private val statusCacheCheckTimeRef = Ref.unsafe[IO, Long](0L)
     private val subscriptions           = List(mock[SubscriptionMechanism[IO]], mock[SubscriptionMechanism[IO]])
     val reProvisioningStatus = new ReProvisioningStatusImpl[IO](subscriptions,
-                                                                rdfStoreConfig,
+                                                                migrationsStoreConfig,
                                                                 statusRefreshInterval,
                                                                 cacheRefreshInterval,
                                                                 statusCacheCheckTimeRef

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinderSpec.scala
@@ -26,7 +26,7 @@ import io.renku.graph.model.RenkuUrl
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Warn
 import io.renku.logging.{TestExecutionTimeRecorder, TestSparqlQueryTimeRecorder}
-import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
+import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder, TriplesStoreConfig}
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.generators.VersionGenerators.renkuVersionPairs
 import org.scalatest._
@@ -64,6 +64,8 @@ class RenkuVersionPairFinderSpec extends AnyWordSpec with IOSpec with InMemoryRd
     }
   }
 
+  override lazy val storeConfig: TriplesStoreConfig = migrationsStoreConfig
+
   private trait TestCase {
     val currentVersionPair = renkuVersionPairs.generateOne
 
@@ -71,6 +73,6 @@ class RenkuVersionPairFinderSpec extends AnyWordSpec with IOSpec with InMemoryRd
     val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] =
       TestSparqlQueryTimeRecorder[IO](executionTimeRecorder)
-    val versionPairFinder = new RenkuVersionPairFinderImpl[IO](rdfStoreConfig)
+    val versionPairFinder = new RenkuVersionPairFinderImpl[IO](migrationsStoreConfig)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdaterSpec.scala
@@ -24,7 +24,7 @@ import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model._
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
-import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
+import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder, TriplesStoreConfig}
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.generators.VersionGenerators._
 import org.scalatest.matchers.should.Matchers
@@ -46,6 +46,8 @@ class RenkuVersionPairUpdaterSpec extends AnyWordSpec with IOSpec with InMemoryR
     }
   }
 
+  override lazy val storeConfig: TriplesStoreConfig = migrationsStoreConfig
+
   private trait TestCase {
     val currentRenkuVersionPair      = renkuVersionPairs.generateOne
     val newVersionCompatibilityPairs = renkuVersionPairs.generateOne
@@ -53,7 +55,7 @@ class RenkuVersionPairUpdaterSpec extends AnyWordSpec with IOSpec with InMemoryR
     private implicit val renkuUrl:     RenkuUrl                    = renkuUrls.generateOne
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val renkuVersionPairUpdater = new RenkuVersionPairUpdaterImpl[IO](rdfStoreConfig)
+    val renkuVersionPairUpdater = new RenkuVersionPairUpdaterImpl[IO](migrationsStoreConfig)
 
     def findPairInDb: Set[RenkuVersionPair] =
       runQuery(s"""|SELECT DISTINCT ?schemaVersion ?cliVersion 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/TriplesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/reprovisioning/TriplesRemoverSpec.scala
@@ -19,7 +19,6 @@
 package io.renku.triplesgenerator.events.categories.tsmigrationrequest.migrations.reprovisioning
 
 import cats.effect.IO
-import io.renku.generators.CommonGraphGenerators.microserviceBaseUrls
 import io.renku.generators.Generators.Implicits.GenOps
 import io.renku.generators.Generators._
 import io.renku.graph.model.testentities._
@@ -40,25 +39,14 @@ class TriplesRemoverSpec extends AnyWordSpec with IOSpec with InMemoryRdfStore w
       loadToStore(
         anyRenkuProjectEntities.generateOne.asJsonLD,
         anyRenkuProjectEntities.generateOne.asJsonLD,
-        renkuVersionPairs.generateOne.asJsonLD,
-        ReProvisioningInfo(ReProvisioningInfo.Status.Running, microserviceBaseUrls.generateOne).asJsonLD
+        renkuVersionPairs.generateOne.asJsonLD
       )
 
-      val graphMetadataTriples = runQuery {
-        """|SELECT DISTINCT ?s ?p ?o 
-           |WHERE {
-           |  ?s a ?type
-           |  FILTER (?type IN (renku:VersionPair, renku:ReProvisioning))
-           |  ?s ?p ?o
-           |}
-           |""".stripMargin
-      }.unsafeRunSync()
-
-      rdfStoreSize should be > graphMetadataTriples.size
+      rdfStoreSize should be > 0
 
       triplesRemover.removeAllTriples().unsafeRunSync() shouldBe ()
 
-      rdfStoreSize shouldBe graphMetadataTriples.size
+      rdfStoreSize shouldBe 0
     }
   }
 
@@ -68,6 +56,6 @@ class TriplesRemoverSpec extends AnyWordSpec with IOSpec with InMemoryRdfStore w
     private val executionTimeRecorder = TestExecutionTimeRecorder[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] =
       TestSparqlQueryTimeRecorder[IO](executionTimeRecorder)
-    val triplesRemover = new TriplesRemoverImpl[IO](removalBatchSize, rdfStoreConfig)
+    val triplesRemover = new TriplesRemoverImpl[IO](removalBatchSize, renkuStoreConfig)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/MigrationExecutionRegisterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/MigrationExecutionRegisterSpec.scala
@@ -29,7 +29,7 @@ import io.renku.graph.model.GraphModelGenerators.renkuUrls
 import io.renku.graph.model.RenkuUrl
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
-import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder}
+import io.renku.rdfstore.{InMemoryRdfStore, SparqlQueryTimeRecorder, TriplesStoreConfig}
 import io.renku.testtools.IOSpec
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -48,6 +48,8 @@ class MigrationExecutionRegisterSpec extends AnyWordSpec with IOSpec with InMemo
       register.findExecution(migrationName).unsafeRunSync() shouldBe None
     }
   }
+
+  override lazy val storeConfig: TriplesStoreConfig = migrationsStoreConfig
 
   private trait TestCase {
     val migrationName  = migrationNames.generateOne

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/ProjectsFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/ProjectsFinderSpec.scala
@@ -55,6 +55,6 @@ class ProjectsFinderSpec extends AnyWordSpec with IOSpec with should.Matchers wi
     )
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val projectsFinder = new ProjectsFinderImpl[IO](query, rdfStoreConfig)
+    val projectsFinder = new ProjectsFinderImpl[IO](query, renkuStoreConfig)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/RecordsFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/RecordsFinderSpec.scala
@@ -60,6 +60,6 @@ class RecordsFinderSpec extends AnyWordSpec with should.Matchers with InMemoryRd
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val client = new RecordsFinderImpl[IO](rdfStoreConfig)
+    val client = new RecordsFinderImpl[IO](renkuStoreConfig)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/UpdateQueryRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsmigrationrequest/migrations/tooling/UpdateQueryRunnerSpec.scala
@@ -52,7 +52,7 @@ class UpdateQueryRunnerSpec extends AnyWordSpec with should.Matchers with IOSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val runner = new UpdateQueryRunnerImpl[IO](rdfStoreConfig)
+    val runner = new UpdateQueryRunnerImpl[IO](renkuStoreConfig)
   }
 
   private def findString = runQuery("SELECT ?str WHERE { <http://localhost/test> schema:name ?str }")

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/activities/KGInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/activities/KGInfoFinderSpec.scala
@@ -113,6 +113,6 @@ class KGInfoFinderSpec extends AnyWordSpec with IOSpec with InMemoryRdfStore wit
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val kgInfoFinder = new KGInfoFinderImpl[IO](rdfStoreConfig)
+    val kgInfoFinder = new KGInfoFinderImpl[IO](renkuStoreConfig)
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/datasets/KGDatasetInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/datasets/KGDatasetInfoFinderSpec.scala
@@ -240,7 +240,7 @@ class KGDatasetInfoFinderSpec extends AnyWordSpec with IOSpec with InMemoryRdfSt
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new KGDatasetInfoFinderImpl[IO](rdfStoreConfig)
+    val finder = new KGDatasetInfoFinderImpl[IO](renkuStoreConfig)
   }
 
   private def removeTopmostSameAs(datasetId: EntityId): Unit = runUpdate {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/persondetails/KGPersonFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/persondetails/KGPersonFinderSpec.scala
@@ -74,7 +74,7 @@ class KGPersonFinderSpec extends AnyWordSpec with IOSpec with InMemoryRdfStore w
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new KGPersonFinderImpl[IO](rdfStoreConfig)
+    val finder = new KGPersonFinderImpl[IO](renkuStoreConfig)
   }
 
   private def findNames(id: entities.Person): Set[persons.Name] =

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/projects/KGProjectFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/projects/KGProjectFinderSpec.scala
@@ -74,6 +74,6 @@ class KGProjectFinderSpec
   private trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new KGProjectFinderImpl[IO](rdfStoreConfig)
+    val finder = new KGProjectFinderImpl[IO](renkuStoreConfig)
   }
 }


### PR DESCRIPTION
There was `migrations` TS dataset created to keep TS migration-related info. The concept works for all the migrations except for the re-provisioning process. This PR switches the mentioned process from the `renku` dataset to `migrations` dataset.

**NOTICE:** Once the PR got deployed to any environment, the re-provisioning process **WILL BE TRIGGERED!!!**