### PR TITLE
fix: logging an error on scheduling problem

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/MicroserviceRoutes.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/MicroserviceRoutes.scala
@@ -27,6 +27,7 @@ import io.renku.http.server.version
 import io.renku.metrics.{MetricsRegistry, RoutesMetrics}
 import io.renku.triplesgenerator.events.EventEndpoint
 import org.http4s.dsl.Http4sDsl
+import org.typelevel.log4cats.Logger
 
 import scala.jdk.CollectionConverters._
 
@@ -60,8 +61,8 @@ private class MicroserviceRoutes[F[_]: MonadThrow](
 }
 
 private object MicroserviceRoutes {
-  def apply[F[_]: Async: MetricsRegistry](consumersRegistry: EventConsumersRegistry[F],
-                                          config: Option[Config]
+  def apply[F[_]: Async: Logger: MetricsRegistry](consumersRegistry: EventConsumersRegistry[F],
+                                                  config: Option[Config]
   ): F[MicroserviceRoutes[F]] = for {
     eventEndpoint <- EventEndpoint(consumersRegistry)
     versionRoutes <- version.Routes[F]


### PR DESCRIPTION
It looks like when there's a problem with scheduling an event on TG, there's absolutely no info in the logs and it's almost impossible to find out what's happened.