### PR TITLE
feat: KG metrics to work against the Named Graphs dataset

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/metrics/StatsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/metrics/StatsFinder.scala
@@ -23,6 +23,8 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.circe.Decoder.decodeList
 import io.circe.{Decoder, DecodingFailure}
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.entities.Person
 import io.renku.tinytypes.{TinyType, TinyTypeFactory}
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
@@ -32,9 +34,8 @@ private trait StatsFinder[F[_]] {
   def entitiesCount(): F[Map[EntityLabel, Count]]
 }
 
-private class StatsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    renkuConnectionConfig: RenkuConnectionConfig
-) extends TSClient[F](renkuConnectionConfig)
+private class StatsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](storeConfig: ProjectsConnectionConfig)
+    extends TSClient[F](storeConfig)
     with StatsFinder[F] {
 
   import EntityCount._
@@ -50,30 +51,36 @@ private class StatsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
         |WHERE {
         |  {
         |    SELECT (schema:Dataset AS ?type) (COUNT(DISTINCT ?id) AS ?count)
-        |    WHERE { ?id a schema:Dataset }
+        |    WHERE { GRAPH ?g { ?id a schema:Dataset } }
         |  } UNION {
         |    SELECT (schema:Project AS ?type) (COUNT(DISTINCT ?id) AS ?count)
-        |    WHERE { ?id a schema:Project }
+        |    WHERE { GRAPH ?g { ?id a schema:Project } }
         |  } UNION {
         |    SELECT (prov:Activity AS ?type) (COUNT(DISTINCT ?id) AS ?count)
-        |    WHERE { ?id a prov:Activity }
+        |    WHERE { GRAPH ?g { ?id a prov:Activity } }
         |  } UNION {
         |    SELECT (prov:Plan AS ?type) (COUNT(DISTINCT ?id) AS ?count)
-        |    WHERE { ?id a prov:Plan }
+        |    WHERE { GRAPH ?g { ?id a prov:Plan } }
         |  } UNION {
         |    SELECT (schema:Person AS ?type) (COUNT(DISTINCT ?id) AS ?count)
-        |    WHERE { 
-        |      ?activityId a prov:Activity;
-        |                  prov:wasAssociatedWith ?id.
-        |      ?id a schema:Person.
+        |    WHERE {
+        |      GRAPH ?g { 
+        |        ?activityId a prov:Activity;
+        |                    prov:wasAssociatedWith ?id
+        |      }
+        |      GRAPH <${GraphClass.Persons.id}> { ?id a schema:Person }
         |    }
         |  } UNION {
         |    SELECT (CONCAT(STR(schema:Person), ' with GitLabId') AS ?type) (COUNT(DISTINCT ?id) AS ?count)
-        |    WHERE { 
-        |      ?activityId a prov:Activity;
-        |                  prov:wasAssociatedWith ?id.
-        |      ?id a schema:Person;
-        |          schema:sameAs/schema:additionalType 'GitLab'.
+        |    WHERE {
+        |      GRAPH ?g {
+        |        ?activityId a prov:Activity;
+        |                    prov:wasAssociatedWith ?id.
+        |        GRAPH <${GraphClass.Persons.id}> {
+        |          ?id a schema:Person;
+        |              schema:sameAs/schema:additionalType '${Person.gitLabSameAsAdditionalType}'.
+        |        }
+        |      }
         |    }
         |  }
         |}
@@ -112,5 +119,5 @@ private object EntityCount {
 
 private object StatsFinder {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[StatsFinder[F]] =
-    RenkuConnectionConfig[F]().map(new StatsFinderImpl[F](_))
+    ProjectsConnectionConfig[F]().map(new StatsFinderImpl[F](_))
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/StatsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/StatsFinderSpec.scala
@@ -26,8 +26,8 @@ import io.renku.graph.model.testentities._
 import io.renku.interpreters.TestLogger
 import io.renku.jsonld.Property
 import io.renku.logging.TestSparqlQueryTimeRecorder
-import io.renku.triplesstore.{InMemoryJenaForSpec, RenkuDataset, SparqlQueryTimeRecorder}
 import io.renku.testtools.IOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQueryTimeRecorder}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -35,7 +35,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class StatsFinderSpec
     extends AnyWordSpec
     with InMemoryJenaForSpec
-    with RenkuDataset
+    with ProjectsDataset
     with ScalaCheckPropertyChecks
     with should.Matchers
     with IOSpec {
@@ -72,7 +72,7 @@ class StatsFinderSpec
         .update(schema / "Person", persons.size)
         .update(schema / "Person with GitLabId", persons.count(_.maybeGitLabId.isDefined))
 
-      upload(to = renkuDataset, projectsWithDatasets.map(_._2) ::: projectsWithActivities: _*)
+      upload(to = projectsDataset, projectsWithDatasets.map(_._2) ::: projectsWithActivities: _*)
 
       stats.entitiesCount().unsafeRunSync() shouldBe entitiesWithActivities
     }
@@ -81,7 +81,7 @@ class StatsFinderSpec
   private trait TestCase {
     implicit val logger:               TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO]
-    val stats = new StatsFinderImpl[IO](renkuDSConnectionInfo)
+    val stats = new StatsFinderImpl[IO](projectsDSConnectionInfo)
   }
 
   private implicit class MapOps(entitiesByType: Map[EntityLabel, Count]) {


### PR DESCRIPTION
This PR switches KG metrics to take data from the Named Graphs dataset in the TS.