### PR TITLE
feat: TS migration to port projects from the Default to Named Graphs DS

### DIFF
--- a/event-log/src/test/scala/io/renku/eventlog/events/EventsFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/EventsFinderSpec.scala
@@ -48,7 +48,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of the project the given path" in new TestCase {
       val projectId = projectIds.generateOne
-      val infos     = eventInfos(fixed(projectPath)).generateList(maxElements = 10)
+      val infos     = eventInfos(fixed(projectPath)).generateList(max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectId)
@@ -83,7 +83,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of the project with the given path and the given PagingRequest" in new TestCase {
       val projectId = projectIds.generateOne
-      val infos     = eventInfos(fixed(projectPath)).generateList(minElements = 3, maxElements = 10)
+      val infos     = eventInfos(fixed(projectPath)).generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectId)
@@ -115,7 +115,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of the project with the given path and the given direction" in new TestCase {
       val projectId = projectIds.generateOne
-      val infos     = eventInfos(fixed(projectPath)).generateList(minElements = 3, maxElements = 10)
+      val infos     = eventInfos(fixed(projectPath)).generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectId)
@@ -163,7 +163,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of the project with the given path and status filter" in new TestCase {
       val projectId = projectIds.generateOne
-      val infos     = eventInfos(fixed(projectPath)).generateList(minElements = 3, maxElements = 10)
+      val infos     = eventInfos(fixed(projectPath)).generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectId)
@@ -194,7 +194,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of the project with the given path and since filters" in new TestCase {
       val projectId = projectIds.generateOne
-      val infos     = eventInfos(fixed(projectPath)).generateList(minElements = 3, maxElements = 10)
+      val infos     = eventInfos(fixed(projectPath)).generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectId)
@@ -229,7 +229,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of the project with the given path and until filters" in new TestCase {
       val projectId = projectIds.generateOne
-      val infos     = eventInfos(fixed(projectPath)).generateList(minElements = 3, maxElements = 10)
+      val infos     = eventInfos(fixed(projectPath)).generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectId)
@@ -264,7 +264,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of all projects matching the given status filter" in new TestCase {
 
-      val infos = eventInfos().generateList(minElements = 3, maxElements = 10)
+      val infos = eventInfos().generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectIds.generateOne)
@@ -366,7 +366,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of all projects matching the given since filter" in new TestCase {
 
-      val infos = eventInfos().generateList(minElements = 3, maxElements = 10)
+      val infos = eventInfos().generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectIds.generateOne)
@@ -398,7 +398,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of all projects matching the given until filter" in new TestCase {
 
