### PR TITLE
feat: added TS migration to create 'projects' dataset

### DIFF
--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -1,0 +1,43 @@
+@prefix :       <http://base/#> .
+@prefix tdb2:   <http://jena.apache.org/2016/tdb#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix text:   <http://jena.apache.org/text#> .
+@prefix schema: <http://schema.org/> .
+@prefix renku:  <https://swissdatasciencecenter.github.io/renku-ontology#> .
+
+:service_tdb_all a                  fuseki:Service ;
+  rdfs:label                        "TDB2 projects" ;
+  fuseki:dataset                    :text_dataset ;
+  fuseki:name                       "projects" ;
+  fuseki:serviceQuery               "query" , "" , "sparql" ;
+  fuseki:serviceReadGraphStore      "get" ;
+  fuseki:serviceReadQuads           "" ;
+  fuseki:serviceReadWriteGraphStore "data" ;
+  fuseki:serviceReadWriteQuads      "" ;
+  fuseki:serviceUpdate              "" , "update" ;
+  fuseki:serviceUpload              "upload" .
+
+:text_dataset a  text:TextDataset ;
+  text:dataset   :tdb_projects ;
+  text:index     <#indexLucene> ;
+.
+
+:tdb_projects a  tdb2:DatasetTDB2 ;
+  tdb2:location  "/fuseki/databases/projects" .
+
+<#indexLucene> a text:TextIndexLucene ;
+  text:directory <file:///fuseki/databases/projects/lucene_index> ;
+  text:entityMap <#entMap> ;
+.
+
+<#entMap> a         text:EntityMap ;
+  text:defaultField "name" ;
+  text:entityField  "uri" ;
+  text:map (
+    [ text:field "name" ;              text:predicate schema:name ]
+    [ text:field "description" ;       text:predicate schema:description ]
+    [ text:field "slug" ;              text:predicate renku:slug ]
+    [ text:field "projectNamespaces" ; text:predicate renku:projectNamespaces ]
+    [ text:field "keywords" ;          text:predicate schema:keywords ]
+  ) .

--- a/graph-commons/src/main/scala/io/renku/graph/triplesstore/DatasetTTLs.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/triplesstore/DatasetTTLs.scala
@@ -23,18 +23,25 @@ import io.renku.triplesstore.{DatasetConfigFile, DatasetConfigFileFactory, Datas
 
 object DatasetTTLs {
 
-  case class RenkuTTL private (value: String) extends DatasetConfigFile
+  final class RenkuTTL private (val value: String) extends DatasetConfigFile
   object RenkuTTL
       extends DatasetConfigFileFactory[RenkuTTL](DatasetName("renku"), new RenkuTTL(_), ttlFileName = "renku-ds.ttl")
 
-  case class MigrationsTTL private (value: String) extends DatasetConfigFile
+  final class ProjectsTTL private (val value: String) extends DatasetConfigFile
+  object ProjectsTTL
+      extends DatasetConfigFileFactory[ProjectsTTL](DatasetName("projects"),
+                                                    new ProjectsTTL(_),
+                                                    ttlFileName = "projects-ds.ttl"
+      )
+
+  final class MigrationsTTL private (val value: String) extends DatasetConfigFile
   object MigrationsTTL
       extends DatasetConfigFileFactory[MigrationsTTL](DatasetName("migrations"),
                                                       new MigrationsTTL(_),
                                                       ttlFileName = "migrations-ds.ttl"
       )
 
-  val allFactories: List[DatasetConfigFileFactory[_ <: DatasetConfigFile]] = List(RenkuTTL, MigrationsTTL)
+  val allFactories: List[DatasetConfigFileFactory[_ <: DatasetConfigFile]] = List(RenkuTTL, ProjectsTTL, MigrationsTTL)
 
   val allNamesAndConfigs: Either[Exception, List[(DatasetName, DatasetConfigFile)]] =
     allFactories.map(factory => factory.fromTtlFile().map(factory.datasetName -> _)).sequence

--- a/graph-commons/src/main/scala/io/renku/triplesstore/DatasetConnectionConfig.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/DatasetConnectionConfig.scala
@@ -71,6 +71,25 @@ object RenkuConnectionConfig {
   } yield RenkuConnectionConfig(url, BasicAuthCredentials(username, password))
 }
 
+final case class ProjectsConnectionConfig(fusekiUrl: FusekiUrl, authCredentials: BasicAuthCredentials)
+    extends DatasetConnectionConfig {
+  val datasetName: DatasetName = ProjectsConnectionConfig.ProjectsDS
+}
+
+object ProjectsConnectionConfig {
+
+  val ProjectsDS: DatasetName = DatasetName("projects")
+
+  import io.renku.config.ConfigLoader._
+  import io.renku.http.client.BasicAuthConfigReaders._
+
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load()): F[ProjectsConnectionConfig] = for {
+    url      <- find[F, FusekiUrl]("services.fuseki.url", config)
+    username <- find[F, BasicAuthUsername]("services.fuseki.renku.username", config)
+    password <- find[F, BasicAuthPassword]("services.fuseki.renku.password", config)
+  } yield ProjectsConnectionConfig(url, BasicAuthCredentials(username, password))
+}
+
 final case class MigrationsConnectionConfig(
     fusekiUrl:       FusekiUrl,
     authCredentials: BasicAuthCredentials

--- a/graph-commons/src/main/scala/io/renku/triplesstore/model.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/model.scala
@@ -32,7 +32,7 @@ object DatasetName extends TinyTypeFactory[DatasetName](new DatasetName(_)) with
   implicit val configReader: ConfigReader[DatasetName] = stringTinyTypeReader(DatasetName)
 }
 
