### PR TITLE
chore: run CA certs injection as non-root

### DIFF
--- a/helm-chart/renku-graph/requirements.yaml
+++ b/helm-chart/renku-graph/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: certificates
-  version: "0.0.2"
+  version: "0.0.3"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -11,7 +11,7 @@ global:
   certificates:
     image:
       repository: renku/certificates
-      tag: '0.0.1'
+      tag: '0.0.2'
     customCAs: []
       # - secret:
 


### PR DESCRIPTION
The latest certificates image and chart can run as non-root.

This is safer than what we had before.

Also the chart and image tags are not tracking each other. This is on purpose.

/deploy #persist