-      val infos = eventInfos().generateList(minElements = 3, maxElements = 10)
+      val infos = eventInfos().generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectIds.generateOne)
@@ -430,7 +430,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
     "return the List of events of all projects matching the given since and until filters" in new TestCase {
 
-      val infos = eventInfos().generateList(minElements = 3, maxElements = 10)
+      val infos = eventInfos().generateList(min = 3, max = 10)
 
       infos foreach { info =>
         val eventId = CompoundEventId(info.eventId, projectIds.generateOne)

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/ProjectEventsToNewUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/ProjectEventsToNewUpdaterSpec.scala
@@ -68,7 +68,7 @@ class ProjectEventsToNewUpdaterSpec
         val project = consumerProjects.generateOne
         val eventsStatuses = Gen
           .oneOf(EventStatus.all diff Set(Skipped, GeneratingTriples, AwaitingDeletion, Deleting))
-          .generateList(minElements = 2)
+          .generateList(min = 2)
 
         val eventsAndDates = eventsStatuses.map { status =>
           val eventDate = timestampsNotInTheFuture.generateAs(EventDate)

--- a/generators/src/main/scala/io/renku/generators/Generators.scala
+++ b/generators/src/main/scala/io/renku/generators/Generators.scala
@@ -88,8 +88,11 @@ object Generators {
   def sentences(minWords:       Int Refined Positive = 1,
                 maxWords:       Int Refined Positive = 10,
                 charsGenerator: Gen[Char] = alphaChar
-  ): Gen[NonBlank] =
+  ): Gen[NonBlank] = {
+    require(minWords.value <= maxWords.value, s"minWords = $minWords has to be > maxWords = $maxWords")
+
     nonEmptyStringsList(minWords, maxWords, charsGenerator) map (_.mkString(" ")) map Refined.unsafeApply
+  }
 
   def sentenceContaining(phrase: NonBlank): Gen[String] = for {
     prefix <- nonEmptyStrings()
@@ -104,35 +107,59 @@ object Generators {
   def nonEmptyStringsList(minElements:    Int Refined Positive = 1,
                           maxElements:    Int Refined Positive = 5,
                           charsGenerator: Gen[Char] = alphaChar
-  ): Gen[List[String]] = for {
-    size  <- choose(minElements.value, maxElements.value)
-    lines <- Gen.listOfN(size, nonEmptyStrings(charsGenerator = charsGenerator))
-  } yield lines
+  ): Gen[List[String]] = {
+    require(minElements.value <= maxElements.value,
+            s"minElements = $minElements has to be > maxElements = $maxElements"
+    )
+
+    for {
+      size  <- choose(minElements.value, maxElements.value)
+      lines <- Gen.listOfN(size, nonEmptyStrings(charsGenerator = charsGenerator))
+    } yield lines
+  }
 
   def nonEmptyList[T](generator:   Gen[T],
                       minElements: Int Refined Positive = 1,
                       maxElements: Int Refined Positive = 5
-  ): Gen[NonEmptyList[T]] = for {
-    size <- choose(minElements.value, maxElements.value)
-    list <- Gen.listOfN(size, generator)
-  } yield NonEmptyList.fromListUnsafe(list)
+  ): Gen[NonEmptyList[T]] = {
+    require(minElements.value <= maxElements.value,
+            s"minElements = $minElements has to be > maxElements = $maxElements"
+    )
+
+    for {
+      size <- choose(minElements.value, maxElements.value)
+      list <- Gen.listOfN(size, generator)
+    } yield NonEmptyList.fromListUnsafe(list)
+  }
 
   def nonEmptySet[T](
       generator:   Gen[T],
       minElements: Int Refined Positive = 1,
       maxElements: Int Refined Positive = 5
-  ): Gen[Set[T]] = for {
-    size <- choose(minElements.value, maxElements.value)
-    set  <- Gen.containerOfN[Set, T](size, generator)
-  } yield set
+  ): Gen[Set[T]] = {
+    require(minElements.value <= maxElements.value,
+            s"minElements = $minElements has to be > maxElements = $maxElements"
+    )
+
+    for {
+      size <- choose(minElements.value, maxElements.value)
+      set  <- Gen.containerOfN[Set, T](size, generator)
+    } yield set
+  }
 
   def listOf[T](generator:   Gen[T],
                 minElements: Int Refined NonNegative = 0,
                 maxElements: Int Refined Positive = 5
-  ): Gen[List[T]] = for {
-    size <- choose(minElements.value, maxElements.value)
-    list <- Gen.listOfN(size, generator)
-  } yield list
+  ): Gen[List[T]] = {
+    require(minElements.value <= maxElements.value,
+            s"minElements = $minElements has to be > maxElements = $maxElements"
+    )
+
+    for {
+      size <- choose(minElements.value, maxElements.value)
+      list <- Gen.listOfN(size, generator)
+    } yield list
+  }
 
   def setOf[T](generator:   Gen[T],
                minElements: Int Refined NonNegative = 0,
@@ -342,8 +369,8 @@ object Generators {
       def generateFixedSizeList(ofSize: Int Refined Positive): List[T] =
         generateNonEmptyList(minElements = ofSize, maxElements = ofSize).toList
 
-      def generateList(minElements: Int Refined NonNegative = 0, maxElements: Int Refined Positive = 5): List[T] =
-        generateExample(listOf(generator, minElements, maxElements))
+      def generateList(min: Int Refined NonNegative = 0, max: Int Refined Positive = 5): List[T] =
+        generateExample(listOf(generator, min, max))
 
       def generateFixedSizeSet(ofSize: Int Refined Positive = 5): Set[T] =
         generateExample(setOf(generator, minElements = ofSize, maxElements = ofSize))

--- a/graph-commons/src/test/scala/io/renku/compression/ZipSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/compression/ZipSpec.scala
@@ -57,7 +57,7 @@ class ZipSpec extends AnyWordSpec with IOSpec with should.Matchers {
     "fail with a meaningful error if unzipping fails" in {
       val actual = intercept[Exception] {
         Zip
-          .unzip[IO](bytes = Arbitrary.arbByte.arbitrary.generateList(minElements = 10, maxElements = 100).toArray)
+          .unzip[IO](bytes = Arbitrary.arbByte.arbitrary.generateList(min = 10, max = 100).toArray)
           .unsafeRunSync()
       }
       actual.getMessage shouldBe "Unzipping content failed"

--- a/graph-commons/src/test/scala/io/renku/http/rest/paging/PagingResponseSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/rest/paging/PagingResponseSpec.scala
@@ -39,8 +39,8 @@ class PagingResponseSpec extends AnyWordSpec with IOSpec with ScalaCheckProperty
 
     "fail if the number of results > perPage" in {
       forAll(perPages, pages) { (perPage, page) =>
-        val results = nonEmptyStrings().generateList(minElements = Refined.unsafeApply(perPage.value + 1),
-                                                     maxElements = Refined.unsafeApply(perPage.value * 2)
+        val results = nonEmptyStrings().generateList(min = Refined.unsafeApply(perPage.value + 1),
+                                                     max = Refined.unsafeApply(perPage.value * 2)
         )
         val total   = Total((page.value - 1) * perPage.value + results.size)
         val request = PagingRequest(page, perPage)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinderSpec.scala
@@ -41,10 +41,10 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val criteria      = criterias.generateOne.copy(filters = Filters(ActivationState.All))
       val commonProject = notActivatedProjects.generateOne
 
-      val tsProjects = commonProject.toActivated :: activatedProjects.generateList(maxElements = 4)
+      val tsProjects = commonProject.toActivated :: activatedProjects.generateList(max = 4)
       (tsProjectsFinder.findProjectsInTS _).expects(criteria).returning(tsProjects.pure[Try])
 
-      val glProjects = notActivatedProjects.generateList(maxElements = 4)
+      val glProjects = notActivatedProjects.generateList(max = 4)
       (glProjectsFinder.findProjectsInGL _)
         .expects(criteria)
         .returning((commonProject :: glProjects).pure[Try])
@@ -61,10 +61,10 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val criteria      = criterias.generateOne.copy(filters = Filters(ActivationState.NotActivated))
       val commonProject = notActivatedProjects.generateOne
 
-      val tsProjects = commonProject.toActivated :: activatedProjects.generateList(maxElements = 4)
+      val tsProjects = commonProject.toActivated :: activatedProjects.generateList(max = 4)
       (tsProjectsFinder.findProjectsInTS _).expects(criteria).returning(tsProjects.pure[Try])
 
-      val glProjects = notActivatedProjects.generateList(maxElements = 4)
+      val glProjects = notActivatedProjects.generateList(max = 4)
       (glProjectsFinder.findProjectsInGL _)
         .expects(criteria)
         .returning((commonProject :: glProjects).pure[Try])
@@ -81,10 +81,10 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val criteria      = criterias.generateOne.copy(filters = Filters(ActivationState.Activated))
       val commonProject = notActivatedProjects.generateOne
 
-      val tsProjects = commonProject.toActivated :: activatedProjects.generateList(maxElements = 4)
+      val tsProjects = commonProject.toActivated :: activatedProjects.generateList(max = 4)
       (tsProjectsFinder.findProjectsInTS _).expects(criteria).returning(tsProjects.pure[Try])
 
-      val glProjects = notActivatedProjects.generateList(maxElements = 4)
+      val glProjects = notActivatedProjects.generateList(max = 4)
       (glProjectsFinder.findProjectsInGL _)
         .expects(criteria)
         .returning((commonProject :: glProjects).pure[Try])

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToNamedGraphs.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToNamedGraphs.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers
+package tsmigrationrequest
+package migrations
+
+import DefaultGraphProjectsFinder.ProjectInfo
+import cats.MonadThrow
+import cats.data.EitherT
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.circe.literal._
+import io.renku.events.producers.EventSender
+import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.model.events.EventStatus.TriplesGenerated
+import io.renku.graph.model.{GraphClass, Schemas, projects}
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import org.typelevel.log4cats.Logger
+import tooling.{RecordsFinder, RecoverableErrorsRecovery}
+
+private class MigrationToNamedGraphs[F[_]: Async](
+    defaultGraphProjectsFinder: DefaultGraphProjectsFinder[F],
+    namedGraphsProjectFinder:   NamedGraphsProjectFinder[F],
+    eventsSender:               EventSender[F],
+    recoveryStrategy:           RecoverableErrorsRecovery = RecoverableErrorsRecovery
+) extends Migration[F] {
+
+  import defaultGraphProjectsFinder._
+  import eventsSender._
+  import fs2._
+  import namedGraphsProjectFinder._
+  import recoveryStrategy._
+
+  override lazy val name: Migration.Name = MigrationToNamedGraphs.name
+
+  override def run(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
+    Stream
+      .iterate(1)(_ + 1)
+      .evalMap(findDefaultGraphProjects)
+      .takeThrough(_.nonEmpty)
+      .flatMap(in => Stream.emits(in))
+      .evalFilterNot { case (projectId, _) => checkExists(projectId) }
+      .map(toRedoEvent)
+      .evalMap { case (payload, ctx) => sendEvent(payload, ctx) }
+      .compile
+      .drain
+      .map(_.asRight[ProcessingRecoverableError])
+      .recoverWith(maybeRecoverableError[F, Unit])
+  }
+
+  private lazy val toRedoEvent: ProjectInfo => (EventRequestContent.NoPayload, EventSender.EventContext) = {
+    case (_, path) =>
+      val eventCategoryName = CategoryName("EVENTS_STATUS_CHANGE")
+      EventRequestContent.NoPayload {
+        json"""{
+          "categoryName": $eventCategoryName,
+          "project": {
+            "path": $path
+          },
+          "newStatus": $TriplesGenerated
+        }"""
+      } -> EventSender.EventContext(eventCategoryName, show"$categoryName: $name cannot send event for $path")
+  }
+}
+
+private object MigrationToNamedGraphs {
+  val name: Migration.Name = Migration.Name("Migration to Named Graphs")
+
+  def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder] = for {
+    defaultGraphProjectsFinder <- DefaultGraphProjectsFinder[F]
+    namedGraphsProjectFinder   <- NamedGraphsProjectFinder[F]
+    eventsSender               <- EventSender[F]
+  } yield new MigrationToNamedGraphs(defaultGraphProjectsFinder, namedGraphsProjectFinder, eventsSender)
+}
+
+private trait DefaultGraphProjectsFinder[F[_]] {
+  def findDefaultGraphProjects(page: Int): F[List[ProjectInfo]]
+}
+
+private object DefaultGraphProjectsFinder {
+
+  type ProjectInfo = (projects.ResourceId, projects.Path)
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[DefaultGraphProjectsFinder[F]] =
+    RenkuConnectionConfig[F]().map(RecordsFinder[F](_)).map(new DefaultGraphProjectsFinderImpl(_))
+}
+
+private class DefaultGraphProjectsFinderImpl[F[_]](recordsFinder: RecordsFinder[F])
+    extends DefaultGraphProjectsFinder[F]
+    with Schemas {
+
+  import ResultsDecoder._
+  import io.renku.tinytypes.json.TinyTypeDecoders._
+
+  private val chunkSize: Int = 30
+
+  override def findDefaultGraphProjects(page: Int): F[List[ProjectInfo]] =
+    recordsFinder.findRecords(query(page))
+
+  private def query(page: Int) = SparqlQuery.of(
+    MigrationToNamedGraphs.name.asRefined,
+    Prefixes of (schema -> "schema", renku -> "renku"),
+    s"""|SELECT DISTINCT ?id ?path
+        |WHERE {
+        |  ?id a schema:Project;
+        |      renku:projectPath ?path
+        |}
+        |ORDER BY ?path
+        |LIMIT $chunkSize
+        |OFFSET ${(page - 1) * chunkSize}
+        |""".stripMargin
+  )
+
+  private implicit lazy val decoder: Decoder[List[ProjectInfo]] = ResultsDecoder[List, ProjectInfo] { implicit cur =>
+    (extract[projects.ResourceId]("id") -> extract[projects.Path]("path")).mapN(_ -> _)
+  }
+}
+
+private trait NamedGraphsProjectFinder[F[_]] {
+  def checkExists(resourceId: projects.ResourceId): F[Boolean]
+}
+
+private object NamedGraphsProjectFinder {
+  def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder]: F[NamedGraphsProjectFinder[F]] =
+    ProjectsConnectionConfig[F]().map(RecordsFinder[F](_)).map(new NamedGraphsProjectFinderImpl[F](_))
+}
+
+private class NamedGraphsProjectFinderImpl[F[_]: MonadThrow](recordsFinder: RecordsFinder[F])
+    extends NamedGraphsProjectFinder[F]
+    with Schemas {
+
+  import ResultsDecoder._
+  import io.renku.graph.model.views.RdfResource
+  import io.renku.tinytypes.json.TinyTypeDecoders._
+
+  override def checkExists(resourceId: projects.ResourceId): F[Boolean] =
+    recordsFinder.findRecords[projects.ResourceId](query(resourceId)) map {
+      case Nil => false
+      case _   => true
+    }
+
+  private def query(id: projects.ResourceId) = SparqlQuery.of(
+    MigrationToNamedGraphs.name.asRefined,
+    Prefixes of (schema -> "schema", renku -> "renku"),
+    s"""|SELECT DISTINCT ?id
+        |FROM <${GraphClass.Project.id(id)}> {
+        |  BIND (${id.showAs[RdfResource]} AS ?id)
+        |  ?id a schema:Project
+        |}
+        |""".stripMargin
+  )
+
+  private implicit lazy val decoder: Decoder[List[projects.ResourceId]] =
+    ResultsDecoder[List, projects.ResourceId](implicit cur => extract[projects.ResourceId]("id"))
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToNamedGraphs.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToNamedGraphs.scala
@@ -112,7 +112,7 @@ private class DefaultGraphProjectsFinderImpl[F[_]](recordsFinder: RecordsFinder[
   import ResultsDecoder._
   import io.renku.tinytypes.json.TinyTypeDecoders._
 
-  private val chunkSize: Int = 30
+  private val chunkSize: Int = 50
 
   override def findDefaultGraphProjects(page: Int): F[List[ProjectInfo]] =
     recordsFinder.findRecords(query(page))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -49,6 +49,7 @@ private[tsmigrationrequest] object Migrations {
     multipleTopmostDerivedFroms       <- MultipleTopmostDerivedFroms[F]
     multipleProjectAgents             <- MultipleProjectAgents[F]
     addProjectNamespaceField          <- AddProjectNamespaceField[F]
+    migrationToNamedGraphs            <- MigrationToNamedGraphs[F]
     migrations <- validateNames(
                     datasetsCreator,
                     reProvisioning,
@@ -65,7 +66,8 @@ private[tsmigrationrequest] object Migrations {
                     multipleDSDescriptions,
                     multipleTopmostDerivedFroms,
                     multipleProjectAgents,
-                    addProjectNamespaceField
+                    addProjectNamespaceField,
+                    migrationToNamedGraphs
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/ProjectsFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/ProjectsFinder.scala
@@ -28,7 +28,7 @@ import org.typelevel.log4cats.Logger
 import scala.concurrent.duration._
 
 private trait ProjectsFinder[F[_]] {
-  def findProjects(): F[List[projects.Path]]
+  def findProjects: F[List[projects.Path]]
 }
 
 private object ProjectsFinder {
@@ -45,7 +45,7 @@ private class ProjectsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     )
     with ProjectsFinder[F] {
 
-  override def findProjects(): F[List[projects.Path]] = queryExpecting[List[projects.Path]](query)
+  override def findProjects: F[List[projects.Path]] = queryExpecting[List[projects.Path]](query)
 
   private implicit lazy val pathsDecoder: Decoder[List[projects.Path]] = ResultsDecoder[List, projects.Path] {
     implicit cursor =>

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigration.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigration.scala
@@ -45,7 +45,7 @@ private[migrations] class QueryBasedMigration[F[_]: MonadThrow: Logger](
   import recoveryStrategy._
 
   protected[tooling] override def migrate(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
-    (findProjects().map(toEvents) >>= sendEvents)
+    ((findProjects map toEvents) >>= sendEvents)
       .map(_.asRight[ProcessingRecoverableError])
       .recoverWith(maybeRecoverableError[F, Unit])
   }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/RecordsFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/RecordsFinder.scala
@@ -32,18 +32,18 @@ private[migrations] trait RecordsFinder[F[_]] {
 }
 
 private[migrations] object RecordsFinder {
+
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[RecordsFinder[F]] =
     RenkuConnectionConfig[F]().map(new RecordsFinderImpl(_))
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-      renkuConnectionConfig: RenkuConnectionConfig
-  ): RecordsFinder[F] = new RecordsFinderImpl(renkuConnectionConfig)
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](connectionConfig: DatasetConnectionConfig): RecordsFinder[F] =
+    new RecordsFinderImpl(connectionConfig)
 }
 
-private class RecordsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl[F](renkuConnectionConfig,
-                          idleTimeoutOverride = (16 minutes).some,
-                          requestTimeoutOverride = (15 minutes).some
+private class RecordsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](connectionConfig: DatasetConnectionConfig)
+    extends TSClientImpl[F](connectionConfig,
+                            idleTimeoutOverride = (16 minutes).some,
+                            requestTimeoutOverride = (15 minutes).some
     )
     with RecordsFinder[F] {
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToNamedGraphsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToNamedGraphsSpec.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import DefaultGraphProjectsFinder.ProjectInfo
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.literal._
+import io.renku.events.producers.EventSender
+import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import GraphModelGenerators.{projectPaths, projectResourceIds}
+import cats.MonadThrow
+import io.renku.generators.Generators.exceptions
+import io.renku.graph.model.events.EventStatus.TriplesGenerated
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.generators.ErrorGenerators.processingRecoverableErrors
+import io.renku.triplesstore._
+import org.scalacheck.Gen
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import tooling.{RecordsFinder, RecoverableErrorsRecovery}
+
+class MigrationToNamedGraphsSpec extends AnyWordSpec with should.Matchers with IOSpec with MockFactory {
+
+  "query" should {
+
+    "find all projects that exists in the Default Graph but not in the Named Graphs dataset" in new TestCase {
+
+      val defaultOnlyProjects = projectInfos.generateList(min = 20, max = 30)
+      val bothDSProjects      = projectInfos.generateNonEmptyList().toList
+
+      val allDefaultDSProjectsChunks = (defaultOnlyProjects ::: bothDSProjects)
+        .sortBy(_._2)
+        .sliding(chunkSize, chunkSize)
+        .toList
+      allDefaultDSProjectsChunks.zipWithIndex foreach givenProjectsChunkReturned
+      givenProjectsChunkReturned(List.empty[ProjectInfo] -> allDefaultDSProjectsChunks.size)
+
+      defaultOnlyProjects foreach (givenProject(_, existsInNamedGraphs = false))
+      bothDSProjects foreach (givenProject(_, existsInNamedGraphs = true))
+
+      defaultOnlyProjects map toRedoEvent foreach givenEventIsSent
+
+      migration.run().value.unsafeRunSync() shouldBe ().asRight
+    }
+
+    "return a Recoverable Error if in case of an exception while finding projects " +
+      "the given strategy returns one" in new TestCase {
+
+        val exception = exceptions.generateOne
+
+        (defaultGraphProjectsFinder.findDefaultGraphProjects _)
+          .expects(1)
+          .returning(exception.raiseError[IO, List[ProjectInfo]])
+
+        migration.run().value.unsafeRunSync() shouldBe recoverableError.asLeft
+      }
+  }
+
+  private trait TestCase {
+    val chunkSize: Int = 30
+
+    val eventCategoryName          = CategoryName("EVENTS_STATUS_CHANGE")
+    val defaultGraphProjectsFinder = mock[DefaultGraphProjectsFinder[IO]]
+    val namedGraphsProjectFinder   = mock[NamedGraphsProjectFinder[IO]]
+    val eventSender                = mock[EventSender[IO]]
+    val recoverableError           = processingRecoverableErrors.generateOne
+    val recoveryStrategy = new RecoverableErrorsRecovery {
+      override def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = { _ =>
+        recoverableError.asLeft[OUT].pure[F]
+      }
+    }
+    val migration = new MigrationToNamedGraphs[IO](defaultGraphProjectsFinder,
+                                                   namedGraphsProjectFinder,
+                                                   eventSender,
+                                                   recoveryStrategy
+    )
+
+    def givenProjectsChunkReturned: ((List[ProjectInfo], Int)) => Unit = { case (chunk, idx) =>
+      (defaultGraphProjectsFinder.findDefaultGraphProjects _)
+        .expects(idx + 1)
+        .returning(chunk.pure[IO])
+      ()
+    }
+
+    def givenProject(project: ProjectInfo, existsInNamedGraphs: Boolean): Unit =
+      givenProject(project, existsInNamedGraphs.pure[IO])
+
+    def givenProject(project: ProjectInfo, existsInNamedGraphsResponse: IO[Boolean]): Unit = {
+      (namedGraphsProjectFinder.checkExists _)
+        .expects(project._1)
+        .returning(existsInNamedGraphsResponse)
+      ()
+    }
+
+    def toRedoEvent(project: ProjectInfo) = project -> EventRequestContent.NoPayload {
+      json"""{
+        "categoryName": $eventCategoryName,
+        "project": {
+          "path": ${project._2}
+        },
+        "newStatus": $TriplesGenerated
+      }"""
+    }
+
+    lazy val givenEventIsSent: ((ProjectInfo, EventRequestContent.NoPayload)) => Unit = { case ((_, path), event) =>
+      (eventSender
+        .sendEvent(_: EventRequestContent.NoPayload, _: EventSender.EventContext))
+        .expects(event,
+                 EventSender.EventContext(eventCategoryName,
+                                          show"$categoryName: ${migration.name} cannot send event for $path"
+                 )
+        )
+        .returning(().pure[IO])
+      ()
+    }
+  }
+
+  private lazy val projectInfos: Gen[ProjectInfo] = (projectResourceIds -> projectPaths).mapN(_ -> _)
+}
+
+class DefaultGraphProjectsFinderSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with RenkuDataset {
+
+  "findDefaultGraphProjects" should {
+
+    "find requested page of projects that exists in the Default Graph" in new TestCase {
+
+      val projects = anyRenkuProjectEntities
+        .generateList(min = 31, max = 40)
+        .map(_.to[entities.Project])
+        .sortBy(_.path)
+
+      upload(to = renkuDataset, projects: _*)
+
+      val (page1, page2) = projects splitAt 30
+      finder.findDefaultGraphProjects(page = 1).unsafeRunSync() shouldBe page1.map(p => p.resourceId -> p.path)
+      finder.findDefaultGraphProjects(page = 2).unsafeRunSync() shouldBe page2.map(p => p.resourceId -> p.path)
+      finder.findDefaultGraphProjects(page = 3).unsafeRunSync() shouldBe Nil
+    }
+  }
+
+  private trait TestCase {
+    private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
+    private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
+    val finder = new DefaultGraphProjectsFinderImpl[IO](RecordsFinder(renkuDSConnectionInfo))
+  }
+}
+
+class NamedGraphsProjectFinderSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset {
+
+  "checkExists" should {
+
+    "return true if project with the given id exisits in the Named Graphs Dataset" in new TestCase {
+
+      val project = anyRenkuProjectEntities.generateOne.to[entities.Project]
+
+      upload(to = projectsDataset, project)
+
+      (finder checkExists project.resourceId).unsafeRunSync()             shouldBe true
+      (finder checkExists projectResourceIds.generateOne).unsafeRunSync() shouldBe false
+    }
+  }
+
+  private trait TestCase {
+    private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
+    private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
+    val finder = new NamedGraphsProjectFinderImpl[IO](RecordsFinder(projectsDSConnectionInfo))
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/ProjectsFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/ProjectsFinderSpec.scala
@@ -46,7 +46,7 @@ class ProjectsFinderSpec
 
       projects foreach (upload(to = renkuDataset, _))
 
-      projectsFinder.findProjects().unsafeRunSync() should contain theSameElementsAs projects.map(_.path)
+      projectsFinder.findProjects.unsafeRunSync() should contain theSameElementsAs projects.map(_.path)
     }
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigrationSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigrationSpec.scala
@@ -52,7 +52,7 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
     "run find records and send an event for each of the found projects" in new TestCase {
       val records = projectPaths.generateNonEmptyList().toList
 
-      (projectsFinder.findProjects _).expects().returning(records.pure[Try])
+      (() => projectsFinder.findProjects).expects().returning(records.pure[Try])
 
       records foreach { record =>
         val event = eventRequestContentNoPayloads.generateOne
@@ -76,7 +76,7 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
       "the given strategy returns one" in new TestCase {
         val exception = exceptions.generateOne
 
-        (projectsFinder.findProjects _).expects().returning(exception.raiseError[Try, List[projects.Path]])
+        (() => projectsFinder.findProjects).expects().returning(exception.raiseError[Try, List[projects.Path]])
 
         migration.migrate().value shouldBe recoverableError.asLeft.pure[Try]
       }
@@ -85,7 +85,7 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
       "the given strategy returns one" in new TestCase {
 
         val record = projectPaths.generateOne
-        (projectsFinder.findProjects _).expects().returning(List(record).pure[Try])
+        (() => projectsFinder.findProjects).expects().returning(List(record).pure[Try])
 
         val event = eventRequestContentNoPayloads.generateOne
         eventProducer.expects(record).returning((record, event, eventCategoryName))


### PR DESCRIPTION
This PR is a part of the work described in #1078. It creates a new TS migration on the TG that finds all projects that do not exist in the Projects but are present in the Default Dataset and sends the `REDO_PROJECT_TRANSFORMATION` events for them.