### PR TITLE
refactor: Choose how Apache Jena is provided in tests

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/TriplesStore.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/TriplesStore.scala
@@ -20,9 +20,7 @@ package io.renku.graph.acceptancetests.db
 
 import cats.effect.{IO, Temporal}
 import cats.{Applicative, Monad}
-import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.Positive
 import io.renku.triplesstore._
 import org.typelevel.log4cats.Logger
 
@@ -30,7 +28,7 @@ import scala.concurrent.duration._
 
 object TriplesStore extends InMemoryJena with RenkuDataset with MigrationsDataset {
 
-  protected override val maybeJenaFixedPort: Option[Int Refined Positive] = Some(3030)
+  protected override val jenaRunMode: JenaRunMode = JenaRunMode.FixedPortContainer(3030)
 
   def start()(implicit logger: Logger[IO]): IO[Unit] = for {
     _ <- Applicative[IO].unlessA(isRunning)(IO(container.start()))

--- a/graph-commons/src/test/scala/io/renku/triplesstore/ExternalJenaForSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/ExternalJenaForSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesstore
+
+import io.renku.testtools.IOSpec
+import org.scalatest.Suite
+import eu.timepit.refined.auto._
+
+/** Use this trait as a replacement for [[InMemoryJenaForSpec]] to connect to a locally/externally running Jena without 
+ * starting a container.  
+ */
+trait ExternalJenaForSpec extends InMemoryJenaForSpec {
+  self: Suite with IOSpec =>
+
+  /** Expect the external Jena instance to accept connections on the default port. */
+  override val jenaRunMode: JenaRunMode = JenaRunMode.Local(3030)
+}

--- a/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
@@ -31,6 +31,7 @@ import io.renku.http.client._
 import io.renku.interpreters.TestLogger
 import io.renku.jsonld.{JsonLD, JsonLDEncoder}
 import io.renku.logging.TestSparqlQueryTimeRecorder
+import org.testcontainers.containers
 import org.testcontainers.containers.wait.strategy.Wait
 
 import scala.collection.mutable
@@ -38,30 +39,36 @@ import scala.language.reflectiveCalls
 
 trait InMemoryJena {
 
-  protected val maybeJenaFixedPort: Option[Int Refined Positive] = None
+  protected val jenaRunMode: JenaRunMode = JenaRunMode.GenericContainer
 
   private val adminCredentials = BasicAuthCredentials(BasicAuthUsername("admin"), BasicAuthPassword("admin"))
 
-  lazy val container: SingleContainer[_] = maybeJenaFixedPort match {
-    case None =>
+  lazy val container: SingleContainer[_] = jenaRunMode match {
+    case JenaRunMode.GenericContainer =>
       GenericContainer(
         dockerImage = "renku/renku-jena:0.0.17",
         exposedPorts = Seq(3030),
         waitStrategy = Wait forHttp "/$/ping"
       )
-    case Some(fixedPort) =>
+    case JenaRunMode.FixedPortContainer(fixedPort) =>
       FixedHostPortGenericContainer(
         imageName = "renku/renku-jena:0.0.17",
         exposedPorts = Seq(3030),
-        exposedHostPort = fixedPort.value,
-        exposedContainerPort = fixedPort.value,
+        exposedHostPort = fixedPort,
+        exposedContainerPort = fixedPort,
         waitStrategy = Wait forHttp "/$/ping"
       )
+    case JenaRunMode.Local(_) =>
+      new GenericContainer(new containers.GenericContainer("") {
+        override def start(): Unit = ()
+        override def stop():  Unit = ()
+      })
   }
 
-  private lazy val fusekiServerPort: Int Refined Positive = maybeJenaFixedPort match {
-    case None       => Refined.unsafeApply(container.mappedPort(container.exposedPorts.head))
-    case Some(port) => port
+  private lazy val fusekiServerPort: Int Refined Positive = jenaRunMode match {
+    case JenaRunMode.GenericContainer         => Refined.unsafeApply(container.mappedPort(container.exposedPorts.head))
+    case JenaRunMode.FixedPortContainer(port) => port
+    case JenaRunMode.Local(port)              => port
   }
 
   lazy val fusekiUrl: FusekiUrl = FusekiUrl(s"http://localhost:$fusekiServerPort")

--- a/graph-commons/src/test/scala/io/renku/triplesstore/JenaRunMode.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/JenaRunMode.scala
@@ -1,0 +1,18 @@
+package io.renku.triplesstore
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
+
+sealed trait JenaRunMode
+
+object JenaRunMode {
+
+  /** A docker container is started creating a port mapping using the given port. */
+  final case class FixedPortContainer(port: Int Refined Positive) extends JenaRunMode
+
+  /** A docker container is started using a random port mapping. */
+  case object GenericContainer extends JenaRunMode
+
+  /** No container is started, it is assumed that Jena is running and accepts connections at the given port */
+  final case class Local(port: Int Refined Positive) extends JenaRunMode
+}


### PR DESCRIPTION
Improve choosing between container flavors and a locally running jena.