### PR TITLE
feat: cross-entity search to work against the Named Graphs dataset

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinder.scala
@@ -26,7 +26,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.renku.http.rest.paging.Paging.PagedResultsFinder
 import io.renku.http.rest.paging.{Paging, PagingResponse}
-import io.renku.triplesstore.{RenkuConnectionConfig, SparqlQueryTimeRecorder, TSClient}
+import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder, TSClient}
 import model._
 import org.typelevel.log4cats.Logger
 
@@ -36,13 +36,13 @@ private[entities] trait EntitiesFinder[F[_]] {
 
 private[entities] object EntitiesFinder {
   def apply[F[_]: Async: NonEmptyParallel: Logger: SparqlQueryTimeRecorder]: F[EntitiesFinder[F]] =
-    RenkuConnectionConfig[F]().map(new EntitiesFinderImpl(_))
+    ProjectsConnectionConfig[F]().map(new EntitiesFinderImpl(_))
 }
 
 private class EntitiesFinderImpl[F[_]: Async: NonEmptyParallel: Logger: SparqlQueryTimeRecorder](
-    renkuConnectionConfig: RenkuConnectionConfig,
-    entityQueries:         List[EntityQuery[Entity]] = List(ProjectsQuery, DatasetsQuery, WorkflowsQuery, PersonsQuery)
-) extends TSClient[F](renkuConnectionConfig)
+    storeConfig:   ProjectsConnectionConfig,
+    entityQueries: List[EntityQuery[Entity]] = List(ProjectsQuery, DatasetsQuery, WorkflowsQuery, PersonsQuery)
+) extends TSClient[F](storeConfig)
     with EntitiesFinder[F]
     with Paging[Entity] {
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/PersonsQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/PersonsQuery.scala
@@ -20,7 +20,7 @@ package io.renku.knowledgegraph.entities
 package finder
 
 import io.circe.Decoder
-import io.renku.graph.model.persons
+import io.renku.graph.model.{GraphClass, persons}
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters.EntityType
 import io.renku.knowledgegraph.entities.model.{Entity, MatchingScore}
 
@@ -43,8 +43,10 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
           |        ${filters.onQuery(
                    s"""(?id ?score) text:query (schema:name '${filters.query}').""",
                    matchingScoreVariableName = "?score")}
-          |        ?id a schema:Person;
-          |            schema:name ?name.
+          |        GRAPH <${GraphClass.Persons.id}> {
+          |          ?id a schema:Person;
+          |              schema:name ?name
+          |        }
           |        ${filters.maybeOnCreatorName("?name")}
           |      }
           |      GROUP BY ?name

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/WorkflowsQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/WorkflowsQuery.scala
@@ -45,29 +45,35 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
     s"""|        {
         |          SELECT ?wkId (MAX(?score) AS ?matchingScore)
         |          WHERE {
-        |            (?wkId ?score) text:query (schema:name schema:keywords schema:description '${filters.query}').
-        |            ?wkId a prov:Plan
+        |            GRAPH ?g {
+        |              (?wkId ?score) text:query (schema:name schema:keywords schema:description '${filters.query}').
+        |              ?wkId a prov:Plan
+        |            }
         |          }
         |          GROUP BY ?wkId
         |        }
         |""")}
-        |        ?wkId a prov:Plan;
-        |              schema:name ?name;
-        |              schema:dateCreated ?date;
-        |              ^renku:hasPlan ?projectId.
-        |        ?projectId renku:projectVisibility ?visibility;
-        |                   renku:projectNamespace ?namespace.
-        |        ${criteria.maybeOnAccessRights("?projectId", "?visibility")}
-        |        ${filters.maybeOnVisibility("?visibility")}
-        |        ${filters.maybeOnNamespace("?namespace")}
-        |        ${filters.maybeOnDateCreated("?date")}
+        |        GRAPH ?projectId {
+        |          ?wkId a prov:Plan;
+        |                schema:name ?name;
+        |                schema:dateCreated ?date;
+        |                ^renku:hasPlan ?projectId.
+        |          ?projectId renku:projectVisibility ?visibility;
+        |                     renku:projectNamespace ?namespace.
+        |          ${criteria.maybeOnAccessRights("?projectId", "?visibility")}
+        |          ${filters.maybeOnVisibility("?visibility")}
+        |          ${filters.maybeOnNamespace("?namespace")}
+        |          ${filters.maybeOnDateCreated("?date")}
+        |        }
         |      }
         |      GROUP BY ?wkId ?matchingScore ?date
         |    }
         |    BIND ('workflow' AS ?entityType)
