### PR TITLE
chore: failure messages for duplicated props to be more descriptive

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/categories/zombieevents/ZombieStatusCleaner.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/categories/zombieevents/ZombieStatusCleaner.scala
@@ -81,8 +81,7 @@ private class ZombieStatusCleanerImpl[F[_]: MonadCancelThrow: SessionResource](
         .flatMapResult {
           case Completion.Update(1) => (Updated: UpdateResult).pure[F]
           case Completion.Update(0) => (NotUpdated: UpdateResult).pure[F]
-          case _ =>
-            new Exception(show"$categoryName: update status - More than one row updated").raiseError[F, UpdateResult]
+          case completion => new Exception(s"$categoryName: update status $completion").raiseError[F, UpdateResult]
         }
     }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/rest/KGProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/rest/KGProjectFinder.scala
@@ -159,7 +159,7 @@ private class KGProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     case Nil            => Option.empty[KGProject].pure[F]
     case project +: Nil => project.some.pure[F]
     case projects =>
-      new RuntimeException(s"More than one project with ${projects.head.path} path")
+      new RuntimeException(s"Multiple projects or values for ${projects.head.path}")
         .raiseError[F, Option[KGProject]]
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/datasets/KGDatasetInfoFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/datasets/KGDatasetInfoFinder.scala
@@ -53,7 +53,7 @@ private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecord
   ): F[Option[TopmostSameAs]] = {
     implicit val decoder: Decoder[Option[TopmostSameAs]] = ResultsDecoder[Option, TopmostSameAs] { implicit cur =>
       extract[TopmostSameAs]("topmostSameAs")
-    }(toOption(onMultiple = show"More than one topmostSameAs found for dataset ${sameAs.show}"))
+    }(toOption(onMultiple = show"Multiple topmostSameAs found for dataset ${sameAs.show}"))
 
     queryExpecting[Option[TopmostSameAs]](using = queryFindingSameAs(sameAs.value))
   }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/projects/KGProjectFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/projects/KGProjectFinder.scala
@@ -90,7 +90,7 @@ private class KGProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
                                  maybeAgent,
                                  maybeCreatorId
       )
-    }(toOption(s"More than one project found for resourceId: '$resourceId'"))
+    }(toOption(s"Multiple projects or values for '$resourceId'"))
 }
 
 private object KGProjectFinder {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/datasets/KGDatasetInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/categories/tsprovisioning/transformation/datasets/KGDatasetInfoFinderSpec.scala
@@ -110,7 +110,7 @@ class KGDatasetInfoFinderSpec extends AnyWordSpec with IOSpec with InMemoryRdfSt
         finder.findParentTopmostSameAs(sameAs).unsafeRunSync()
       }
 
-      exception.getMessage should include(s"More than one topmostSameAs found for dataset ${sameAs.show}")
+      exception.getMessage should include(s"Multiple topmostSameAs found for dataset ${sameAs.show}")
     }
   }
 


### PR DESCRIPTION
This PR makes few log messages reporting duplicates in entities properties more descriptive