### PR TITLE
feat: DB migration adding expiry and created dates

### DIFF
--- a/token-repository/src/main/scala/io/renku/tokenrepository/Microservice.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/Microservice.scala
@@ -49,8 +49,8 @@ object Microservice extends IOMicroservice {
       certificateLoader                  <- CertificateLoader[IO]
       sentryInitializer                  <- SentryInitializer[IO]
       queriesExecTimes                   <- QueriesExecutionTimes[IO]
-      dbInitializer                      <- DbInitializer(sessionResource, queriesExecTimes)
-      microserviceRoutes                 <- MicroserviceRoutes[IO](sessionResource, queriesExecTimes).map(_.routes)
+      dbInitializer                      <- DbInitializer(queriesExecTimes)
+      microserviceRoutes                 <- MicroserviceRoutes[IO](queriesExecTimes).map(_.routes)
       exitCode <- microserviceRoutes.use { routes =>
                     new MicroserviceRunner(
                       certificateLoader,

--- a/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
@@ -21,11 +21,10 @@ package io.renku.tokenrepository
 import cats.MonadThrow
 import cats.effect.{Async, Clock, Resource}
 import cats.syntax.all._
-import io.renku.db.SessionResource
 import io.renku.graph.http.server.binders.{ProjectId, ProjectPath}
 import io.renku.http.server.version
 import io.renku.metrics.{LabeledHistogram, MetricsRegistry, RoutesMetrics}
-import io.renku.tokenrepository.repository.ProjectsTokensDB
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import io.renku.tokenrepository.repository.association.AssociateTokenEndpoint
 import io.renku.tokenrepository.repository.deletion.DeleteTokenEndpoint
 import io.renku.tokenrepository.repository.fetching.FetchTokenEndpoint
@@ -59,13 +58,12 @@ private class MicroserviceRoutes[F[_]: MonadThrow](
 }
 
 private object MicroserviceRoutes {
-  def apply[F[_]: Async: Logger: MetricsRegistry](
-      sessionResource:  SessionResource[F, ProjectsTokensDB],
+  def apply[F[_]: Async: Logger: MetricsRegistry: SessionResource](
       queriesExecTimes: LabeledHistogram[F]
   ): F[MicroserviceRoutes[F]] = for {
-    fetchTokenEndpoint     <- FetchTokenEndpoint(sessionResource, queriesExecTimes)
-    associateTokenEndpoint <- AssociateTokenEndpoint(sessionResource, queriesExecTimes)
-    deleteTokenEndpoint    <- DeleteTokenEndpoint(sessionResource, queriesExecTimes)
+    fetchTokenEndpoint     <- FetchTokenEndpoint(queriesExecTimes)
+    associateTokenEndpoint <- AssociateTokenEndpoint(queriesExecTimes)
+    deleteTokenEndpoint    <- DeleteTokenEndpoint(queriesExecTimes)
     versionRoutes          <- version.Routes[F]
   } yield new MicroserviceRoutes(fetchTokenEndpoint,
                                  associateTokenEndpoint,

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/ProjectsTokensDbConfigProvider.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/ProjectsTokensDbConfigProvider.scala
@@ -24,6 +24,15 @@ import io.renku.db.DBConfigProvider
 
 sealed trait ProjectsTokensDB
 
+object ProjectsTokensDB {
+
+  type SessionResource[F[_]] = io.renku.db.SessionResource[F, ProjectsTokensDB]
+
+  object SessionResource {
+    def apply[F[_]](implicit sr: SessionResource[F]): SessionResource[F] = sr
+  }
+}
+
 class ProjectsTokensDbConfigProvider[F[_]: MonadThrow](
 ) extends DBConfigProvider[F, ProjectsTokensDB](
       namespace = "projects-tokens",

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociateTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociateTokenEndpoint.scala
@@ -22,13 +22,12 @@ import cats.MonadThrow
 import cats.effect.Async
 import cats.effect.kernel.Concurrent
 import cats.syntax.all._
-import io.renku.db.SessionResource
 import io.renku.graph.model.projects.Id
 import io.renku.http.ErrorMessage
 import io.renku.http.ErrorMessage._
 import io.renku.http.client.AccessToken
 import io.renku.metrics.LabeledHistogram
-import io.renku.tokenrepository.repository.ProjectsTokensDB
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{EntityDecoder, Request, Response}
@@ -74,10 +73,7 @@ class AssociateTokenEndpointImpl[F[_]: Concurrent: Logger](
 
 object AssociateTokenEndpoint {
 
-  def apply[F[_]: Async: Logger](
-      sessionResource:  SessionResource[F, ProjectsTokensDB],
+  def apply[F[_]: Async: Logger: SessionResource](
       queriesExecTimes: LabeledHistogram[F]
-  ): F[AssociateTokenEndpoint[F]] =
-    TokenAssociator(sessionResource, queriesExecTimes)
-      .map(new AssociateTokenEndpointImpl[F](_))
+  ): F[AssociateTokenEndpoint[F]] = TokenAssociator(queriesExecTimes).map(new AssociateTokenEndpointImpl[F](_))
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -21,12 +21,11 @@ package io.renku.tokenrepository.repository.deletion
 import cats.MonadThrow
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
-import io.renku.db.SessionResource
 import io.renku.graph.model.projects.Id
 import io.renku.http.ErrorMessage
 import io.renku.http.ErrorMessage._
 import io.renku.metrics.LabeledHistogram
-import io.renku.tokenrepository.repository.ProjectsTokensDB
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
 import org.typelevel.log4cats.Logger
@@ -56,10 +55,9 @@ class DeleteTokenEndpointImpl[F[_]: MonadThrow: Logger](
 }
 
 object DeleteTokenEndpoint {
-  def apply[F[_]: MonadCancelThrow: Logger](
-      sessionResource:  SessionResource[F, ProjectsTokensDB],
+  def apply[F[_]: MonadCancelThrow: Logger: SessionResource](
       queriesExecTimes: LabeledHistogram[F]
   ): F[DeleteTokenEndpoint[F]] = MonadThrow[F].catchNonFatal {
-    new DeleteTokenEndpointImpl[F](new TokenRemoverImpl[F](sessionResource, queriesExecTimes))
+    new DeleteTokenEndpointImpl[F](new TokenRemoverImpl[F](queriesExecTimes))
   }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
@@ -23,13 +23,12 @@ import cats.data.OptionT
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import io.circe.syntax._
-import io.renku.db.SessionResource
 import io.renku.graph.model.projects
 import io.renku.http.ErrorMessage._
 import io.renku.http.client.AccessToken
 import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.metrics.LabeledHistogram
-import io.renku.tokenrepository.repository.ProjectsTokensDB
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.http4s.Response
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
@@ -77,10 +76,7 @@ class FetchTokenEndpointImpl[F[_]: MonadThrow: Logger](tokenFinder: TokenFinder[
 }
 
 object FetchTokenEndpoint {
-  def apply[F[_]: MonadCancelThrow: Logger](
-      sessionResource:  SessionResource[F, ProjectsTokensDB],
+  def apply[F[_]: MonadCancelThrow: Logger: SessionResource](
       queriesExecTimes: LabeledHistogram[F]
-  ): F[FetchTokenEndpoint[F]] = for {
-    tokenFinder <- TokenFinder(sessionResource, queriesExecTimes)
-  } yield new FetchTokenEndpointImpl[F](tokenFinder)
+  ): F[FetchTokenEndpoint[F]] = TokenFinder(queriesExecTimes).map(new FetchTokenEndpointImpl[F](_))
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
@@ -56,10 +56,13 @@ class DbInitializerImpl[F[_]: Async: Logger](migrators: List[Runnable[F, Unit]],
 object DbInitializer {
 
   def apply[F[_]: Async: Logger: SessionResource](queriesExecTimes: LabeledHistogram[F]): F[DbInitializer[F]] = for {
-    tableCreator             <- ProjectsTokensTableCreator[F].pure[F]
-    pathAdder                <- ProjectPathAdder[F](queriesExecTimes)
-    duplicateProjectsRemover <- DuplicateProjectsRemover[F].pure[F]
-  } yield new DbInitializerImpl[F](List[Runnable[F, Unit]](tableCreator, pathAdder, duplicateProjectsRemover))
+    tableCreator               <- ProjectsTokensTableCreator[F].pure[F]
+    pathAdder                  <- ProjectPathAdder[F](queriesExecTimes)
+    duplicateProjectsRemover   <- DuplicateProjectsRemover[F].pure[F]
+    expireAndCreatedDatesAdder <- ExpireAndCreatedDatesAdder[F].pure[F]
+  } yield new DbInitializerImpl[F](
+    List[Runnable[F, Unit]](tableCreator, pathAdder, duplicateProjectsRemover, expireAndCreatedDatesAdder)
+  )
 
   private[init] type Runnable[F[_], R] = { def run(): F[R] }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdder.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+package init
+
+import ProjectsTokensDB.SessionResource
+import cats.data.Kleisli
+import cats.effect.Spawn
+import cats.syntax.all._
+import org.typelevel.log4cats.Logger
+
+private trait ExpireAndCreatedDatesAdder[F[_]] {
+  def run(): F[Unit]
+}
+
+private object ExpireAndCreatedDatesAdder {
+  def apply[F[_]: Spawn: Logger: SessionResource]: ExpireAndCreatedDatesAdder[F] =
+    new ExpireAndCreatedDatesAdderImpl[F]
+}
+
+private class ExpireAndCreatedDatesAdderImpl[F[_]: Spawn: Logger: SessionResource]
+    extends ExpireAndCreatedDatesAdder[F] {
+
+  import MigrationTools._
+  import skunk._
+  import skunk.implicits._
+
+  override def run(): F[Unit] = SessionResource[F].useK {
+    addIfNotExists(column = "expiry_date") >> addIfNotExists(column = "created_at")
+  }
+
+  private def addIfNotExists(column: String) =
+    checkColumnExists("projects_tokens", column) >>= {
+      case true  => Kleisli.liftF(Logger[F].info(s"'$column' column existed"))
+      case false => addColumn(column)
+    }
+
+  private def addColumn(column: String): Kleisli[F, Session[F], Unit] = Kleisli { implicit session =>
+    for {
+      _ <- execute(sql"ALTER TABLE projects_tokens ADD COLUMN IF NOT EXISTS #$column TIMESTAMPTZ".command)
+      _ <- execute(sql"CREATE INDEX IF NOT EXISTS idx_#$column ON projects_tokens(#$column)".command)
+      _ <- Logger[F].info(s"'$column' column added")
+    } yield ()
+  }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.init
+
+import cats.MonadThrow
+import cats.data.Kleisli
+import cats.effect.MonadCancelThrow
+import cats.syntax.all._
+import skunk.codec.all._
+import skunk.implicits._
+import skunk._
+
+private object MigrationTools {
+
+  def execute[F[_]: MonadThrow](sql: Command[skunk.Void])(implicit session: Session[F]): F[Unit] =
+    session.execute(sql).void
+
+  def checkColumnExists[F[_]: MonadCancelThrow](table: String, column: String): Kleisli[F, Session[F], Boolean] =
+    Kleisli { session =>
+      val query: Query[String ~ String, Boolean] =
+        sql"""SELECT EXISTS (
+            SELECT *
+            FROM information_schema.columns
+            WHERE table_name = $varchar AND column_name = $varchar
+          )""".query(bool)
+      session
+        .prepare(query)
+        .use(_.unique(table ~ column))
+        .recover { case _ => false }
+    }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
@@ -21,14 +21,14 @@ package io.renku.tokenrepository.repository.init
 import cats.data.Kleisli
 import cats.effect._
 import cats.syntax.all._
-import io.renku.db.SessionResource
 import io.renku.graph.model.projects
 import io.renku.graph.model.projects.{Id, Path}
 import io.renku.metrics.LabeledHistogram
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import io.renku.tokenrepository.repository.association.ProjectPathFinder
 import io.renku.tokenrepository.repository.deletion.{TokenRemover, TokenRemoverImpl}
-import io.renku.tokenrepository.repository.{AccessTokenCrypto, ProjectsTokensDB, TokenRepositoryTypeSerializers}
+import io.renku.tokenrepository.repository.{AccessTokenCrypto, TokenRepositoryTypeSerializers}
 import org.typelevel.log4cats.Logger
 import skunk._
 import skunk.implicits._
@@ -39,8 +39,7 @@ private trait ProjectPathAdder[F[_]] {
   def run(): F[Unit]
 }
 
-private class ProjectPathAdderImpl[F[_]: Spawn: Logger](
-    sessionResource:   SessionResource[F, ProjectsTokensDB],
+private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource](
     accessTokenCrypto: AccessTokenCrypto[F],
     pathFinder:        ProjectPathFinder[F],
     tokenRemover:      TokenRemover[F]
@@ -50,7 +49,7 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger](
   import accessTokenCrypto._
   import pathFinder._
 
-  def run(): F[Unit] = sessionResource.useK {
+  def run(): F[Unit] = SessionResource[F].useK {
     checkColumnExists >>= {
       case true  => Kleisli.liftF(Logger[F].info("'project_path' column exists"))
       case false => addColumn()
@@ -72,7 +71,7 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger](
     } recoverWith logging
   }
 
-  private def addMissingPaths(): F[Unit] = sessionResource.useK {
+  private def addMissingPaths(): F[Unit] = SessionResource[F].useK {
     Kleisli { implicit session =>
       for {
         _ <- addPathIfMissing().run(session)
@@ -132,12 +131,9 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger](
 
 private object ProjectPathAdder {
 
-  def apply[F[_]: Async: Logger](
-      sessionResource:  SessionResource[F, ProjectsTokensDB],
-      queriesExecTimes: LabeledHistogram[F]
-  ): F[ProjectPathAdder[F]] = for {
+  def apply[F[_]: Async: Logger: SessionResource](queriesExecTimes: LabeledHistogram[F]): F[ProjectPathAdder[F]] = for {
     accessTokenCrypto <- AccessTokenCrypto[F]()
     pathFinder        <- ProjectPathFinder[F]
-    tokenRemover = new TokenRemoverImpl[F](sessionResource, queriesExecTimes)
-  } yield new ProjectPathAdderImpl[F](sessionResource, accessTokenCrypto, pathFinder, tokenRemover)
+    tokenRemover = new TokenRemoverImpl[F](queriesExecTimes)
+  } yield new ProjectPathAdderImpl[F](accessTokenCrypto, pathFinder, tokenRemover)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
@@ -46,6 +46,7 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource](
 ) extends ProjectPathAdder[F]
     with TokenRepositoryTypeSerializers {
 
+  import MigrationTools._
   import accessTokenCrypto._
   import pathFinder._
 
@@ -119,9 +120,6 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource](
       sql"update projects_tokens set project_path = $projectPathEncoder where project_id = $projectIdEncoder".command
     Kleisli(_.prepare(query).use(_.execute(path ~ id)).void)
   }
-
-  private def execute(sql: Command[Void])(implicit session: Session[F]): F[Unit] =
-    session.execute(sql).void
 
   private lazy val logging: PartialFunction[Throwable, F[Unit]] = { case NonFatal(exception) =>
     Logger[F].error(exception)("'project_path' column adding failure")

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreator.scala
@@ -21,8 +21,7 @@ package io.renku.tokenrepository.repository.init
 import cats.data.Kleisli
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
-import io.renku.db.SessionResource
-import io.renku.tokenrepository.repository.ProjectsTokensDB
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.typelevel.log4cats.Logger
 import skunk.codec.all.bool
 
@@ -31,18 +30,16 @@ private trait ProjectsTokensTableCreator[F[_]] {
 }
 
 private object ProjectsTokensTableCreator {
-  def apply[F[_]: MonadCancelThrow: Logger](
-      sessionResource: SessionResource[F, ProjectsTokensDB]
-  ): ProjectsTokensTableCreator[F] = new ProjectsTokensTableCreatorImpl(sessionResource)
+  def apply[F[_]: MonadCancelThrow: Logger: SessionResource]: ProjectsTokensTableCreator[F] =
+    new ProjectsTokensTableCreatorImpl[F]
 }
 
-private class ProjectsTokensTableCreatorImpl[F[_]: MonadCancelThrow: Logger](
-    sessionResource: SessionResource[F, ProjectsTokensDB]
-) extends ProjectsTokensTableCreator[F] {
+private class ProjectsTokensTableCreatorImpl[F[_]: MonadCancelThrow: Logger: SessionResource]
+    extends ProjectsTokensTableCreator[F] {
   import skunk._
   import skunk.implicits._
 
-  def run(): F[Unit] = sessionResource.useK {
+  def run(): F[Unit] = SessionResource[F].useK {
     checkTableExists >>= {
       case false => createTable.flatMapF(_ => Logger[F].info("'projects_tokens' table created"))
       case true  => Kleisli.liftF(Logger[F].info("'projects_tokens' table existed"))

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
@@ -65,6 +65,21 @@ trait InMemoryProjectsTokensDb extends ForAllTestContainer {
     }
   }
 
+  protected def verifyColumnExists(table: String, column: String): Boolean = execute[Boolean] {
+    Kleisli { session =>
+      val query: Query[String ~ String, Boolean] =
+        sql"""SELECT EXISTS (
+                SELECT *
+                FROM information_schema.columns
+                WHERE table_name = $varchar AND column_name = $varchar
+              )""".query(bool)
+      session
+        .prepare(query)
+        .use(_.unique(table ~ column))
+        .recover { case _ => false }
+    }
+  }
+
   protected def verifyTrue(sql: Command[Void]): Unit = execute {
     Kleisli[IO, Session[IO], Unit] { session =>
       session.execute(sql).void

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
@@ -105,6 +105,6 @@ class AssociationPersisterSpec extends AnyWordSpec with IOSpec with InMemoryProj
     val projectPath = projectPaths.generateOne
 
     private val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
-    val associator               = new AssociationPersisterImpl[IO](sessionResource, queriesExecTimes)
+    val associator               = new AssociationPersisterImpl[IO](queriesExecTimes)
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
@@ -53,6 +53,6 @@ class TokenRemoverSpec extends AnyWordSpec with IOSpec with InMemoryProjectsToke
     val projectPath = projectPaths.generateOne
 
     private val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
-    val remover                  = new TokenRemoverImpl(sessionResource, queriesExecTimes)
+    val remover                  = new TokenRemoverImpl(queriesExecTimes)
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinderSpec.scala
@@ -60,6 +60,6 @@ class PersistedTokensFinderSpec extends AnyWordSpec with IOSpec with InMemoryPro
     val projectPath = projectPaths.generateOne
 
     private val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
-    val finder                   = new PersistedTokensFinderImpl(sessionResource, queriesExecTimes)
+    val finder                   = new PersistedTokensFinderImpl(queriesExecTimes)
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
@@ -34,9 +34,9 @@ trait DbMigrations {
     TestLabeledHistogram[SqlStatement.Name]("query_id")
   protected implicit lazy val logger: TestLogger[IO] = TestLogger[IO]()
 
-  protected lazy val projectsTokensTableCreator: Migration = ProjectsTokensTableCreator(sessionResource)
-  protected lazy val projectPathAdded: Migration = ProjectPathAdder(sessionResource, queriesExecTimes).unsafeRunSync()
-  protected lazy val duplicateProjectsRemover: Migration = DuplicateProjectsRemover(sessionResource)
+  protected lazy val projectsTokensTableCreator: Migration = ProjectsTokensTableCreator[IO]
+  protected lazy val projectPathAdded:           Migration = ProjectPathAdder(queriesExecTimes).unsafeRunSync()
+  protected lazy val duplicateProjectsRemover:   Migration = DuplicateProjectsRemover[IO]
 
   protected lazy val allMigrations: List[Migration] =
     List(projectsTokensTableCreator, projectPathAdded, duplicateProjectsRemover)

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
@@ -37,7 +37,8 @@ trait DbMigrations {
   protected lazy val projectsTokensTableCreator: Migration = ProjectsTokensTableCreator[IO]
   protected lazy val projectPathAdded:           Migration = ProjectPathAdder(queriesExecTimes).unsafeRunSync()
   protected lazy val duplicateProjectsRemover:   Migration = DuplicateProjectsRemover[IO]
+  protected lazy val expireAndCreatedDatesAdder: Migration = ExpireAndCreatedDatesAdder[IO]
 
   protected lazy val allMigrations: List[Migration] =
-    List(projectsTokensTableCreator, projectPathAdded, duplicateProjectsRemover)
+    List(projectsTokensTableCreator, projectPathAdded, duplicateProjectsRemover, expireAndCreatedDatesAdder)
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
@@ -73,7 +73,7 @@ class DuplicateProjectsRemoverSpec extends AnyWordSpec with IOSpec with DbInitSp
 
   private trait TestCase {
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
-    val deduplicator = new DuplicateProjectsRemoverImpl[IO](sessionResource)
+    val deduplicator = new DuplicateProjectsRemoverImpl[IO]
   }
 
   protected def insert(projectId: Id, projectPath: Path, encryptedToken: EncryptedAccessToken): Unit =

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
@@ -41,8 +41,10 @@ class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInit
 
       datesAdder.run().unsafeRunSync() shouldBe ()
 
-      verifyColumnExists("projects_tokens", "expiry_date") shouldBe true
-      verifyColumnExists("projects_tokens", "created_at")  shouldBe true
+      verifyColumnExists("projects_tokens", "expiry_date")    shouldBe true
+      verifyColumnExists("projects_tokens", "created_at")     shouldBe true
+      verifyIndexExists("projects_tokens", "idx_expiry_date") shouldBe true
+      verifyIndexExists("projects_tokens", "idx_created_at")  shouldBe true
 
       logger.loggedOnly(Info("'expiry_date' column added"), Info("'created_at' column added"))
       logger.reset()

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.init
+
+import cats.effect.IO
+import io.renku.interpreters.TestLogger.Level.Info
+import io.renku.testtools.IOSpec
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
+
+  protected override lazy val migrationsToRun: List[Migration] = allMigrations.takeWhile {
+    case _: ExpireAndCreatedDatesAdder[_] => false
+    case _ => true
+  }
+
+  "run" should {
+
+    "create 'expiry_date' and 'created_at' columns; do nothing if they already exist" in new TestCase {
+      logger.reset()
+
+      verifyColumnExists("projects_tokens", "expiry_date") shouldBe false
+      verifyColumnExists("projects_tokens", "created_at")  shouldBe false
+
+      datesAdder.run().unsafeRunSync() shouldBe ()
+
+      verifyColumnExists("projects_tokens", "expiry_date") shouldBe true
+      verifyColumnExists("projects_tokens", "created_at")  shouldBe true
+
+      logger.loggedOnly(Info("'expiry_date' column added"), Info("'created_at' column added"))
+      logger.reset()
+
+      datesAdder.run().unsafeRunSync() shouldBe ()
+
+      logger.loggedOnly(Info("'expiry_date' column existed"), Info("'created_at' column existed"))
+    }
+  }
+
+  private trait TestCase {
+    val datesAdder = new ExpireAndCreatedDatesAdderImpl[IO]
+  }
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
@@ -61,17 +61,17 @@ class ProjectPathAdderSpec
 
     "do nothing if the 'project_path' column already exists" in new TestCase {
       addProjectPath()
-      checkColumnExists shouldBe true
+      verifyColumnExists("projects_tokens", "project_path") shouldBe true
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ((): Unit)
+      projectPathAdder.run().unsafeRunSync() shouldBe ()
 
-      checkColumnExists shouldBe true
+      verifyColumnExists("projects_tokens", "project_path") shouldBe true
 
       logger.loggedOnly(Info("'project_path' column exists"))
     }
 
     "add the 'project_path' column if does not exist and add paths fetched from GitLab" in new TestCase {
-      checkColumnExists shouldBe false
+      verifyColumnExists("projects_tokens", "project_path") shouldBe false
 
       val project1Id             = projectIds.generateOne
       val project1Path           = projectPaths.generateOne
@@ -103,7 +103,7 @@ class ProjectPathAdderSpec
     }
 
     "add the 'project_path' column if does not exist and remove entries for non-existing projects in GitLab" in new TestCase {
-      checkColumnExists shouldBe false
+      verifyColumnExists("projects_tokens", "project_path") shouldBe false
 
       val project1Id             = projectIds.generateOne
       val project1TokenEncrypted = encryptedAccessTokens.generateOne
@@ -169,19 +169,6 @@ class ProjectPathAdderSpec
       session.execute(query).void
     }
   }
-
-  private def checkColumnExists: Boolean = sessionResource
-    .useK {
-      val query: Query[Void, Path] = sql"select project_path from projects_tokens limit 1"
-        .query(varchar)
-        .gmap[Path]
-      Kleisli {
-        _.option(query)
-          .map(_ => true)
-          .recover { case _ => false }
-      }
-    }
-    .unsafeRunSync()
 
   def insert(projectId: Id, encryptedToken: EncryptedAccessToken): Unit = execute {
     Kleisli[IO, Session[IO], Unit] { session =>

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
@@ -140,8 +140,8 @@ class ProjectPathAdderSpec
     val accessTokenCrypto = mock[AccessTokenCrypto[IO]]
     val pathFinder        = mock[ProjectPathFinder[IO]]
     val queriesExecTimes  = TestLabeledHistogram[SqlStatement.Name]("query_id")
-    val tokenRemover      = new TokenRemoverImpl[IO](sessionResource, queriesExecTimes)
-    val projectPathAdder  = new ProjectPathAdderImpl[IO](sessionResource, accessTokenCrypto, pathFinder, tokenRemover)
+    val tokenRemover      = new TokenRemoverImpl[IO](queriesExecTimes)
+    val projectPathAdder  = new ProjectPathAdderImpl[IO](accessTokenCrypto, pathFinder, tokenRemover)
 
     def assumePathExistsInGitLab(projectId:        Id,
                                  maybeProjectPath: Option[Path],

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
@@ -31,13 +31,13 @@ class ProjectsTokensTableCreatorSpec extends AnyWordSpec with IOSpec with DbInit
   "run" should {
 
     "create the projects_tokens table if id does not exist" in new TestCase {
-      tableExists() shouldBe false
+      tableExists("projects_tokens") shouldBe false
 
       tableCreator.run().unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'projects_tokens' table created"))
 
-      tableExists() shouldBe true
+      tableExists("projects_tokens") shouldBe true
 
       tableCreator.run().unsafeRunSync() shouldBe ()
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
@@ -46,6 +46,6 @@ class ProjectsTokensTableCreatorSpec extends AnyWordSpec with IOSpec with DbInit
   }
 
   private trait TestCase {
-    val tableCreator = new ProjectsTokensTableCreatorImpl[IO](sessionResource)
+    val tableCreator = new ProjectsTokensTableCreatorImpl[IO]
   }
 }


### PR DESCRIPTION
This PR adds two new nullable, timestampz columns to the `projects_tokens` table: `expiry_date` and `created_at`