### PR TITLE
refactor: TSClientImpl renamed to TSClient

### DIFF
--- a/graph-commons/src/main/scala/io/renku/graph/http/server/security/DatasetIdRecordsFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/http/server/security/DatasetIdRecordsFinder.scala
@@ -36,7 +36,7 @@ object DatasetIdRecordsFinder {
 
 private class DatasetIdRecordsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with SecurityRecordFinder[F, datasets.Identifier] {
 
   override def apply(id: datasets.Identifier): F[List[SecurityRecord]] =

--- a/graph-commons/src/main/scala/io/renku/graph/http/server/security/ProjectPathRecordsFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/http/server/security/ProjectPathRecordsFinder.scala
@@ -37,7 +37,7 @@ object ProjectPathRecordsFinder {
 
 private class ProjectPathRecordsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with SecurityRecordFinder[F, projects.Path] {
 
   override def apply(path: projects.Path): F[List[SecurityRecord]] =

--- a/graph-commons/src/main/scala/io/renku/triplesstore/TSClient.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/TSClient.scala
@@ -37,7 +37,7 @@ import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-abstract class TSClientImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+abstract class TSClient[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     triplesStoreConfig:     DatasetConnectionConfig,
     retryInterval:          FiniteDuration = SleepAfterConnectionIssue,
     maxRetries:             Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
@@ -54,7 +54,7 @@ abstract class TSClientImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     with ResultsDecoder
     with RdfMediaTypes {
 
-  import TSClientImpl._
+  import TSClient._
   import eu.timepit.refined.auto._
   import io.renku.http.client.UrlEncoder.urlEncode
   import org.http4s.MediaType.application._
@@ -170,7 +170,7 @@ abstract class TSClientImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     }
 }
 
-object TSClientImpl {
+object TSClient {
 
   private trait SparqlQueryType
   private final implicit case object SparqlSelect extends SparqlQueryType

--- a/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
@@ -151,7 +151,7 @@ trait InMemoryJena {
 
   protected def queryRunnerFor(datasetName: DatasetName) = queryRunner(findConnectionInfo(datasetName))
 
-  private def queryRunner(connectionInfo: DatasetConnectionConfig) = new TSClientImpl[IO](connectionInfo) {
+  private def queryRunner(connectionInfo: DatasetConnectionConfig) = new TSClient[IO](connectionInfo) {
 
     import io.circe.Decoder._
 

--- a/graph-commons/src/test/scala/io/renku/triplesstore/TSClientSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/TSClientSpec.scala
@@ -45,16 +45,11 @@ import org.typelevel.log4cats.Logger
 
 import scala.util.Try
 
-class TSClientImplSpec
-    extends AnyWordSpec
-    with IOSpec
-    with ExternalServiceStubbing
-    with MockFactory
-    with should.Matchers {
+class TSClientSpec extends AnyWordSpec with IOSpec with ExternalServiceStubbing with MockFactory with should.Matchers {
 
   "TSClientImpl" should {
     "be a RestClient" in new QueryClientTestCase {
-      type IOTSClientImpl = TSClientImpl[IO]
+      type IOTSClientImpl = TSClient[IO]
       client shouldBe a[IOTSClientImpl]
       client shouldBe a[RestClient[IO, _]]
     }
@@ -427,7 +422,7 @@ class TSClientImplSpec
       val query:             SparqlQuery,
       renkuConnectionConfig: RenkuConnectionConfig
   )(implicit logger:         Logger[IO], timeRecorder: SparqlQueryTimeRecorder[IO])
-      extends TSClientImpl[IO](renkuConnectionConfig) {
+      extends TSClient[IO](renkuConnectionConfig) {
 
     def sendUpdate: IO[Unit] = updateWithNoResult(query)
 
@@ -441,7 +436,7 @@ class TSClientImplSpec
   private class TestTSQueryClientImpl(val query: SparqlQuery, renkuConnectionConfig: RenkuConnectionConfig)(implicit
       logger:                                    Logger[IO],
       timeRecorder:                              SparqlQueryTimeRecorder[IO]
-  ) extends TSClientImpl[IO](renkuConnectionConfig)
+  ) extends TSClient[IO](renkuConnectionConfig)
       with Paging[String] {
 
     def callRemote: IO[Json] = queryExpecting[Json](query)

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/CreatorsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/CreatorsFinder.scala
@@ -36,7 +36,7 @@ private trait CreatorsFinder[F[_]] {
 
 private class CreatorsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with CreatorsFinder[F] {
 
   import CreatorsFinder._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetsFinder.scala
@@ -56,7 +56,7 @@ private object DatasetsFinder {
 private class DatasetsFinderImpl[F[_]: Parallel: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig,
     creatorsFinder:        CreatorsFinder[F]
-) extends TSClientImpl[F](renkuConnectionConfig)
+) extends TSClient[F](renkuConnectionConfig)
     with DatasetsFinder[F]
     with Paging[DatasetSearchResult] {
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
@@ -43,7 +43,7 @@ private trait BaseDetailsFinder[F[_]] {
 
 private class BaseDetailsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with BaseDetailsFinder[F] {
 
   import BaseDetailsFinderImpl._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/PartsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/PartsFinder.scala
@@ -36,7 +36,7 @@ private trait PartsFinder[F[_]] {
 
 private class PartsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with PartsFinder[F] {
 
   import PartsFinderImpl._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/ProjectsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/ProjectsFinder.scala
@@ -43,7 +43,7 @@ private trait ProjectsFinder[F[_]] {
 
 private class ProjectsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with ProjectsFinder[F] {
 
   import ProjectsFinderImpl._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinder.scala
@@ -26,7 +26,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.renku.http.rest.paging.Paging.PagedResultsFinder
 import io.renku.http.rest.paging.{Paging, PagingResponse}
-import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClientImpl}
+import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClient}
 import model._
 import org.typelevel.log4cats.Logger
 
@@ -42,7 +42,7 @@ private[entities] object EntitiesFinder {
 private class EntitiesFinderImpl[F[_]: Async: NonEmptyParallel: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig,
     entityQueries:         List[EntityQuery[Entity]] = List(ProjectsQuery, DatasetsQuery, WorkflowsQuery, PersonsQuery)
-) extends TSClientImpl[F](renkuConnectionConfig)
+) extends TSClient[F](renkuConnectionConfig)
     with EntitiesFinder[F]
     with Paging[Entity] {
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/metrics/StatsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/metrics/StatsFinder.scala
@@ -34,7 +34,7 @@ private trait StatsFinder[F[_]] {
 
 private class StatsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl[F](renkuConnectionConfig)
+) extends TSClient[F](renkuConnectionConfig)
     with StatsFinder[F] {
 
   import EntityCount._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetsFinder.scala
@@ -43,7 +43,7 @@ private object ProjectDatasetsFinder {
 
 private class ProjectDatasetsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with ProjectDatasetsFinder[F] {
 
   import ProjectDatasetsFinderImpl._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/tags/TagsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/tags/TagsFinder.scala
@@ -23,7 +23,7 @@ import cats.NonEmptyParallel
 import cats.effect.Async
 import cats.syntax.all._
 import io.renku.http.rest.paging.{Paging, PagingResponse}
-import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClientImpl}
+import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClient}
 import org.typelevel.log4cats.Logger
 
 private trait TagsFinder[F[_]] {
@@ -37,7 +37,7 @@ private object TagsFinder {
 
 private class TagsFinderImpl[F[_]: Async: NonEmptyParallel: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl[F](renkuConnectionConfig)
+) extends TSClient[F](renkuConnectionConfig)
     with TagsFinder[F]
     with Paging[model.Tag] {
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/KGProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/KGProjectFinder.scala
@@ -34,7 +34,7 @@ private trait KGProjectFinder[F[_]] {
 
 private class KGProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGProjectFinder[F] {
 
   import cats.syntax.all._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinder.scala
@@ -41,7 +41,7 @@ private trait EdgesFinder[F[_]] {
 private class EdgesFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig,
     renkuUrl:              RenkuUrl
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with EdgesFinder[F] {
 
   private type EdgeData = (ExecutionInfo, Option[Location], Option[Node.Location])

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/NodeDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/NodeDetailsFinder.scala
@@ -45,7 +45,7 @@ private trait NodeDetailsFinder[F[_]] {
 private class NodeDetailsFinderImpl[F[_]: Async: Parallel: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig,
     renkuUrl:              RenkuUrl
-) extends TSClientImpl[F](renkuConnectionConfig)
+) extends TSClient[F](renkuConnectionConfig)
     with NodeDetailsFinder[F] {
 
   override def findDetails[T](

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinder.scala
@@ -26,7 +26,7 @@ import io.circe.Decoder
 import io.renku.graph.model.entities.Person
 import io.renku.graph.model.projects
 import io.renku.knowledgegraph.users.projects.model.Project
-import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClientImpl}
+import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClient}
 import org.typelevel.log4cats.Logger
 
 private trait TSProjectFinder[F[_]] {
@@ -40,7 +40,7 @@ private object TSProjectFinder {
 
 private class TSProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with TSProjectFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/defaultgraph/SameAsHierarchyFixer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/defaultgraph/SameAsHierarchyFixer.scala
@@ -44,9 +44,9 @@ private object SameAsHierarchyFixer {
 
 private class SameAsHierarchyFixer[F[_]: Async: Logger: SparqlQueryTimeRecorder](path: projects.Path)(
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig,
-                       idleTimeoutOverride = (11 minutes).some,
-                       requestTimeoutOverride = (10 minutes).some
+) extends TSClient(renkuConnectionConfig,
+                   idleTimeoutOverride = (11 minutes).some,
+                   requestTimeoutOverride = (10 minutes).some
     ) {
 
   import io.renku.jsonld.syntax._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/defaultgraph/TSCleaner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/defaultgraph/TSCleaner.scala
@@ -57,11 +57,11 @@ private class TSCleanerImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     maxRetries:            Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeout:           Duration = 16 minutes,
     requestTimeout:        Duration = 15 minutes
-) extends TSClientImpl(renkuConnectionConfig,
-                       retryInterval = retryInterval,
-                       maxRetries = maxRetries,
-                       idleTimeoutOverride = idleTimeout.some,
-                       requestTimeoutOverride = requestTimeout.some
+) extends TSClient(renkuConnectionConfig,
+                   retryInterval = retryInterval,
+                   maxRetries = maxRetries,
+                   idleTimeoutOverride = idleTimeout.some,
+                   requestTimeoutOverride = requestTimeout.some
     )
     with TSCleaner[F] {
   import SameAsHierarchyFixer._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/SameAsHierarchyFixer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/SameAsHierarchyFixer.scala
@@ -42,9 +42,9 @@ private object SameAsHierarchyFixer {
 
 private class SameAsHierarchyFixer[F[_]: Async: Logger: SparqlQueryTimeRecorder](path: projects.Path)(
     connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig,
-                       idleTimeoutOverride = (11 minutes).some,
-                       requestTimeoutOverride = (10 minutes).some
+) extends TSClient(connectionConfig,
+                   idleTimeoutOverride = (11 minutes).some,
+                   requestTimeoutOverride = (10 minutes).some
     ) {
 
   import io.renku.jsonld.syntax._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/TSCleaner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/TSCleaner.scala
@@ -26,7 +26,7 @@ import io.circe.Decoder
 import io.renku.graph.model.{GraphClass, projects}
 import io.renku.http.client.RestClient.{MaxRetriesAfterConnectionTimeout, SleepAfterConnectionIssue}
 import io.renku.jsonld.EntityId
-import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder, TSClientImpl}
+import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder, TSClient}
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
@@ -52,11 +52,11 @@ private class TSCleanerImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     maxRetries:       Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeout:      Duration = 16 minutes,
     requestTimeout:   Duration = 15 minutes
-) extends TSClientImpl(connectionConfig,
-                       retryInterval = retryInterval,
-                       maxRetries = maxRetries,
-                       idleTimeoutOverride = idleTimeout.some,
-                       requestTimeoutOverride = requestTimeout.some
+) extends TSClient(connectionConfig,
+                   retryInterval = retryInterval,
+                   maxRetries = maxRetries,
+                   idleTimeoutOverride = idleTimeout.some,
+                   requestTimeoutOverride = requestTimeout.some
     )
     with TSCleaner[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/defaultgraph/KGPersonFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/defaultgraph/KGPersonFinder.scala
@@ -34,7 +34,7 @@ private trait KGPersonFinder[F[_]] {
 
 private class KGPersonFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGPersonFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/defaultgraph/KGProjectMembersFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/defaultgraph/KGProjectMembersFinder.scala
@@ -38,7 +38,7 @@ private trait KGProjectMembersFinder[F[_]] {
 private class KGProjectMembersFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig,
     renkuUrl:              RenkuUrl
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGProjectMembersFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/defaultgraph/KGSynchronizer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/defaultgraph/KGSynchronizer.scala
@@ -32,7 +32,7 @@ private[membersync] object KGSynchronizer {
     kgPersonFinder         <- KGPersonFinder[F]
     updatesCreator         <- UpdatesCreator[F]
     renkuConnectionConfig  <- RenkuConnectionConfig[F]()
-    querySender <- MonadThrow[F].catchNonFatal(new TSClientImpl(renkuConnectionConfig) with QuerySender[F] {
+    querySender <- MonadThrow[F].catchNonFatal(new TSClient(renkuConnectionConfig) with QuerySender[F] {
                      override def send(query: SparqlQuery): F[Unit] = updateWithNoResult(query)
                    })
   } yield new KGSynchronizerImpl[F](kgProjectMembersFinder, kgPersonFinder, updatesCreator, querySender)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGPersonFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGPersonFinder.scala
@@ -34,7 +34,7 @@ private trait KGPersonFinder[F[_]] {
 
 private class KGPersonFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig)
+) extends TSClient(connectionConfig)
     with KGPersonFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGProjectMembersFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGProjectMembersFinder.scala
@@ -39,7 +39,7 @@ private trait KGProjectMembersFinder[F[_]] {
 private class KGProjectMembersFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     connectionConfig: ProjectsConnectionConfig
 )(implicit renkuUrl:  RenkuUrl)
-    extends TSClientImpl(connectionConfig)
+    extends TSClient(connectionConfig)
     with KGProjectMembersFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGSynchronizer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGSynchronizer.scala
@@ -33,7 +33,7 @@ private[membersync] object KGSynchronizer {
       kgPersonFinder         <- KGPersonFinder[F]
       updatesCreator         <- UpdatesCreator[F]
       connectionConfig       <- ProjectsConnectionConfig[F]()
-      querySender <- MonadThrow[F].catchNonFatal(new TSClientImpl(connectionConfig) with QuerySender[F] {
+      querySender <- MonadThrow[F].catchNonFatal(new TSClient(connectionConfig) with QuerySender[F] {
                        override def send(query: SparqlQuery): F[Unit] = updateWithNoResult(query)
                      })
     } yield new KGSynchronizerImpl[F](kgProjectMembersFinder, kgPersonFinder, updatesCreator, querySender)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatus.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisioningStatus.scala
@@ -50,7 +50,7 @@ private class ReProvisioningStatusImpl[F[_]: Async: Parallel: Logger: SparqlQuer
     subscriptionsRegistry: Ref[F, List[SubscriptionMechanism[F]]],
     lastCacheCheckTimeRef: Ref[F, Long]
 )(implicit renkuUrl:       RenkuUrl)
-    extends TSClientImpl(storeConfig)
+    extends TSClient(storeConfig)
     with ReProvisioningStatus[F] {
 
   import io.renku.jsonld.syntax._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairFinder.scala
@@ -35,7 +35,7 @@ trait RenkuVersionPairFinder[F[_]] {
 private class RenkuVersionPairFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     storeConfig:     MigrationsConnectionConfig
 )(implicit renkuUrl: RenkuUrl)
-    extends TSClientImpl[F](storeConfig)
+    extends TSClient[F](storeConfig)
     with RenkuVersionPairFinder[F] {
 
   override def find(): F[Option[RenkuVersionPair]] = queryExpecting[List[RenkuVersionPair]] {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
@@ -35,7 +35,7 @@ trait RenkuVersionPairUpdater[F[_]] {
 private class RenkuVersionPairUpdaterImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     storeConfig:     MigrationsConnectionConfig
 )(implicit renkuUrl: RenkuUrl)
-    extends TSClientImpl(storeConfig)
+    extends TSClient(storeConfig)
     with RenkuVersionPairUpdater[F] {
 
   override def update(versionPair: RenkuVersionPair): F[Unit] =

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/TriplesRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/TriplesRemover.scala
@@ -39,9 +39,9 @@ private class TriplesRemoverImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig,
     idleTimeout:           Duration = 11 minutes,
     requestTimeout:        Duration = 10 minutes
-) extends TSClientImpl(renkuConnectionConfig,
-                       idleTimeoutOverride = idleTimeout.some,
-                       requestTimeoutOverride = requestTimeout.some
+) extends TSClient(renkuConnectionConfig,
+                   idleTimeoutOverride = idleTimeout.some,
+                   requestTimeoutOverride = requestTimeout.some
     )
     with TriplesRemover[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/MigrationExecutionRegister.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/MigrationExecutionRegister.scala
@@ -42,7 +42,7 @@ private class MigrationExecutionRegisterImpl[F[_]: Async: Logger: SparqlQueryTim
     serviceVersion:  ServiceVersion,
     storeConfig:     MigrationsConnectionConfig
 )(implicit renkuUrl: RenkuUrl)
-    extends TSClientImpl(storeConfig)
+    extends TSClient(storeConfig)
     with MigrationExecutionRegister[F] {
 
   import MigrationExecutionRegister._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/ProjectsFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/ProjectsFinder.scala
@@ -39,9 +39,9 @@ private object ProjectsFinder {
 private class ProjectsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     query:                 SparqlQuery,
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl[F](renkuConnectionConfig,
-                          idleTimeoutOverride = (16 minutes).some,
-                          requestTimeoutOverride = (15 minutes).some
+) extends TSClient[F](renkuConnectionConfig,
+                      idleTimeoutOverride = (16 minutes).some,
+                      requestTimeoutOverride = (15 minutes).some
     )
     with ProjectsFinder[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/RecordsFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/RecordsFinder.scala
@@ -41,9 +41,9 @@ private[migrations] object RecordsFinder {
 
 private class RecordsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl[F](renkuConnectionConfig,
-                          idleTimeoutOverride = (16 minutes).some,
-                          requestTimeoutOverride = (15 minutes).some
+) extends TSClient[F](renkuConnectionConfig,
+                      idleTimeoutOverride = (16 minutes).some,
+                      requestTimeoutOverride = (15 minutes).some
     )
     with RecordsFinder[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/UpdateQueryRunner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/UpdateQueryRunner.scala
@@ -31,9 +31,9 @@ private[migrations] trait UpdateQueryRunner[F[_]] {
 
 private class UpdateQueryRunnerImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl[F](renkuConnectionConfig,
-                          idleTimeoutOverride = (16 minutes).some,
-                          requestTimeoutOverride = (15 minutes).some
+) extends TSClient[F](renkuConnectionConfig,
+                      idleTimeoutOverride = (16 minutes).some,
+                      requestTimeoutOverride = (15 minutes).some
     )
     with UpdateQueryRunner[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/KGInfoFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/KGInfoFinder.scala
@@ -41,7 +41,7 @@ private object KGInfoFinder {
 
 private class KGInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGInfoFinder[F] {
 
   override def findActivityAuthors(resourceId: activities.ResourceId): F[Set[persons.ResourceId]] =

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/datasets/KGDatasetInfoFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/datasets/KGDatasetInfoFinder.scala
@@ -40,7 +40,7 @@ private trait KGDatasetInfoFinder[F[_]] {
 
 private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGDatasetInfoFinder[F] {
 
   import cats.syntax.all._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/persons/KGPersonFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/persons/KGPersonFinder.scala
@@ -42,7 +42,7 @@ private object KGPersonFinder {
 
 private class KGPersonFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGPersonFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/projects/KGProjectFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/projects/KGProjectFinder.scala
@@ -33,7 +33,7 @@ private trait KGProjectFinder[F[_]] {
 
 private class KGProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClientImpl(renkuConnectionConfig)
+) extends TSClient(renkuConnectionConfig)
     with KGProjectFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/KGInfoFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/KGInfoFinder.scala
@@ -43,7 +43,7 @@ private object KGInfoFinder {
 
 private class KGInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig)
+) extends TSClient(connectionConfig)
     with KGInfoFinder[F] {
 
   override def findActivityAuthors(projectId:  projects.ResourceId,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/KGDatasetInfoFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/KGDatasetInfoFinder.scala
@@ -41,7 +41,7 @@ private trait KGDatasetInfoFinder[F[_]] {
 
 private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig)
+) extends TSClient(connectionConfig)
     with KGDatasetInfoFinder[F] {
 
   import cats.syntax.all._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/persons/KGPersonFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/persons/KGPersonFinder.scala
@@ -41,7 +41,7 @@ private object KGPersonFinder {
 
 private class KGPersonFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig)
+) extends TSClient(connectionConfig)
     with KGPersonFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/KGProjectFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/KGProjectFinder.scala
@@ -33,7 +33,7 @@ private trait KGProjectFinder[F[_]] {
 
 private class KGProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig)
+) extends TSClient(connectionConfig)
     with KGProjectFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesuploading/JsonLDUploader.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesuploading/JsonLDUploader.scala
@@ -44,11 +44,11 @@ private class JsonLDUploaderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     maxRetries:         Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeout:        Duration = 11 minutes,
     requestTimeout:     Duration = 10 minutes
-) extends TSClientImpl(dsConnectionConfig,
-                       retryInterval = retryInterval,
-                       maxRetries = maxRetries,
-                       idleTimeoutOverride = idleTimeout.some,
-                       requestTimeoutOverride = requestTimeout.some
+) extends TSClient(dsConnectionConfig,
+                   retryInterval = retryInterval,
+                   maxRetries = maxRetries,
+                   idleTimeoutOverride = idleTimeout.some,
+                   requestTimeoutOverride = requestTimeout.some
     )
     with JsonLDUploader[F] {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesuploading/UpdateQueryRunner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesuploading/UpdateQueryRunner.scala
@@ -44,11 +44,11 @@ private class UpdateQueryRunnerImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder
     maxRetries:         Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeout:        Duration = 11 minutes,
     requestTimeout:     Duration = 10 minutes
-) extends TSClientImpl[F](dsConnectionConfig,
-                          retryInterval,
-                          maxRetries,
-                          idleTimeoutOverride = idleTimeout.some,
-                          requestTimeoutOverride = requestTimeout.some
+) extends TSClient[F](dsConnectionConfig,
+                      retryInterval,
+                      maxRetries,
+                      idleTimeoutOverride = idleTimeout.some,
+                      requestTimeoutOverride = requestTimeout.some
     )
     with UpdateQueryRunner[F] {
 


### PR DESCRIPTION
This PR simply renames a not so well named `TSClientImpl` class to `TSClient`.