### PR TITLE
feat: Start a nix development setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+watch_file flake.nix
+watch_file flake.lock
+watch_dir nix/
+
+{
+  # shell gc root dir
+  mkdir -p "$(direnv_layout_dir)"
+  eval "$(nix print-dev-env --profile $(direnv_layout_dir)/flake-profile)"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ helm-chart/renku-graph/charts/*tgz
 
 # MAc
 .DS_Store
+
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1664790708,
+        "narHash": "sha256-fzxmpOPjzOVIt9KeDN4EDPI13xJn+u0uMxheKCWken8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "81a3237b64e67b66901c735654017e75f0c50943",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.05",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{ description = "Development environment for renku-graph";
+
+  # Install direnv and run `direnv allow` to automatically drop into
+  # this environment when entering the directory in your shell.
+  # Alternatively, run `nix develop` to drop into a bash shell.
+  #
+  # Look for packages here:
+  # https://search.nixos.org/packages?channel=22.05
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-22.05";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        overlays = import ./nix/overlays.nix;
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            overlays.jena
+            overlays.sbt
+            overlays.postgres-fg
+          ];
+        };
+      in
+        { devShell = pkgs.mkShell {
+            buildInputs = with pkgs;
+              [ postgresql_14
+                postgres-fg
+                apache-jena-fuseki
+                openjdk17
+                sbt
+              ];
+
+            JAVA_HOME = "${pkgs.openjdk17}/lib/openjdk";
+          };
+        }
+    );
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,39 @@
+{
+  # Fix the version of Jena explicitely (nixpkgs-22.05 comes with 4.3.1)
+  jena = self: super: {
+    apache-jena-fuseki = super.apache-jena-fuseki.overrideAttrs (old: rec {
+      version = "4.6.1";
+      src = super.fetchurl {
+        url = "https://dlcdn.apache.org/jena/binaries/apache-jena-fuseki-${version}.tar.gz";
+        sha256 = "sha256-LUaNpYcegMxd7WX3DCvgb2Hxsre4EHp7GkASzJfwaM0=";
+      };
+    });
+  };
+
+  # Make sure sbt is run with jdk17 (which is currently the default)
+  sbt = self: super: {
+    sbt = super.sbt.override { jre = super.openjdk17; };
+  };
+
+  # A simple startup script for postgresql running in foreground.
+  postgres-fg = self: super: {
+    postgres-fg = self.writeShellScriptBin "postgres-fg" ''
+      data_dir="$1"
+      port="''${2:-5432}"
+
+      if [ -z "$data_dir" ]; then
+          echo "A data directory is required!"
+          exit 1
+      fi
+
+      if ! [ -f "$data_dir/PG_VERSION" ]; then
+          echo "Initialize postgres cluster…"
+          mkdir -p "$data_dir"
+          chmod -R 700 "$data_dir"
+          ${self.postgresql_14}/bin/pg_ctl init -D "$data_dir"
+      fi
+
+      ${self.postgresql_14}/bin/postgres -D "$data_dir" -k /tmp -h localhost -p $port
+    '';
+  };
+}


### PR DESCRIPTION
Running `nix develop` (or using direnv) creates an environment containing necessary tools for developing. The correct jdk, postgres and fuseki server is installed along with helper scripts for starting external services.