### PR TITLE
fix: Cross-Entities search does not return all for *

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/DatasetsQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/DatasetsQuery.scala
@@ -47,6 +47,7 @@ private case object DatasetsQuery extends EntityQuery[model.Entity.Dataset] {
 
   override def query(criteria: Endpoint.Criteria) = (criteria.filters whenRequesting entityType) {
     import criteria._
+    // format: off
     s"""|{
         |  SELECT ?entityType ?matchingScore ?name ?idsPathsVisibilities ?sameAs
         |    ?maybeDateCreated ?maybeDatePublished ?date
@@ -65,7 +66,8 @@ private case object DatasetsQuery extends EntityQuery[model.Entity.Dataset] {
         |            (GROUP_CONCAT(DISTINCT ?childProjectId; separator='|') AS ?childProjectsIds)
         |            (GROUP_CONCAT(DISTINCT ?projectIdWhereInvalidated; separator='|') AS ?projectsIdsWhereInvalidated)
         |          WHERE {
-        |            {
+        |            ${filters.onQuery(
+    s"""|            {
         |              SELECT ?dsId (MAX(?score) AS ?matchingScore)
         |              WHERE {
         |                {
@@ -80,7 +82,9 @@ private case object DatasetsQuery extends EntityQuery[model.Entity.Dataset] {
         |              }
         |              GROUP BY ?dsId
         |            }
-        |            ?dsId renku:topmostSameAs ?sameAs;
+        |""")}
+        |            ?dsId a schema:Dataset;
+        |                  renku:topmostSameAs ?sameAs;
         |                  ^renku:hasDataset ?projectId.
         |            OPTIONAL {
         |            ?childDsId prov:wasDerivedFrom/schema:url ?dsId;
@@ -122,6 +126,7 @@ private case object DatasetsQuery extends EntityQuery[model.Entity.Dataset] {
         |    BIND ('dataset' AS ?entityType)
         |  }
         |}""".stripMargin
+    // format: on
   }
 
   override def decoder[EE >: Entity.Dataset]: Decoder[EE] = { implicit cursor =>

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/EntityQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/EntityQuery.scala
@@ -22,8 +22,9 @@ package finder
 import io.circe.Decoder
 import io.renku.knowledgegraph.entities.Endpoint.Criteria
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters.EntityType
+import io.renku.triplesstore.ResultsDecoder
 
-trait EntityQuery[+E <: model.Entity] extends Product with Serializable {
+trait EntityQuery[+E <: model.Entity] extends ResultsDecoder with Product with Serializable {
   val entityType:      EntityType
   val selectVariables: Set[String]
   def query(criteria: Criteria): Option[String]

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/PersonsQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/PersonsQuery.scala
@@ -52,12 +52,12 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
           |""".stripMargin
     }
 
-  override def decoder[EE >: Entity.Person]: Decoder[EE] = { cursor =>
+  override def decoder[EE >: Entity.Person]: Decoder[EE] = { implicit cursor =>
     import io.renku.tinytypes.json.TinyTypeDecoders._
 
     for {
-      matchingScore <- cursor.downField("matchingScore").downField("value").as[MatchingScore]
-      name          <- cursor.downField("name").downField("value").as[persons.Name]
+      matchingScore <- extract[MatchingScore]("matchingScore")
+      name          <- extract[persons.Name]("name")
     } yield Entity.Person(matchingScore, name)
   }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/package.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/package.scala
@@ -51,7 +51,8 @@ package object finder {
 
     import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
 
-    lazy val query: String = filters.maybeQuery.map(_.value).getOrElse("*")
+    private val queryAll: String = "*"
+    lazy val query:       String = filters.maybeQuery.map(_.value).getOrElse(queryAll)
 
     def whenRequesting(entityType: Filters.EntityType, predicates: Boolean*)(query: => String): Option[String] = {
       val typeMatching = filters.entityTypes match {
@@ -60,6 +61,10 @@ package object finder {
       }
       Option.when(typeMatching && predicates.forall(_ == true))(query)
     }
+
+    def onQuery(snippet: String, matchingScoreVariableName: String = "?matchingScore"): String =
+      if (query.trim != queryAll) snippet
+      else s"BIND(xsd:float(1.0) AS $matchingScoreVariableName)"
 
     lazy val withNoOrPublicVisibility: Boolean = filters.visibilities match {
       case v if v.isEmpty => true


### PR DESCRIPTION
This PR tries to fix the problem of not all entities being returned when `query=*`