### PR TITLE
feat: Send COMMIT_SYNC events on all webhook creation attempts

### DIFF
--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -89,6 +89,15 @@ class HookCreatorSpec extends AnyWordSpec with MockFactory with should.Matchers 
         .expects(projectId, Some(accessToken))
         .returning(HookExists.pure[IO])
 
+      (projectInfoFinder
+        .findProjectInfo(_: Id)(_: Option[AccessToken]))
+        .expects(projectId, Some(accessToken))
+        .returning(projectInfo.pure[IO])
+
+      (commitSyncRequestSender.sendCommitSyncRequest _)
+        .expects(CommitSyncRequest(Project(projectInfo.id, projectInfo.path)), "HookCreation")
+        .returning(().pure[IO])
+
       hookCreation.createHook(projectId, accessToken).unsafeRunSync() shouldBe HookExisted
 
       logger.expectNoLogs()


### PR DESCRIPTION
The event is now send even if the hook already exists to ensure the projects are properly synchronized in KG.

Closes: #1091