-        |    ?wkId schema:name ?name.
-        |    OPTIONAL { ?wkId schema:description ?maybeDescription }
-        |    OPTIONAL { ?wkId schema:keywords ?keyword }
+        |    GRAPH ?g {
+        |      ?wkId schema:name ?name.
+        |      OPTIONAL { ?wkId schema:description ?maybeDescription }
+        |      OPTIONAL { ?wkId schema:keywords ?keyword }
+        |    }
         |  }
         |  GROUP BY ?entityType ?matchingScore ?wkId ?name ?visibilities ?date ?maybeDescription
         |}

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/DatasetsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/DatasetsEntitiesFinderSpec.scala
@@ -28,8 +28,8 @@ import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model._
 import io.renku.graph.model.testentities._
 import io.renku.http.rest.SortBy
-import io.renku.triplesstore.{InMemoryJenaForSpec, RenkuDataset}
 import io.renku.testtools.IOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -38,7 +38,7 @@ class DatasetsEntitiesFinderSpec
     with should.Matchers
     with FinderSpecOps
     with InMemoryJenaForSpec
-    with RenkuDataset
+    with ProjectsDataset
     with IOSpec {
 
   "findEntities - in case of a shared datasets" should {
@@ -52,7 +52,7 @@ class DatasetsEntitiesFinderSpec
         .importDataset(originalDS)
         .generateOne
 
-      upload(to = renkuDataset, originalDSProject, importedDSProject)
+      upload(to = projectsDataset, originalDSProject, importedDSProject)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(Filters.EntityType.Dataset))))
@@ -75,7 +75,7 @@ class DatasetsEntitiesFinderSpec
         .importDataset(importedDS1)
         .generateOne
 
-      upload(to = renkuDataset, project1WithImportedDS, project2WithImportedDS, projectWithDSImportedFromProject)
+      upload(to = projectsDataset, project1WithImportedDS, project2WithImportedDS, projectWithDSImportedFromProject)
 
       val results = finder
         .findEntities(Criteria(Filters(entityTypes = Set(Filters.EntityType.Dataset))))
@@ -101,7 +101,7 @@ class DatasetsEntitiesFinderSpec
         .importDataset(originalDS)
         .generateOne
 
-      upload(to = renkuDataset, originalDSProject, importedDSProject)
+      upload(to = projectsDataset, originalDSProject, importedDSProject)
 
       finder
         .findEntities(
@@ -128,7 +128,7 @@ class DatasetsEntitiesFinderSpec
         .importDataset(originalDS)
         .generateOne
 
-      upload(to = renkuDataset, originalDSProject, importedDSProject)
+      upload(to = projectsDataset, originalDSProject, importedDSProject)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(Filters.EntityType.Dataset))))
@@ -146,7 +146,7 @@ class DatasetsEntitiesFinderSpec
 
       val original ::~ fork = originalDSProject.forkOnce()
 
-      upload(to = renkuDataset, original, fork)
+      upload(to = projectsDataset, original, fork)
 
       val results = finder
         .findEntities(Criteria(Filters(entityTypes = Set(Filters.EntityType.Dataset))))
@@ -175,7 +175,7 @@ class DatasetsEntitiesFinderSpec
         original -> fork.copy(visibility = visibilityNonPublic.generateOne, members = Set(member))
       }
 
-      upload(to = renkuDataset, original, fork)
+      upload(to = projectsDataset, original, fork)
 
       finder
         .findEntities(
@@ -199,7 +199,7 @@ class DatasetsEntitiesFinderSpec
         original -> fork.copy(visibility = projects.Visibility.Private, members = Set(member))
       }
 
