### PR TITLE
refactor: Update scala to 2.13.9

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubSupport.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubSupport.scala
@@ -70,6 +70,7 @@ object GitLabStubSupport {
     def shutdown(): Unit =
       close.unsafeRunSync()
   }
+
   object GitLabStubStarter {
     def apply(gitLabUrl: GitLabUrl)(implicit rt: IORuntime, logger: Logger[IO]): GitLabStubStarter = {
       val stub = GitLabApiStub.empty[IO].unsafeRunSync()

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubSupport.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubSupport.scala
@@ -19,11 +19,14 @@
 package io.renku.graph.acceptancetests.stubs.gitlab
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import io.renku.graph.acceptancetests.stubs.gitlab.GitLabStubSupport.GitLabStubStarter
 import io.renku.graph.acceptancetests.tooling.AcceptanceSpec
 import io.renku.graph.config.GitLabUrlLoader
 import io.renku.graph.model.{GitLabApiUrl, GitLabUrl}
 import org.http4s.Uri
 import org.scalatest._
+import org.typelevel.log4cats.Logger
 
 import scala.util.Try
 
@@ -33,26 +36,44 @@ trait GitLabStubSupport extends BeforeAndAfterAll with BeforeAndAfter with GitLa
   implicit val gitLabUrl:    GitLabUrl    = GitLabUrlLoader[Try]().fold(throw _, identity)
   implicit val gitLabApiUrl: GitLabApiUrl = gitLabUrl.apiV4
 
-  lazy val gitLabStub: GitLabApiStub[IO] = GitLabApiStub.empty[IO].unsafeRunSync()
-
-  private var gitLabStubShutdown: IO[Unit] = IO.pure(())
+  private lazy val gitLabStubStarter = GitLabStubStarter(gitLabUrl)
+  lazy val gitLabStub: GitLabApiStub[IO] = gitLabStubStarter.stub
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val uri           = Uri.unsafeFromString(gitLabUrl.value)
-    val host          = uri.host.getOrElse(sys.error("No gitlab host found"))
-    val port          = uri.port.getOrElse(sys.error("No gitlab port found"))
-    val (_, shutdown) = gitLabStub.resource(host.value, port).allocated.unsafeRunSync()
-    this.gitLabStubShutdown = shutdown
+    gitLabStubStarter.startup()
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
     testLogger.info("Shutting down GitLabApiStub").unsafeRunSync()
-    gitLabStubShutdown.unsafeRunSync()
+    gitLabStubStarter.shutdown()
   }
 
   before {
     gitLabStub.clearState()
+  }
+}
+object GitLabStubSupport {
+  final class GitLabStubStarter(gitLabUrl: GitLabUrl, val stub: GitLabApiStub[IO])(implicit rt: IORuntime) {
+    private val uri  = Uri.unsafeFromString(gitLabUrl.value)
+    private val host = uri.host.getOrElse(sys.error("No gitlab host found"))
+    private val port = uri.port.getOrElse(sys.error("No gitlab port found"))
+
+    private var close: IO[Unit] = IO.pure(())
+
+    def startup(): Unit = {
+      val (_, close) = stub.resource(host.value, port).allocated.unsafeRunSync()
+      this.close = close
+    }
+
+    def shutdown(): Unit =
+      close.unsafeRunSync()
+  }
+  object GitLabStubStarter {
+    def apply(gitLabUrl: GitLabUrl)(implicit rt: IORuntime, logger: Logger[IO]): GitLabStubStarter = {
+      val stub = GitLabApiStub.empty[IO].unsafeRunSync()
+      new GitLabStubStarter(gitLabUrl, stub)
+    }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "io.renku"
 name := "renku-graph"
-scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.9"
 
 // This project contains nothing to package, like pure POM maven project
 packagedArtifacts := Map.empty
@@ -169,7 +169,6 @@ lazy val acceptanceTests = Project(
 
 lazy val commonSettings = Seq(
   organization := "io.renku",
-  scalaVersion := "2.13.8",
   publish / skip := true,
   publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))),
   Compile / packageDoc / publishArtifact := false,

--- a/generators/src/main/scala/io/renku/generators/Generators.scala
+++ b/generators/src/main/scala/io/renku/generators/Generators.scala
@@ -300,10 +300,10 @@ object Generators {
 
     val tuples = for {
       key <- nonEmptyStrings(maxLength = 5)
-      value <- oneOf(nonEmptyStrings(maxLength = 5),
-                     Arbitrary.arbNumber.arbitrary,
-                     Arbitrary.arbBool.arbitrary,
-                     Gen.nonEmptyListOf(nonEmptyStrings())
+      value <- oneOf[Any](nonEmptyStrings(maxLength = 5),
+                          Arbitrary.arbNumber.arbitrary,
+                          Arbitrary.arbBool.arbitrary,
+                          Gen.nonEmptyListOf(nonEmptyStrings())
                )
     } yield key -> value
 

--- a/graph-commons/src/test/scala/io/renku/config/sentry/SentryConfigSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/config/sentry/SentryConfigSpec.scala
@@ -55,7 +55,7 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
       "'services.sentry.url', 'services.sentry.environment', 'service-name' and 'version' are set" in {
         forAll { sentryConfig: SentryConfig =>
           val config = ConfigFactory.parseMap(
-            Map(
+            Map[String, AnyRef](
               "service-name" -> sentryConfig.serviceName.value,
               "services" -> Map(
                 "sentry" -> Map(
@@ -78,7 +78,7 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
     "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.dsn' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
-        Map(
+        Map[String, AnyRef](
           "service-name" -> sentryConfig.serviceName.value,
           "services" -> Map(
             "sentry" -> Map(
@@ -101,7 +101,7 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
     "fail if 'services.sentry.enabled' is 'true' but 'service-name' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
-        Map(
+        Map[String, AnyRef](
           "service-name" -> "",
           "services" -> Map(
             "sentry" -> Map(
@@ -124,7 +124,7 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
     "fail if 'services.sentry.enabled' is 'true' but 'services.sentry.environment' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
-        Map(
+        Map[String, AnyRef](
           "service-name" -> sentryConfig.serviceName.value,
           "services" -> Map(
             "sentry" -> Map(
@@ -147,7 +147,7 @@ class SentryConfigSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
     "fail if 'services.sentry.enabled' is 'true' but 'version' is invalid" in {
       val sentryConfig = sentryConfigs.generateOne
       val config = ConfigFactory.parseMap(
-        Map(
+        Map[String, AnyRef](
           "service-name" -> sentryConfig.serviceName.value,
           "services" -> Map(
             "sentry" -> Map(

--- a/graph-commons/src/test/scala/io/renku/db/DBConfigProviderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/db/DBConfigProviderSpec.scala
@@ -45,7 +45,7 @@ class DBConfigProviderSpec extends AnyWordSpec with should.Matchers {
 
       val config = ConfigFactory.parseMap(
         Map(
-          namespace -> Map(
+          namespace -> Map[String, Any](
             "db-host"         -> host.value,
             "db-port"         -> port.value,
             "db-user"         -> user,
@@ -74,7 +74,7 @@ class DBConfigProviderSpec extends AnyWordSpec with should.Matchers {
     "fail if there is no '<config-namespace>.db-host' in the config" in new TestCase {
       val config = ConfigFactory.parseMap(
         Map(
-          namespace -> Map(
+          namespace -> Map[String, Any](
             "db-host"         -> "",
             "db-port"         -> positiveInts().generateOne.value,
             "db-user"         -> nonEmptyStrings().generateOne,
@@ -92,7 +92,7 @@ class DBConfigProviderSpec extends AnyWordSpec with should.Matchers {
     "fail if there is no '<config-namespace>.db-port' in the config" in new TestCase {
       val config = ConfigFactory.parseMap(
         Map(
-          namespace -> Map(
+          namespace -> Map[String, Any](
             "db-host"         -> nonEmptyStrings().generateOne,
             "db-user"         -> nonEmptyStrings().generateOne,
             "db-pass"         -> nonEmptyStrings().generateOne,
@@ -109,7 +109,7 @@ class DBConfigProviderSpec extends AnyWordSpec with should.Matchers {
     "fail if there is no '<config-namespace>.db-user' in the config" in new TestCase {
       val config = ConfigFactory.parseMap(
         Map(
-          namespace -> Map(
+          namespace -> Map[String, Any](
             "db-host"         -> hosts.generateOne.value,
             "db-user"         -> "",
             "db-port"         -> positiveInts().generateOne.value,
@@ -127,7 +127,7 @@ class DBConfigProviderSpec extends AnyWordSpec with should.Matchers {
     "fail if there is no '<config-namespace>.db-pass' in the config" in new TestCase {
       val config = ConfigFactory.parseMap(
         Map(
-          namespace -> Map(
+          namespace -> Map[String, Any](
             "db-host"         -> hosts.generateOne.value,
             "db-user"         -> nonEmptyStrings().generateOne,
             "db-port"         -> positiveInts().generateOne.value,
@@ -144,7 +144,7 @@ class DBConfigProviderSpec extends AnyWordSpec with should.Matchers {
     "fail if there is no '<config-namespace>.connection-pool' in the config" in new TestCase {
       val config = ConfigFactory.parseMap(
         Map(
-          namespace -> Map(
+          namespace -> Map[String, Any](
             "db-host" -> hosts.generateOne.value,
             "db-port" -> positiveInts().generateOne.value,
             "db-user" -> nonEmptyStrings().generateOne,

--- a/graph-commons/src/test/scala/io/renku/events/Generators.scala
+++ b/graph-commons/src/test/scala/io/renku/events/Generators.scala
@@ -40,9 +40,9 @@ object Generators {
 
   implicit val eventRequestContents: Gen[EventRequestContent] = for {
     event        <- jsons
-    maybePayload <- oneOf(nonEmptyStrings(), zippedContents).toGeneratorOfOptions
+    maybePayload <- oneOf[Any](nonEmptyStrings(), zippedContents).toGeneratorOfOptions
   } yield maybePayload match {
-    case Some(payload) => events.EventRequestContent.WithPayload(event, payload)
+    case Some(payload) => events.EventRequestContent.WithPayload[Any](event, payload)
     case None          => events.EventRequestContent.NoPayload(event)
   }
 

--- a/graph-commons/src/test/scala/io/renku/triplesstore/DatasetConnectionConfigSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/DatasetConnectionConfigSpec.scala
@@ -38,7 +38,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
         val config = ConfigFactory.parseMap(
           Map(
             "services" -> Map(
-              "fuseki" -> Map(
+              "fuseki" -> Map[String, Any](
                 "url" -> storeConfig.fusekiUrl.toString,
                 "admin" -> Map(
                   "username" -> storeConfig.authCredentials.username.value,
@@ -61,7 +61,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "fuseki" -> Map(
+            "fuseki" -> Map[String, Any](
               "url" -> "invalid-url",
               "admin" -> Map(
                 "username" -> adminConnectionConfigs.generateOne.authCredentials.username.value,
@@ -81,7 +81,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "fuseki" -> Map(
+            "fuseki" -> Map[String, Any](
               "url" -> adminConnectionConfigs.generateOne.fusekiUrl.toString,
               "admin" -> Map(
                 "username" -> "  ",
@@ -101,7 +101,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "fuseki" -> Map(
+            "fuseki" -> Map[String, Any](
               "url" -> adminConnectionConfigs.generateOne.fusekiUrl.toString,
               "admin" -> Map(
                 "username" -> adminConnectionConfigs.generateOne.authCredentials.username.value,
@@ -125,7 +125,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
         val config = ConfigFactory.parseMap(
           Map(
             "services" -> Map(
-              "fuseki" -> Map(
+              "fuseki" -> Map[String, Any](
                 "url" -> storeConfig.fusekiUrl.toString,
                 "renku" -> Map(
                   "username" -> storeConfig.authCredentials.username.value,
@@ -149,7 +149,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "fuseki" -> Map(
+            "fuseki" -> Map[String, Any](
               "url" -> "invalid-url",
               "renku" -> Map(
                 "username" -> renkuConnectionConfigs.generateOne.authCredentials.username.value,
@@ -169,7 +169,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "fuseki" -> Map(
+            "fuseki" -> Map[String, Any](
               "url" -> renkuConnectionConfigs.generateOne.fusekiUrl.toString,
               "renku" -> Map(
                 "username" -> "  ",
@@ -189,7 +189,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "fuseki" -> Map(
+            "fuseki" -> Map[String, Any](
               "url" -> renkuConnectionConfigs.generateOne.fusekiUrl.toString,
               "renku" -> Map(
                 "username" -> renkuConnectionConfigs.generateOne.authCredentials.username.value,
@@ -213,7 +213,7 @@ class DatasetConnectionConfigSpec extends AnyWordSpec with ScalaCheckPropertyChe
         val config = ConfigFactory.parseMap(
           Map(
             "services" -> Map(
-              "fuseki" -> Map(
+              "fuseki" -> Map[String, Any](
                 "url" -> storeConfig.fusekiUrl.toString,
                 "admin" -> Map(
                   "username" -> storeConfig.authCredentials.username.value,

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/docs/model.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/docs/model.scala
@@ -96,7 +96,7 @@ object model {
           case StringPart(value)                        => value
         }
         .mkString("/")
-        .prepended("/")
+        .prepended('/')
         .mkString("")
 
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.2

--- a/tiny-types/src/test/scala/io/renku/tinytypes/TinyTypeSpec.scala
+++ b/tiny-types/src/test/scala/io/renku/tinytypes/TinyTypeSpec.scala
@@ -29,12 +29,17 @@ import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
+object TinyTypeData {
+  val arbitraryValues: List[Any] =
+    "abc" +: 2 +: 2L +: true +: List.empty[Any]
+}
+
 class TinyTypeSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
 
   "toString" should {
 
     "return a String value of the 'value' property" in {
-      ("abc" +: 2 +: 2L +: true +: Nil) foreach { someValue =>
+      TinyTypeData.arbitraryValues foreach { someValue =>
         val tinyType: TinyType = new TinyType {
           type V = Any
           override val value: Any = someValue
@@ -71,7 +76,7 @@ class SensitiveSpec extends AnyWordSpec with should.Matchers {
   "toString" should {
 
     "return a '<sensitive>' instead of the value" in {
-      ("abc" +: 2 +: 2L +: true +: Nil) foreach { someValue =>
+      TinyTypeData.arbitraryValues foreach { someValue =>
         val tinyType: TinyType = new TinyType with Sensitive {
           type V = Any
           override val value: Any = someValue
@@ -138,7 +143,7 @@ class TinyTypeFactorySpec extends AnyWordSpec with should.Matchers {
   "implicit show" should {
 
     "return a String value of the 'value' property" in {
-      ("abc" +: 2 +: 2L +: true +: Nil) foreach { someValue =>
+      TinyTypeData.arbitraryValues foreach { someValue =>
         case class InnerTinyType(v: Any) extends TinyType {
           type V = Any
           override val value: Any = v

--- a/tiny-types/src/test/scala/io/renku/tinytypes/TinyTypeSpec.scala
+++ b/tiny-types/src/test/scala/io/renku/tinytypes/TinyTypeSpec.scala
@@ -29,17 +29,14 @@ import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-object TinyTypeData {
+class TinyTypeSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
   val arbitraryValues: List[Any] =
     "abc" +: 2 +: 2L +: true +: List.empty[Any]
-}
-
-class TinyTypeSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
 
   "toString" should {
 
     "return a String value of the 'value' property" in {
-      TinyTypeData.arbitraryValues foreach { someValue =>
+      arbitraryValues foreach { someValue =>
         val tinyType: TinyType = new TinyType {
           type V = Any
           override val value: Any = someValue
@@ -72,11 +69,13 @@ class TinyTypeSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
 }
 
 class SensitiveSpec extends AnyWordSpec with should.Matchers {
+  val arbitraryValues: List[Any] =
+    "abc" +: 2 +: 2L +: true +: List.empty[Any]
 
   "toString" should {
 
     "return a '<sensitive>' instead of the value" in {
-      TinyTypeData.arbitraryValues foreach { someValue =>
+      arbitraryValues foreach { someValue =>
         val tinyType: TinyType = new TinyType with Sensitive {
           type V = Any
           override val value: Any = someValue
@@ -89,6 +88,8 @@ class SensitiveSpec extends AnyWordSpec with should.Matchers {
 }
 
 class TinyTypeFactorySpec extends AnyWordSpec with should.Matchers {
+  val arbitraryValues: List[Any] =
+    "abc" +: 2 +: 2L +: true +: List.empty[Any]
 
   import TinyTypeTest._
 
@@ -143,7 +144,7 @@ class TinyTypeFactorySpec extends AnyWordSpec with should.Matchers {
   "implicit show" should {
 
     "return a String value of the 'value' property" in {
-      TinyTypeData.arbitraryValues foreach { someValue =>
+      arbitraryValues foreach { someValue =>
         case class InnerTinyType(v: Any) extends TinyType {
           type V = Any
           override val value: Any = v
@@ -218,7 +219,7 @@ private object TinyTypeTest extends TinyTypeFactory[TinyTypeTest](new TinyTypeTe
 
   override val transform: String => Either[Throwable, String] = {
     case `invalidForTransformation` => Left(invalidTransformationException)
-    case other                      => Right(other.toString)
+    case other                      => Right(other)
   }
 
   addConstraint(

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/triplesgeneration/TriplesGeneratorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/triplesgeneration/TriplesGeneratorSpec.scala
@@ -35,7 +35,7 @@ class TriplesGeneratorSpec extends AnyWordSpec with IOSpec with should.Matchers 
 
     s"return an instance of RenkuLogTriplesGenerator if TriplesGeneration is $RenkuLog" in {
       val config = ConfigFactory.parseMap(
-        Map(
+        Map[String, Any](
           "triples-generation" -> "renku-log",
           "services" -> Map(
             "triples-generator" -> Map("url" -> "http://host").asJava,
@@ -52,7 +52,7 @@ class TriplesGeneratorSpec extends AnyWordSpec with IOSpec with should.Matchers 
     s"return an instance of RemoteTriplesGenerator if TriplesGeneration is $RemoteTriplesGeneration" in {
 
       val config = ConfigFactory.parseMap(
-        Map(
+        Map[String, Any](
           "triples-generation" -> "remote-generator",
           "services"           -> Map("triples-generator" -> Map("url" -> "http://host").asJava).asJava
         ).asJava

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/RecoverableErrorsRecoverySpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/RecoverableErrorsRecoverySpec.scala
@@ -49,7 +49,9 @@ private class RecoverableErrorsRecoverySpec extends AnyWordSpec with should.Matc
     ) { case (problemName, exception) =>
       s"return a Recoverable Failure for $problemName" in {
         val Success(Left(failure: ProcessingRecoverableError)) =
-          exception.raiseError[Try, Unit] recoverWith maybeRecoverableError[Try, Unit]
+          exception
+            .raiseError[Try, Either[ProcessingRecoverableError, Unit]]
+            .recoverWith(maybeRecoverableError[Try, Unit])
 
         failure         shouldBe a[LogWorthyRecoverableError]
         failure.message shouldBe exception.getMessage

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/RecoverableErrorsRecoverySpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/RecoverableErrorsRecoverySpec.scala
@@ -61,7 +61,9 @@ class RecoverableErrorsRecoverySpec extends AnyWordSpec with should.Matchers wit
     ) { case (problemName, exception, failureTypeAssertion) =>
       s"return a Recoverable Failure for $problemName" in {
         val Success(Left(failure: ProcessingRecoverableError)) =
-          exception.raiseError[Try, Unit] recoverWith maybeRecoverableError[Try, Unit]
+          exception
+            .raiseError[Try, Either[ProcessingRecoverableError, Unit]]
+            .recoverWith(maybeRecoverableError[Try, Unit])
 
         failureTypeAssertion(failure)
       }
@@ -70,7 +72,9 @@ class RecoverableErrorsRecoverySpec extends AnyWordSpec with should.Matchers wit
     s"fail with MalformedRepository for ${Status.InternalServerError}" in {
       val exception = UnexpectedResponseException(Status.InternalServerError, nonEmptyStrings().generateOne)
 
-      val Failure(failure) = exception.raiseError[Try, Unit] recoverWith maybeRecoverableError[Try, Unit]
+      val Failure(failure) = exception
+        .raiseError[Try, Either[ProcessingRecoverableError, Unit]]
+        .recoverWith(maybeRecoverableError[Try, Unit])
 
       failure            shouldBe a[ProcessingNonRecoverableError.MalformedRepository]
       failure.getMessage shouldBe exception.message


### PR DESCRIPTION
Some source changes are required:

- Infering the type `Any` is now emitting a warning. All occurences have been annotated explicitely or the type parameters have been corrected.

- Working around issue https://github.com/scala/bug/issues/12646 by moving a `var` from a `trait` into a `class`