### PR TITLE
fix: handling all errors thrown by event processor in event handler

### DIFF
--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/globalcommitsync/EventHandler.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/globalcommitsync/EventHandler.scala
@@ -60,7 +60,7 @@ private[events] class EventHandler[F[_]: Spawn: Concurrent: Logger](
     event <- fromEither[F](request.event.as[GlobalCommitSyncEvent].leftMap(_ => BadRequest))
     result <-
       Spawn[F]
-        .start(synchronizeEvents(event).recoverWith(errorLogging(event)) >> process.complete(()))
+        .start((synchronizeEvents(event) recoverWith logError(event)) >> process.complete(()))
         .toRightT
         .map(_ => Accepted)
         .semiflatTap(Logger[F] log event)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/projectsync/EventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/projectsync/EventHandler.scala
@@ -48,7 +48,7 @@ private class EventHandler[F[_]: Concurrent: Logger](override val categoryName: 
   private def startProcessingEvent(request: EventRequestContent, processing: Deferred[F, Unit]) = for {
     event <- fromEither(request.event.getProject).map(p => ProjectSyncEvent(p.id, p.path))
     result <- Spawn[F]
-                .start(syncProjectInfo(event).recoverWith(errorLogging(event)) >> processing.complete(()))
+                .start((syncProjectInfo(event) recoverWith logError(event)) >> processing.complete(()))
                 .toRightT
                 .map(_ => Accepted)
                 .semiflatTap(Logger[F].log(event))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/EventHandler.scala
@@ -41,7 +41,9 @@ private[events] class EventHandler[F[_]: MonadThrow: Concurrent: Logger](
     subscriptionMechanism:      SubscriptionMechanism[F],
     concurrentProcessesLimiter: ConcurrentProcessesLimiter[F]
 ) extends consumers.EventHandlerWithProcessLimiter[F](concurrentProcessesLimiter) {
+
   import eventBodyDeserializer.toCleanUpEvent
+  import eventProcessor._
   import tsReadinessChecker._
 
   override def createHandlingProcess(requestContent: EventRequestContent): F[EventHandlingProcess[F]] =
@@ -54,7 +56,7 @@ private[events] class EventHandler[F[_]: MonadThrow: Concurrent: Logger](
     event <- toCleanUpEvent(requestContent.event).toRightT(recoverTo = BadRequest)
     result <-
       Spawn[F]
-        .start(eventProcessor.process(event.project).recoverWith(errorLogging(event.project)) >> deferred.complete(()))
+        .start((process(event.project) recoverWith logError(event.project)) >> deferred.complete(()))
         .toRightT
         .map(_ => Accepted)
         .semiflatTap(Logger[F].log(event))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/EventHandler.scala
@@ -55,7 +55,7 @@ private[events] class EventHandler[F[_]: Concurrent: Logger](
     project <- fromEither(request.event.getProject)
     result <-
       Spawn[F]
-        .start(process(MinProjectInfoEvent(project)).recoverWith(errorLogging(project)) >> processing.complete(()))
+        .start((process(MinProjectInfoEvent(project)) recoverWith logError(project)) >> processing.complete(()))
         .toRightT
         .map(_ => Accepted)
         .semiflatTap(Logger[F].log(project))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EventHandler.scala
@@ -71,7 +71,7 @@ private[events] class EventHandler[F[_]: Concurrent: Logger](
                }
     event <- toEvent(eventId, project, payload).toRightT(recoverTo = BadRequest)
     result <- Spawn[F]
-                .start(process(event).recoverWith(errorLogging(event)) >> processing.complete(()))
+                .start((process(event) recoverWith logError(event)) >> processing.complete(()))
                 .toRightT
                 .map(_ => Accepted)
                 .semiflatTap(Logger[F].log(eventId -> event.project))


### PR DESCRIPTION
It looks like catching only non-fatal errors in recovery on event processing, caused the deferred controlling the number of concurrent event processes to be not cleared. As a consequence when the processor failed in some very specific conditions (e.g. during logging) neither the deferred was cleared nor info in the logs was written.
This PR catches all event processor exceptions, logs them and clears the deferred.

closes #1150 