-      upload(to = renkuDataset, original, fork)
+      upload(to = projectsDataset, original, fork)
 
       finder
         .findEntities(
@@ -218,7 +218,7 @@ class DatasetsEntitiesFinderSpec
         .importDataset(externalDS)
         .generateOne
 
-      upload(to = renkuDataset, privateProject)
+      upload(to = projectsDataset, privateProject)
 
       finder
         .findEntities(

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
@@ -35,8 +35,8 @@ import io.renku.graph.model.testentities._
 import io.renku.http.rest.SortBy
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.rest.paging.model._
-import io.renku.triplesstore.{InMemoryJenaForSpec, RenkuDataset}
 import io.renku.testtools.IOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -49,7 +49,7 @@ class EntitiesFinderSpec
     with should.Matchers
     with FinderSpecOps
     with InMemoryJenaForSpec
-    with RenkuDataset
+    with ProjectsDataset
     with IOSpec {
 
   "findEntities - no filters" should {
@@ -60,7 +60,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder.findEntities(Criteria()).unsafeRunSync().results shouldBe
         allEntitiesFrom(project).sortBy(_.name.value)
@@ -103,7 +103,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, loneProject, dsProject, planProject, notMatchingProject)
+      upload(to = projectsDataset, loneProject, dsProject, planProject, notMatchingProject)
 
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))
@@ -150,7 +150,7 @@ class EntitiesFinderSpec
         .generateOne
       val plan :: Nil = planProject.plans.toList
 
-      upload(to = renkuDataset, soleProject, dsProject, planProject, projectEntities(visibilityPublic).generateOne)
+      upload(to = projectsDataset, soleProject, dsProject, planProject, projectEntities(visibilityPublic).generateOne)
 
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))
@@ -187,7 +187,7 @@ class EntitiesFinderSpec
         .generateOne
       val plan :: Nil = planProject.plans.toList
 
-      upload(to = renkuDataset, soleProject, dsProject, planProject, projectEntities(visibilityPublic).generateOne)
+      upload(to = projectsDataset, soleProject, dsProject, planProject, projectEntities(visibilityPublic).generateOne)
 
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))
@@ -206,7 +206,7 @@ class EntitiesFinderSpec
         .modify(_.copy(path = projects.Path(s"$query/${relativePaths(maxSegments = 2).generateOne}")))
         .generateOne
 
-      upload(to = renkuDataset, soleProject, projectEntities(visibilityPublic).generateOne)
+      upload(to = projectsDataset, soleProject, projectEntities(visibilityPublic).generateOne)
 
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))
@@ -233,7 +233,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, soleProject, dsProject, projectEntities(visibilityPublic).generateOne)
+      upload(to = projectsDataset, soleProject, dsProject, projectEntities(visibilityPublic).generateOne)
 
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))
@@ -255,7 +255,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(EntityType.Project))))
@@ -269,7 +269,7 @@ class EntitiesFinderSpec
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(EntityType.Dataset))))
@@ -283,7 +283,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(EntityType.Workflow))))
@@ -298,7 +298,7 @@ class EntitiesFinderSpec
         .modify(removeMembers())
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(EntityType.Person, EntityType.Project))))
@@ -316,7 +316,7 @@ class EntitiesFinderSpec
         .modify(removeMembers())
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(EntityType.Person))))
@@ -344,7 +344,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, soleProject, dsProject, projectEntities(visibilityPublic).generateOne)
+      upload(to = projectsDataset, soleProject, dsProject, projectEntities(visibilityPublic).generateOne)
 
       finder
         .findEntities(Criteria(Filters(creators = Set(creator.name))))
@@ -373,7 +373,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, soleProject, dsProject)
+      upload(to = projectsDataset, soleProject, dsProject)
 
       finder
         .findEntities(Criteria(Filters(creators = Set(randomiseCases(creator.name.show).generateAs(persons.Name)))))
@@ -403,7 +403,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, soleProject, dsProject, projectEntities(visibilityPublic).generateOne)
+      upload(to = projectsDataset, soleProject, dsProject, projectEntities(visibilityPublic).generateOne)
 
       finder
         .findEntities(Criteria(Filters(creators = Set(projectCreator.name, dsCreator.name))))
