### PR TITLE
chore: Log starting gitlab stub at trace level

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
@@ -155,7 +155,7 @@ final class GitLabApiStub[F[_]: Async: Logger](private val stateRef: Ref[F, Stat
     Client.fromHttpApp(allRoutes.orNotFound)
 
   def resource(bindAddress: Host, port: Port): Resource[F, Server] =
-    Resource.eval(logger.info(s"Starting GitLab stub on $bindAddress:$port")) *>
+    Resource.eval(logger.trace(s"Starting GitLab stub on $bindAddress:$port")) *>
       BlazeServerBuilder[F]
         .bindHttp(port.value, bindAddress.show)
         .withoutBanner


### PR DESCRIPTION
This silences the log statement by default. I'm also happy to remove the whole line :) 