### PR TITLE
fix: project transformation no to update date if > than in KG

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/DateCreatedUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/DateCreatedUpdater.scala
@@ -1,0 +1,32 @@
+package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation.projects
+
+import cats.syntax.all._
+import io.renku.graph.model.entities.{NonRenkuProject, Project, RenkuProject}
+import io.renku.triplesgenerator.events.consumers.tsprovisioning.TransformationStep.Queries
+import io.renku.triplesgenerator.events.consumers.tsprovisioning.TransformationStep.Queries.preDataQueriesOnly
+
+private trait DateCreatedUpdater {
+  def updateDateCreated(kgData: ProjectMutableData): ((Project, Queries)) => (Project, Queries)
+}
+
+private object DateCreatedUpdater {
+  def apply(): DateCreatedUpdater = new DateCreatedUpdaterImpl(UpdatesCreator)
+}
+
+private class DateCreatedUpdaterImpl(updatesCreator: UpdatesCreator) extends DateCreatedUpdater {
+  import updatesCreator._
+
+  override def updateDateCreated(kgData: ProjectMutableData): ((Project, Queries)) => (Project, Queries) = {
+    case (project, queries) if (project.dateCreated compareTo kgData.dateCreated) < 0 =>
+      project -> (queries |+| preDataQueriesOnly(dateCreatedDeletion(project, kgData)))
+    case (project, queries) if (project.dateCreated compareTo kgData.dateCreated) > 0 =>
+      val updatedProj = project match {
+        case p: RenkuProject.WithoutParent    => p.copy(dateCreated = kgData.dateCreated)
+        case p: RenkuProject.WithParent       => p.copy(dateCreated = kgData.dateCreated)
+        case p: NonRenkuProject.WithoutParent => p.copy(dateCreated = kgData.dateCreated)
+        case p: NonRenkuProject.WithParent    => p.copy(dateCreated = kgData.dateCreated)
+      }
+      updatedProj -> queries
+    case (project, queries) => project -> queries
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/UpdatesCreator.scala
@@ -27,14 +27,14 @@ import io.renku.rdfstore.SparqlQuery
 import io.renku.rdfstore.SparqlQuery.Prefixes
 
 private trait UpdatesCreator {
-  def prepareUpdates(project: Project, kgData: ProjectMutableData): List[SparqlQuery]
+  def prepareUpdates(project:      Project, kgData: ProjectMutableData): List[SparqlQuery]
+  def dateCreatedDeletion(project: Project, kgData: ProjectMutableData): List[SparqlQuery]
 }
 
 private object UpdatesCreator extends UpdatesCreator {
 
   override def prepareUpdates(project: Project, kgData: ProjectMutableData): List[SparqlQuery] = List(
     nameDeletion(project, kgData),
-    dateCreatedDeletion(project, kgData),
     maybeParentDeletion(project, kgData),
     visibilityDeletion(project, kgData),
     descriptionDeletion(project, kgData),
@@ -51,18 +51,6 @@ private object UpdatesCreator extends UpdatesCreator {
         Prefixes.of(schema -> "schema"),
         s"""|DELETE { $resource schema:name ?name }
             |WHERE  { $resource schema:name ?name }
-            |""".stripMargin
-      )
-    }
-
-  private def dateCreatedDeletion(project: Project, kgData: ProjectMutableData) =
-    Option.when(project.dateCreated != kgData.dateCreated) {
-      val resource = project.resourceId.showAs[RdfResource]
-      SparqlQuery.of(
-        name = "transformation - project dateCreated delete",
-        Prefixes.of(schema -> "schema"),
-        s"""|DELETE { $resource schema:dateCreated ?date }
-            |WHERE  { $resource schema:dateCreated ?date }
             |""".stripMargin
       )
     }
@@ -168,4 +156,18 @@ private object UpdatesCreator extends UpdatesCreator {
             |""".stripMargin
       )
     }
+
+  override def dateCreatedDeletion(project: Project, kgData: ProjectMutableData) =
+    Option
+      .when(project.dateCreated != kgData.dateCreated) {
+        val resource = project.resourceId.showAs[RdfResource]
+        SparqlQuery.of(
+          name = "transformation - project dateCreated delete",
+          Prefixes.of(schema -> "schema"),
+          s"""|DELETE { $resource schema:dateCreated ?date }
+              |WHERE  { $resource schema:dateCreated ?date }
+              |""".stripMargin
+        )
+      }
+      .toList
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/DateCreatedUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/DateCreatedUpdaterSpec.scala
@@ -1,0 +1,83 @@
+package io.renku.triplesgenerator.events.consumers.tsprovisioning
+package transformation
+package projects
+
+import Generators.queriesGen
+import TestDataTools._
+import io.renku.generators.CommonGraphGenerators.sparqlQueries
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators._
+import io.renku.graph.model.entities
+import io.renku.graph.model.entities.{NonRenkuProject, RenkuProject}
+import io.renku.graph.model.projects.DateCreated
+import io.renku.graph.model.testentities._
+import io.renku.rdfstore.SparqlQuery
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class DateCreatedUpdaterSpec extends AnyWordSpec with should.Matchers with MockFactory {
+
+  "updateDateCreated" should {
+
+    "prepare dateCreated deletion queries and do not change the given project " +
+      "if project dateCreated on the model is < dateCreated currently in KG" in new TestCase {
+        val project = anyProjectEntities.generateOne.to[entities.Project]
+        val kgData = toProjectMutableData(project).copy(dateCreated =
+          timestampsNotInTheFuture(butYoungerThan = project.dateCreated.value).generateAs(DateCreated)
+        )
+
+        val updateQueries = sparqlQueries.generateList()
+        givenDateCreatedUpdates(project, kgData, updateQueries)
+
+        val updatedProject -> queries = updater.updateDateCreated(kgData)(project -> initialQueries)
+
+        updatedProject                shouldBe project
+        queries.preDataUploadQueries  shouldBe initialQueries.preDataUploadQueries ::: updateQueries
+        queries.postDataUploadQueries shouldBe initialQueries.postDataUploadQueries
+      }
+
+    "update the given project's dateCreated and do not create any deletion queries " +
+      "if project dateCreated on the model is > dateCreated currently in KG" in new TestCase {
+        val project       = anyProjectEntities.generateOne.to[entities.Project]
+        val kgDateCreated = timestamps(max = project.dateCreated.value.minusMillis(1)).generateAs(DateCreated)
+        val kgData        = toProjectMutableData(project).copy(dateCreated = kgDateCreated)
+
+        val updatedProject -> queries = updater.updateDateCreated(kgData)(project -> initialQueries)
+
+        queries shouldBe initialQueries
+        updatedProject shouldBe {
+          project match {
+            case p: RenkuProject.WithoutParent    => p.copy(dateCreated = kgDateCreated)
+            case p: RenkuProject.WithParent       => p.copy(dateCreated = kgDateCreated)
+            case p: NonRenkuProject.WithoutParent => p.copy(dateCreated = kgDateCreated)
+            case p: NonRenkuProject.WithParent    => p.copy(dateCreated = kgDateCreated)
+          }
+        }
+      }
+
+    "do not update the given project's dateCreated and do not create any deletion queries " +
+      "if both the dates are the same" in new TestCase {
+        val project = anyProjectEntities.generateOne.to[entities.Project]
+        val kgData  = toProjectMutableData(project)
+
+        updater.updateDateCreated(kgData)(project -> initialQueries) shouldBe (project -> initialQueries)
+      }
+  }
+
+  private trait TestCase {
+    val initialQueries = queriesGen.generateOne
+    val updatesCreator = mock[UpdatesCreator]
+    val updater        = new DateCreatedUpdaterImpl(updatesCreator)
+
+    def givenDateCreatedUpdates(modelProject:  entities.Project,
+                                kgProject:     ProjectMutableData,
+                                updateQueries: List[SparqlQuery] = sparqlQueries.generateList()
+    ): Unit = {
+      (updatesCreator.dateCreatedDeletion _)
+        .expects(modelProject, kgProject)
+        .returning(updateQueries)
+      ()
+    }
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/projects/UpdatesCreatorSpec.scala
@@ -59,18 +59,6 @@ class UpdatesCreatorSpec
       findProjects shouldBe Set(CurrentProjectState.from(project).copy(maybeName = None))
     }
 
-    "generate queries which delete the project dateCreated when changed" in {
-      val project = anyProjectEntities.generateOne.to[entities.Project]
-
-      loadToStore(project)
-
-      prepareUpdates(project,
-                     toProjectMutableData(project).copy(dateCreated = projectCreatedDates().generateOne)
-      ).runAll.unsafeRunSync()
-
-      findProjects shouldBe Set(CurrentProjectState.from(project).copy(maybeDateCreated = None))
-    }
-
     val projectWithParentScenarios = Table(
       "project" -> "type",
       renkuProjectWithParentEntities(anyVisibility).generateOne.to[entities.RenkuProject.WithParent] ->
@@ -202,6 +190,21 @@ class UpdatesCreatorSpec
       prepareUpdates(project, toProjectMutableData(project)).runAll.unsafeRunSync()
 
       findProjects shouldBe Set(CurrentProjectState.from(project))
+    }
+  }
+
+  "dateCreatedDeletion" should {
+
+    "generate queries which delete the project dateCreated when changed" in {
+      val project = anyProjectEntities.generateOne.to[entities.Project]
+
+      loadToStore(project)
+
+      dateCreatedDeletion(project,
+                          toProjectMutableData(project).copy(dateCreated = projectCreatedDates().generateOne)
+      ).runAll.unsafeRunSync()
+
+      findProjects shouldBe Set(CurrentProjectState.from(project).copy(maybeDateCreated = None))
     }
   }
 


### PR DESCRIPTION
This change prevents the Transformation flow from updating project's dateCreated if there's an older date for the project in the TS already.