### PR TITLE
fix: Plan entity invalidation modelling

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ReProvisioningSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ReProvisioningSpec.scala
@@ -102,7 +102,7 @@ class ReProvisioningSpec extends AcceptanceSpec with ApplicationServices with TS
 
     val testEntitiesProject = renkuProjectEntities(visibilityPublic)
       .map(_.copy(version = initialProjectSchemaVersion))
-      .withActivities(activityEntities(planEntities()))
+      .withActivities(activityEntities(stepPlanEntities()))
       .generateOne
       .copy(members = Set(personEntities.generateOne.copy(maybeGitLabId = user.id.some)))
   }

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/CrossEntitiesSearchSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/CrossEntitiesSearchSpec.scala
@@ -56,7 +56,7 @@ class CrossEntitiesSearchSpec extends AcceptanceSpec with ApplicationServices wi
         )
         .withActivities(
           activityEntities(
-            planEntities().modify(replacePlanName(sentenceContaining(commonPhrase).generateAs[plans.Name]))
+            stepPlanEntities().modify(_.replacePlanName(sentenceContaining(commonPhrase).generateAs[plans.Name]))
           )
         )
         .withDatasets(

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/LineageQuerySpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/LineageQuerySpec.scala
@@ -19,8 +19,8 @@
 package io.renku.graph.acceptancetests.knowledgegraph
 
 import cats.syntax.all._
-import io.circe.Json
 import io.circe.literal._
+import io.circe.{DecodingFailure, Json}
 import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.fixed
@@ -254,33 +254,29 @@ class LineageQuerySpec extends AcceptanceSpec with ApplicationServices with TSPr
       }
     }"""
 
-  private def theExpectedEdges(exemplarData: ExemplarData): Right[Nothing, Set[Json]] = {
+  private def theExpectedEdges(exemplarData: ExemplarData): Either[DecodingFailure, Set[Json]] = {
     import exemplarData._
-    Right {
-      Set(
-        json"""{"source": ${`zhbikes folder`.location},     "target": ${`activity3 node`.location}}""",
-        json"""{"source": ${`clean_data entity`.location},  "target": ${`activity3 node`.location}}""",
-        json"""{"source": ${`activity3 node`.location},     "target": ${`bikesparquet entity`.location}}""",
-        json"""{"source": ${`bikesparquet entity`.location},"target": ${`activity4 node`.location}}""",
-        json"""{"source": ${`plot_data entity`.location},   "target": ${`activity4 node`.location}}""",
-        json"""{"source": ${`activity4 node`.location},     "target": ${`grid_plot entity`.location}}"""
-      )
-    }
+    Set(
+      json"""{"source": ${`zhbikes folder`.location},     "target": ${`activity3 node`.location}}""",
+      json"""{"source": ${`clean_data entity`.location},  "target": ${`activity3 node`.location}}""",
+      json"""{"source": ${`activity3 node`.location},     "target": ${`bikesparquet entity`.location}}""",
+      json"""{"source": ${`bikesparquet entity`.location},"target": ${`activity4 node`.location}}""",
+      json"""{"source": ${`plot_data entity`.location},   "target": ${`activity4 node`.location}}""",
+      json"""{"source": ${`activity4 node`.location},     "target": ${`grid_plot entity`.location}}"""
+    ).asRight
   }
 
-  private def theExpectedNodes(exemplarData: ExemplarData): Right[Nothing, Set[Json]] = {
+  private def theExpectedNodes(exemplarData: ExemplarData): Either[DecodingFailure, Set[Json]] = {
     import exemplarData._
-    Right {
-      Set(
-        json"""{"id": ${`zhbikes folder`.location},      "location": ${`zhbikes folder`.location},      "label": ${`zhbikes folder`.label},      "type": ${`zhbikes folder`.singleWordType}}""",
-        json"""{"id": ${`activity3 node`.location},      "location": ${`activity3 node`.location},      "label": ${`activity3 node`.label},      "type": ${`activity3 node`.singleWordType}}""",
-        json"""{"id": ${`clean_data entity`.location},   "location": ${`clean_data entity`.location},   "label": ${`clean_data entity`.label},   "type": ${`clean_data entity`.singleWordType}}""",
-        json"""{"id": ${`bikesparquet entity`.location}, "location": ${`bikesparquet entity`.location}, "label": ${`bikesparquet entity`.label}, "type": ${`bikesparquet entity`.singleWordType}}""",
-        json"""{"id": ${`plot_data entity`.location},    "location": ${`plot_data entity`.location},    "label": ${`plot_data entity`.label},    "type": ${`plot_data entity`.singleWordType}}""",
-        json"""{"id": ${`activity4 node`.location},      "location": ${`activity4 node`.location},      "label": ${`activity4 node`.label},      "type": ${`activity4 node`.singleWordType}}""",
-        json"""{"id": ${`grid_plot entity`.location},    "location": ${`grid_plot entity`.location},    "label": ${`grid_plot entity`.label},    "type": ${`grid_plot entity`.singleWordType}}"""
-      )
-    }
+    Set(
+      json"""{"id": ${`zhbikes folder`.location},      "location": ${`zhbikes folder`.location},      "label": ${`zhbikes folder`.label},      "type": ${`zhbikes folder`.singleWordType}}""",
+      json"""{"id": ${`activity3 node`.location},      "location": ${`activity3 node`.location},      "label": ${`activity3 node`.label},      "type": ${`activity3 node`.singleWordType}}""",
+      json"""{"id": ${`clean_data entity`.location},   "location": ${`clean_data entity`.location},   "label": ${`clean_data entity`.label},   "type": ${`clean_data entity`.singleWordType}}""",
+      json"""{"id": ${`bikesparquet entity`.location}, "location": ${`bikesparquet entity`.location}, "label": ${`bikesparquet entity`.label}, "type": ${`bikesparquet entity`.singleWordType}}""",
+      json"""{"id": ${`plot_data entity`.location},    "location": ${`plot_data entity`.location},    "label": ${`plot_data entity`.label},    "type": ${`plot_data entity`.singleWordType}}""",
+      json"""{"id": ${`activity4 node`.location},      "location": ${`activity4 node`.location},      "label": ${`activity4 node`.label},      "type": ${`activity4 node`.singleWordType}}""",
+      json"""{"id": ${`grid_plot entity`.location},    "location": ${`grid_plot entity`.location},    "label": ${`grid_plot entity`.label},    "type": ${`grid_plot entity`.singleWordType}}"""
+    ).asRight
   }
 
   private implicit class NodeOps(node: NodeDef) {

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubSupport.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubSupport.scala
@@ -46,7 +46,6 @@ trait GitLabStubSupport extends BeforeAndAfterAll with BeforeAndAfter with GitLa
 
   override def afterAll(): Unit = {
     super.afterAll()
-    testLogger.info("Shutting down GitLabApiStub").unsafeRunSync()
     gitLabStubStarter.shutdown()
   }
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
@@ -1050,7 +1050,9 @@ class EntitiesFinderSpec
 
       finder
         .findEntities(
-          Criteria(maybeUser = personEntities(personGitLabIds.toGeneratorOfSomes).generateSome.map(_.toAuthUser))
+          Criteria(maybeUser = personEntities(personGitLabIds.toGeneratorOfSomes).generateSome.map(_.toAuthUser),
+                   paging = PagingRequest.default.copy(perPage = PerPage(50))
+          )
         )
         .unsafeRunSync()
         .results shouldBe List
@@ -1065,7 +1067,12 @@ class EntitiesFinderSpec
 
       upload(to = projectsDataset, privateProject, internalProject, publicProject)
 
-      finder.findEntities(Criteria(maybeUser = member.toAuthUser.some)).unsafeRunSync().results shouldBe List
+      finder
+        .findEntities(
+          Criteria(maybeUser = member.toAuthUser.some, paging = PagingRequest.default.copy(perPage = PerPage(50)))
+        )
+        .unsafeRunSync()
+        .results shouldBe List
         .empty[model.Entity]
         .addAllEntitiesFrom(publicProject)
         .addAllEntitiesFrom(internalProject)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
@@ -55,7 +55,7 @@ class EntitiesFinderSpec
 
     "return all entities sorted by name if no query is given" in new TestCase {
       val project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -91,14 +91,14 @@ class EntitiesFinderSpec
       val planProject = renkuProjectEntities(visibilityPublic)
         .withActivities(
           activityEntities(
-            planEntities().modify(replacePlanName(to = sentenceContaining(query).generateAs(plans.Name)))
+            stepPlanEntities().modify(_.replacePlanName(to = sentenceContaining(query).generateAs(plans.Name)))
           )
         )
         .generateOne
       val plan :: Nil = planProject.plans.toList
 
       val notMatchingProject = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -139,8 +139,8 @@ class EntitiesFinderSpec
       val planProject = renkuProjectEntities(visibilityPublic)
         .withActivities(
           activityEntities(
-            planEntities().modify(
-              replacePlanKeywords(to =
+            stepPlanEntities().modify(
+              _.replacePlanKeywords(to =
                 List(sentenceContaining(query).generateAs(plans.Keyword), planKeywords.generateOne)
               )
             )
@@ -180,7 +180,8 @@ class EntitiesFinderSpec
       val planProject = renkuProjectEntities(visibilityPublic)
         .withActivities(
           activityEntities(
-            planEntities().modify(replacePlanDesc(to = sentenceContaining(query).generateAs(plans.Description).some))
+            stepPlanEntities()
+              .modify(_.replacePlanDesc(to = sentenceContaining(query).generateAs(plans.Description).some))
           )
         )
         .generateOne
@@ -250,7 +251,7 @@ class EntitiesFinderSpec
 
     "return only projects when 'project' type given" in new TestCase {
       val project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -264,7 +265,7 @@ class EntitiesFinderSpec
 
     "return only datasets when 'dataset' type given" in new TestCase {
       val dsAndProject @ _ ::~ project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -278,7 +279,7 @@ class EntitiesFinderSpec
 
     "return only workflows when 'workflow' type given" in new TestCase {
       val project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -434,19 +435,19 @@ class EntitiesFinderSpec
     "return entities with matching visibility only" in new TestCase {
 
       val publicProject = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
       val internalProject = renkuProjectEntities(fixed(projects.Visibility.Internal))
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
       val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val privateProject = renkuProjectEntities(fixed(projects.Visibility.Private))
         .modify(replaceMembers(to = Set(member)))
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -469,7 +470,7 @@ class EntitiesFinderSpec
 
     "return no entities when no match on visibility" in new TestCase {
       val _ ::~ project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -487,12 +488,12 @@ class EntitiesFinderSpec
     "return entities with matching namespace only" in new TestCase {
 
       val matchingProject = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
       val nonMatchingProject = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -513,7 +514,7 @@ class EntitiesFinderSpec
 
     "return no namespace aware entities when no match on namespace" in new TestCase {
       val _ ::~ project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .addDataset(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -537,8 +538,8 @@ class EntitiesFinderSpec
         .modify(replaceProjectDateCreated(to = projectDateCreated))
         .withActivities(
           activityEntities(
-            planEntities().modify(
-              replacePlanDateCreated(to =
+            stepPlanEntities().modify(
+              _.replacePlanDateCreated(to =
                 timestampsNotInTheFuture(butYoungerThan = projectDateCreated.value).generateAs[plans.DateCreated]
               )
             )
@@ -578,8 +579,8 @@ class EntitiesFinderSpec
         .modify(replaceProjectDateCreated(to = projectDateCreated))
         .withActivities(
           activityEntities(
-            planEntities().modify(
-              replacePlanDateCreated(to =
+            stepPlanEntities().modify(
+              _.replacePlanDateCreated(to =
                 timestamps(min = projectDateCreated.value, max = sinceAsInstant minus (1, DAYS))
                   .generateAs[plans.DateCreated]
               )
@@ -666,8 +667,8 @@ class EntitiesFinderSpec
         .modify(replaceProjectDateCreated(to = projectDateCreated))
         .withActivities(
           activityEntities(
-            planEntities().modify(
-              replacePlanDateCreated(to =
+            stepPlanEntities().modify(
+              _.replacePlanDateCreated(to =
                 timestamps(min = projectDateCreated.value, max = untilAsInstant).generateAs[plans.DateCreated]
               )
             )
@@ -708,8 +709,8 @@ class EntitiesFinderSpec
         .modify(replaceProjectDateCreated(to = projectDateCreated))
         .withActivities(
           activityEntities(
-            planEntities().modify(
-              replacePlanDateCreated(to =
+            stepPlanEntities().modify(
+              _.replacePlanDateCreated(to =
                 timestampsNotInTheFuture(butYoungerThan = projectDateCreated.value).generateAs[plans.DateCreated]
               )
             )
@@ -800,8 +801,8 @@ class EntitiesFinderSpec
         .modify(replaceProjectDateCreated(to = projectDateCreated))
         .withActivities(
           activityEntities(
-            planEntities().modify(
-              replacePlanDateCreated(to =
+            stepPlanEntities().modify(
+              _.replacePlanDateCreated(to =
                 timestamps(min = projectDateCreated.value, max = untilAsInstant).generateAs[plans.DateCreated]
               )
             )
@@ -864,7 +865,7 @@ class EntitiesFinderSpec
 
     "be sorting by Name if requested" in new TestCase {
       val project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
@@ -880,7 +881,7 @@ class EntitiesFinderSpec
 
     "be sorting by Date if requested" in new TestCase {
       val project = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()), activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()), activityEntities(stepPlanEntities()))
         .withDatasets(datasetEntities(provenanceImportedExternal))
         .withDatasets(datasetEntities(provenanceInternal))
         .generateOne
@@ -917,7 +918,7 @@ class EntitiesFinderSpec
 
       val ds ::~ project = renkuProjectEntities(visibilityPublic)
         .modify(replaceProjectName(to = projects.Name(query.value)))
-        .withActivities(activityEntities(planEntities().modify(replacePlanName(to = plans.Name(s"smth $query")))))
+        .withActivities(activityEntities(stepPlanEntities().modify(_.replacePlanName(to = plans.Name(s"smth $query")))))
         .addDataset(
           datasetEntities(provenanceNonModified)
             .modify(replaceDSName(to = sentenceContaining(query).generateAs(datasets.Name)))
@@ -1015,19 +1016,19 @@ class EntitiesFinderSpec
 
     val privateProject = renkuProjectEntities(fixed(Visibility.Private))
       .modify(replaceMembers(to = Set(member)))
-      .withActivities(activityEntities(planEntities()))
+      .withActivities(activityEntities(stepPlanEntities()))
       .withDatasets(datasetEntities(provenanceNonModified))
       .generateOne
 
     val internalProject = renkuProjectEntities(fixed(Visibility.Internal))
       .modify(replaceMembers(to = Set(member)))
-      .withActivities(activityEntities(planEntities()))
+      .withActivities(activityEntities(stepPlanEntities()))
       .withDatasets(datasetEntities(provenanceNonModified))
       .generateOne
 
     val publicProject = renkuProjectEntities(visibilityPublic)
       .modify(replaceMembers(to = Set(member)))
-      .withActivities(activityEntities(planEntities()))
+      .withActivities(activityEntities(stepPlanEntities()))
       .withDatasets(datasetEntities(provenanceNonModified))
       .generateOne
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
@@ -93,6 +93,7 @@ trait FinderSpecOps {
       addPersons((project.members ++ project.maybeCreator).toList)
         .addPersons(project.datasets.flatMap(_.provenance.creators.toList))
         .addPersons(project.activities.map(_.author))
+        .addPersons(project.plans.flatMap(_.creators))
         .distinct
 
     def removeAllPersons(): List[model.Entity] = entities.filterNot {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
@@ -137,4 +137,25 @@ class WorkflowsEntitiesFinderSpec
         .results shouldBe List((plan -> privateProject).to[model.Entity.Workflow])
     }
   }
+
+  "findEntities - in case of invalidated Plans" should {
+
+    "not return workflows that have been invalidated" in new TestCase {
+
+      val project = {
+        val p = renkuProjectEntities(visibilityPublic)
+          .withActivities(activityEntities(stepPlanEntities()))
+          .generateOne
+
+        p.addOtherPlan(p.plans.toList.head.invalidate())
+      }
+
+      upload(to = projectsDataset, project)
+
+      finder
+        .findEntities(Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Workflow))))
+        .unsafeRunSync()
+        .results shouldBe List.empty
+    }
+  }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
@@ -47,7 +47,7 @@ class WorkflowsEntitiesFinderSpec
         .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
         .forkOnce()
-      val plan :: Nil = fork.plans.toList
+      val plan :: Nil = fork.plans
 
       upload(to = projectsDataset, original, fork)
 
@@ -76,7 +76,7 @@ class WorkflowsEntitiesFinderSpec
         val original ::~ fork = publicProject.forkOnce()
         original -> fork.copy(visibility = visibilityNonPublic.generateOne, members = Set(member))
       }
-      val plan :: Nil = publicProject.plans.toList
+      val plan :: Nil = publicProject.plans
 
       upload(to = projectsDataset, original, fork)
 
@@ -102,7 +102,7 @@ class WorkflowsEntitiesFinderSpec
         val original ::~ fork = internalProject.forkOnce()
         original -> fork.copy(visibility = projects.Visibility.Private, members = Set(member))
       }
-      val plan :: Nil = internalProject.plans.toList
+      val plan :: Nil = internalProject.plans
 
       upload(to = projectsDataset, original, fork)
 
@@ -123,7 +123,7 @@ class WorkflowsEntitiesFinderSpec
         .modify(replaceMembers(to = Set(member)))
         .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
-      val plan :: Nil = privateProject.plans.toList
+      val plan :: Nil = privateProject.plans
 
       upload(to = projectsDataset, privateProject)
 
@@ -147,7 +147,7 @@ class WorkflowsEntitiesFinderSpec
           .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
 
-        p.addOtherPlan(p.plans.toList.head.invalidate())
+        p.addUnlinkedStepPlan(p.stepPlans.head.invalidate())
       }
 
       upload(to = projectsDataset, project)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
@@ -44,7 +44,7 @@ class WorkflowsEntitiesFinderSpec
 
     "de-duplicate workflows when on forked projects" in new TestCase {
       val original ::~ fork = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
         .forkOnce()
       val plan :: Nil = fork.plans.toList
@@ -68,7 +68,7 @@ class WorkflowsEntitiesFinderSpec
     "favour workflows on public projects if exist" in new TestCase {
 
       val publicProject = renkuProjectEntities(visibilityPublic)
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
 
       val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
@@ -95,7 +95,7 @@ class WorkflowsEntitiesFinderSpec
       val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val internalProject = renkuProjectEntities(fixed(projects.Visibility.Internal))
         .modify(replaceMembers(to = Set(member)))
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
 
       val original ::~ fork = {
@@ -121,7 +121,7 @@ class WorkflowsEntitiesFinderSpec
       val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val privateProject = renkuProjectEntities(fixed(projects.Visibility.Private))
         .modify(replaceMembers(to = Set(member)))
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
       val plan :: Nil = privateProject.plans.toList
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/package.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/package.scala
@@ -41,7 +41,7 @@ package object entities {
   private[entities] val modelDatasets: Gen[model.Entity.Dataset] =
     anyRenkuProjectEntities.addDataset(datasetEntities(provenanceNonModified)).map(_.to[model.Entity.Dataset])
   private[entities] val modelWorkflows: Gen[model.Entity.Workflow] =
-    anyRenkuProjectEntities.withActivities(activityEntities(planEntities())) map { project =>
+    anyRenkuProjectEntities.withActivities(activityEntities(stepPlanEntities())) map { project =>
       val plan :: Nil = project.plans.toList
       (plan -> project).to[model.Entity.Workflow]
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/StatsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/StatsFinderSpec.scala
@@ -57,7 +57,7 @@ class StatsFinderSpec
       val projectsWithDatasets =
         anyRenkuProjectEntities.addDataset(datasetEntities(provenanceNonModified)).generateNonEmptyList().toList
       val projectsWithActivities = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateNonEmptyList(min = 10, max = 50)
         .toList
       val persons = projectsWithActivities.flatMap(_.activities.map(_.author))

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
@@ -96,9 +96,9 @@ class EdgesFinderSpec
       val in1  = entityLocations.generateOne
       val in2  = entityLocations.generateOne
       val out1 = entityLocations.generateOne
-      val plan = planEntities(CommandInput.fromLocation(in1),
-                              CommandInput.fromLocation(in2),
-                              CommandOutput.fromLocation(out1)
+      val plan = stepPlanEntities(CommandInput.fromLocation(in1),
+                                  CommandInput.fromLocation(in2),
+                                  CommandOutput.fromLocation(out1)
       )(planCommands)(project.dateCreated).generateOne
 
       val activity1 = executionPlanners(_ => fixed(plan), project).generateOne

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/NodeDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/NodeDetailsFinderSpec.scala
@@ -208,7 +208,7 @@ class NodeDetailsFinderSpec
               CommandInput.streamedFromLocation(input),
               CommandOutput.streamedFromLocation(output, CommandOutput.stdOut),
               CommandOutput.streamedFromLocation(errOutput, CommandOutput.stdErr)
-            ).andThen(genPlan => genPlan.map(_.copy(maybeCommand = None))),
+            ).andThen(genPlan => genPlan.map(_.replaceCommand(to = None))),
             project
           ).map(
             _.planInputParameterValuesFromChecksum(input -> entityChecksums.generateOne) // add some override values

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/NodeDetailsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/NodeDetailsFinderSpec.scala
@@ -56,7 +56,7 @@ class NodeDetailsFinderSpec
       val project = anyRenkuProjectEntities
         .addActivity(project =>
           executionPlanners(
-            planEntities(
+            stepPlanEntities(
               CommandInput.fromLocation(input),
               CommandOutput.fromLocation(output)
             ),
@@ -88,7 +88,7 @@ class NodeDetailsFinderSpec
       val project = anyRenkuProjectEntities
         .addActivity(project =>
           executionPlanners(
-            planEntities(
+            stepPlanEntities(
               CommandInput.fromLocation(input),
               CommandOutput.fromLocation(output)
             ),
@@ -126,7 +126,7 @@ class NodeDetailsFinderSpec
       val project = anyRenkuProjectEntities
         .addActivity(project =>
           executionPlanners(
-            planEntities(
+            stepPlanEntities(
               CommandInput.fromLocation(input),
               CommandOutput.fromLocation(output)
             ),
@@ -138,7 +138,7 @@ class NodeDetailsFinderSpec
         )
         .addActivity(project =>
           executionPlanners(
-            planEntities(CommandInput.fromLocation(output)),
+            stepPlanEntities(CommandInput.fromLocation(output)),
             project
           ).generateOne
             .planInputParameterValuesFromEntity(
@@ -172,7 +172,7 @@ class NodeDetailsFinderSpec
       val project = anyRenkuProjectEntities
         .addActivity(project =>
           executionPlanners(
-            planEntities(
+            stepPlanEntities(
               CommandInput.streamedFromLocation(input),
               CommandOutput.streamedFromLocation(output, CommandOutput.stdOut),
               CommandOutput.streamedFromLocation(errOutput, CommandOutput.stdErr)
@@ -204,7 +204,7 @@ class NodeDetailsFinderSpec
       val project: RenkuProject = anyRenkuProjectEntities
         .addActivity(project =>
           executionPlanners(
-            planEntities(
+            stepPlanEntities(
               CommandInput.streamedFromLocation(input),
               CommandOutput.streamedFromLocation(output, CommandOutput.stdOut),
               CommandOutput.streamedFromLocation(errOutput, CommandOutput.stdErr)

--- a/renku-model/src/main/scala/io/renku/graph/model/activities.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/activities.scala
@@ -21,7 +21,7 @@ package io.renku.graph.model
 import cats.syntax.all._
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints.{BoundedInstant, Url}
-import views.{AnyResourceRenderer, EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import views.{AnyResourceRenderer, EntityIdJsonLDOps, TinyTypeJsonLDOps}
 
 import java.time.Instant
 
@@ -31,7 +31,7 @@ object activities {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
       with AnyResourceRenderer[ResourceId]
 
   final class StartTime private (val value: Instant) extends AnyVal with InstantTinyType

--- a/renku-model/src/main/scala/io/renku/graph/model/agents.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/agents.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.{EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.tinytypes.constraints.{NonBlank, Url}
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 
@@ -30,5 +30,5 @@ object agents {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/associations.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/associations.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLdOps}
+import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLDOps}
 import io.renku.tinytypes.constraints.Url
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 
@@ -27,6 +27,6 @@ object associations {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
       with AnyResourceRenderer[ResourceId]
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/commandParameters.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/commandParameters.scala
@@ -25,7 +25,7 @@ import eu.timepit.refined.collection.NonEmpty
 import io.circe.DecodingFailure
 import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model.entityModel.{Location, LocationLike}
-import io.renku.graph.model.views.{EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.jsonld._
 import io.renku.jsonld.ontology._
 import io.renku.jsonld.syntax._
@@ -38,7 +38,7 @@ object commandParameters {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 
   final class Name private (val value: String) extends AnyVal with StringTinyType
   implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank[Name] with TinyTypeJsonLDOps[Name]
@@ -110,7 +110,7 @@ object commandParameters {
     implicit object ResourceId
         extends TinyTypeFactory[ResourceId](new ResourceId(_))
         with Url[ResourceId]
-        with EntityIdJsonLdOps[ResourceId]
+        with EntityIdJsonLDOps[ResourceId]
 
     sealed trait In                                       extends IOStream
     sealed trait Out                                      extends IOStream

--- a/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
@@ -181,7 +181,7 @@ object datasets {
 
     final def apply(entityId: EntityId): TopmostDerivedFrom = apply(entityId.toString)
 
-    implicit lazy val topmostDerivedFromJsonLdEncoder: JsonLDEncoder[TopmostDerivedFrom] =
+    implicit lazy val jsonLDEncoder: JsonLDEncoder[TopmostDerivedFrom] =
       derivedFrom => EntityId.of(derivedFrom.value).asJsonLD
   }
 

--- a/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
@@ -42,7 +42,7 @@ object datasets {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with UrlConstraint[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
       with AnyResourceRenderer[ResourceId]
 
   sealed trait DatasetIdentifier extends Any with StringTinyType
@@ -100,7 +100,7 @@ object datasets {
   implicit object ImageResourceId
       extends TinyTypeFactory[ImageResourceId](new ImageResourceId(_))
       with UrlConstraint[ImageResourceId]
-      with EntityIdJsonLdOps[ImageResourceId]
+      with EntityIdJsonLDOps[ImageResourceId]
 
   final class ImagePosition private (val value: Int) extends AnyVal with IntTinyType
   implicit object ImagePosition
@@ -175,14 +175,11 @@ object datasets {
       extends TinyTypeFactory[TopmostDerivedFrom](new TopmostDerivedFrom(_))
       with constraints.Url[TopmostDerivedFrom]
       with UrlResourceRenderer[TopmostDerivedFrom]
-      with EntityIdJsonLdOps[TopmostDerivedFrom] {
+      with EntityIdJsonLDOps[TopmostDerivedFrom] {
 
     final def apply(derivedFrom: DerivedFrom): TopmostDerivedFrom = apply(derivedFrom.value)
 
     final def apply(entityId: EntityId): TopmostDerivedFrom = apply(entityId.toString)
-
-    implicit lazy val jsonLDEncoder: JsonLDEncoder[TopmostDerivedFrom] =
-      derivedFrom => EntityId.of(derivedFrom.value).asJsonLD
   }
 
   sealed trait SameAs extends Any with UrlTinyType {
@@ -277,20 +274,18 @@ object datasets {
       extends TinyTypeFactory[TopmostSameAs](new TopmostSameAs(_))
       with constraints.Url[TopmostSameAs]
       with UrlResourceRenderer[TopmostSameAs]
-      with EntityIdJsonLdOps[TopmostSameAs] {
+      with EntityIdJsonLDOps[TopmostSameAs] {
 
     final def apply(sameAs: SameAs): TopmostSameAs = apply(sameAs.value)
 
     final def apply(entityId: EntityId): TopmostSameAs = apply(entityId.toString)
-
-    implicit lazy val topmostSameAsJsonLdEncoder: JsonLDEncoder[TopmostSameAs] = _.asEntityId.asJsonLD
   }
 
   class PartResourceId private (val value: String) extends AnyVal with StringTinyType
   implicit object PartResourceId
       extends TinyTypeFactory[PartResourceId](new PartResourceId(_))
       with UrlConstraint[PartResourceId]
-      with EntityIdJsonLdOps[PartResourceId]
+      with EntityIdJsonLDOps[PartResourceId]
 
   sealed trait Date extends Any with TinyType {
     def instant: Instant

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ActivityLens.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ActivityLens.scala
@@ -31,9 +31,9 @@ object ActivityLens {
   val activityAssociationAgent: Lens[Activity, Either[Agent, Person]] =
     activityAssociation >>> AssociationLens.associationAgent
 
-  val activityPlan: Lens[Activity, Plan] =
+  val activityPlan: Lens[Activity, StepPlan] =
     activityAssociation >>> AssociationLens.associationPlan
 
   val activityPlanCreators: Lens[Activity, Set[Person]] =
-    activityPlan >>> PlanLens.planCreators
+    activityPlan >>> PlanLens.stepPlanCreators
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ActivityLens.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ActivityLens.scala
@@ -22,6 +22,7 @@ import cats.syntax.all._
 import monocle.Lens
 
 object ActivityLens {
+
   val activityAssociation: Lens[Activity, Association] =
     Lens[Activity, Association](_.association)(assoc => act => act.copy(association = assoc))
 
@@ -30,10 +31,4 @@ object ActivityLens {
 
   val activityAssociationAgent: Lens[Activity, Either[Agent, Person]] =
     activityAssociation >>> AssociationLens.associationAgent
-
-  val activityPlan: Lens[Activity, StepPlan] =
-    activityAssociation >>> AssociationLens.associationPlan
-
-  val activityPlanCreators: Lens[Activity, Set[Person]] =
-    activityPlan >>> PlanLens.stepPlanCreators
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Association.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Association.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 import io.circe.DecodingFailure
 import io.renku.graph.model.Schemas.prov
 import io.renku.graph.model.associations.ResourceId
-import io.renku.graph.model.{GitLabApiUrl, GraphClass, RenkuUrl}
+import io.renku.graph.model._
 import io.renku.jsonld._
 import io.renku.jsonld.ontology._
 import io.renku.jsonld.syntax._
@@ -31,28 +31,29 @@ sealed trait Association {
   type AgentType
   val resourceId: ResourceId
   val agent:      AgentType
-  val plan:       StepPlan
+  val planId:     plans.ResourceId
 
   def fold[A](fa: Association.WithPersonAgent => A)(fb: Association.WithRenkuAgent => A): A
 }
 
 object Association {
 
-  implicit def functions(implicit glUrl: GitLabApiUrl, efp: EntityFunctions[Plan]): EntityFunctions[Association] =
+  implicit def functions(implicit glUrl: GitLabApiUrl): EntityFunctions[Association] =
     new EntityFunctions[Association] {
 
       override val findAllPersons: Association => Set[Person] =
-        a => efp.findAllPersons(a.plan) ++ AssociationLens.associationAgent.get(a).toOption.toSet
+        AssociationLens.associationAgent.get(_).toOption.toSet
 
       override val encoder: GraphClass => JsonLDEncoder[Association] = Association.encoder(glUrl, _)
     }
 
-  final case class WithRenkuAgent(resourceId: ResourceId, agent: Agent, plan: StepPlan) extends Association {
+  final case class WithRenkuAgent(resourceId: ResourceId, agent: Agent, planId: plans.ResourceId) extends Association {
     type AgentType = Agent
 
     def fold[A](fa: Association.WithPersonAgent => A)(fb: Association.WithRenkuAgent => A): A = fb(this)
   }
-  final case class WithPersonAgent(resourceId: ResourceId, agent: Person, plan: StepPlan) extends Association {
+  final case class WithPersonAgent(resourceId: ResourceId, agent: Person, planId: plans.ResourceId)
+      extends Association {
     type AgentType = Person
 
     def fold[A](fa: Association.WithPersonAgent => A)(fb: Association.WithRenkuAgent => A): A = fa(this)
@@ -60,41 +61,49 @@ object Association {
 
   val entityTypes: EntityTypes = EntityTypes of (prov / "Association")
 
-  implicit def encoder(implicit gitLabApiUrl: GitLabApiUrl, graph: GraphClass): JsonLDEncoder[Association] =
+  implicit def encoder(implicit glApiUrl: GitLabApiUrl, gc: GraphClass): JsonLDEncoder[Association] =
     JsonLDEncoder.instance {
-      case WithRenkuAgent(resourceId, agent, plan) =>
+      case WithRenkuAgent(resourceId, agent, planId) =>
         JsonLD.entity(
           resourceId.asEntityId,
           entityTypes,
           prov / "agent"   -> agent.asJsonLD,
-          prov / "hadPlan" -> plan.resourceId.asEntityId.asJsonLD
+          prov / "hadPlan" -> planId.asEntityId.asJsonLD
         )
-      case WithPersonAgent(resourceId, agent, plan) =>
+      case WithPersonAgent(resourceId, agent, planId) =>
         JsonLD.entity(
           resourceId.asEntityId,
           entityTypes,
           prov / "agent"   -> agent.asJsonLD,
-          prov / "hadPlan" -> plan.resourceId.asEntityId.asJsonLD
+          prov / "hadPlan" -> planId.asEntityId.asJsonLD
         )
     }
 
-  implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Association] =
-    JsonLDDecoder.entity(entityTypes) { implicit cursor =>
+  implicit def decoder(implicit dependencyLinks: DependencyLinks, renkuUrl: RenkuUrl): JsonLDDecoder[Association] = {
+    def checkValid(implicit associationId: ResourceId): plans.ResourceId => JsonLDDecoder.Result[Unit] = planId =>
+      dependencyLinks.findStepPlan(planId) match {
+        case Some(_) => ().asRight
+        case None => DecodingFailure(show"Association $associationId points to a non-existing Plan $planId", Nil).asLeft
+      }
+
+    JsonLDDecoder.entity(entityTypes) { cursor =>
       for {
-        resourceId <- cursor.downEntityId.as[ResourceId]
-        plan       <- cursor.downField(prov / "hadPlan").as[StepPlan]
+        implicit0(resourceId: ResourceId) <- cursor.downEntityId.as[ResourceId]
+        planId <- cursor.downField(prov / "hadPlan").downEntityId.as[plans.ResourceId] flatTap checkValid
         association <- cursor.downField(prov / "agent").as[Option[Agent]] match {
-                         case Right(Some(agent)) => Association.WithRenkuAgent(resourceId, agent, plan).asRight
-                         case _                  => tryAsPersonAgent(resourceId, plan)
+                         case Right(Some(agent)) => Association.WithRenkuAgent(resourceId, agent, planId).asRight
+                         case _                  => tryAsPersonAgent(cursor, resourceId, planId)
                        }
       } yield association
     }
+  }
 
-  private def tryAsPersonAgent(resourceId: ResourceId, plan: StepPlan)(implicit cursor: Cursor, renkuUrl: RenkuUrl) =
-    cursor.downField(prov / "agent").as[Option[Person]] >>= {
-      case Some(agent) => Association.WithPersonAgent(resourceId, agent, plan).asRight
-      case None        => DecodingFailure(show"Association $resourceId without a valid ${prov / "agent"}", Nil).asLeft
-    }
+  private def tryAsPersonAgent(cursor: Cursor, resourceId: ResourceId, planId: plans.ResourceId)(implicit
+      renkuUrl:                        RenkuUrl
+  ) = cursor.downField(prov / "agent").as[Option[Person]] >>= {
+    case Some(agent) => Association.WithPersonAgent(resourceId, agent, planId).asRight
+    case None        => DecodingFailure(show"Association $resourceId without a valid ${prov / "agent"}", Nil).asLeft
+  }
 
   lazy val ontology: Type = Type.Def(
     Class(prov / "Association"),

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/AssociationLens.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/AssociationLens.scala
@@ -23,9 +23,6 @@ import monocle.Lens
 
 object AssociationLens {
 
-  val associationPlan: Lens[Association, StepPlan] =
-    Lens[Association, StepPlan](_.plan)(p => a => a.fold[Association](_.copy(plan = p))(_.copy(plan = p)))
-
   val associationAgent: Lens[Association, Either[Agent, Person]] =
     Lens[Association, Either[Agent, Person]](_.fold(_.agent.asRight[Agent])(_.agent.asLeft[Person])) {
       case Right(person) => {

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/AssociationLens.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/AssociationLens.scala
@@ -23,8 +23,8 @@ import monocle.Lens
 
 object AssociationLens {
 
-  val associationPlan: Lens[Association, Plan] =
-    Lens[Association, Plan](_.plan)(p => a => a.fold[Association](_.copy(plan = p))(_.copy(plan = p)))
+  val associationPlan: Lens[Association, StepPlan] =
+    Lens[Association, StepPlan](_.plan)(p => a => a.fold[Association](_.copy(plan = p))(_.copy(plan = p)))
 
   val associationAgent: Lens[Association, Either[Agent, Person]] =
     Lens[Association, Either[Agent, Person]](_.fold(_.agent.asRight[Agent])(_.agent.asLeft[Person])) {

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/DependencyLinks.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/DependencyLinks.scala
@@ -18,18 +18,8 @@
 
 package io.renku.graph.model.entities
 
-import monocle.Lens
+import io.renku.graph.model.plans
 
-object PlanLens {
-
-  val stepPlanCreators: Lens[StepPlan, List[Person]] = Lens[StepPlan, List[Person]](_.creators) { persons =>
-    {
-      case plan: StepPlan.NonModified => plan.copy(creators = persons)
-      case plan: StepPlan.Modified    => plan.copy(creators = persons)
-    }
-  }
-
-  val planCreators: Lens[Plan, List[Person]] = Lens[Plan, List[Person]](_.creators) { persons =>
-    { case plan: StepPlan => stepPlanCreators.modify(_ => persons)(plan) }
-  }
+trait DependencyLinks {
+  def findStepPlan(planId: plans.ResourceId): Option[StepPlan]
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ParameterValue.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ParameterValue.scala
@@ -91,7 +91,7 @@ object ParameterValue {
         )
     }
 
-  def decoder(plan: Plan): JsonLDDecoder[ParameterValue] = JsonLDDecoder.entity(parameterValueTypes) { cursor =>
+  def decoder(plan: StepPlan): JsonLDDecoder[ParameterValue] = JsonLDDecoder.entity(parameterValueTypes) { cursor =>
     def maybeCommandParameter(resourceId: ResourceId, valueReferenceId: commandParameters.ResourceId) = plan
       .findParameter(valueReferenceId)
       .map(parameter =>

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
@@ -34,7 +34,7 @@ sealed trait Plan extends Product with Serializable {
   val resourceId:       ResourceId
   val name:             Name
   val maybeDescription: Option[Description]
-  val creators:         Set[Person]
+  val creators:         List[Person]
   val dateCreated:      DateCreated
   val keywords:         List[Keyword]
 
@@ -45,7 +45,7 @@ object Plan {
 
   implicit def entityFunctions(implicit gitLabApiUrl: GitLabApiUrl): EntityFunctions[Plan] =
     new EntityFunctions[Plan] {
-      val findAllPersons: Plan => Set[Person]               = _.creators
+      val findAllPersons: Plan => Set[Person]               = _.creators.toSet
       val encoder:        GraphClass => JsonLDEncoder[Plan] = Plan.encoder(gitLabApiUrl, _)
     }
 
@@ -86,7 +86,7 @@ object StepPlan {
   final case class NonModified(resourceId:               ResourceId,
                                name:                     Name,
                                maybeDescription:         Option[Description],
-                               creators:                 Set[Person],
+                               creators:                 List[Person],
                                dateCreated:              DateCreated,
                                keywords:                 List[Keyword],
                                maybeCommand:             Option[Command],
@@ -100,7 +100,7 @@ object StepPlan {
   final case class Modified(resourceId:               ResourceId,
                             name:                     Name,
                             maybeDescription:         Option[Description],
-                            creators:                 Set[Person],
+                            creators:                 List[Person],
                             dateCreated:              DateCreated,
                             keywords:                 List[Keyword],
                             maybeCommand:             Option[Command],
@@ -117,7 +117,7 @@ object StepPlan {
            name:                     Name,
            maybeDescription:         Option[Description],
            maybeCommand:             Option[Command],
-           creators:                 Set[Person],
+           creators:                 List[Person],
            dateCreated:              DateCreated,
            maybeProgrammingLanguage: Option[ProgrammingLanguage],
            keywords:                 List[Keyword],
@@ -143,7 +143,7 @@ object StepPlan {
            name:                     Name,
            maybeDescription:         Option[Description],
            maybeCommand:             Option[Command],
-           creators:                 Set[Person],
+           creators:                 List[Person],
            dateCreated:              DateCreated,
            maybeProgrammingLanguage: Option[ProgrammingLanguage],
            keywords:                 List[Keyword],
@@ -197,7 +197,7 @@ object StepPlan {
           schema / "name"                -> plan.name.asJsonLD,
           schema / "description"         -> plan.maybeDescription.asJsonLD,
           renku / "command"              -> plan.maybeCommand.asJsonLD,
-          schema / "creator"             -> plan.creators.toList.asJsonLD,
+          schema / "creator"             -> plan.creators.asJsonLD,
           schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
           schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
           schema / "keywords"            -> plan.keywords.asJsonLD,
@@ -213,7 +213,7 @@ object StepPlan {
           schema / "name"                -> plan.name.asJsonLD,
           schema / "description"         -> plan.maybeDescription.asJsonLD,
           renku / "command"              -> plan.maybeCommand.asJsonLD,
-          schema / "creator"             -> plan.creators.toList.asJsonLD,
+          schema / "creator"             -> plan.creators.asJsonLD,
           schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
           schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
           schema / "keywords"            -> plan.keywords.asJsonLD,
@@ -234,7 +234,7 @@ object StepPlan {
         name                  <- cursor.downField(schema / "name").as[Name]
         maybeDescription      <- cursor.downField(schema / "description").as[Option[Description]]
         maybeCommand          <- cursor.downField(renku / "command").as[Option[Command]]
-        creators              <- cursor.downField(schema / "creator").as[List[Person]].map(_.toSet)
+        creators              <- cursor.downField(schema / "creator").as[List[Person]]
         dateCreated           <- cursor.downField(schema / "dateCreated").as[DateCreated]
         maybeProgrammingLang  <- cursor.downField(schema / "programmingLanguage").as[Option[ProgrammingLanguage]]
         keywords              <- cursor.downField(schema / "keywords").as[List[Option[Keyword]]].map(_.flatten)

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
@@ -158,7 +158,7 @@ object StepPlan {
            maybeInvalidationTime:    Option[InvalidationTime]
   ): ValidatedNel[String, StepPlan] = {
 
-    def validateInvalidation(mit: Option[InvalidationTime]): ValidatedNel[String, Unit] = mit match {
+    lazy val validateInvalidationTime: ValidatedNel[String, Unit] = maybeInvalidationTime match {
       case None => Validated.validNel(())
       case Some(time) =>
         Validated.condNel(
@@ -168,7 +168,7 @@ object StepPlan {
         )
     }
 
-    validateInvalidation(maybeInvalidationTime).map(_ =>
+    validateInvalidationTime.map(_ =>
       Modified(
         resourceId,
         name,

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/PlanLens.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/PlanLens.scala
@@ -22,6 +22,14 @@ import monocle.Lens
 
 object PlanLens {
 
-  val planCreators: Lens[Plan, Set[Person]] =
-    Lens[Plan, Set[Person]](_.creators)(persons => plan => plan.copy(creators = persons))
+  val stepPlanCreators: Lens[StepPlan, Set[Person]] = Lens[StepPlan, Set[Person]](_.creators) { persons =>
+    {
+      case plan: StepPlan.NonModified => plan.copy(creators = persons)
+      case plan: StepPlan.Modified    => plan.copy(creators = persons)
+    }
+  }
+
+  val planCreators: Lens[Plan, Set[Person]] = Lens[Plan, Set[Person]](_.creators) { persons =>
+    { case plan: StepPlan => stepPlanCreators.modify(_ => persons)(plan) }
+  }
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ProjectLens.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ProjectLens.scala
@@ -18,18 +18,7 @@
 
 package io.renku.graph.model.entities
 
-import monocle.Lens
+object ProjectLens {
 
-object PlanLens {
-
-  val stepPlanCreators: Lens[StepPlan, List[Person]] = Lens[StepPlan, List[Person]](_.creators) { persons =>
-    {
-      case plan: StepPlan.NonModified => plan.copy(creators = persons)
-      case plan: StepPlan.Modified    => plan.copy(creators = persons)
-    }
-  }
-
-  val planCreators: Lens[Plan, List[Person]] = Lens[Plan, List[Person]](_.creators) { persons =>
-    { case plan: StepPlan => stepPlanCreators.modify(_ => persons)(plan) }
-  }
+  val collectStepPlans: List[Plan] => List[StepPlan] = _.collect { case p: StepPlan => p }
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entityModel.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entityModel.scala
@@ -20,7 +20,7 @@ package io.renku.graph.model
 
 import cats.syntax.all._
 import io.renku.graph.model.entityModel.Location.FileOrFolder.from
-import io.renku.graph.model.views.{EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.jsonld.JsonLDDecoder._
 import io.renku.jsonld.JsonLDEncoder._
 import io.renku.jsonld.{JsonLDDecoder, JsonLDEncoder}
@@ -33,7 +33,7 @@ object entityModel {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 
   sealed trait LocationLike extends Any with RelativePathTinyType {
     override def equals(obj: Any): Boolean =

--- a/renku-model/src/main/scala/io/renku/graph/model/generations.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/generations.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.EntityIdJsonLdOps
+import io.renku.graph.model.views.EntityIdJsonLDOps
 import io.renku.tinytypes.constraints.Url
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 
@@ -27,5 +27,5 @@ object generations {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/parameterValues.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/parameterValues.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.{EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.tinytypes.constraints.{NonBlank, Url}
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 
@@ -28,7 +28,7 @@ object parameterValues {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 
   final class ValueOverride private (val value: String) extends AnyVal with StringTinyType
   implicit object ValueOverride

--- a/renku-model/src/main/scala/io/renku/graph/model/persons.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/persons.scala
@@ -20,7 +20,7 @@ package io.renku.graph.model
 
 import cats.syntax.all._
 import io.circe.DecodingFailure
-import io.renku.graph.model.views.{EntityIdJsonLdOps, RdfResource, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, RdfResource, TinyTypeJsonLDOps}
 import io.renku.jsonld.{EntityId, EntityIdEncoder, JsonLDDecoder}
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints.{NonBlank, NonNegativeInt}
@@ -172,7 +172,7 @@ object persons {
   }
   implicit object OrcidId
       extends TinyTypeFactory[OrcidId](new OrcidId(_))
-      with EntityIdJsonLdOps[OrcidId]
+      with EntityIdJsonLDOps[OrcidId]
       with Constraints[OrcidId]
       with NonBlank[OrcidId] {
     private[persons] val validator      = "^https:\\/\\/orcid.org\\/(\\d{4}-\\d{4}-\\d{4}-\\d{4})$"

--- a/renku-model/src/main/scala/io/renku/graph/model/plans.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/plans.scala
@@ -19,7 +19,8 @@
 package io.renku.graph.model
 
 import cats.syntax.all._
-import io.renku.graph.model.views.{EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLDOps, TinyTypeJsonLDOps}
+import io.renku.jsonld.EntityId
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints._
 
@@ -32,7 +33,7 @@ object plans {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId] {
+      with EntityIdJsonLDOps[ResourceId] {
 
     def apply(identifier: Identifier)(implicit renkuUrl: RenkuUrl): ResourceId =
       ResourceId((renkuUrl / "plans" / identifier).value)
@@ -88,4 +89,14 @@ object plans {
       extends TinyTypeFactory[DateCreated](new DateCreated(_))
       with InstantNotInTheFuture[DateCreated]
       with TinyTypeJsonLDOps[DateCreated]
+
+  final class DerivedFrom private (val value: String) extends AnyVal with StringTinyType
+  implicit object DerivedFrom
+      extends TinyTypeFactory[DerivedFrom](new DerivedFrom(_))
+      with constraints.Url[DerivedFrom]
+      with AnyResourceRenderer[DerivedFrom]
+      with EntityIdJsonLDOps[DerivedFrom] {
+
+    def apply(entityId: EntityId): DerivedFrom = DerivedFrom(entityId.toString)
+  }
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/plans.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/plans.scala
@@ -88,5 +88,4 @@ object plans {
       extends TinyTypeFactory[DateCreated](new DateCreated(_))
       with InstantNotInTheFuture[DateCreated]
       with TinyTypeJsonLDOps[DateCreated]
-
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/projects.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/projects.scala
@@ -21,7 +21,7 @@ package io.renku.graph.model
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.jsonld.{EntityId, JsonLDDecoder, JsonLDEncoder}
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints._
@@ -62,7 +62,7 @@ object projects {
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
       with AnyResourceRenderer[ResourceId]
-      with EntityIdJsonLdOps[ResourceId] {
+      with EntityIdJsonLDOps[ResourceId] {
 
     private val regexValidator = s"^http[s]?:\\/\\/.*\\/projects\\/${Path.regexValidator.drop(1)}"
 

--- a/renku-model/src/main/scala/io/renku/graph/model/publicationEvents.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/publicationEvents.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.{EntityIdJsonLdOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.tinytypes.constraints.{InstantNotInTheFuture, NonBlank, Url}
 import io.renku.tinytypes.{InstantTinyType, StringTinyType, TinyTypeFactory}
 
@@ -30,10 +30,10 @@ object publicationEvents {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 
   class About private (val value: String) extends AnyVal with StringTinyType
-  implicit object About extends TinyTypeFactory[About](new About(_)) with Url[About] with EntityIdJsonLdOps[About]
+  implicit object About extends TinyTypeFactory[About](new About(_)) with Url[About] with EntityIdJsonLDOps[About]
 
   final class Description private (val value: String) extends AnyVal with StringTinyType
   implicit object Description

--- a/renku-model/src/main/scala/io/renku/graph/model/usages.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/usages.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.EntityIdJsonLdOps
+import io.renku.graph.model.views.EntityIdJsonLDOps
 import io.renku.tinytypes.constraints.Url
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 
@@ -27,5 +27,5 @@ object usages {
   implicit object ResourceId
       extends TinyTypeFactory[ResourceId](new ResourceId(_))
       with Url[ResourceId]
-      with EntityIdJsonLdOps[ResourceId]
+      with EntityIdJsonLDOps[ResourceId]
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/views/EntityIdJsonLDOps.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/views/EntityIdJsonLDOps.scala
@@ -20,16 +20,19 @@ package io.renku.graph.model.views
 
 import cats.syntax.all._
 import io.circe.DecodingFailure
-import io.renku.jsonld.{EntityId, EntityIdEncoder, JsonLDDecoder}
+import io.renku.jsonld.syntax._
+import io.renku.jsonld.{EntityId, EntityIdEncoder, JsonLDDecoder, JsonLDEncoder}
 import io.renku.tinytypes.{TinyType, TinyTypeFactory}
 
-trait EntityIdJsonLdOps[TT <: TinyType { type V = String }] {
+trait EntityIdJsonLDOps[TT <: TinyType { type V = String }] {
   self: TinyTypeFactory[TT] =>
 
-  implicit lazy val encoder: EntityIdEncoder[TT] =
+  implicit lazy val entityIdEncoder: EntityIdEncoder[TT] =
     EntityIdEncoder.instance[TT](id => EntityId.of(id.value))
 
-  implicit lazy val decoder: JsonLDDecoder[TT] =
+  implicit lazy val ttEncoder: JsonLDEncoder[TT] = _.asEntityId.asJsonLD
+
+  implicit lazy val ttDecoder: JsonLDDecoder[TT] =
     JsonLDDecoder.instance {
       JsonLDDecoder.decodeEntityId >>> {
         _.flatMap(entityId =>

--- a/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
@@ -228,7 +228,7 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     "serialise TopmostDerivedFrom to an object having @id property as the DerivedFrom's value" in {
       val derivedFrom = datasetTopmostDerivedFroms.generateOne
 
-      val json = TopmostDerivedFrom.topmostDerivedFromJsonLdEncoder(derivedFrom).toJson
+      val json = TopmostDerivedFrom.jsonLDEncoder(derivedFrom).toJson
 
       json.hcursor.downField("@id").as[String] shouldBe Right(derivedFrom.toString)
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
@@ -205,7 +205,7 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     "serialise TopmostSameAs to an object having @id property as the SameAs's value" in {
       val sameAs = datasetTopmostSameAs.generateOne
 
-      val json = TopmostSameAs.topmostSameAsJsonLdEncoder(sameAs).toJson
+      val json = TopmostSameAs.ttEncoder(sameAs).toJson
 
       json.hcursor.downField("@id").as[String] shouldBe Right(sameAs.toString)
     }
@@ -228,7 +228,7 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     "serialise TopmostDerivedFrom to an object having @id property as the DerivedFrom's value" in {
       val derivedFrom = datasetTopmostDerivedFroms.generateOne
 
-      val json = TopmostDerivedFrom.jsonLDEncoder(derivedFrom).toJson
+      val json = TopmostDerivedFrom.ttEncoder(derivedFrom).toJson
 
       json.hcursor.downField("@id").as[String] shouldBe Right(derivedFrom.toString)
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ActivityLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ActivityLensSpec.scala
@@ -45,7 +45,7 @@ class ActivityLensSpec extends AnyWordSpec with should.Matchers with EntitiesGen
   }
 
   private def createActivity =
-    activityEntities(planEntities())
+    activityEntities(stepPlanEntities())
       .apply(GraphModelGenerators.projectCreatedDates().generateOne)
       .generateOne
       .to[Activity]

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ActivitySpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ActivitySpec.scala
@@ -39,7 +39,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     implicit val graph: GraphClass = GraphClass.Default
 
     "turn JsonLD Activity entity into the Activity object" in {
-      forAll(activityEntities(planEntities())(projectCreatedDates().generateOne)) { activity =>
+      forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)) { activity =>
         JsonLD
           .arr(activity.asJsonLD, activity.association.plan.asJsonLD)
           .flatten
@@ -52,7 +52,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     "fail if there are Input Parameter Values for non-existing Usage Entities" in {
       val location = entityLocations.generateOne
       val activity =
-        executionPlanners(planEntities(CommandInput.fromLocation(location)),
+        executionPlanners(stepPlanEntities(CommandInput.fromLocation(location)),
                           anyRenkuProjectEntities.generateOne
         ).generateOne
           .planInputParameterValuesFromChecksum(location -> entityChecksums.generateOne)
@@ -87,7 +87,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     "fail if there are Output Parameter Values for non-existing Generation Entities" in {
       val location = entityLocations.generateOne
       val activity = executionPlanners(
-        planEntities(CommandOutput.fromLocation(location)),
+        stepPlanEntities(CommandOutput.fromLocation(location)),
         anyRenkuProjectEntities.generateOne
       ).generateOne.buildProvenanceUnsafe()
 
@@ -118,7 +118,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     }
 
     "fail if there is no Agent entity" in {
-      val activity = executionPlanners(planEntities(), anyRenkuProjectEntities.generateOne).generateOne
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
         .buildProvenanceUnsafe()
         .to[entities.Activity]
 
@@ -148,7 +148,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     }
 
     "fail if there is no Author entity" in {
-      val activity = executionPlanners(planEntities(), anyRenkuProjectEntities.generateOne).generateOne
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
         .buildProvenanceUnsafe()
         .to[entities.Activity]
 
@@ -182,7 +182,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     implicit val graph: GraphClass = GraphClass.Default
 
     "produce JsonLD with all the relevant properties" in {
-      val activity = executionPlanners(planEntities(), anyRenkuProjectEntities.generateOne).generateOne
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
         .buildProvenanceUnsafe()
         .to[entities.Activity]
 
@@ -204,7 +204,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     implicit val graph: GraphClass = GraphClass.Project
 
     "produce JsonLD with all the relevant properties and only links to Person entities" in {
-      val activity = executionPlanners(planEntities(), anyRenkuProjectEntities.generateOne).generateOne
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
         .buildProvenanceUnsafe()
         .to[entities.Activity]
 
@@ -227,7 +227,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
   "entityFunctions.findAllPersons" should {
 
     "return Activity's author and Association's agent if exists" in {
-      val activity = executionPlanners(planEntities(), anyRenkuProjectEntities.generateOne).generateOne
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
         .buildProvenanceUnsafe()
         .to[entities.Activity]
 
@@ -244,7 +244,7 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
   "entityFunctions.encoder" should {
 
     "return encoder that honors the given GraphClass" in {
-      val activity = executionPlanners(planEntities(), anyRenkuProjectEntities.generateOne).generateOne
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
         .buildProvenanceUnsafe()
         .to[entities.Activity]
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ActivitySpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ActivitySpec.scala
@@ -21,14 +21,15 @@ package io.renku.graph.model.entities
 import cats.syntax.all._
 import io.circe.DecodingFailure
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestamps
 import io.renku.graph.model.GraphModelGenerators.{graphClasses, projectCreatedDates}
 import io.renku.graph.model.Schemas.{prov, renku}
 import io.renku.graph.model.entities.Activity.entityTypes
 import io.renku.graph.model.testentities.CommandParameterBase.{CommandInput, CommandOutput}
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.{GraphClass, entities}
+import io.renku.graph.model._
+import io.renku.jsonld._
 import io.renku.jsonld.syntax._
-import io.renku.jsonld.{JsonLD, JsonLDEncoder, Reverse}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -40,9 +41,9 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
 
     "turn JsonLD Activity entity into the Activity object" in {
       forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)) { activity =>
-        JsonLD
-          .arr(activity.asJsonLD, activity.association.plan.asJsonLD)
-          .flatten
+        implicit val decoder: JsonLDDecoder[entities.Activity] = createDecoder(activity.association.plan)
+
+        activity.asJsonLD.flatten
           .fold(throw _, identity)
           .cursor
           .as[List[entities.Activity]] shouldBe List(activity.to[entities.Activity]).asRight
@@ -73,9 +74,9 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
         )
       }
 
-      val Left(error) = JsonLD
-        .arr(activity.asJsonLD, activity.association.plan.asJsonLD)
-        .flatten
+      implicit val decoder: JsonLDDecoder[entities.Activity] = createDecoder(activity.association.plan)
+
+      val Left(error) = activity.asJsonLD.flatten
         .fold(throw _, _.asArray.fold(fail("JsonLD is not an array"))(replaceEntityLocation))
         .cursor
         .as[List[entities.Activity]]
@@ -106,9 +107,9 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
         )
       }
 
-      val Left(error) = JsonLD
-        .arr(activity.asJsonLD, activity.association.plan.asJsonLD)
-        .flatten
+      implicit val decoder: JsonLDDecoder[entities.Activity] = createDecoder(activity.association.plan)
+
+      val Left(error) = activity.asJsonLD.flatten
         .fold(throw _, _.asArray.fold(fail("JsonLD is not an array"))(replaceEntityLocation))
         .cursor
         .as[List[entities.Activity]]
@@ -118,9 +119,6 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
     }
 
     "fail if there is no Agent entity" in {
-      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
-        .buildProvenanceUnsafe()
-        .to[entities.Activity]
 
       val encoder = JsonLDEncoder.instance[entities.Activity] { entity =>
         JsonLD.entity(
@@ -136,21 +134,25 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
         )
       }
 
-      val Left(error) = JsonLD
-        .arr(activity.asJsonLD(encoder), activity.association.plan.asJsonLD)
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
+        .buildProvenanceUnsafe()
+
+      implicit val decoder: JsonLDDecoder[entities.Activity] = createDecoder(activity.association.plan)
+
+      val entitiesActivity = activity.to[entities.Activity]
+
+      val Left(error) = entitiesActivity
+        .asJsonLD(encoder)
         .flatten
         .fold(throw _, identity)
         .cursor
         .as[List[entities.Activity]]
 
       error       shouldBe a[DecodingFailure]
-      error.message should endWith(s"Activity ${activity.resourceId} without or with multiple agents")
+      error.message should endWith(s"Activity ${entitiesActivity.resourceId} without or with multiple agents")
     }
 
     "fail if there is no Author entity" in {
-      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
-        .buildProvenanceUnsafe()
-        .to[entities.Activity]
 
       val encoder = JsonLDEncoder.instance[entities.Activity] { entity =>
         JsonLD.entity(
@@ -166,15 +168,43 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
         )
       }
 
-      val Left(error) = JsonLD
-        .arr(activity.asJsonLD(encoder), activity.association.plan.asJsonLD)
+      val activity = executionPlanners(stepPlanEntities(), anyRenkuProjectEntities.generateOne).generateOne
+        .buildProvenanceUnsafe()
+
+      implicit val decoder: JsonLDDecoder[entities.Activity] = createDecoder(activity.association.plan)
+
+      val entitiesActivity = activity.to[entities.Activity]
+
+      val Left(error) = entitiesActivity
+        .asJsonLD(encoder)
         .flatten
         .fold(throw _, identity)
         .cursor
         .as[List[entities.Activity]]
 
       error       shouldBe a[DecodingFailure]
-      error.message should endWith(s"Activity ${activity.resourceId} without or with multiple authors")
+      error.message should endWith(s"Activity ${entitiesActivity.resourceId} without or with multiple authors")
+    }
+
+    "fail if Activity startTime is older than Plan creation date" in {
+
+      val activity = {
+        val a = activityEntities(stepPlanEntities())(projectCreatedDates().generateOne).generateOne
+        a.replaceStartTime(timestamps(max = a.plan.dateCreated.value.minusSeconds(1)).generateAs(activities.StartTime))
+      }
+      val entitiesActivity = activity.to[entities.Activity]
+
+      implicit val decoder: JsonLDDecoder[entities.Activity] = createDecoder(activity.association.plan)
+
+      val Left(error) = entitiesActivity.asJsonLD.flatten
+        .fold(throw _, identity)
+        .cursor
+        .as[List[entities.Activity]]
+
+      error shouldBe a[DecodingFailure]
+      error.message should endWith(
+        show"Activity ${entitiesActivity.resourceId} date ${entitiesActivity.startTime} is older than plan ${activity.plan.dateCreated}"
+      )
     }
   }
 
@@ -253,5 +283,14 @@ class ActivitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
 
       activity.asJsonLD(functionsEncoder) shouldBe activity.asJsonLD
     }
+  }
+
+  private def createDecoder(plan: StepPlan): JsonLDDecoder[entities.Activity] = {
+    val entitiesPlan = plan.to[entities.StepPlan]
+
+    implicit val dl: DependencyLinks = (planId: plans.ResourceId) =>
+      Option.when(planId == entitiesPlan.resourceId)(entitiesPlan)
+
+    entities.Activity.decoder
   }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationLensSpec.scala
@@ -28,18 +28,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class AssociationLensSpec extends AnyWordSpec with should.Matchers with EntitiesGenerators {
 
-  "associationPlan" should {
-    "get and set" in {
-      val assoc1 = createAssociationPerson
-      val assoc2 = createAssociationAgent
-
-      AssociationLens.associationPlan.get(assoc1)              shouldBe assoc1.plan
-      AssociationLens.associationPlan.get(assoc2)              shouldBe assoc2.plan
-      AssociationLens.associationPlan.set(assoc1.plan)(assoc2) shouldBe assoc2.copy(plan = assoc1.plan)
-      AssociationLens.associationPlan.set(assoc2.plan)(assoc1) shouldBe assoc1.copy(plan = assoc2.plan)
-    }
-  }
-
   "associationAgent" should {
     "get and set" in {
       val assoc1 = createAssociationAgent
@@ -49,9 +37,9 @@ class AssociationLensSpec extends AnyWordSpec with should.Matchers with Entities
       AssociationLens.associationAgent.get(assoc2) shouldBe Right(assoc2.agent)
 
       AssociationLens.associationAgent.set(assoc1.agent.asLeft)(assoc2) shouldBe
-        Association.WithRenkuAgent(assoc2.resourceId, assoc1.agent, assoc2.plan)
+        Association.WithRenkuAgent(assoc2.resourceId, assoc1.agent, assoc2.planId)
       AssociationLens.associationAgent.set(assoc2.agent.asRight)(assoc1) shouldBe
-        Association.WithPersonAgent(assoc1.resourceId, assoc2.agent, assoc1.plan)
+        Association.WithPersonAgent(assoc1.resourceId, assoc2.agent, assoc1.planId)
 
       val assoc3 = createAssociationAgent
       val assoc4 = createAssociationPerson
@@ -72,13 +60,13 @@ class AssociationLensSpec extends AnyWordSpec with should.Matchers with Entities
     Association.WithRenkuAgent(
       ResourceId(s"http://localhost/${activityIds.generateOne.value}"),
       EntitiesGenerators.agentEntities.generateOne,
-      createPlan
+      createPlan.resourceId
     )
 
   private def createAssociationPerson: Association.WithPersonAgent =
     Association.WithPersonAgent(
       ResourceId(s"http://localhost/${activityIds.generateOne.value}"),
       personEntities.generateOne.to[Person],
-      createPlan
+      createPlan.resourceId
     )
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationLensSpec.scala
@@ -63,7 +63,7 @@ class AssociationLensSpec extends AnyWordSpec with should.Matchers with Entities
   }
 
   private def createPlan =
-    planEntities()
+    stepPlanEntities()
       .apply(GraphModelGenerators.projectCreatedDates().generateOne)
       .generateOne
       .to[Plan]

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationLensSpec.scala
@@ -66,7 +66,7 @@ class AssociationLensSpec extends AnyWordSpec with should.Matchers with Entities
     stepPlanEntities()
       .apply(GraphModelGenerators.projectCreatedDates().generateOne)
       .generateOne
-      .to[Plan]
+      .to[StepPlan]
 
   private def createAssociationAgent: Association.WithRenkuAgent =
     Association.WithRenkuAgent(

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
@@ -35,13 +35,14 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
     implicit val graph: GraphClass = GraphClass.Default
 
     "turn JsonLD Association entity with Renku agent into the Association object" in {
-      forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne).map(_.association)) { association =>
-        JsonLD
-          .arr(association.asJsonLD, association.plan.asJsonLD)
-          .flatten
-          .fold(throw _, identity)
-          .cursor
-          .as[List[entities.Association]] shouldBe List(association.to[entities.Association]).asRight
+      forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne).map(_.association)) {
+        association =>
+          JsonLD
+            .arr(association.asJsonLD, association.plan.asJsonLD)
+            .flatten
+            .fold(throw _, identity)
+            .cursor
+            .as[List[entities.Association]] shouldBe List(association.to[entities.Association]).asRight
       }
     }
 
@@ -96,7 +97,8 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
       val (association, agent) = generateAssociationWithPersonAgent
 
-      EntityFunctions[entities.Association].findAllPersons(association) shouldBe Set(agent.to[entities.Person])
+      EntityFunctions[entities.Association].findAllPersons(association) shouldBe
+        Set(agent.to[entities.Person]) ++ association.plan.creators
     }
   }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
@@ -35,7 +35,7 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
     implicit val graph: GraphClass = GraphClass.Default
 
     "turn JsonLD Association entity with Renku agent into the Association object" in {
-      forAll(activityEntities(planEntities())(projectCreatedDates().generateOne).map(_.association)) { association =>
+      forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne).map(_.association)) { association =>
         JsonLD
           .arr(association.asJsonLD, association.plan.asJsonLD)
           .flatten
@@ -115,7 +115,7 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
   private def generateAssociationWithPersonAgent: (entities.Association, Person) = {
     val associationWithRenkuAgent =
-      activityEntities(planEntities())(projectCreatedDates().generateOne)
+      activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)
         .map(_.association)
         .generateOne
         .to[entities.Association]

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
@@ -22,9 +22,9 @@ import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators.{graphClasses, projectCreatedDates}
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.{GraphClass, entities}
-import io.renku.jsonld.JsonLD
+import io.renku.graph.model.{GraphClass, entities, plans}
 import io.renku.jsonld.syntax._
+import io.renku.jsonld.{JsonLD, JsonLDDecoder}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -37,25 +37,41 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
     "turn JsonLD Association entity with Renku agent into the Association object" in {
       forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne).map(_.association)) {
         association =>
-          JsonLD
-            .arr(association.asJsonLD, association.plan.asJsonLD)
-            .flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.Association]] shouldBe List(association.to[entities.Association]).asRight
+          implicit val decoder: JsonLDDecoder[entities.Association] =
+            createDecoder(association.plan.to[entities.StepPlan])
+
+          association.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.Association]] shouldBe
+            List(association.to[entities.Association]).asRight
       }
     }
 
     "turn JsonLD Association entity with Person agent into the Association object" in {
 
-      val (association, _) = generateAssociationWithPersonAgent
+      val (association, _, plan) = generateAssociationWithPersonAgent
 
-      JsonLD
-        .arr(association.asJsonLD, association.plan.asJsonLD)
-        .flatten
+      implicit val decoder: JsonLDDecoder[entities.Association] = createDecoder(plan)
+
+      association.asJsonLD.flatten
         .fold(throw _, identity)
         .cursor
         .as[List[entities.Association]] shouldBe List(association).asRight
+    }
+
+    "fail decoding if there's no Plan with the Id the Association points to" in {
+
+      val association =
+        activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)
+          .map(_.association)
+          .generateOne
+          .to[entities.Association]
+
+      implicit val dl: DependencyLinks = (_: plans.ResourceId) => Option.empty[entities.StepPlan]
+
+      val Left(failure) = association.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.Association]]
+
+      failure.message should include(
+        show"Association ${association.resourceId} points to a non-existing Plan ${association.planId}"
+      )
     }
   }
 
@@ -64,13 +80,13 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "produce JsonLD with all the relevant properties" in {
 
-      val (association, agent) = generateAssociationWithPersonAgent
+      val (association, agent, _) = generateAssociationWithPersonAgent
 
       association.asJsonLD shouldBe JsonLD.entity(
         association.resourceId.asEntityId,
         entities.Association.entityTypes,
         prov / "agent"   -> agent.asJsonLD,
-        prov / "hadPlan" -> association.plan.resourceId.asEntityId.asJsonLD
+        prov / "hadPlan" -> association.planId.asEntityId.asJsonLD
       )
     }
   }
@@ -80,13 +96,13 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "produce JsonLD with all the relevant properties and only links to Person entities" in {
 
-      val (association, agent) = generateAssociationWithPersonAgent
+      val (association, agent, _) = generateAssociationWithPersonAgent
 
       association.asJsonLD shouldBe JsonLD.entity(
         association.resourceId.asEntityId,
         entities.Association.entityTypes,
         prov / "agent"   -> agent.asEntityId.asJsonLD,
-        prov / "hadPlan" -> association.plan.resourceId.asEntityId.asJsonLD
+        prov / "hadPlan" -> association.planId.asEntityId.asJsonLD
       )
     }
   }
@@ -95,10 +111,9 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "return Association's agent if of type Person" in {
 
-      val (association, agent) = generateAssociationWithPersonAgent
+      val (association, agent, _) = generateAssociationWithPersonAgent
 
-      EntityFunctions[entities.Association].findAllPersons(association) shouldBe
-        Set(agent.to[entities.Person]) ++ association.plan.creators
+      EntityFunctions[entities.Association].findAllPersons(association) shouldBe Set(agent.to[entities.Person])
     }
   }
 
@@ -106,7 +121,7 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "return encoder that honors the given GraphClass" in {
 
-      val (association, _) = generateAssociationWithPersonAgent
+      val (association, _, _) = generateAssociationWithPersonAgent
 
       implicit val graph: GraphClass = graphClasses.generateOne
       val functionsEncoder = EntityFunctions[entities.Association].encoder(graph)
@@ -115,19 +130,27 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
     }
   }
 
-  private def generateAssociationWithPersonAgent: (entities.Association, Person) = {
+  private def generateAssociationWithPersonAgent: (entities.Association, Person, entities.StepPlan) = {
     val associationWithRenkuAgent =
       activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)
         .map(_.association)
         .generateOne
-        .to[entities.Association]
 
     val agent = personEntities.generateOne
-    val association = entities.Association.WithPersonAgent(associationWithRenkuAgent.resourceId,
-                                                           agent.to[entities.Person],
-                                                           associationWithRenkuAgent.plan
+    val plan  = associationWithRenkuAgent.plan.to[entities.StepPlan]
+    val association = entities.Association.WithPersonAgent(
+      associationWithRenkuAgent.to[entities.Association].resourceId,
+      agent.to[entities.Person],
+      plan.resourceId
     )
 
-    association -> agent
+    (association, agent, plan)
+  }
+
+  private def createDecoder(plan: entities.StepPlan): JsonLDDecoder[entities.Association] = {
+
+    implicit val dl: DependencyLinks = (planId: plans.ResourceId) => Option.when(planId == plan.resourceId)(plan)
+
+    entities.Association.decoder
   }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/CommandParameterBaseSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/CommandParameterBaseSpec.scala
@@ -36,7 +36,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of ExplicitCommandParameter entity into the ExplicitCommandParameter object" in {
         forAll(explicitCommandParameterObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.parameters.head
 
           plan.asJsonLD.flatten
@@ -49,7 +49,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of ImplicitCommandParameter entity into the ExplicitCommandParameter object" in {
         forAll(implicitCommandParameterObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.parameters.head
 
           plan.asJsonLD.flatten
@@ -65,7 +65,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of LocationCommandInput entity into the LocationCommandInput object" in {
         forAll(locationCommandInputObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.inputs.head
 
           plan.asJsonLD.flatten
@@ -78,7 +78,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of MappedCommandInput entity into the MappedCommandInput object" in {
         forAll(mappedCommandInputObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.inputs.head
 
           plan.asJsonLD.flatten
@@ -91,7 +91,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of ImplicitCommandInput entity into the ImplicitCommandInput object" in {
         forAll(implicitCommandInputObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.inputs.head
 
           plan.asJsonLD.flatten
@@ -107,7 +107,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of LocationCommandOutput entity into the LocationCommandOutput object" in {
         forAll(locationCommandOutputObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.outputs.head
 
           plan.asJsonLD.flatten
@@ -120,7 +120,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of MappedCommandOutput entity into the MappedCommandOutput object" in {
         forAll(mappedCommandOutputObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.outputs.head
 
           plan.asJsonLD.flatten
@@ -133,7 +133,7 @@ class CommandParameterBaseSpec extends AnyWordSpec with should.Matchers with Sca
 
       "turn JsonLD of ImplicitCommandOutput entity into the ImplicitCommandOutput object" in {
         forAll(implicitCommandOutputObjects) { parameterFactory =>
-          val plan      = planEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
+          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
           val parameter = plan.outputs.head
 
           plan.asJsonLD.flatten

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
@@ -47,7 +47,7 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
 
     "turn JsonLD Output entity into the Entity object " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity = activityEntities(planEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
+        val activity = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
 
         val Right(decodedEntities) = JsonLD
           .arr(activity.asJsonLD, datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne.asJsonLD)
@@ -64,7 +64,7 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
 
     "turn JsonLD Output entity into the OutputEntity object for the given generation Id " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity = activityEntities(planEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
+        val activity = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
           .to[entities.Activity]
 
         val Right(decodedEntities) = JsonLD
@@ -82,7 +82,7 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
 
     "turn JsonLD Output entity with multiple Generations into the Entity object " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity = activityEntities(planEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
+        val activity = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
           .to[entities.Activity]
 
         val updateGenerations = activity.generations.map { generation =>

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/GenerationSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/GenerationSpec.scala
@@ -38,9 +38,9 @@ class GenerationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPro
 
     "turn JsonLD Generation entity into the Generation object " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity1 = activityEntities(planEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
+        val activity1 = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
           .to[entities.Activity]
-        val activity2 = activityEntities(planEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
+        val activity2 = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
           .to[entities.Activity]
 
         JsonLD

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/Generators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/Generators.scala
@@ -25,6 +25,7 @@ import io.renku.graph.model.commandParameters._
 import io.renku.graph.model.testentities.CommandParameterBase.CommandInput._
 import io.renku.graph.model.testentities.CommandParameterBase.CommandOutput._
 import io.renku.graph.model.testentities.CommandParameterBase._
+import io.renku.graph.model.testentities.StepPlan.CommandParameters.CommandParameterFactory
 import io.renku.graph.model.testentities._
 import org.scalacheck.Gen
 
@@ -128,4 +129,13 @@ private object Generators {
     IOStream.StdErr(IOStream.ResourceId((renkuUrl / nonEmptyStrings().generateOne).show))
   )
 
+  implicit lazy val commandParametersLists: Gen[List[CommandParameterFactory]] = for {
+    explicitParameters <- explicitCommandParameterObjects.toGeneratorOfList()
+    locationInputs     <- locationCommandInputObjects.toGeneratorOfList()
+    mappedInputs       <- mappedCommandInputObjects.toGeneratorOfList()
+    implicitInputs     <- implicitCommandInputObjects.toGeneratorOfList()
+    locationOutputs    <- locationCommandOutputObjects.toGeneratorOfList()
+    mappedOutputs      <- mappedCommandOutputObjects.toGeneratorOfList()
+    implicitOutputs    <- implicitCommandOutputObjects.toGeneratorOfList()
+  } yield explicitParameters ::: locationInputs ::: mappedInputs ::: implicitInputs ::: locationOutputs ::: mappedOutputs ::: implicitOutputs
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ParameterValueSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ParameterValueSpec.scala
@@ -40,7 +40,7 @@ class ParameterValueSpec extends AnyWordSpec with should.Matchers with ScalaChec
       forAll(nonEmptyStrings().toGeneratorOf(ParameterDefaultValue), parameterValueOverrides) {
         (defaultValue, valueOverride) =>
           val activity =
-            executionPlannersDecoupledFromProject(planEntities(CommandParameter.from(defaultValue))).generateOne
+            executionPlannersDecoupledFromProject(stepPlanEntities(CommandParameter.from(defaultValue))).generateOne
               .planParameterValues(defaultValue -> valueOverride)
               .buildProvenanceUnsafe()
               .to[entities.Activity]
@@ -60,7 +60,7 @@ class ParameterValueSpec extends AnyWordSpec with should.Matchers with ScalaChec
     "turn JsonLD InputParameterValue entity into the InputParameterValue object " in {
       forAll(entityLocations, entityChecksums) { (location, checksum) =>
         val activity = executionPlannersDecoupledFromProject(
-          planEntities(CommandInput.fromLocation(location))
+          stepPlanEntities(CommandInput.fromLocation(location))
         ).generateOne
           .planInputParameterValuesFromChecksum(location -> checksum)
           .buildProvenanceUnsafe()
@@ -81,7 +81,7 @@ class ParameterValueSpec extends AnyWordSpec with should.Matchers with ScalaChec
     "turn JsonLD OutputParameterValue entity into the OutputParameterValue object " in {
       forAll(entityLocations) { location =>
         val activity = executionPlannersDecoupledFromProject(
-          planEntities(CommandOutput.fromLocation(location))
+          stepPlanEntities(CommandOutput.fromLocation(location))
         ).generateOne
           .buildProvenanceUnsafe()
           .to[entities.Activity]
@@ -102,7 +102,7 @@ class ParameterValueSpec extends AnyWordSpec with should.Matchers with ScalaChec
       val defaultValue  = nonEmptyStrings().toGeneratorOf(ParameterDefaultValue).generateOne
       val valueOverride = parameterValueOverrides.generateOne
       val activity = executionPlannersDecoupledFromProject(
-        planEntities(CommandParameter.from(defaultValue))
+        stepPlanEntities(CommandParameter.from(defaultValue))
       ).generateOne
         .planParameterValues(defaultValue -> valueOverride)
         .buildProvenanceUnsafe()
@@ -124,7 +124,7 @@ class ParameterValueSpec extends AnyWordSpec with should.Matchers with ScalaChec
       val location = entityLocations.generateOne
       val checksum = entityChecksums.generateOne
       val activity = executionPlannersDecoupledFromProject(
-        planEntities(CommandInput.fromLocation(location))
+        stepPlanEntities(CommandInput.fromLocation(location))
       ).generateOne
         .planInputParameterValuesFromChecksum(location -> checksum)
         .buildProvenanceUnsafe()
@@ -145,7 +145,7 @@ class ParameterValueSpec extends AnyWordSpec with should.Matchers with ScalaChec
     "fail if there are OutputParameterValue for non-existing OutputParameters" in {
       val location = entityLocations.generateOne
       val activity = executionPlannersDecoupledFromProject(
-        planEntities(CommandOutput.fromLocation(location))
+        stepPlanEntities(CommandOutput.fromLocation(location))
       ).generateOne
         .buildProvenanceUnsafe()
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanLensSpec.scala
@@ -37,7 +37,7 @@ class PlanLensSpec extends AnyWordSpec with should.Matchers with EntitiesGenerat
   }
 
   private def createPlan =
-    planEntities()
+    stepPlanEntities()
       .apply(GraphModelGenerators.projectCreatedDates().generateOne)
       .generateOne
       .to[Plan]

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanLensSpec.scala
@@ -31,8 +31,13 @@ class PlanLensSpec extends AnyWordSpec with should.Matchers with EntitiesGenerat
       val p1 = createPlan
       val p2 = createPlan
 
-      PlanLens.planCreators.get(p1)              shouldBe p1.creators
-      PlanLens.planCreators.set(p2.creators)(p1) shouldBe p1.copy(creators = p2.creators)
+      PlanLens.planCreators.get(p1) shouldBe p1.creators
+      PlanLens.planCreators.set(p2.creators)(p1) shouldBe {
+        p1 match {
+          case p: StepPlan.NonModified => p.copy(creators = p2.creators)
+          case p: StepPlan.Modified    => p.copy(creators = p2.creators)
+        }
+      }
     }
   }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -119,7 +119,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
     implicit val graph: GraphClass = GraphClass.Default
 
     "produce JsonLD for a non-modified Plan with all the relevant properties" in {
-      val plan = plans.generateOne.replaceCreators(personEntities.generateSet(min = 1)).to[entities.StepPlan]
+      val plan = plans.generateOne.replaceCreators(personEntities.generateList(min = 1)).to[entities.StepPlan]
 
       plan.asJsonLD shouldBe JsonLD
         .entity(
@@ -128,7 +128,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
           schema / "name"                -> plan.name.asJsonLD,
           schema / "description"         -> plan.maybeDescription.asJsonLD,
           renku / "command"              -> plan.maybeCommand.asJsonLD,
-          schema / "creator"             -> plan.creators.toList.asJsonLD,
+          schema / "creator"             -> plan.creators.asJsonLD,
           schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
           schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
           schema / "keywords"            -> plan.keywords.asJsonLD,
@@ -142,7 +142,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
     "produce JsonLD for a modified Plan with all the relevant properties" in {
       val plan = plans.generateOne
         .invalidate()
-        .replaceCreators(personEntities.generateSet(min = 1))
+        .replaceCreators(personEntities.generateList(min = 1))
         .to(StepPlan.Modified.toEntitiesStepPlan)
 
       plan.asJsonLD shouldBe JsonLD
@@ -170,7 +170,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
     implicit val graph: GraphClass = GraphClass.Project
 
     "produce JsonLD for a non-modified Plan with all the relevant properties" in {
-      val plan = plans.generateOne.replaceCreators(personEntities.generateSet(min = 1)).to[entities.StepPlan]
+      val plan = plans.generateOne.replaceCreators(personEntities.generateList(min = 1)).to[entities.StepPlan]
 
       plan.asJsonLD shouldBe JsonLD
         .entity(
@@ -179,7 +179,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
           schema / "name"                -> plan.name.asJsonLD,
           schema / "description"         -> plan.maybeDescription.asJsonLD,
           renku / "command"              -> plan.maybeCommand.asJsonLD,
-          schema / "creator"             -> plan.creators.toList.map(_.resourceId.asEntityId).asJsonLD,
+          schema / "creator"             -> plan.creators.map(_.resourceId.asEntityId).asJsonLD,
           schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
           schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
           schema / "keywords"            -> plan.keywords.asJsonLD,
@@ -193,7 +193,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
     "produce JsonLD for a modified Plan with all the relevant properties" in {
       val plan = plans.generateOne
         .invalidate()
-        .replaceCreators(personEntities.generateSet(min = 1))
+        .replaceCreators(personEntities.generateList(min = 1))
         .to(StepPlan.Modified.toEntitiesStepPlan)
 
       plan.asJsonLD shouldBe JsonLD
@@ -221,10 +221,10 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
 
     "return all creators" in {
       val plan = plans.generateOne
-        .replaceCreators(personEntities.generateSet(min = 1))
+        .replaceCreators(personEntities.generateList(min = 1))
         .to[entities.StepPlan]
 
-      EntityFunctions[entities.Plan].findAllPersons shouldBe plan.creators
+      EntityFunctions[entities.Plan].findAllPersons(plan) shouldBe plan.creators.toSet
     }
   }
 
@@ -242,5 +242,5 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
   }
 
   private lazy val plans = stepPlanEntities(commandParametersLists.generateOne: _*)(planCommands)
-    .modify(_.replaceCreators(personEntities.generateSet(max = 2)))(projectCreatedDates().generateOne)
+    .modify(_.replaceCreators(personEntities.generateList(max = 2)))(projectCreatedDates().generateOne)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -51,7 +51,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
     }
 
     "turn JsonLD of a modified Plan entity into the StepPlan object" in {
-      forAll(plans.map(_.createModification(identity))) { plan =>
+      forAll(plans.map(_.createModification())) { plan =>
         plan.asJsonLD.flatten
           .fold(throw _, identity)
           .cursor

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -22,96 +22,225 @@ import cats.syntax.all._
 import io.circe.Json
 import io.circe.literal._
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.{nonEmptyStrings, timestamps, timestampsNotInTheFuture}
+import io.renku.generators.Generators.timestamps
+import io.renku.graph.model.GraphModelGenerators.{graphClasses, projectCreatedDates}
 import io.renku.graph.model._
-import io.renku.graph.model.commandParameters.Position
 import io.renku.graph.model.entities.Generators._
 import io.renku.graph.model.testentities._
+import io.renku.jsonld.JsonLD
+import io.renku.jsonld.JsonLDEncoder.encodeEntityId
 import io.renku.jsonld.parser._
 import io.renku.jsonld.syntax._
-import org.scalacheck.Gen
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
-  (GraphClass.Default :: GraphClass.Persons :: Nil).foreach { implicit graphClass =>
-    show"decode via graphClass=$graphClass" should {
-      "turn JsonLD Plan entity into the Plan object" in {
-        forAll(stepPlanObjects) { plan =>
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.Plan]] shouldBe List(plan.to[entities.Plan]).asRight
-        }
+  "decode (StepEntity)" should {
+    implicit val graph: GraphClass = GraphClass.Default
+
+    "turn JsonLD of a non-modified Plan entity into the StepPlan object" in {
+      forAll(plans) { plan =>
+        plan.asJsonLD.flatten
+          .fold(throw _, identity)
+          .cursor
+          .as[List[entities.StepPlan]] shouldBe List(plan.to[entities.StepPlan]).asRight
       }
+    }
 
-      "decode if invalidation after the creation date" in {
-
-        val plan = stepPlanObjects
-          .map(p =>
-            p.invalidate(
-              timestampsNotInTheFuture(butYoungerThan = p.dateCreated.value).generateAs(InvalidationTime)
-            ).fold(err => fail(err.intercalate("; ")), identity)
-          )
-          .generateOne
-          .to[entities.Plan]
-
-        plan.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.Plan]] shouldBe List(plan).asRight
+    "turn JsonLD of a modified Plan entity into the StepPlan object" in {
+      forAll(plans.map(_.createModification(identity))) { plan =>
+        plan.asJsonLD.flatten
+          .fold(throw _, identity)
+          .cursor
+          .as[List[entities.StepPlan]] shouldBe List(plan.to[entities.StepPlan]).asRight
       }
+    }
 
-      "fail if invalidation done before the creation date" in {
+    "decode if invalidation after the creation date" in {
 
-        val plan = stepPlanObjects.generateOne.to[entities.Plan]
+      val plan = plans
+        .map(_.invalidate())
+        .generateOne
+        .to[entities.StepPlan]
 
-        val invalidationTime = timestamps(max = plan.dateCreated.value.minusSeconds(1)).generateAs(InvalidationTime)
-        val jsonLD = parse {
-          plan.asJsonLD.toJson.deepMerge(
+      plan.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.StepPlan]] shouldBe List(plan).asRight
+    }
+
+    "fail if invalidatedAtTime present on non-modified Plan" in {
+
+      val plan = plans
+        .map(_.invalidate())
+        .generateOne
+        .to[entities.StepPlan]
+
+      val jsonLD = parse {
+        plan.asJsonLD.toJson.hcursor
+          .downField((prov / "wasDerivedFrom").show)
+          .delete
+          .top
+          .getOrElse(fail("Invalid Json after removing property"))
+      }.flatMap(_.flatten).fold(throw _, identity)
+
+      val Left(message) = jsonLD.cursor.as[List[entities.StepPlan]].leftMap(_.message)
+      message should include(show"Plan ${plan.resourceId} has no parent but invalidation time")
+    }
+
+    "fail if invalidation done before the creation date" in {
+
+      val plan = plans
+        .map(_.invalidate())
+        .generateOne
+        .to[entities.StepPlan]
+
+      val invalidationTime = timestamps(max = plan.dateCreated.value.minusSeconds(1)).generateAs(InvalidationTime)
+      val jsonLD = parse {
+        plan.asJsonLD.toJson.hcursor
+          .downField((prov / "invalidatedAtTime").show)
+          .delete
+          .top
+          .getOrElse(fail("Invalid Json after removing property"))
+          .deepMerge(
             Json.obj(
               (prov / "invalidatedAtTime").show -> json"""{"@value": ${invalidationTime.show}}"""
             )
           )
-        }.flatMap(_.flatten).fold(throw _, identity)
+      }.flatMap(_.flatten).fold(throw _, identity)
 
-        val Left(message) = jsonLD.cursor.as[List[entities.Plan]].leftMap(_.message)
-        message should include {
-          show"Invalidation time $invalidationTime on StepPlan with id: ${plan.resourceId} is older than dateCreated ${plan.dateCreated}"
-        }
+      val Left(message) = jsonLD.cursor.as[List[entities.StepPlan]].leftMap(_.message)
+      message should include {
+        show"Invalidation time $invalidationTime on StepPlan ${plan.resourceId} is older than dateCreated ${plan.dateCreated}"
       }
     }
   }
 
-  private implicit lazy val parameterFactoryLists: Gen[List[Position => Plan => CommandParameterBase]] = for {
-    explicitParameters <- explicitCommandParameterObjects.toGeneratorOfList()
-    locationInputs     <- locationCommandInputObjects.toGeneratorOfList()
-    mappedInputs       <- mappedCommandInputObjects.toGeneratorOfList()
-    locationOutputs    <- locationCommandOutputObjects.toGeneratorOfList()
-    mappedOutputs      <- mappedCommandOutputObjects.toGeneratorOfList()
-  } yield explicitParameters ::: locationInputs ::: mappedInputs ::: locationOutputs ::: mappedOutputs
+  "encode for the Default Graph (StepEntity)" should {
+    implicit val graph: GraphClass = GraphClass.Default
 
-  private lazy val stepPlanObjects: Gen[StepPlan] = for {
-    name                     <- planNames
-    maybeCommand             <- planCommands.toGeneratorOfOptions
-    maybeDescription         <- planDescriptions.toGeneratorOfOptions
-    dateCreated              <- timestampsNotInTheFuture.toGeneratorOf(plans.DateCreated)
-    maybeProgrammingLanguage <- planProgrammingLanguages.toGeneratorOfOptions
-    keywords                 <- nonEmptyStrings().map(plans.Keyword).toGeneratorOfList()
-    paramFactories           <- parameterFactoryLists
-    successCodes             <- planSuccessCodes.toGeneratorOfList()
-    creators                 <- personEntities.toGeneratorOfList()
-  } yield StepPlan(
-    planIdentifiers.generateOne,
-    name,
-    maybeDescription,
-    creators.toSet,
-    dateCreated,
-    keywords,
-    maybeCommand,
-    maybeProgrammingLanguage,
-    successCodes,
-    commandParameterFactories = paramFactories.zipWithIndex.map { case (factory, idx) =>
-      factory(Position(idx + 1))
+    "produce JsonLD for a non-modified Plan with all the relevant properties" in {
+      val plan = plans.generateOne.replaceCreators(personEntities.generateSet(min = 1)).to[entities.StepPlan]
+
+      plan.asJsonLD shouldBe JsonLD
+        .entity(
+          plan.resourceId.asEntityId,
+          entities.StepPlan.entityTypes,
+          schema / "name"                -> plan.name.asJsonLD,
+          schema / "description"         -> plan.maybeDescription.asJsonLD,
+          renku / "command"              -> plan.maybeCommand.asJsonLD,
+          schema / "creator"             -> plan.creators.toList.asJsonLD,
+          schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
+          schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
+          schema / "keywords"            -> plan.keywords.asJsonLD,
+          renku / "hasArguments"         -> plan.parameters.asJsonLD,
+          renku / "hasInputs"            -> plan.inputs.asJsonLD,
+          renku / "hasOutputs"           -> plan.outputs.asJsonLD,
+          renku / "successCodes"         -> plan.successCodes.asJsonLD
+        )
     }
-  )
+
+    "produce JsonLD for a modified Plan with all the relevant properties" in {
+      val plan = plans.generateOne
+        .invalidate()
+        .replaceCreators(personEntities.generateSet(min = 1))
+        .to(StepPlan.Modified.toEntitiesStepPlan)
+
+      plan.asJsonLD shouldBe JsonLD
+        .entity(
+          plan.resourceId.asEntityId,
+          entities.StepPlan.entityTypes,
+          schema / "name"                -> plan.name.asJsonLD,
+          schema / "description"         -> plan.maybeDescription.asJsonLD,
+          renku / "command"              -> plan.maybeCommand.asJsonLD,
+          schema / "creator"             -> plan.creators.toList.asJsonLD,
+          schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
+          schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
+          schema / "keywords"            -> plan.keywords.asJsonLD,
+          renku / "hasArguments"         -> plan.parameters.asJsonLD,
+          renku / "hasInputs"            -> plan.inputs.asJsonLD,
+          renku / "hasOutputs"           -> plan.outputs.asJsonLD,
+          renku / "successCodes"         -> plan.successCodes.asJsonLD,
+          prov / "wasDerivedFrom"        -> plan.derivedFrom.asJsonLD,
+          prov / "invalidatedAtTime"     -> plan.maybeInvalidationTime.asJsonLD
+        )
+    }
+  }
+
+  "encode for the Named Graphs (StepEntity)" should {
+    implicit val graph: GraphClass = GraphClass.Project
+
+    "produce JsonLD for a non-modified Plan with all the relevant properties" in {
+      val plan = plans.generateOne.replaceCreators(personEntities.generateSet(min = 1)).to[entities.StepPlan]
+
+      plan.asJsonLD shouldBe JsonLD
+        .entity(
+          plan.resourceId.asEntityId,
+          entities.StepPlan.entityTypes,
+          schema / "name"                -> plan.name.asJsonLD,
+          schema / "description"         -> plan.maybeDescription.asJsonLD,
+          renku / "command"              -> plan.maybeCommand.asJsonLD,
+          schema / "creator"             -> plan.creators.toList.map(_.resourceId.asEntityId).asJsonLD,
+          schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
+          schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
+          schema / "keywords"            -> plan.keywords.asJsonLD,
+          renku / "hasArguments"         -> plan.parameters.asJsonLD,
+          renku / "hasInputs"            -> plan.inputs.asJsonLD,
+          renku / "hasOutputs"           -> plan.outputs.asJsonLD,
+          renku / "successCodes"         -> plan.successCodes.asJsonLD
+        )
+    }
+
+    "produce JsonLD for a modified Plan with all the relevant properties" in {
+      val plan = plans.generateOne
+        .invalidate()
+        .replaceCreators(personEntities.generateSet(min = 1))
+        .to(StepPlan.Modified.toEntitiesStepPlan)
+
+      plan.asJsonLD shouldBe JsonLD
+        .entity(
+          plan.resourceId.asEntityId,
+          entities.StepPlan.entityTypes,
+          schema / "name"                -> plan.name.asJsonLD,
+          schema / "description"         -> plan.maybeDescription.asJsonLD,
+          renku / "command"              -> plan.maybeCommand.asJsonLD,
+          schema / "creator"             -> plan.creators.toList.map(_.resourceId.asEntityId).asJsonLD,
+          schema / "dateCreated"         -> plan.dateCreated.asJsonLD,
+          schema / "programmingLanguage" -> plan.maybeProgrammingLanguage.asJsonLD,
+          schema / "keywords"            -> plan.keywords.asJsonLD,
+          renku / "hasArguments"         -> plan.parameters.asJsonLD,
+          renku / "hasInputs"            -> plan.inputs.asJsonLD,
+          renku / "hasOutputs"           -> plan.outputs.asJsonLD,
+          renku / "successCodes"         -> plan.successCodes.asJsonLD,
+          prov / "wasDerivedFrom"        -> plan.derivedFrom.asJsonLD,
+          prov / "invalidatedAtTime"     -> plan.maybeInvalidationTime.asJsonLD
+        )
+    }
+  }
+
+  "entityFunctions.findAllPersons" should {
+
+    "return all creators" in {
+      val plan = plans.generateOne
+        .replaceCreators(personEntities.generateSet(min = 1))
+        .to[entities.StepPlan]
+
+      EntityFunctions[entities.Plan].findAllPersons shouldBe plan.creators
+    }
+  }
+
+  "entityFunctions.encoder" should {
+
+    "return encoder that honors the given GraphClass" in {
+
+      val plan = plans.generateOne.to[entities.Plan]
+
+      implicit val graph: GraphClass = graphClasses.generateOne
+      val functionsEncoder = EntityFunctions[entities.Plan].encoder(graph)
+
+      plan.asJsonLD(functionsEncoder) shouldBe plan.asJsonLD
+    }
+  }
+
+  private lazy val plans = stepPlanEntities(commandParametersLists.generateOne: _*)(planCommands)
+    .modify(_.replaceCreators(personEntities.generateSet(max = 2)))(projectCreatedDates().generateOne)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -24,6 +24,7 @@ import io.circe.literal._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
 import io.renku.graph.model.GraphModelGenerators.{graphClasses, projectCreatedDates}
+import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model._
 import io.renku.graph.model.entities.Generators._
 import io.renku.graph.model.testentities._
@@ -135,6 +136,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
           renku / "hasArguments"         -> plan.parameters.asJsonLD,
           renku / "hasInputs"            -> plan.inputs.asJsonLD,
           renku / "hasOutputs"           -> plan.outputs.asJsonLD,
+          renku / "topmostDerivedFrom"   -> plan.resourceId.asEntityId.asJsonLD,
           renku / "successCodes"         -> plan.successCodes.asJsonLD
         )
     }
@@ -160,7 +162,8 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
           renku / "hasInputs"            -> plan.inputs.asJsonLD,
           renku / "hasOutputs"           -> plan.outputs.asJsonLD,
           renku / "successCodes"         -> plan.successCodes.asJsonLD,
-          prov / "wasDerivedFrom"        -> plan.derivedFrom.asJsonLD,
+          prov / "wasDerivedFrom"        -> plan.derivation.derivedFrom.asJsonLD,
+          renku / "topmostDerivedFrom"   -> plan.derivation.originalResourceId.asEntityId.asJsonLD,
           prov / "invalidatedAtTime"     -> plan.maybeInvalidationTime.asJsonLD
         )
     }
@@ -186,6 +189,7 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
           renku / "hasArguments"         -> plan.parameters.asJsonLD,
           renku / "hasInputs"            -> plan.inputs.asJsonLD,
           renku / "hasOutputs"           -> plan.outputs.asJsonLD,
+          renku / "topmostDerivedFrom"   -> plan.resourceId.asEntityId.asJsonLD,
           renku / "successCodes"         -> plan.successCodes.asJsonLD
         )
     }
@@ -211,7 +215,8 @@ class PlanSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyC
           renku / "hasInputs"            -> plan.inputs.asJsonLD,
           renku / "hasOutputs"           -> plan.outputs.asJsonLD,
           renku / "successCodes"         -> plan.successCodes.asJsonLD,
-          prov / "wasDerivedFrom"        -> plan.derivedFrom.asJsonLD,
+          prov / "wasDerivedFrom"        -> plan.derivation.derivedFrom.asJsonLD,
+          renku / "topmostDerivedFrom"   -> plan.derivation.originalResourceId.asEntityId.asJsonLD,
           prov / "invalidatedAtTime"     -> plan.maybeInvalidationTime.asJsonLD
         )
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -333,7 +333,7 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
         projectInfo.keywords,
         projectInfo.maybeCreator.map(c => c.toCLIPayloadPerson(c.chooseSomeName)),
         projectInfo.dateCreated,
-        activities = activityEntities(planEntities())
+        activities = activityEntities(stepPlanEntities())
           .withDateBefore(projectInfo.dateCreated)
           .generateFixedSizeList(1)
           .map(_.to[entities.Activity]),
@@ -379,7 +379,7 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
     "return a DecodingFailure when there's an Activity entity created before project creation" in {
       val projectInfo = gitLabProjectInfos.map(_.copy(maybeParentPath = None)).generateOne
       val resourceId  = projects.ResourceId(projectInfo.path)
-      val activity    = activityEntities(planEntities()).withDateBefore(projectInfo.dateCreated).generateOne
+      val activity    = activityEntities(stepPlanEntities()).withDateBefore(projectInfo.dateCreated).generateOne
       val jsonLD = cliLikeJsonLD(
         resourceId,
         cliVersions.generateOne,
@@ -1026,11 +1026,11 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
   }
 
   private def activityWith(author: entities.Person): projects.DateCreated => entities.Activity = dateCreated =>
-    activityEntities(planEntities())(dateCreated).generateOne.to[entities.Activity].copy(author = author)
+    activityEntities(stepPlanEntities())(dateCreated).generateOne.to[entities.Activity].copy(author = author)
 
   private def activityWithAssociationAgent(agent: entities.Person): projects.DateCreated => entities.Activity =
     dateCreated => {
-      val activity = activityEntities(planEntities())(dateCreated).generateOne.to[entities.Activity]
+      val activity = activityEntities(stepPlanEntities())(dateCreated).generateOne.to[entities.Activity]
       activity.copy(association =
         entities.Association.WithPersonAgent(activity.association.resourceId, agent, activity.association.plan)
       )

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -353,17 +353,19 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
 
     "return a DecodingFailure if there's a modified Plan pointing to a non-existing parent" in new TestCase {
 
-      val info         = gitLabProjectInfos.map(projectInfoMaybeParent.set(None)).generateOne
-      val resourceId   = projects.ResourceId(info.path)
-      val activity     = activityEntities(stepPlanEntities())(info.dateCreated).generateOne
-      val plan         = activity.plan
-      val entitiesPlan = plan.to[entities.Plan]
-      val planModification = plan
-        .createModification()
-        .to[entities.StepPlan.Modified]
-        .copy(derivation =
-          entities.Plan.Derivation(plans.DerivedFrom(planResourceIds.generateOne.value), planResourceIds.generateOne)
-        )
+      val info       = gitLabProjectInfos.generateOne
+      val resourceId = projects.ResourceId(info.path)
+      val activity   = activityEntities(stepPlanEntities())(info.dateCreated).generateOne
+      val (plan, planModification) = {
+        val p = activity.plan
+        val modification = p
+          .createModification()
+          .to[entities.StepPlan.Modified]
+          .copy(derivation =
+            entities.Plan.Derivation(plans.DerivedFrom(planResourceIds.generateOne.value), planResourceIds.generateOne)
+          )
+        p.to[entities.Plan] -> modification
+      }
 
       val jsonLD = cliLikeJsonLD(
         resourceId,
@@ -374,13 +376,49 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
         maybeCreator = None,
         info.dateCreated,
         activities = activity.to[entities.Activity] :: Nil,
-        plans = entitiesPlan :: planModification :: Nil
+        plans = plan :: planModification :: Nil
       )
 
       val Left(error) = jsonLD.cursor.as(decodeList(entities.Project.decoder(info)))
 
       error            shouldBe a[DecodingFailure]
       error.getMessage() should include(s"Cannot find parent plan ${planModification.derivation.derivedFrom}")
+    }
+
+    "return a DecodingFailure if there's a modified Plan with the date from before the parent date" in new TestCase {
+
+      val info       = gitLabProjectInfos.generateOne
+      val resourceId = projects.ResourceId(info.path)
+      val activity   = activityEntities(stepPlanEntities())(info.dateCreated).generateOne
+      val (plan, planModification) = {
+        val p = activity.plan
+        val modification = p
+          .createModification()
+          .to[entities.StepPlan.Modified]
+          .copy(dateCreated =
+            timestamps(info.dateCreated.value, p.dateCreated.value.minusSeconds(1)).generateAs(plans.DateCreated)
+          )
+        p.to[entities.Plan] -> modification
+      }
+
+      val jsonLD = cliLikeJsonLD(
+        resourceId,
+        cliVersion,
+        schemaVersion,
+        info.maybeDescription,
+        info.keywords,
+        maybeCreator = None,
+        info.dateCreated,
+        activities = activity.to[entities.Activity] :: Nil,
+        plans = plan :: planModification :: Nil
+      )
+
+      val Left(error) = jsonLD.cursor.as(decodeList(entities.Project.decoder(info)))
+
+      error shouldBe a[DecodingFailure]
+      error.getMessage() should include(
+        show"Plan ${planModification.resourceId} is older than it's parent ${planModification.derivation.derivedFrom}"
+      )
     }
 
     "return a DecodingFailure when there's a Dataset entity that cannot be decoded" in new TestCase {

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/UsageSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/UsageSpec.scala
@@ -36,7 +36,7 @@ class UsageSpec extends AnyWordSpec with should.Matchers with ScalaCheckProperty
 
     "turn JsonLD Usage entity into the Usage object" in {
       forAll(entityLocations, entityChecksums) { (location, checksum) =>
-        val activity = executionPlanners(planEntities(CommandInput.fromLocation(location)),
+        val activity = executionPlanners(stepPlanEntities(CommandInput.fromLocation(location)),
                                          projectCreatedDates().generateOne
         ).generateOne
           .planInputParameterValuesFromChecksum(location -> checksum)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
@@ -58,6 +58,10 @@ final case class Activity(id:                  Id,
 
   def findGenerationChecksum(location: Location): Option[Checksum] =
     findGenerationEntity(location).map(_.checksum)
+
+  def replaceStartTime(startTime: StartTime) = copy(startTime = startTime)
+
+  def modify(f: Activity => Activity) = f(this)
 }
 
 object Activity {

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
@@ -39,7 +39,7 @@ final case class Activity(id:                  Id,
 ) {
 
   val association: Association          = associationFactory(this)
-  val plan:        Plan                 = association.plan
+  val plan:        StepPlan             = association.plan
   val usages:      List[Usage]          = usageFactories.map(_.apply(this))
   val parameters:  List[ParameterValue] = parameterFactories.map(_.apply(this))
   val generations: List[Generation]     = generationFactories.map(_.apply(this))

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
@@ -26,19 +26,19 @@ sealed trait Association {
   type AgentType
   val activity: Activity
   val agent:    AgentType
-  val plan:     Plan
+  val plan:     StepPlan
 }
 
 object Association {
 
-  final case class WithRenkuAgent(activity: Activity, agent: Agent, plan: Plan) extends Association {
+  final case class WithRenkuAgent(activity: Activity, agent: Agent, plan: StepPlan) extends Association {
     type AgentType = Agent
   }
-  final case class WithPersonAgent(activity: Activity, agent: Person, plan: Plan) extends Association {
+  final case class WithPersonAgent(activity: Activity, agent: Person, plan: StepPlan) extends Association {
     type AgentType = Person
   }
 
-  def factory(agent: Agent, plan: Plan): Activity => Association = Association.WithRenkuAgent(_, agent, plan)
+  def factory(agent: Agent, plan: StepPlan): Activity => Association = Association.WithRenkuAgent(_, agent, plan)
 
   import io.renku.jsonld.syntax._
 
@@ -46,12 +46,12 @@ object Association {
     case a @ Association.WithRenkuAgent(_, agent, plan) =>
       entities.Association.WithRenkuAgent(associations.ResourceId(a.asEntityId.show),
                                           agent.to[entities.Agent],
-                                          plan.to[entities.Plan]
+                                          plan.to[entities.StepPlan]
       )
     case a @ Association.WithPersonAgent(_, agent, plan) =>
       entities.Association.WithPersonAgent(associations.ResourceId(a.asEntityId.show),
                                            agent.to[entities.Person],
-                                           plan.to[entities.Plan]
+                                           plan.to[entities.StepPlan]
       )
   }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
@@ -46,12 +46,12 @@ object Association {
     case a @ Association.WithRenkuAgent(_, agent, plan) =>
       entities.Association.WithRenkuAgent(associations.ResourceId(a.asEntityId.show),
                                           agent.to[entities.Agent],
-                                          plan.to[entities.StepPlan]
+                                          plan.to[entities.StepPlan].resourceId
       )
     case a @ Association.WithPersonAgent(_, agent, plan) =>
       entities.Association.WithPersonAgent(associations.ResourceId(a.asEntityId.show),
                                            agent.to[entities.Person],
-                                           plan.to[entities.StepPlan]
+                                           plan.to[entities.StepPlan].resourceId
       )
   }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ExecutionPlanner.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ExecutionPlanner.scala
@@ -33,7 +33,7 @@ import io.renku.graph.model.testentities.Entity.{InputEntity, OutputEntity}
 import io.renku.graph.model.testentities.ExecutionPlanner.ActivityData
 import io.renku.graph.model.testentities.ParameterValue.{CommandParameterValue, LocationParameterValue}
 
-final case class ExecutionPlanner(plan:                     Plan,
+final case class ExecutionPlanner(plan:                     StepPlan,
                                   activityData:             ActivityData,
                                   parametersValueOverrides: List[(ParameterDefaultValue, ValueOverride)],
                                   inputsValueOverrides:     List[(InputDefaultValue, Entity)],
@@ -213,10 +213,10 @@ object ExecutionPlanner {
 
   private type ActivityData = (activities.StartTime, Person, CliVersion)
 
-  def of(plan: Plan, activityTime: activities.StartTime, author: Person, project: RenkuProject): ExecutionPlanner =
+  def of(plan: StepPlan, activityTime: activities.StartTime, author: Person, project: RenkuProject): ExecutionPlanner =
     of(plan, activityTime, author, project.agent, project.topAncestorDateCreated)
 
-  def of(plan:               Plan,
+  def of(plan:               StepPlan,
          activityTime:       activities.StartTime,
          author:             Person,
          cliVersion:         CliVersion,

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
@@ -31,7 +31,7 @@ import io.renku.graph.model.testentities.CommandParameterBase._
 import io.renku.graph.model.testentities.Entity.InputEntity
 import io.renku.graph.model.testentities.ParameterValue.CommandParameterValue
 import io.renku.graph.model.testentities.ParameterValue.LocationParameterValue.{CommandInputValue, CommandOutputValue}
-import io.renku.graph.model.testentities.Plan.CommandParameters
+import io.renku.graph.model.testentities.StepPlan.CommandParameters
 import io.renku.jsonld.syntax.JsonEncoderOps
 
 /** ====================== Exemplar data visualization ====================== zhbikes folder clean_data \ / run plan 1 \
@@ -210,9 +210,12 @@ object NodeDef {
     )
 
   private implicit lazy val activityShow: Show[Activity] = Show.show { activity =>
-    val commandComponent = activity.association.plan.maybeCommand match {
-      case Some(command) => s"$command "
-      case None          => ""
+    val commandComponent = activity.association.plan match {
+      case p: StepPlan =>
+        p.maybeCommand match {
+          case Some(command) => s"$command "
+          case None          => ""
+        }
     }
     activity.parameters
       .collect {

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
@@ -106,7 +106,7 @@ object LineageExemplarData {
     )
 
     val activity1Plan1 = ExecutionPlanner
-      .of(plan1, activityStartTimes(after = project.dateCreated).generateOne, personEntities.generateOne, project)
+      .of(plan1, activityStartTimes(after = plan1.dateCreated).generateOne, personEntities.generateOne, project)
       .planInputParameterValuesFromChecksum(
         cleanData     -> entityChecksums.generateOne,
         zhbikesFolder -> entityChecksums.generateOne
@@ -117,7 +117,7 @@ object LineageExemplarData {
     val plan2 = Plan.of(
       plans.Name("plan2"),
       Command("python").some,
-      planDatesCreated(after = project.dateCreated).generateOne,
+      planDatesCreated(after = activity1Plan1.startTime).generateOne,
       creators = Nil,
       CommandParameters.of(
         CommandInput.fromLocation(plotData),
@@ -128,7 +128,7 @@ object LineageExemplarData {
     )
 
     val activity2Plan2 = ExecutionPlanner
-      .of(plan2, activityStartTimes(after = activity1Plan1.startTime).generateOne, personEntities.generateOne, project)
+      .of(plan2, activityStartTimes(after = plan2.dateCreated).generateOne, personEntities.generateOne, project)
       .planInputParameterValuesFromChecksum(
         plotData -> entityChecksums.generateOne
       )

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
@@ -98,7 +98,7 @@ object LineageExemplarData {
       plans.Name("plan1"),
       Command("python").some,
       planDatesCreated(after = project.dateCreated).generateOne,
-      creators = Set.empty,
+      creators = Nil,
       CommandParameters.of(CommandInput.fromLocation(cleanData),
                            CommandInput.fromLocation(zhbikesFolder),
                            CommandOutput.fromLocation(bikesParquet)
@@ -118,7 +118,7 @@ object LineageExemplarData {
       plans.Name("plan2"),
       Command("python").some,
       planDatesCreated(after = project.dateCreated).generateOne,
-      creators = Set.empty,
+      creators = Nil,
       CommandParameters.of(
         CommandInput.fromLocation(plotData),
         CommandInput.fromLocation(bikesParquet),

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/LineageExemplarData.scala
@@ -98,6 +98,7 @@ object LineageExemplarData {
       plans.Name("plan1"),
       Command("python").some,
       planDatesCreated(after = project.dateCreated).generateOne,
+      creators = Set.empty,
       CommandParameters.of(CommandInput.fromLocation(cleanData),
                            CommandInput.fromLocation(zhbikesFolder),
                            CommandOutput.fromLocation(bikesParquet)
@@ -117,6 +118,7 @@ object LineageExemplarData {
       plans.Name("plan2"),
       Command("python").some,
       planDatesCreated(after = project.dateCreated).generateOne,
+      creators = Set.empty,
       CommandParameters.of(
         CommandInput.fromLocation(plotData),
         CommandInput.fromLocation(bikesParquet),

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
@@ -483,27 +483,6 @@ trait ModelOps extends Dataset.ProvenanceOps {
       )
   }
 
-  implicit class PlanOps(plan: Plan) {
-
-    def to[T](implicit convert: Plan => T): T = convert(plan)
-
-    def invalidate(time: InvalidationTime): Plan with HavingInvalidationTime =
-      new Plan(
-        plan.id,
-        plan.name,
-        plan.maybeDescription,
-        plan.maybeCommand,
-        plan.creators,
-        plan.dateCreated,
-        plan.maybeProgrammingLanguage,
-        plan.keywords,
-        plan.commandParameterFactories,
-        plan.successCodes
-      ) with HavingInvalidationTime {
-        override val invalidationTime: InvalidationTime = time
-      }
-  }
-
   implicit class CommandParameterBaseOps[P <: CommandParameterBase](parameter: P) {
     def to[T](implicit convert: P => T): T = convert(parameter)
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
@@ -42,7 +42,7 @@ trait PlanAlg { self: Plan =>
 
   def to[T](implicit convert: PlanType => T): T
 
-  def createModification(f: PlanType => PlanType): PlanGroupModified
+  def createModification(f: PlanType => PlanType = identity): PlanGroupModified
 
   def invalidate(): PlanGroupModified with HavingInvalidationTime = invalidate(
     timestampsNotInTheFuture(butYoungerThan = this.dateCreated.value).generateAs(InvalidationTime)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
@@ -30,7 +30,7 @@ trait Plan extends PlanAlg {
   val id:               Identifier
   val name:             Name
   val maybeDescription: Option[Description]
-  val creators:         Set[Person]
+  val creators:         List[Person]
   val dateCreated:      DateCreated
   val keywords:         List[Keyword]
   type PlanGroup <: Plan
@@ -59,7 +59,9 @@ trait PlanAlg { self: Plan =>
       show"Invalidation time $invalidationTime on StepPlan with id: $id is older than dateCreated"
     )
 
-  def replaceCreators(creators: Set[Person]): PlanType
+  def replaceCreators(creators: List[Person]): PlanType
+
+  def removeCreators(): PlanType = replaceCreators(Nil)
 
   def replacePlanName(to: plans.Name): PlanType
 
@@ -85,7 +87,7 @@ object Plan {
   def of(name:                      Name,
          maybeCommand:              Option[Command],
          dateCreated:               DateCreated,
-         creators:                  Set[Person],
+         creators:                  List[Person],
          commandParameterFactories: List[Position => StepPlan => CommandParameterBase]
   ): StepPlan.NonModified = StepPlan.of(name, maybeCommand, dateCreated, creators, commandParameterFactories)
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
@@ -21,173 +21,80 @@ package io.renku.graph.model.testentities
 import cats.data.{Validated, ValidatedNel}
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestampsNotInTheFuture
 import io.renku.graph.model._
 import io.renku.graph.model.commandParameters.Position
-import io.renku.graph.model.entityModel.Location
 import io.renku.graph.model.plans._
-import io.renku.graph.model.testentities.CommandParameterBase.{CommandInput, CommandOutput, CommandParameter}
 
-sealed trait Plan {
+trait Plan extends PlanAlg {
   val id:               Identifier
   val name:             Name
   val maybeDescription: Option[Description]
   val creators:         Set[Person]
   val dateCreated:      DateCreated
   val keywords:         List[Keyword]
+  type PlanGroup <: Plan
+  type PlanGroupModified <: PlanGroup with Plan.Modified
+  type PlanType <: PlanGroup
+}
+
+trait PlanAlg { self: Plan =>
+
+  def to[T](implicit convert: PlanType => T): T
+
+  def createModification(f: PlanType => PlanType): PlanGroupModified
+
+  def invalidate(): PlanGroupModified with HavingInvalidationTime = invalidate(
+    timestampsNotInTheFuture(butYoungerThan = this.dateCreated.value).generateAs(InvalidationTime)
+  ).fold(err => throw new Exception(s"Save invalidate failed: ${err.intercalate("; ")}"), identity)
+
+  def invalidate(time: InvalidationTime): ValidatedNel[String, PlanGroupModified with HavingInvalidationTime]
+
+  protected def validate(dateCreated:      plans.DateCreated,
+                         invalidationTime: InvalidationTime
+  ): ValidatedNel[String, InvalidationTime] =
+    Validated.condNel(
+      test = (invalidationTime.value compareTo dateCreated.value) >= 0,
+      invalidationTime,
+      show"Invalidation time $invalidationTime on StepPlan with id: $id is older than dateCreated"
+    )
+
+  def replaceCreators(creators: Set[Person]): PlanType
+
+  def replacePlanName(to: plans.Name): PlanType
+
+  def replaceCommand(to: Option[Command]): PlanType
+
+  def replacePlanKeywords(to: List[plans.Keyword]): PlanType
+
+  def replacePlanDesc(to: Option[plans.Description]): PlanType
+
+  def replacePlanDateCreated(to: plans.DateCreated): PlanType
 }
 
 object Plan {
 
+  trait Modified { self: Plan =>
+    type ParentType <: Plan
+    val parent: ParentType
+  }
+
   import io.renku.jsonld._
   import io.renku.jsonld.syntax._
 
   def of(name:                      Name,
          maybeCommand:              Option[Command],
          dateCreated:               DateCreated,
-         commandParameterFactories: List[Position => Plan => CommandParameterBase]
-  ): StepPlan = StepPlan.of(name, maybeCommand, dateCreated, commandParameterFactories)
+         creators:                  Set[Person],
+         commandParameterFactories: List[Position => StepPlan => CommandParameterBase]
+  ): StepPlan.NonModified = StepPlan.of(name, maybeCommand, dateCreated, creators, commandParameterFactories)
 
-  implicit class PlanOps[P <: Plan](plan: P) {
-
-    def to[T](implicit convert: P => T): T = convert(plan)
-
-    def invalidate(time: InvalidationTime): ValidatedNel[String, P with HavingInvalidationTime] = plan match {
-      case p: StepPlan => p.invalidate(time).asInstanceOf
-    }
-
-    def replaceCreators(creators: Set[Person]): P = plan match {
-      case p: StepPlan => p.copy(creators = creators).asInstanceOf
-    }
-
-    def replacePlanName(to: plans.Name): P = plan match {
-      case p: StepPlan => p.copy(name = to).asInstanceOf
-    }
-
-    def replacePlanKeywords(to: List[plans.Keyword]): P = plan match {
-      case p: StepPlan => p.copy(keywords = to).asInstanceOf
-    }
-
-    def replacePlanDesc(to: Option[plans.Description]): P = plan match {
-      case p: StepPlan => p.copy(maybeDescription = to).asInstanceOf
-    }
-
-    def replacePlanDateCreated(to: plans.DateCreated): P = plan match {
-      case p: StepPlan => p.copy(dateCreated = to).asInstanceOf
-    }
-  }
-
-  implicit def toEntitiesPlan[P <: Plan](implicit renkuUrl: RenkuUrl): P => entities.Plan = { case p: StepPlan =>
-    p.to[entities.Plan](StepPlan.toEntitiesStepPlan)
+  implicit def toEntitiesPlan[P <: Plan](implicit renkuUrl: RenkuUrl): P => entities.Plan = {
+    case p: StepPlan.NonModified => p.to[entities.Plan](StepPlan.NonModified.toEntitiesStepPlan)
+    case p: StepPlan.Modified    => p.to[entities.Plan](StepPlan.Modified.toEntitiesStepPlan)
   }
 
   implicit def encoder[P <: Plan](implicit renkuUrl: RenkuUrl, graphClass: GraphClass): JsonLDEncoder[P] =
-    JsonLDEncoder.instance(_.to[entities.Plan].asJsonLD)
-
-  implicit def entityIdEncoder[R <: Plan](implicit renkuUrl: RenkuUrl): EntityIdEncoder[R] =
-    EntityIdEncoder.instance(plan => ResourceId(plan.id).asEntityId)
-}
-
-case class StepPlan(id:                        Identifier,
-                    name:                      Name,
-                    maybeDescription:          Option[Description],
-                    creators:                  Set[Person],
-                    dateCreated:               DateCreated,
-                    keywords:                  List[Keyword],
-                    maybeCommand:              Option[Command],
-                    maybeProgrammingLanguage:  Option[ProgrammingLanguage],
-                    successCodes:              List[SuccessCode],
-                    commandParameterFactories: List[StepPlan => CommandParameterBase]
-) extends Plan
-    with StepPlanAlg {
-
-  private lazy val commandParameters: List[CommandParameterBase] = commandParameterFactories.map(_.apply(this))
-  lazy val parameters: List[CommandParameter] = commandParameters.collect { case param: CommandParameter => param }
-  lazy val inputs:     List[CommandInput]     = commandParameters.collect { case in: CommandInput => in }
-  lazy val outputs:    List[CommandOutput]    = commandParameters.collect { case out: CommandOutput => out }
-
-  def getInput(location: Location): Option[CommandInput] = inputs.find(_.defaultValue.value == location)
-}
-
-trait StepPlanAlg {
-  this: StepPlan =>
-
-  def invalidate(time: InvalidationTime): ValidatedNel[String, StepPlan with HavingInvalidationTime] =
-    Validated.condNel(
-      test = (time.value compareTo dateCreated.value) >= 0,
-      new StepPlan(
-        planIdentifiers.generateOne,
-        name,
-        maybeDescription,
-        creators,
-        dateCreated,
-        keywords,
-        maybeCommand,
-        maybeProgrammingLanguage,
-        successCodes,
-        commandParameterFactories
-      ) with HavingInvalidationTime {
-        override val invalidationTime: InvalidationTime = time
-      },
-      s"Invalidation time $time on StepPlan with id: $id is older than dateCreated"
-    )
-}
-
-object StepPlan {
-
-  import io.renku.generators.Generators.Implicits._
-  import io.renku.jsonld._
-  import io.renku.jsonld.syntax._
-
-  def of(name:                      Name,
-         maybeCommand:              Option[Command],
-         dateCreated:               DateCreated,
-         commandParameterFactories: List[Position => Plan => CommandParameterBase]
-  ): StepPlan = StepPlan(
-    planIdentifiers.generateOne,
-    name,
-    maybeDescription = None,
-    creators = Set.empty,
-    dateCreated,
-    keywords = Nil,
-    maybeCommand = maybeCommand,
-    maybeProgrammingLanguage = None,
-    commandParameterFactories = commandParameterFactories.zipWithIndex.map { case (factory, idx) =>
-      factory(Position(idx + 1))
-    },
-    successCodes = Nil
-  )
-
-  object CommandParameters {
-
-    type CommandParameterFactory = Position => Plan => CommandParameterBase
-
-    def of(parameters: CommandParameterFactory*): List[CommandParameterFactory] = parameters.toList
-  }
-
-  implicit def toEntitiesStepPlan(implicit renkuUrl: RenkuUrl): StepPlan => entities.Plan = plan => {
-    val maybeInvalidationTime = plan match {
-      case plan: StepPlan with HavingInvalidationTime => plan.invalidationTime.some
-      case _ => None
-    }
-
-    entities.Plan(
-      plans.ResourceId(plan.asEntityId.show),
-      plan.name,
-      plan.maybeDescription,
-      plan.maybeCommand,
-      plan.creators.map(_.to[entities.Person]),
-      plan.dateCreated,
-      plan.maybeProgrammingLanguage,
-      plan.keywords,
-      plan.parameters.map(_.to[entities.CommandParameterBase.CommandParameter]),
-      plan.inputs.map(_.to[entities.CommandParameterBase.CommandInput]),
-      plan.outputs.map(_.to[entities.CommandParameterBase.CommandOutput]),
-      plan.successCodes,
-      maybeInvalidationTime
-    )
-  }
-
-  implicit def encoder(implicit renkuUrl: RenkuUrl, graphClass: GraphClass): JsonLDEncoder[StepPlan] =
     JsonLDEncoder.instance(_.to[entities.Plan].asJsonLD)
 
   implicit def entityIdEncoder[R <: Plan](implicit renkuUrl: RenkuUrl): EntityIdEncoder[R] =

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
@@ -27,42 +27,43 @@ import io.renku.graph.model.projects._
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.DatasetGenFactory
 
 sealed trait RenkuProject extends Project with RenkuProject.RenkuProjectAlg with Product with Serializable {
-  val path:             Path
-  val name:             Name
-  val maybeDescription: Option[Description]
-  val agent:            CliVersion
-  val dateCreated:      DateCreated
-  val maybeCreator:     Option[Person]
-  val visibility:       Visibility
-  val forksCount:       ForksCount
-  val keywords:         Set[Keyword]
-  val members:          Set[Person]
-  val version:          SchemaVersion
-  val activities:       List[Activity]
-  val datasets:         List[Dataset[Dataset.Provenance]]
-  val otherPlans:       Set[Plan]
+  val path:              Path
+  val name:              Name
+  val maybeDescription:  Option[Description]
+  val agent:             CliVersion
+  val dateCreated:       DateCreated
+  val maybeCreator:      Option[Person]
+  val visibility:        Visibility
+  val forksCount:        ForksCount
+  val keywords:          Set[Keyword]
+  val members:           Set[Person]
+  val version:           SchemaVersion
+  val activities:        List[Activity]
+  val datasets:          List[Dataset[Dataset.Provenance]]
+  val unlinkedStepPlans: List[StepPlan]
 
   type ProjectType <: RenkuProject
 
-  lazy val plans: Set[Plan] = activities.map(_.association.plan).toSet ++ otherPlans
+  lazy val plans:     List[Plan]     = activities.map(_.association.plan) ::: unlinkedStepPlans
+  lazy val stepPlans: List[StepPlan] = plans.collect { case p: StepPlan => p }
 }
 
 object RenkuProject {
 
-  final case class WithoutParent(path:             Path,
-                                 name:             Name,
-                                 maybeDescription: Option[Description],
-                                 agent:            CliVersion,
-                                 dateCreated:      DateCreated,
-                                 maybeCreator:     Option[Person],
-                                 visibility:       Visibility,
-                                 forksCount:       ForksCount,
-                                 keywords:         Set[Keyword],
-                                 members:          Set[Person],
-                                 version:          SchemaVersion,
-                                 activities:       List[Activity],
-                                 datasets:         List[Dataset[Dataset.Provenance]],
-                                 otherPlans:       Set[Plan] = Set.empty
+  final case class WithoutParent(path:              Path,
+                                 name:              Name,
+                                 maybeDescription:  Option[Description],
+                                 agent:             CliVersion,
+                                 dateCreated:       DateCreated,
+                                 maybeCreator:      Option[Person],
+                                 visibility:        Visibility,
+                                 forksCount:        ForksCount,
+                                 keywords:          Set[Keyword],
+                                 members:           Set[Person],
+                                 version:           SchemaVersion,
+                                 activities:        List[Activity],
+                                 datasets:          List[Dataset[Dataset.Provenance]],
+                                 unlinkedStepPlans: List[StepPlan] = List.empty
   ) extends RenkuProject {
 
     validateDates(dateCreated, activities, datasets)
@@ -83,8 +84,8 @@ object RenkuProject {
       dataset -> copy(datasets = datasets ::: dataset :: Nil)
     }
 
-    override def addOtherPlan(plan: Plan): ProjectType =
-      copy(otherPlans = otherPlans + plan)
+    override def addUnlinkedStepPlan(plan: StepPlan): ProjectType =
+      copy(unlinkedStepPlans = plan :: unlinkedStepPlans)
 
     override def replaceDatasets(newDatasets: Dataset[Dataset.Provenance]*): RenkuProject.WithoutParent =
       copy(datasets = newDatasets.toList)
@@ -120,21 +121,21 @@ object RenkuProject {
       .void
   }
 
-  final case class WithParent(path:             Path,
-                              name:             Name,
-                              maybeDescription: Option[Description],
-                              agent:            CliVersion,
-                              dateCreated:      DateCreated,
-                              maybeCreator:     Option[Person],
-                              visibility:       Visibility,
-                              forksCount:       ForksCount,
-                              keywords:         Set[Keyword],
-                              members:          Set[Person],
-                              version:          SchemaVersion,
-                              activities:       List[Activity],
-                              datasets:         List[Dataset[Dataset.Provenance]],
-                              parent:           RenkuProject,
-                              otherPlans:       Set[Plan] = Set.empty
+  final case class WithParent(path:              Path,
+                              name:              Name,
+                              maybeDescription:  Option[Description],
+                              agent:             CliVersion,
+                              dateCreated:       DateCreated,
+                              maybeCreator:      Option[Person],
+                              visibility:        Visibility,
+                              forksCount:        ForksCount,
+                              keywords:          Set[Keyword],
+                              members:           Set[Person],
+                              version:           SchemaVersion,
+                              activities:        List[Activity],
+                              datasets:          List[Dataset[Dataset.Provenance]],
+                              parent:            RenkuProject,
+                              unlinkedStepPlans: List[StepPlan] = Nil
   ) extends RenkuProject
       with Parent {
     override type ProjectType = RenkuProject.WithParent
@@ -152,8 +153,7 @@ object RenkuProject {
       dataset -> copy(datasets = datasets ::: dataset :: Nil)
     }
 
-    override def addOtherPlan(plan: Plan): ProjectType =
-      copy(otherPlans = otherPlans + plan)
+    override def addUnlinkedStepPlan(plan: StepPlan): ProjectType = copy(unlinkedStepPlans = plan :: unlinkedStepPlans)
 
     override def replaceDatasets(newDatasets: Dataset[Dataset.Provenance]*): RenkuProject.WithParent =
       copy(datasets = newDatasets.toList)
@@ -179,7 +179,7 @@ object RenkuProject {
 
     def addDataset[P <: Dataset.Provenance](toAdd: DatasetGenFactory[P]): (Dataset[P], ProjectType)
 
-    def addOtherPlan(plan: Plan): ProjectType
+    def addUnlinkedStepPlan(plan: StepPlan): ProjectType
 
     def replaceDatasets(newDatasets: Dataset[Dataset.Provenance]*): ProjectType
 
@@ -187,8 +187,8 @@ object RenkuProject {
   }
 
   implicit def toEntitiesRenkuProject(implicit renkuUrl: RenkuUrl): RenkuProject => entities.RenkuProject = {
-    case p: RenkuProject.WithParent    => toEntitiesRenkuProjectWithParent(renkuUrl)(p)
     case p: RenkuProject.WithoutParent => toEntitiesRenkuProjectWithoutParent(renkuUrl)(p)
+    case p: RenkuProject.WithParent    => toEntitiesRenkuProjectWithParent(renkuUrl)(p)
   }
 
   implicit def toEntitiesRenkuProjectWithoutParent(implicit
@@ -209,7 +209,8 @@ object RenkuProject {
           project.members.map(_.to[entities.Person]),
           project.version,
           project.activities.map(_.to[entities.Activity]),
-          project.datasets.map(_.to[entities.Dataset[entities.Dataset.Provenance]])
+          project.datasets.map(_.to[entities.Dataset[entities.Dataset.Provenance]]),
+          project.plans.map(_.to[entities.Plan])
         )
         .fold(errors => throw new IllegalStateException(errors.intercalate("; ")), identity)
 
@@ -232,6 +233,7 @@ object RenkuProject {
           project.version,
           project.activities.map(_.to[entities.Activity]),
           project.datasets.map(_.to[entities.Dataset[entities.Dataset.Provenance]]),
+          project.plans.map(_.to[entities.Plan]),
           projects.ResourceId(project.parent.asEntityId)
         )
         .fold(errors => throw new IllegalStateException(errors.intercalate("; ")), identity)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model
+package testentities
+
+import CommandParameterBase.{CommandInput, CommandOutput, CommandParameter}
+import cats.data.{Validated, ValidatedNel}
+import cats.syntax.all._
+import commandParameters.Position
+import entityModel.Location
+import plans.{Command, DateCreated, DerivedFrom, Description, Identifier, Keyword, Name, ProgrammingLanguage, ResourceId, SuccessCode}
+
+trait StepPlan extends Plan {
+  val maybeCommand:              Option[Command]
+  val maybeProgrammingLanguage:  Option[ProgrammingLanguage]
+  val successCodes:              List[SuccessCode]
+  val commandParameterFactories: List[StepPlan => CommandParameterBase]
+
+  override type PlanGroup         = StepPlan
+  override type PlanGroupModified = StepPlan.Modified
+
+  private lazy val commandParameters: List[CommandParameterBase] = commandParameterFactories.map(_.apply(this))
+  lazy val parameters: List[CommandParameter] = commandParameters.collect { case param: CommandParameter => param }
+  lazy val inputs:     List[CommandInput]     = commandParameters.collect { case in: CommandInput => in }
+  lazy val outputs:    List[CommandOutput]    = commandParameters.collect { case out: CommandOutput => out }
+
+  def getInput(location: Location): Option[CommandInput] = inputs.find(_.defaultValue.value == location)
+}
+
+object StepPlan {
+
+  import io.renku.generators.Generators.Implicits._
+  import io.renku.jsonld._
+  import io.renku.jsonld.syntax._
+
+  case class NonModified(id:                        Identifier,
+                         name:                      Name,
+                         maybeDescription:          Option[Description],
+                         creators:                  Set[Person],
+                         dateCreated:               DateCreated,
+                         keywords:                  List[Keyword],
+                         maybeCommand:              Option[Command],
+                         maybeProgrammingLanguage:  Option[ProgrammingLanguage],
+                         successCodes:              List[SuccessCode],
+                         commandParameterFactories: List[StepPlan => CommandParameterBase]
+  ) extends StepPlan
+      with NonModifiedAlg {
+
+    override type PlanType = StepPlan.NonModified
+  }
+
+  object NonModified {
+    implicit def toEntitiesStepPlan(implicit renkuUrl: RenkuUrl): NonModified => entities.StepPlan.NonModified = plan =>
+      entities.StepPlan.NonModified(
+        plans.ResourceId(plan.asEntityId.show),
+        plan.name,
+        plan.maybeDescription,
+        plan.creators.map(_.to[entities.Person]),
+        plan.dateCreated,
+        plan.keywords,
+        plan.maybeCommand,
+        plan.maybeProgrammingLanguage,
+        plan.parameters.map(_.to[entities.CommandParameterBase.CommandParameter]),
+        plan.inputs.map(_.to[entities.CommandParameterBase.CommandInput]),
+        plan.outputs.map(_.to[entities.CommandParameterBase.CommandOutput]),
+        plan.successCodes
+      )
+  }
+
+  trait NonModifiedAlg extends PlanAlg {
+    self: StepPlan.NonModified =>
+
+    override def to[T](implicit convert: StepPlan.NonModified => T): T = convert(this)
+
+    def createModification(f: StepPlan.NonModified => StepPlan.NonModified): StepPlan.Modified = {
+      val modified = f(self)
+      new Modified(
+        planIdentifiers.generateOne,
+        modified.name,
+        modified.maybeDescription,
+        modified.creators,
+        modified.dateCreated,
+        modified.keywords,
+        modified.maybeCommand,
+        modified.maybeProgrammingLanguage,
+        modified.successCodes,
+        modified.commandParameterFactories,
+        parent = self
+      )
+    }
+
+    override def invalidate(
+        time: InvalidationTime
+    ): ValidatedNel[String, StepPlan.Modified with HavingInvalidationTime] =
+      validate(dateCreated, time).map(time =>
+        new Modified(
+          planIdentifiers.generateOne,
+          name,
+          maybeDescription,
+          creators,
+          dateCreated,
+          keywords,
+          maybeCommand,
+          maybeProgrammingLanguage,
+          successCodes,
+          commandParameterFactories,
+          parent = self
+        ) with HavingInvalidationTime {
+          override val invalidationTime: InvalidationTime = time
+        }
+      )
+
+    override def replaceCreators(creators: Set[Person]): StepPlan.NonModified = copy(creators = creators)
+
+    override def replacePlanName(to: plans.Name): StepPlan.NonModified = copy(name = to)
+
+    override def replaceCommand(to: Option[Command]): StepPlan.NonModified = copy(maybeCommand = to)
+
+    override def replacePlanKeywords(to: List[plans.Keyword]): StepPlan.NonModified = copy(keywords = to)
+
+    override def replacePlanDesc(to: Option[plans.Description]): StepPlan.NonModified = copy(maybeDescription = to)
+
+    override def replacePlanDateCreated(to: plans.DateCreated): StepPlan.NonModified = copy(dateCreated = to)
+  }
+
+  case class Modified(id:                        Identifier,
+                      name:                      Name,
+                      maybeDescription:          Option[Description],
+                      creators:                  Set[Person],
+                      dateCreated:               DateCreated,
+                      keywords:                  List[Keyword],
+                      maybeCommand:              Option[Command],
+                      maybeProgrammingLanguage:  Option[ProgrammingLanguage],
+                      successCodes:              List[SuccessCode],
+                      commandParameterFactories: List[StepPlan => CommandParameterBase],
+                      parent:                    StepPlan
+  ) extends StepPlan
+      with Plan.Modified
+      with ModifiedAlg {
+    override type ParentType = StepPlan
+    override type PlanType   = StepPlan.Modified
+  }
+
+  object Modified {
+    implicit def toEntitiesStepPlan[P <: Modified](implicit renkuUrl: RenkuUrl): P => entities.StepPlan.Modified =
+      plan => {
+        val maybeInvalidationTime = plan match {
+          case plan: StepPlan with HavingInvalidationTime => plan.invalidationTime.some
+          case _ => None
+        }
+
+        entities.StepPlan.Modified(
+          plans.ResourceId(plan.asEntityId.show),
+          plan.name,
+          plan.maybeDescription,
+          plan.creators.map(_.to[entities.Person]),
+          plan.dateCreated,
+          plan.keywords,
+          plan.maybeCommand,
+          plan.maybeProgrammingLanguage,
+          plan.parameters.map(_.to[entities.CommandParameterBase.CommandParameter]),
+          plan.inputs.map(_.to[entities.CommandParameterBase.CommandInput]),
+          plan.outputs.map(_.to[entities.CommandParameterBase.CommandOutput]),
+          plan.successCodes,
+          DerivedFrom(plan.parent.asEntityId),
+          maybeInvalidationTime
+        )
+      }
+  }
+
+  trait ModifiedAlg extends PlanAlg {
+    self: StepPlan.Modified =>
+
+    override def to[T](implicit convert: StepPlan.Modified => T): T = convert(this)
+
+    def createModification(f: StepPlan.Modified => StepPlan.Modified): StepPlan.Modified = {
+      val modified = f(self)
+      if (modified.isInstanceOf[HavingInvalidationTime])
+        throw new UnsupportedOperationException("Creating modification out of invalidated Plan not supported")
+      new Modified(
+        planIdentifiers.generateOne,
+        modified.name,
+        modified.maybeDescription,
+        modified.creators,
+        modified.dateCreated,
+        modified.keywords,
+        modified.maybeCommand,
+        modified.maybeProgrammingLanguage,
+        modified.successCodes,
+        modified.commandParameterFactories,
+        parent = self
+      )
+    }
+
+    override def invalidate(
+        time: InvalidationTime
+    ): ValidatedNel[String, StepPlan.Modified with HavingInvalidationTime] =
+      (validate(dateCreated, time), checkIfNotInvalidated)
+        .mapN { (time, _) =>
+          new Modified(
+            planIdentifiers.generateOne,
+            name,
+            maybeDescription,
+            creators,
+            dateCreated,
+            keywords,
+            maybeCommand,
+            maybeProgrammingLanguage,
+            successCodes,
+            commandParameterFactories,
+            this
+          ) with HavingInvalidationTime {
+            override val invalidationTime: InvalidationTime = time
+          }
+        }
+
+    private lazy val checkIfNotInvalidated: ValidatedNel[String, Unit] = this match {
+      case _: HavingInvalidationTime =>
+        Validated.invalidNel(show"Plan with id: $id is invalidated and cannot be invalidated again")
+      case _ => Validated.valid(())
+    }
+
+    override def replaceCreators(creators: Set[Person]): StepPlan.Modified = copy(creators = creators)
+
+    override def replacePlanName(to: plans.Name): StepPlan.Modified = copy(name = to)
+
+    override def replaceCommand(to: Option[Command]): StepPlan.Modified = copy(maybeCommand = to)
+
+    override def replacePlanKeywords(to: List[plans.Keyword]): StepPlan.Modified = copy(keywords = to)
+
+    override def replacePlanDesc(to: Option[plans.Description]): StepPlan.Modified = copy(maybeDescription = to)
+
+    override def replacePlanDateCreated(to: plans.DateCreated): StepPlan.Modified = copy(dateCreated = to)
+  }
+
+  def of(name:                      Name,
+         maybeCommand:              Option[Command],
+         dateCreated:               DateCreated,
+         creators:                  Set[Person],
+         commandParameterFactories: List[Position => StepPlan => CommandParameterBase]
+  ): StepPlan.NonModified = StepPlan.NonModified(
+    planIdentifiers.generateOne,
+    name,
+    maybeDescription = None,
+    creators,
+    dateCreated,
+    keywords = Nil,
+    maybeCommand = maybeCommand,
+    maybeProgrammingLanguage = None,
+    commandParameterFactories = commandParameterFactories.zipWithIndex.map { case (factory, idx) =>
+      factory(Position(idx + 1))
+    },
+    successCodes = Nil
+  )
+
+  implicit def toEntitiesStepPlan(implicit renkuUrl: RenkuUrl): StepPlan => entities.StepPlan = {
+    case p: StepPlan.NonModified => StepPlan.NonModified.toEntitiesStepPlan(renkuUrl)(p)
+    case p: StepPlan.Modified    => StepPlan.Modified.toEntitiesStepPlan(renkuUrl)(p)
+  }
+
+  object CommandParameters {
+
+    type CommandParameterFactory = Position => StepPlan => CommandParameterBase
+
+    def of(parameters: CommandParameterFactory*): List[CommandParameterFactory] = parameters.toList
+  }
+
+  implicit def encoder(implicit renkuUrl: RenkuUrl, graphClass: GraphClass): JsonLDEncoder[StepPlan] =
+    JsonLDEncoder.instance(_.to[entities.Plan].asJsonLD)
+
+  implicit def entityIdEncoder[R <: Plan](implicit renkuUrl: RenkuUrl): EntityIdEncoder[R] =
+    EntityIdEncoder.instance(plan => ResourceId(plan.id).asEntityId)
+}

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
@@ -155,6 +155,11 @@ object StepPlan {
       with ModifiedAlg {
     override type ParentType = StepPlan
     override type PlanType   = StepPlan.Modified
+
+    lazy val topmostParent: StepPlan = parent match {
+      case p: NonModified => p
+      case p: Modified    => p.topmostParent
+    }
   }
 
   object Modified {
@@ -178,7 +183,9 @@ object StepPlan {
           plan.inputs.map(_.to[entities.CommandParameterBase.CommandInput]),
           plan.outputs.map(_.to[entities.CommandParameterBase.CommandOutput]),
           plan.successCodes,
-          DerivedFrom(plan.parent.asEntityId),
+          entities.Plan.Derivation(DerivedFrom(plan.parent.asEntityId),
+                                   plans.ResourceId(plan.topmostParent.asEntityId.show)
+          ),
           maybeInvalidationTime
         )
       }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
@@ -196,7 +196,7 @@ object StepPlan {
 
     override def to[T](implicit convert: StepPlan.Modified => T): T = convert(this)
 
-    def createModification(f: StepPlan.Modified => StepPlan.Modified): StepPlan.Modified = {
+    def createModification(f: StepPlan.Modified => StepPlan.Modified = identity): StepPlan.Modified = {
       val modified = f(self)
       if (modified.isInstanceOf[HavingInvalidationTime])
         throw new UnsupportedOperationException("Creating modification out of invalidated Plan not supported")

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
@@ -52,7 +52,7 @@ object StepPlan {
   case class NonModified(id:                        Identifier,
                          name:                      Name,
                          maybeDescription:          Option[Description],
-                         creators:                  Set[Person],
+                         creators:                  List[Person],
                          dateCreated:               DateCreated,
                          keywords:                  List[Keyword],
                          maybeCommand:              Option[Command],
@@ -126,7 +126,7 @@ object StepPlan {
         }
       )
 
-    override def replaceCreators(creators: Set[Person]): StepPlan.NonModified = copy(creators = creators)
+    override def replaceCreators(creators: List[Person]): StepPlan.NonModified = copy(creators = creators)
 
     override def replacePlanName(to: plans.Name): StepPlan.NonModified = copy(name = to)
 
@@ -142,7 +142,7 @@ object StepPlan {
   case class Modified(id:                        Identifier,
                       name:                      Name,
                       maybeDescription:          Option[Description],
-                      creators:                  Set[Person],
+                      creators:                  List[Person],
                       dateCreated:               DateCreated,
                       keywords:                  List[Keyword],
                       maybeCommand:              Option[Command],
@@ -236,7 +236,7 @@ object StepPlan {
       case _ => Validated.valid(())
     }
 
-    override def replaceCreators(creators: Set[Person]): StepPlan.Modified = copy(creators = creators)
+    override def replaceCreators(creators: List[Person]): StepPlan.Modified = copy(creators = creators)
 
     override def replacePlanName(to: plans.Name): StepPlan.Modified = copy(name = to)
 
@@ -252,7 +252,7 @@ object StepPlan {
   def of(name:                      Name,
          maybeCommand:              Option[Command],
          dateCreated:               DateCreated,
-         creators:                  Set[Person],
+         creators:                  List[Person],
          commandParameterFactories: List[Position => StepPlan => CommandParameterBase]
   ): StepPlan.NonModified = StepPlan.NonModified(
     planIdentifiers.generateOne,

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ActivityGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ActivityGenerators.scala
@@ -51,6 +51,7 @@ trait ActivityGenerators {
   val entityChecksums:       Gen[Checksum]        = nonBlankStrings(40, 40).map(_.value).map(Checksum.apply)
 
   implicit val planIdentifiers: Gen[plans.Identifier] = noDashUuid.toGeneratorOf(plans.Identifier)
+  def planResourceIds(implicit renkuUrl: RenkuUrl): Gen[plans.ResourceId] = planIdentifiers.map(plans.ResourceId(_))
   implicit val planNames:    Gen[plans.Name]    = nonBlankStrings(minLength = 5).map(_.value).toGeneratorOf[plans.Name]
   implicit val planKeywords: Gen[plans.Keyword] = nonBlankStrings(minLength = 5) map (_.value) map plans.Keyword.apply
   implicit val planDescriptions: Gen[plans.Description] = sentences().map(_.value).toGeneratorOf[plans.Description]

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ActivityGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ActivityGenerators.scala
@@ -103,7 +103,8 @@ trait ActivityGenerators {
       name         <- planNames
       maybeCommand <- planCommandsGen.toGeneratorOfOptions
       dateCreated  <- planDatesCreated(after = projectDateCreated)
-    } yield Plan.of(name, maybeCommand, dateCreated, CommandParameters.of(parameterFactories: _*))
+      creators     <- personEntities.toGeneratorOfSet(min = 0, max = 2)
+    } yield Plan.of(name, maybeCommand, dateCreated, creators, CommandParameters.of(parameterFactories: _*))
 
   def executionPlanners(planGen: projects.DateCreated => Gen[StepPlan], project: RenkuProject): Gen[ExecutionPlanner] =
     executionPlanners(planGen, project.topAncestorDateCreated)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/EntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/EntitiesGenerators.scala
@@ -32,7 +32,7 @@ import java.time.Instant
 object EntitiesGenerators extends EntitiesGenerators {
   type DatasetGenFactory[+P <: Dataset.Provenance] = projects.DateCreated => Gen[Dataset[P]]
   type ActivityGenFactory                          = projects.DateCreated => Gen[Activity]
-  type PlanGenFactory                              = projects.DateCreated => Gen[Plan]
+  type StepPlanGenFactory                          = projects.DateCreated => Gen[StepPlan]
 }
 
 private object Instances {

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -55,7 +55,7 @@ trait RenkuProjectEntitiesGenerators {
   lazy val renkuProjectEntitiesWithDatasetsAndActivities: Gen[RenkuProject] =
     renkuProjectEntities(anyVisibility)
       .withActivities(
-        List.fill(nonNegativeInts(max = 5).generateOne.value)(activityEntities(planEntities())): _*
+        List.fill(nonNegativeInts(max = 5).generateOne.value)(activityEntities(stepPlanEntities())): _*
       )
       .withDatasets(
         List.fill(nonNegativeInts(max = 5).generateOne.value)(datasetEntities(provenanceNonModified)): _*

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctions.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctions.scala
@@ -38,8 +38,9 @@ private trait ProjectFunctions {
     project
       .updateMember(oldPerson, newPerson)
       .updateCreator(oldPerson, newPerson)
-      .updateActivities(_.updateAuthorsAndAgents(oldPerson, newPerson))
-      .updateDatasets(_.updateCreators(oldPerson, newPerson))
+      .updateActivities(updateAuthorsAndAgents(oldPerson, newPerson))
+      .updateDatasets(updateDatasetCreators(oldPerson, newPerson))
+      .updatePlans(updatePlanCreators(oldPerson, newPerson))
 
   def update(oldDataset: Dataset[Provenance], newDataset: Dataset[Provenance]): Project => Project = project =>
     if (oldDataset == newDataset) project
@@ -120,12 +121,12 @@ private object ProjectFunctions extends ProjectFunctions {
   private implicit class ProjectOps(project: Project) {
 
     def updateMember(oldPerson: Person, newPerson: Person): Project =
-      projectMembersLens.modify {
-        membersLens.modify {
+      projectMembersLens
+        .composeTraversal(membersLens)
+        .modify {
           case `oldPerson` => newPerson
           case p           => p
-        }
-      }(project)
+        }(project)
 
     def updateCreator(oldPerson: Person, newPerson: Person): Project =
       projectCreatorLens.modify {
@@ -138,45 +139,49 @@ private object ProjectFunctions extends ProjectFunctions {
 
     def updateDatasets(function: List[Dataset[Dataset.Provenance]] => List[Dataset[Dataset.Provenance]]): Project =
       projectDatasetsLens.modify(function)(project)
+
+    def updatePlans(function: List[Plan] => List[Plan]): Project =
+      projectPlans.modify(function)(project)
   }
 
-  private implicit class ActivitiesOps(activities: List[Activity]) {
+  private def updateAuthorsAndAgents(oldPerson: Person, newPerson: Person): List[Activity] => List[Activity] = {
 
-    def updateAuthorsAndAgents(oldPerson: Person, newPerson: Person): List[Activity] =
-      activitiesLens.modify {
-        updateAuthor(oldPerson, newPerson) >>> updateAssociationAgents(oldPerson, newPerson) >>> updatePlanCreators(
-          oldPerson,
-          newPerson
-        )
-      }(activities)
-
-    private def updateAuthor(oldPerson: Person, newPerson: Person) =
+    def updateAuthor(oldPerson: Person, newPerson: Person) =
       ActivityLens.activityAuthor.modify {
         case `oldPerson` => newPerson
         case other       => other
       }
 
-    private def updateAssociationAgents(oldPerson: Person, newPerson: Person): Activity => Activity =
+    def updateAssociationAgents(oldPerson: Person, newPerson: Person): Activity => Activity =
       ActivityLens.activityAssociationAgent.modify {
         case Right(`oldPerson`) => Right(newPerson)
         case other              => other
       }
 
-    private def updatePlanCreators(oldPerson: Person, newPerson: Person): Activity => Activity =
-      ActivityLens.activityPlanCreators.modify(_.map(p => if (p == oldPerson) newPerson else p))
+    activitiesLens.modify {
+      updateAuthor(oldPerson, newPerson) >>> updateAssociationAgents(oldPerson, newPerson)
+    }
   }
 
-  private implicit class DatasetsOps(datasets: List[Dataset[Provenance]]) {
+  private def updateDatasetCreators(oldPerson: Person,
+                                    newPerson: Person
+  ): List[Dataset[Provenance]] => List[Dataset[Provenance]] =
+    datasetsLens
+      .composeLens(provenanceLens >>> provCreatorsLens)
+      .composeTraversal(creatorsLens)
+      .modify {
+        case `oldPerson` => newPerson
+        case p           => p
+      }
 
-    def updateCreators(oldPerson: Person, newPerson: Person): List[Dataset[Provenance]] =
-      datasetsLens
-        .composeLens(provenanceLens >>> provCreatorsLens)
-        .composeTraversal(creatorsLens)
-        .modify {
-          case `oldPerson` => newPerson
-          case p           => p
-        }(datasets)
-  }
+  private def updatePlanCreators(oldPerson: Person, newPerson: Person): List[Plan] => List[Plan] =
+    plansLens
+      .composeLens(PlanLens.planCreators)
+      .composeTraversal(Traversal.fromTraverse[List, Person])
+      .modify {
+        case `oldPerson` => newPerson
+        case p           => p
+      }
 
   private object Lenses {
     val membersLens = Traversal.fromTraverse[List, Person]
@@ -217,5 +222,12 @@ private object ProjectFunctions extends ProjectFunctions {
         case p: Provenance.Modified                         => p.copy(creators = crts.sortBy(_.name))
       }
     }
+
+    val projectPlans: Lens[Project, List[Plan]] = Lens[Project, List[Plan]](_.plans)(plans => {
+      case p: RenkuProject.WithoutParent => p.copy(plans = plans)
+      case p: RenkuProject.WithParent    => p.copy(plans = plans)
+      case p: NonRenkuProject            => p
+    })
+    val plansLens: Traversal[List[Plan], Plan] = Traversal.fromTraverse[List, Plan]
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctionsSpec.scala
@@ -24,7 +24,7 @@ import io.renku.graph.model._
 import GraphModelGenerators.datasetTopmostDerivedFroms
 import cats.data.NonEmptyList
 import io.renku.graph.model.datasets.TopmostDerivedFrom
-import io.renku.graph.model.entities.ActivityLens
+import io.renku.graph.model.entities.{ActivityLens, PlanLens}
 import io.renku.graph.model.testentities._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -124,9 +124,8 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
       val newPerson         = personEntities().generateOne.to[entities.Person]
 
       val updated = update(entitiesOldPerson, newPerson)(project)
-      updated.activities shouldBe project.activities.map {
-        ActivityLens.activityPlanCreators.set(Set(newPerson))
-      }
+
+      updated.plans shouldBe project.plans.map(PlanLens.planCreators.set(List(newPerson)))
     }
 
     "replace the old person with the new on all datasets" in {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctionsSpec.scala
@@ -25,7 +25,7 @@ import GraphModelGenerators.datasetTopmostDerivedFroms
 import cats.data.NonEmptyList
 import io.renku.graph.model.datasets.TopmostDerivedFrom
 import io.renku.graph.model.entities.ActivityLens
-import io.renku.graph.model.testentities.{::~, activityEntities, anyRenkuProjectEntities, anyVisibility, creatorsLens, datasetAndModificationEntities, datasetEntities, personEntities, planEntities, provenanceInternal, provenanceLens, provenanceNonModified, renkuProjectEntities, renkuProjectWithParentEntities, _}
+import io.renku.graph.model.testentities._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -74,8 +74,8 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
 
       val project = anyRenkuProjectEntities
         .withActivities(
-          activityEntities(planEntities()).modify(_.copy(author = oldPerson)),
-          activityEntities(planEntities())
+          activityEntities(stepPlanEntities()).modify(_.copy(author = oldPerson)),
+          activityEntities(stepPlanEntities())
         )
         .generateOne
         .to[entities.Project]
@@ -93,8 +93,8 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
 
       val project = anyRenkuProjectEntities
         .withActivities(
-          activityEntities(planEntities()).modify(toAssociationPersonAgent(oldPerson)),
-          activityEntities(planEntities())
+          activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent(oldPerson)),
+          activityEntities(stepPlanEntities())
         )
         .generateOne
         .to[entities.Project]
@@ -110,10 +110,10 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
     "replace the old person with the new person in all plan creators" in {
       val project = anyRenkuProjectEntities
         .withActivities(
-          activityEntities(planEntities())
+          activityEntities(stepPlanEntities())
             .modify(setPlanCreator(oldPerson))
             .modify(toAssociationRenkuAgent(agentEntities.generateOne)),
-          activityEntities(planEntities())
+          activityEntities(stepPlanEntities())
             .modify(setPlanCreator(oldPerson))
             .modify(toAssociationRenkuAgent(agentEntities.generateOne))
         )

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/ActivityTransformerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/ActivityTransformerSpec.scala
@@ -42,7 +42,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "create update queries for changed/deleted activities' authors " +
       "and associations' agents" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent).multiple: _*)
+          .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent).multiple: _*)
           .generateOne
           .to[entities.RenkuProject]
 
@@ -59,7 +59,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "return the ProcessingRecoverableFailure if calls to KG fails with a network or HTTP error " +
       "- failure in the author unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 
@@ -79,7 +79,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "return the ProcessingRecoverableFailure if calls to KG fails with a network or HTTP error " +
       "- failure in the agent unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 
@@ -101,7 +101,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "fail with NonRecoverableFailure if calls to KG fails with an unknown exception " +
       "- failure in the author unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 
@@ -117,7 +117,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "fail with NonRecoverableFailure if calls to KG fails with an unknown exception " +
       "- failure in the agent unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/KGInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/KGInfoFinderSpec.scala
@@ -38,7 +38,7 @@ class KGInfoFinderSpec extends AnyWordSpec with IOSpec with should.Matchers with
 
     "return activity author's resourceIds" in new TestCase {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
         .to[entities.RenkuProject]
 
@@ -65,7 +65,7 @@ class KGInfoFinderSpec extends AnyWordSpec with IOSpec with should.Matchers with
 
     "return activity association person agent resourceIds" in new TestCase {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .generateOne
         .to[entities.RenkuProject]
 
@@ -95,7 +95,7 @@ class KGInfoFinderSpec extends AnyWordSpec with IOSpec with should.Matchers with
 
     "return no agent if there's association with SoftwareAgent agent" in new TestCase {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
         .to[entities.RenkuProject]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/defaultgraph/activities/UpdatesCreatorSpec.scala
@@ -46,7 +46,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if new activity has different author that it's set in the TS" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -69,7 +69,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if there's more than one author for the activity in the TS" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -94,7 +94,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no author in KG" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -105,7 +105,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no change in Activity author" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -119,7 +119,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if the new Association's person agent is different from what's set in the TS" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -143,7 +143,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if there's more than one person agent for the Association set in the TS" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -167,7 +167,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries for association with SoftwareAgent" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -179,7 +179,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no Person agent in KG" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -190,7 +190,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no change in association's person agent" in {
       val kgProject = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/ActivityTransformerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/ActivityTransformerSpec.scala
@@ -44,7 +44,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "create update queries for changed/deleted activities' authors " +
       "and associations' agents" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent).multiple: _*)
+          .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent).multiple: _*)
           .generateOne
           .to[entities.RenkuProject]
 
@@ -61,7 +61,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "return the ProcessingRecoverableFailure if calls to KG fails with a network or HTTP error " +
       "- failure in the author unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 
@@ -82,7 +82,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "return the ProcessingRecoverableFailure if calls to KG fails with a network or HTTP error " +
       "- failure in the agent unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 
@@ -105,7 +105,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "fail with NonRecoverableFailure if calls to KG fails with an unknown exception " +
       "- failure in the author unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 
@@ -122,7 +122,7 @@ class ActivityTransformerSpec extends AnyWordSpec with should.Matchers with Mock
     "fail with NonRecoverableFailure if calls to KG fails with an unknown exception " +
       "- failure in the agent unlinking flow" in new TestCase {
         val project = anyRenkuProjectEntities
-          .withActivities(activityEntities(planEntities()))
+          .withActivities(activityEntities(stepPlanEntities()))
           .generateOne
           .to[entities.RenkuProject]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/KGInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/KGInfoFinderSpec.scala
@@ -47,7 +47,7 @@ class KGInfoFinderSpec
 
     "return activity author's resourceIds" in new TestCase {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
         .to[entities.RenkuProject]
 
@@ -86,7 +86,7 @@ class KGInfoFinderSpec
 
     "return activity association person agent resourceIds" in new TestCase {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .generateOne
         .to[entities.RenkuProject]
 
@@ -117,7 +117,7 @@ class KGInfoFinderSpec
 
     "return no agent if there's association with SoftwareAgent agent" in new TestCase {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
         .to[entities.RenkuProject]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/activities/UpdatesCreatorSpec.scala
@@ -48,7 +48,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if new activity has different author that it's set in the TS" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -70,7 +70,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if there's more than one author for the activity in the TS" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -111,7 +111,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no author in KG" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -122,7 +122,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no change in Activity author" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -136,7 +136,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if the new Association's person agent is different from what's set in the TS" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -165,7 +165,7 @@ class UpdatesCreatorSpec
 
     "prepare delete query if there's more than one person agent for the Association set in the TS" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -204,7 +204,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries for association with SoftwareAgent" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()))
+        .withActivities(activityEntities(stepPlanEntities()))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -219,7 +219,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no Person agent in KG" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 
@@ -230,7 +230,7 @@ class UpdatesCreatorSpec
 
     "prepare no queries if there's no change in association's person agent" in {
       val project = anyRenkuProjectEntities
-        .withActivities(activityEntities(planEntities()).modify(toAssociationPersonAgent))
+        .withActivities(activityEntities(stepPlanEntities()).modify(toAssociationPersonAgent))
         .map(_.to[entities.RenkuProject])
         .generateOne
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilderSpec.scala
@@ -228,7 +228,11 @@ class EntityBuilderSpec extends AnyWordSpec with MockFactory with should.Matcher
               .to[entities.RenkuProject.WithoutParent]
               .copy(activities =
                 activityEntities
-                  .withDateBefore(project.dateCreated)
+                  .modify(
+                    _.replaceStartTime(
+                      timestamps(max = project.dateCreated.value.minusSeconds(1)).generateAs(activities.StartTime)
+                    )
+                  )(project.dateCreated)
                   .generateFixedSizeList(1)
                   .map(_.to[entities.Activity])
               )

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilderSpec.scala
@@ -291,7 +291,7 @@ class EntityBuilderSpec extends AnyWordSpec with MockFactory with should.Matcher
     val input      = entityLocations.generateOne
     val output     = entityLocations.generateOne
     executionPlanners(
-      planEntities(
+      stepPlanEntities(
         CommandParameter.from(paramValue),
         CommandInput.fromLocation(input),
         CommandOutput.fromLocation(output)


### PR DESCRIPTION
This PR:
* introduces `StepPlan` entity as a specification of `Plan`
* introduces `derivedFrom` on `Plan`
* adds validation of the `Plan`'s invalidation time
* fixes modelling of the `Plan` invalidation logic in the tests
* fixes Cross-Entity search to work with invalidated Plans.