@@ -421,7 +421,7 @@ class EntitiesFinderSpec
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(creators = Set(personNames.generateOne))))
@@ -451,7 +451,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, publicProject, internalProject, privateProject)
+      upload(to = projectsDataset, publicProject, internalProject, privateProject)
 
       finder
         .findEntities(
@@ -474,7 +474,7 @@ class EntitiesFinderSpec
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(visibilities = visibilityNonPublic.generateSome.toSet)))
@@ -497,7 +497,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, matchingProject, nonMatchingProject)
+      upload(to = projectsDataset, matchingProject, nonMatchingProject)
 
       finder
         .findEntities(
@@ -518,7 +518,7 @@ class EntitiesFinderSpec
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(namespaces = projectNamespaces.generateFixedSizeSet(1))))
@@ -558,7 +558,7 @@ class EntitiesFinderSpec
         .generateOne
       val plan :: _ = project.plans.toList
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(maybeSince = since.some)))
@@ -612,7 +612,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(maybeSince = since.some)))
@@ -645,7 +645,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, dsProject)
+      upload(to = projectsDataset, dsProject)
 
       finder
         .findEntities(Criteria(Filters(maybeSince = since.some)))
@@ -687,7 +687,7 @@ class EntitiesFinderSpec
         .generateOne
       val plan :: _ = project.plans.toList
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(maybeUntil = until.some)))
@@ -740,7 +740,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(maybeUntil = until.some)))
@@ -773,7 +773,7 @@ class EntitiesFinderSpec
         )
         .generateOne
 
-      upload(to = renkuDataset, dsProject)
+      upload(to = projectsDataset, dsProject)
 
       finder
         .findEntities(Criteria(Filters(maybeUntil = until.some)))
@@ -847,7 +847,7 @@ class EntitiesFinderSpec
         .generateOne
       val plan :: _ = project.plans.toList
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       finder
         .findEntities(Criteria(Filters(maybeSince = since.some, maybeUntil = until.some)))
@@ -869,7 +869,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       val direction = sortingDirections.generateOne
 
@@ -886,7 +886,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceInternal))
         .generateOne
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       val direction = sortingDirections.generateOne
 
@@ -926,7 +926,7 @@ class EntitiesFinderSpec
         .generateOne
       val plan :: Nil = project.plans.toList
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       val direction = sortingDirections.generateOne
 