-trait DatasetConfigFile extends StringTinyType
+trait DatasetConfigFile extends Any with StringTinyType
 object DatasetConfigFile {
   implicit lazy val show: Show[DatasetConfigFile] = Show.show(_.toString)
 }

--- a/graph-commons/src/main/scala/io/renku/triplesstore/model.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/model.scala
@@ -32,7 +32,7 @@ object DatasetName extends TinyTypeFactory[DatasetName](new DatasetName(_)) with
   implicit val configReader: ConfigReader[DatasetName] = stringTinyTypeReader(DatasetName)
 }
 
-trait DatasetConfigFile extends Any with StringTinyType
+trait DatasetConfigFile extends StringTinyType
 object DatasetConfigFile {
   implicit lazy val show: Show[DatasetConfigFile] = Show.show(_.toString)
 }

--- a/graph-commons/src/test/scala/io/renku/graph/triplesstore/DatasetTTLsSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/triplesstore/DatasetTTLsSpec.scala
@@ -30,6 +30,7 @@ class DatasetTTLsSpec extends AnyWordSpec with should.Matchers {
     "return a List comprised of Renku and Migrations datasets" in {
       DatasetTTLs.allNamesAndConfigs shouldBe List(
         RenkuTTL.fromTtlFile().map(RenkuTTL.datasetName -> _),
+        ProjectsTTL.fromTtlFile().map(ProjectsTTL.datasetName -> _),
         MigrationsTTL.fromTtlFile().map(MigrationsTTL.datasetName -> _)
       ).sequence
     }

--- a/graph-commons/src/test/scala/io/renku/http/rest/paging/PagingResponseSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/rest/paging/PagingResponseSpec.scala
@@ -53,7 +53,7 @@ class PagingResponseSpec extends AnyWordSpec with IOSpec with ScalaCheckProperty
     }
 
     "fix the total if results is not empty and (page.value - 1) * perPage.value + results.size > total.value" in {
-      forAll(perPages.retryUntil(_.value > 1), pages) { (perPage, page) =>
+      forAll(perPages.retryUntil(_.value > 1), pages.retryUntil(_.value > 1)) { (perPage, page) =>
         val results = nonEmptyStrings().generateNonEmptyList(maxElements = perPage.asRefined).toList
         val total   = positiveInts((page.value - 1) * perPage.value + results.size - 1).map(_.value).generateAs(Total)
         val request = PagingRequest(page, perPage)
@@ -67,7 +67,7 @@ class PagingResponseSpec extends AnyWordSpec with IOSpec with ScalaCheckProperty
     }
 
     "instantiate successfully if results list is empty and (page.value - 1) * perPage.value > total.value" in {
-      forAll(perPages.retryUntil(_.value > 1), pages) { (perPage, page) =>
+      forAll(perPages.retryUntil(_.value > 1), pages.retryUntil(_.value > 1)) { (perPage, page) =>
         val results = List.empty[String]
         val total   = positiveInts((page.value - 1) * perPage.value + results.size - 1).map(_.value).generateAs(Total)
         val request = PagingRequest(page, perPage)

--- a/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
@@ -211,6 +211,21 @@ trait RenkuDataset extends JenaDataset {
   registerDataset(connectionInfoFactory, configFile)
 }
 
+trait ProjectsDataset extends JenaDataset {
+  self: InMemoryJena =>
+
+  private lazy val configFile: Either[Exception, DatasetConfigFile] = ProjectsTTL.fromTtlFile()
+  private lazy val connectionInfoFactory: FusekiUrl => ProjectsConnectionConfig = ProjectsConnectionConfig(
+    _,
+    BasicAuthCredentials(BasicAuthUsername("renku"), BasicAuthPassword("renku"))
+  )
+
+  def projectsDSConnectionInfo: ProjectsConnectionConfig = connectionInfoFactory(fusekiUrl)
+  def projectsDataset:          DatasetName              = projectsDSConnectionInfo.datasetName
+
+  registerDataset(connectionInfoFactory, configFile)
+}
+
 trait MigrationsDataset extends JenaDataset {
   self: InMemoryJena =>
 
@@ -220,8 +235,8 @@ trait MigrationsDataset extends JenaDataset {
     BasicAuthCredentials(BasicAuthUsername("admin"), BasicAuthPassword("admin"))
   )
 
-  def migrationsDataset:          DatasetName                = migrationsDSConnectionInfo.datasetName
   def migrationsDSConnectionInfo: MigrationsConnectionConfig = connectionInfoFactory(fusekiUrl)
+  def migrationsDataset:          DatasetName                = migrationsDSConnectionInfo.datasetName
 
   registerDataset(connectionInfoFactory, configFile)
 }

--- a/helm-chart/renku-graph/templates/jena-shiro-ini.yaml
+++ b/helm-chart/renku-graph/templates/jena-shiro-ini.yaml
@@ -31,4 +31,5 @@ data:
     ## and the rest are restricted
     /$/** = authcBasic,user[admin]
     /renku/** = authcBasic,user[renku]
+    /projects/** = authcBasic,user[renku]
     /migrations/** = authcBasic,user[admin]


### PR DESCRIPTION
This is part of the #1078 and adds the creation of the new 'projects' dataset in the TS.

/deploy #persist 

