### PR TITLE
feat: include plan-type info into cross entity search

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -168,7 +168,7 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
       plans.DateCreated(Instant.parse("2012-11-15T10:00:00.000Z")),
       List(plans.Keyword("key")),
       plans.Description("description").some,
-      Workflow.WorkflowType.Basic
+      Workflow.WorkflowType.Step
     ).asJson,
     Person(
       MatchingScore(1),

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -167,7 +167,8 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
       projects.Visibility.Public,
       plans.DateCreated(Instant.parse("2012-11-15T10:00:00.000Z")),
       List(plans.Keyword("key")),
-      plans.Description("description").some
+      plans.Description("description").some,
+      Workflow.WorkflowType.Basic
     ).asJson,
     Person(
       MatchingScore(1),

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/WorkflowsQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/WorkflowsQuery.scala
@@ -170,7 +170,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
       case _ if str.contains(CompositePlan.Ontology.typeDef.clazz.id.show) =>
         Right(WorkflowType.Composite)
       case _ if str.contains(StepPlan.ontology.clazz.id.show) =>
-        Right(WorkflowType.Basic)
+        Right(WorkflowType.Step)
       case _ =>
         Left(s"Unknown workflowType value: $str")
     }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/model.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/model.scala
@@ -180,10 +180,10 @@ private object model {
       }
       object WorkflowType {
         case object Composite extends WorkflowType
-        case object Basic     extends WorkflowType
+        case object Step      extends WorkflowType
 
         val all: NonEmptyList[WorkflowType] =
-          NonEmptyList.of(Composite, Basic)
+          NonEmptyList.of(Composite, Step)
 
         def fromName(str: String): Either[String, WorkflowType] =
           all.find(_.name.equalsIgnoreCase(str)).toRight(s"Invalid workflowType name: $str")

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
@@ -40,6 +40,7 @@ import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters
 import io.renku.knowledgegraph.entities.finder.EntitiesFinder
+import io.renku.knowledgegraph.entities.model.Entity.Workflow.WorkflowType
 import io.renku.knowledgegraph.entities.model.MatchingScore
 import io.renku.testtools.IOSpec
 import org.http4s.MediaType.application
@@ -168,6 +169,9 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
       (cursor.downField("rel").as[Rel] -> cursor.downField("namespace").as[projects.Namespace]).mapN(_ -> _)
     }
 
+    implicit val workflowTypeDecoder: Decoder[WorkflowType] =
+      Decoder.decodeString.emap(WorkflowType.fromName)
+
     def expectedNamespaces(path: projects.Path) = path.toNamespaces
       .foldLeft(List.empty[(Rel, List[projects.Namespace])]) {
         case (Nil, namespace) => List(Rel(namespace.show) -> List(namespace))
@@ -250,13 +254,14 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
         )
       case Endpoint.Criteria.Filters.EntityType.Workflow =>
         for {
-          score      <- cursor.downField("matchingScore").as[MatchingScore]
-          name       <- cursor.downField("name").as[plans.Name]
-          visibility <- cursor.downField("visibility").as[projects.Visibility]
-          date       <- cursor.downField("date").as[plans.DateCreated]
-          keywords   <- cursor.downField("keywords").as[List[plans.Keyword]]
-          maybeDesc  <- cursor.downField("description").as[Option[plans.Description]]
-        } yield model.Entity.Workflow(score, name, visibility, date, keywords, maybeDesc)
+          score        <- cursor.downField("matchingScore").as[MatchingScore]
+          name         <- cursor.downField("name").as[plans.Name]
+          visibility   <- cursor.downField("visibility").as[projects.Visibility]
+          date         <- cursor.downField("date").as[plans.DateCreated]
+          keywords     <- cursor.downField("keywords").as[List[plans.Keyword]]
+          maybeDesc    <- cursor.downField("description").as[Option[plans.Description]]
+          workflowType <- cursor.downField("workflowType").as[WorkflowType]
+        } yield model.Entity.Workflow(score, name, visibility, date, keywords, maybeDesc, workflowType)
       case Endpoint.Criteria.Filters.EntityType.Person =>
         for {
           score <- cursor.downField("matchingScore").as[MatchingScore]

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/WorkflowsEntitiesFinderSpec.scala
@@ -182,7 +182,7 @@ class WorkflowsEntitiesFinderSpec
       val wfs = results.results.collect { case e: model.Entity.Workflow => e }
       wfs should have size (project.plans.size)
 
-      wfs.map(_.workflowType) should contain theSameElementsAs List(WorkflowType.Basic, WorkflowType.Composite)
+      wfs.map(_.workflowType) should contain theSameElementsAs List(WorkflowType.Step, WorkflowType.Composite)
     }
   }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/package.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/package.scala
@@ -95,7 +95,7 @@ package object entities {
       plan.maybeDescription,
       plan match {
         case _: CompositePlan => WorkflowType.Composite
-        case _: StepPlan      => WorkflowType.Basic
+        case _: StepPlan      => WorkflowType.Step
       }
     )
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -167,7 +167,7 @@ class PlanSpec
     }
 
     "fail decode if a parameter maps to itself" in {
-      val plan = compositePlanGen().filter(_.mappings.nonEmpty).generateOne
+      val plan = compositePlanGen().generateOne
       val pm_  = plan.mappings.head
       val pm   = pm_.copy(mappedParam = NonEmptyList.one(pm_))
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -439,7 +439,6 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
 
     "validate a composite plan that has references outside its children" in {
       val testPlan = compositePlanGen()
-        .suchThat(p => p.mappings.nonEmpty)
         .generateOne
         .asInstanceOf[CompositePlan.NonModified]
 


### PR DESCRIPTION
When querying workflows an additional attribute indicates whether it is a "normal" workflow or a composite.