@@ -956,7 +956,7 @@ class EntitiesFinderSpec
 
     "return the only page" in new TestCase {
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       val paging = PagingRequest(Page(1), PerPage(3))
 
@@ -973,7 +973,7 @@ class EntitiesFinderSpec
 
     "return the requested page with info if there are more" in new TestCase {
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       val paging = PagingRequest(Page(Random.nextInt(3) + 1), PerPage(1))
 
@@ -994,7 +994,7 @@ class EntitiesFinderSpec
 
     "return no results if non-existing page requested" in new TestCase {
 
-      upload(to = renkuDataset, project)
+      upload(to = projectsDataset, project)
 
       val paging = PagingRequest(Page(4), PerPage(1))
 
@@ -1034,7 +1034,7 @@ class EntitiesFinderSpec
 
     "return public entities only if no auth user is given" in new TestCase {
 
-      upload(to = renkuDataset, privateProject, internalProject, publicProject)
+      upload(to = projectsDataset, privateProject, internalProject, publicProject)
 
       finder.findEntities(Criteria()).unsafeRunSync().results shouldBe List
         .empty[model.Entity]
@@ -1046,7 +1046,7 @@ class EntitiesFinderSpec
 
     "return public and internal entities only if auth user is given" in new TestCase {
 
-      upload(to = renkuDataset, privateProject, internalProject, publicProject)
+      upload(to = projectsDataset, privateProject, internalProject, publicProject)
 
       finder
         .findEntities(
@@ -1063,7 +1063,7 @@ class EntitiesFinderSpec
 
     "return any visibility entities if the given auth user has access to them" in new TestCase {
 
-      upload(to = renkuDataset, privateProject, internalProject, publicProject)
+      upload(to = projectsDataset, privateProject, internalProject, publicProject)
 
       finder.findEntities(Criteria(maybeUser = member.toAuthUser.some)).unsafeRunSync().results shouldBe List
         .empty[model.Entity]

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
@@ -28,18 +28,18 @@ import io.renku.http.rest.paging.PagingResponse
 import io.renku.http.server.security.model.AuthUser
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
-import io.renku.triplesstore.{InMemoryJenaForSpec, RenkuDataset, SparqlQueryTimeRecorder}
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQueryTimeRecorder}
 import org.scalatest.TestSuite
 
 import java.time.Instant
 
 trait FinderSpecOps {
-  self: TestSuite with InMemoryJenaForSpec with RenkuDataset =>
+  self: TestSuite with InMemoryJenaForSpec with ProjectsDataset =>
 
   protected[finder] trait TestCase {
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val finder = new EntitiesFinderImpl[IO](renkuDSConnectionInfo)
+    val finder = new EntitiesFinderImpl[IO](projectsDSConnectionInfo)
   }
 
   protected[finder] implicit class PagingResponseOps(response: PagingResponse[model.Entity]) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/PersonsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/PersonsEntitiesFinderSpec.scala
@@ -28,8 +28,8 @@ import io.renku.graph.model.testentities._
 import io.renku.knowledgegraph.entities.Endpoint.Criteria
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters.Query
-import io.renku.triplesstore.{InMemoryJenaForSpec, RenkuDataset}
 import io.renku.testtools.IOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -38,7 +38,7 @@ class PersonsEntitiesFinderSpec
     with should.Matchers
     with FinderSpecOps
     with InMemoryJenaForSpec
-    with RenkuDataset
+    with ProjectsDataset
     with IOSpec {
 
   "findEntities - persons" should {
@@ -55,7 +55,7 @@ class PersonsEntitiesFinderSpec
         .map(_.copy(name = sentenceContaining(query).generateAs(persons.Name)))
         .generateOne
 
-      upload(to = renkuDataset, person1SameName, person2SameName, person3, personEntities.generateOne)
+      upload(to = projectsDataset, person1SameName, person2SameName, person3, personEntities.generateOne)
 
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
@@ -27,8 +27,8 @@ import io.renku.graph.model._
 import io.renku.graph.model.testentities._
 import io.renku.knowledgegraph.entities.Endpoint.Criteria
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters
-import io.renku.triplesstore.{InMemoryJenaForSpec, RenkuDataset}
 import io.renku.testtools.IOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -37,7 +37,7 @@ class WorkflowsEntitiesFinderSpec
     with should.Matchers
     with FinderSpecOps
     with InMemoryJenaForSpec
-    with RenkuDataset
+    with ProjectsDataset
     with IOSpec {
 
   "findEntities - in case of a forks with workflows" should {
@@ -49,7 +49,7 @@ class WorkflowsEntitiesFinderSpec
         .forkOnce()
       val plan :: Nil = fork.plans.toList
 
-      upload(to = renkuDataset, original, fork)
+      upload(to = projectsDataset, original, fork)
 
       val results = finder
         .findEntities(Criteria(Filters(entityTypes = Set(Filters.EntityType.Workflow))))
@@ -78,7 +78,7 @@ class WorkflowsEntitiesFinderSpec
       }
       val plan :: Nil = publicProject.plans.toList
 
-      upload(to = renkuDataset, original, fork)
+      upload(to = projectsDataset, original, fork)
 
       finder
         .findEntities(
@@ -104,7 +104,7 @@ class WorkflowsEntitiesFinderSpec
       }
       val plan :: Nil = internalProject.plans.toList
 
-      upload(to = renkuDataset, original, fork)
+      upload(to = projectsDataset, original, fork)
 
       finder
         .findEntities(
@@ -125,7 +125,7 @@ class WorkflowsEntitiesFinderSpec
         .generateOne
       val plan :: Nil = privateProject.plans.toList
 
-      upload(to = renkuDataset, privateProject)
+      upload(to = projectsDataset, privateProject)
 
       finder
         .findEntities(


### PR DESCRIPTION
This PR switches the Cross-Entity Search API to fetch data from the Named Graphs dataset in the TS.