### PR TITLE
feat: PUT /projects/:id/tokens to generate Project Access Token for the project

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
@@ -27,7 +27,6 @@ import io.renku.graph.acceptancetests.tooling._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.events.EventStatus._
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
-import io.renku.http.server.security.model.AuthUser
 import io.renku.webhookservice.model.HookToken
 import org.http4s.Status._
 
@@ -37,7 +36,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
 
     Scenario("Valid events get through to the Triples store") {
 
-      val user: AuthUser = authUsers.generateOne
+      val user     = authUsers.generateOne
       val project  = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne
       val commitId = commitIds.generateOne
 
@@ -65,7 +64,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
 
     Scenario("A non recoverable generation error arises and the events are reported as failed") {
 
-      val user: AuthUser = authUsers.generateOne
+      val user     = authUsers.generateOne
       val project  = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne
       val commitId = commitIds.generateOne
 
@@ -95,7 +94,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
       "A recoverable error arises and the events are reported as a recoverable failure"
     ) {
 
-      val user: AuthUser = authUsers.generateOne
+      val user     = authUsers.generateOne
       val project  = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne
       val commitId = commitIds.generateOne
 
@@ -125,7 +124,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
 
     Scenario("A non recoverable transformation error arises and the events are reported as a non recoverable failure") {
 
-      val user: AuthUser = authUsers.generateOne
+      val user     = authUsers.generateOne
       val project  = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne
       val commitId = commitIds.generateOne
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
@@ -90,9 +90,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(GenerationNonRecoverableFailure)
     }
 
-    Scenario(
-      "A recoverable error arises and the events are reported as a recoverable failure"
-    ) {
+    Scenario("A recoverable error arises and the events are reported as a recoverable failure") {
 
       val user     = authUsers.generateOne
       val project  = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventsProcessingStatusSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventsProcessingStatusSpec.scala
@@ -31,7 +31,6 @@ import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServic
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphClass
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
-import io.renku.http.server.security.model.AuthUser
 import io.renku.jsonld.syntax._
 import org.http4s.Status._
 import org.scalatest.concurrent.Eventually
@@ -52,7 +51,7 @@ class EventsProcessingStatusSpec
 
     Scenario("As a user I would like to see progress of events processing for my project") {
 
-      val user: AuthUser = authUsers.generateOne
+      val user    = authUsers.generateOne
       val project = dataProjects(renkuProjectEntities(visibilityPublic), CommitsCount(numberOfEvents.value)).generateOne
 
       When("there's no webhook for a given project in GitLab")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/FastTractEventRouteSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/FastTractEventRouteSpec.scala
@@ -27,7 +27,6 @@ import io.renku.graph.acceptancetests.testing.AcceptanceTestPatience
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{renkuProjectEntities, visibilityPublic}
-import io.renku.http.server.security.model.AuthUser
 import io.renku.webhookservice.model.HookToken
 import org.http4s.Status.{Accepted, Ok}
 import org.scalatest.concurrent.Eventually
@@ -43,7 +42,7 @@ class FastTractEventRouteSpec
 
     Scenario("Project with no events in the TS") {
 
-      val user: AuthUser = authUsers.generateOne
+      val user     = authUsers.generateOne
       val project  = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne
       val commitId = commitIds.generateOne
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectSyncFlowSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectSyncFlowSpec.scala
@@ -31,7 +31,6 @@ import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphClass
 import io.renku.graph.model.GraphModelGenerators.projectPaths
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{renkuProjectEntities, visibilityPublic}
-import io.renku.http.server.security.model.AuthUser
 import io.renku.jsonld.syntax._
 import org.http4s.Status.{NotFound, Ok}
 
@@ -46,7 +45,7 @@ class ProjectSyncFlowSpec extends AcceptanceSpec with ApplicationServices with T
 
     Scenario("There's a project_path change in GitLab for a repo that is already in KG") {
 
-      val user: AuthUser = authUsers.generateOne
+      val user                = authUsers.generateOne
       val testEntitiesProject = renkuProjectEntities(visibilityPublic).generateOne
       val project             = dataProjects(testEntitiesProject).generateOne
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectSyncFlowSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectSyncFlowSpec.scala
@@ -66,9 +66,9 @@ class ProjectSyncFlowSpec extends AcceptanceSpec with ApplicationServices with T
       When("project_path changes in GitLab")
       val updatedProject = project.copy(entitiesProject = testEntitiesProject.copy(path = projectPaths.generateOne))
       gitLabStub.replaceProject(updatedProject)
-      mockCommitDataOnTripleGenerator(updatedProject, updatedProject.entitiesProject.asJsonLD, commitId)
-      resetTriplesGenerator()
       givenAccessTokenPresentFor(updatedProject, user.accessToken)
+      resetTriplesGenerator()
+      mockCommitDataOnTripleGenerator(updatedProject, updatedProject.entitiesProject.asJsonLD, commitId)
 
       And("PROJECT_SYNC event is sent and handled")
       EventLog.forceCategoryEventTriggering(CategoryName("PROJECT_SYNC"), updatedProject.id)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookCreationSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookCreationSpec.scala
@@ -27,6 +27,7 @@ import io.renku.graph.acceptancetests.flows.AccessTokenPresence
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices, ModelImplicits}
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
+import io.renku.http.client.AccessToken
 import org.http4s.Status._
 
 class WebhookCreationSpec extends AcceptanceSpec with ModelImplicits with ApplicationServices with AccessTokenPresence {
@@ -76,13 +77,14 @@ class WebhookCreationSpec extends AcceptanceSpec with ModelImplicits with Applic
       Then("he should get CREATED response back")
       response.status shouldBe Created
 
-      And("the Access Token used in the POST should be added to the token repository")
-
-      val expectedAccessTokenJson = user.accessToken.asJson
-
+      And("a Project Access Token should created for the Project and added to the token repository")
       tokenRepositoryClient
         .GET(s"projects/${project.id}/tokens")
-        .jsonBody shouldBe expectedAccessTokenJson
+        .jsonBody shouldBe gitLabStub
+        .query(_.projectAccessTokens(project.id))
+        .unsafeRunSync()
+        .asInstanceOf[AccessToken]
+        .asJson
     }
   }
 }

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
@@ -26,6 +26,7 @@ import io.renku.graph.acceptancetests.data.Project.Statistics.CommitsCount
 import io.renku.graph.acceptancetests.data.dataProjects
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
+import io.renku.http.client.AccessToken
 import org.http4s.Status._
 
 class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServices {
@@ -86,10 +87,14 @@ class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServi
       Then("he should get OK response back")
       response.status shouldBe Ok
 
-      And("the Access Token used in the POST should be added to the token repository")
+      And("a Project Access Token should created for the Project and added to the token repository")
       tokenRepositoryClient
         .GET(s"projects/${project.id}/tokens")
-        .jsonBody shouldBe user.accessToken.asJson
+        .jsonBody shouldBe gitLabStub
+        .query(_.projectAccessTokens(project.id))
+        .unsafeRunSync()
+        .asInstanceOf[AccessToken]
+        .asJson
 
       And("when the hook get deleted from GitLab")
       gitLabStub.removeWebhook(project.id)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ZombieEventDetectionSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ZombieEventDetectionSpec.scala
@@ -35,7 +35,6 @@ import io.renku.graph.model.events.EventStatus._
 import io.renku.graph.model.events.{BatchDate, CommitId, EventBody, EventId, EventStatus}
 import io.renku.graph.model.projects._
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
-import io.renku.http.server.security.model.AuthUser
 import io.renku.microservices.MicroserviceIdentifier
 import org.scalacheck.Gen
 import org.scalatest.concurrent.Eventually
@@ -66,7 +65,7 @@ class ZombieEventDetectionSpec
     s"An event which got stuck in either $GeneratingTriples or $TransformingTriples status " +
       s"should be detected and re-processes"
   ) {
-    val user: AuthUser = authUsers.generateOne
+    val user      = authUsers.generateOne
     val project   = dataProjects(renkuProjectEntities(visibilityPublic)).generateOne
     val commitId  = commitIds.generateOne
     val eventDate = eventDates.generateOne

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
@@ -38,7 +38,6 @@ import io.renku.http.client.AccessToken
 import io.renku.http.client.UrlEncoder.urlEncode
 import io.renku.http.rest.Links.Rel
 import io.renku.http.server.EndpointTester._
-import io.renku.http.server.security.model.AuthUser
 import io.renku.jsonld.syntax._
 import io.renku.tinytypes.json.TinyTypeDecoders._
 import org.http4s.Status._
@@ -52,8 +51,8 @@ class DatasetsResourcesSpec
     with TSData
     with DatasetsApiEncoders {
 
-  val creator: AuthUser = authUsers.generateOne
-  val user:    AuthUser = authUsers.generateOne
+  private val creator = authUsers.generateOne
+  private val user    = authUsers.generateOne
 
   private implicit val graph: GraphClass = GraphClass.Default
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabAuth.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabAuth.scala
@@ -23,72 +23,99 @@ import cats.data.{Kleisli, OptionT}
 import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabApiStub.State
+import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.AccessToken._
-import io.renku.http.server.security.model.AuthUser
-import org.http4s._
-import org.http4s.dsl.Http4sDsl
+import io.renku.http.client.{AccessToken, ProjectAccessTokenDefaultPrefix, UserAccessToken}
 import org.http4s.headers.Authorization
 import org.http4s.server.AuthMiddleware
+import org.http4s.{Request, _}
 import org.typelevel.ci._
 
 private[gitlab] object GitLabAuth {
-  private def authFail[F[_]: Applicative]: AuthedRoutes[String, F] = {
-    val dsl = Http4sDsl[F]
-    import dsl._
-    Kleisli(req => OptionT.liftF(Forbidden(req.context)))
+  import GitLabStateQueries.{findAuthedProject, findAuthedUser}
+
+  sealed trait AuthedReq extends Product with Serializable {
+    type AT <: AccessToken
+    def accessToken: AT
   }
 
-  def auth[F[_]: Async](state: State)(cont: AuthUser => HttpRoutes[F]): HttpRoutes[F] = {
-    val authUser: Kleisli[F, Request[F], Either[String, AuthUser]] = Kleisli { req =>
-      req.headers.get[PersonalAccessToken].orElse(req.headers.get[UserOAuthAccessToken]) match {
-        case None => "No token provided in request".asLeft[AuthUser].pure[F]
-        case Some(token) =>
-          GitLabStateQueries.findUserByToken(token)(state).toRight("User not found").pure[F]
+  object AuthedReq {
+    final case class AuthedUser(userId: persons.GitLabId, accessToken: UserAccessToken) extends AuthedReq {
+      type AT = UserAccessToken
+    }
+    final case class AuthedProject(projectId: projects.Id, accessToken: ProjectAccessToken) extends AuthedReq {
+      type AT = ProjectAccessToken
+    }
+  }
+
+  def auth[F[_]: Async](state: State)(cont: AuthedReq => HttpRoutes[F]): HttpRoutes[F] = {
+
+    val authedReq: Kleisli[F, Request[F], Either[String, AuthedReq]] = Kleisli { req =>
+      maybeProjectAuthedReq(req, state) orElse maybeUserAuthedReq(req, state) match {
+        case None => "No token provided in request".asLeft[AuthedReq].pure[F]
+        case someAuthReq @ Some(_) =>
+          someAuthReq
+            .toRight("User or Project unknown")
+            .pure[F]
+            .widen
       }
     }
-    val middleware = AuthMiddleware(authUser, authFail)
+    val middleware = AuthMiddleware(authedReq, authFail(Status.Unauthorized))
     middleware(AuthedRoutes(authReq => cont(authReq.context).run(authReq.req)))
   }
 
-  def authF[F[_]: Async](stateRef: Ref[F, State])(cont: AuthUser => HttpRoutes[F]): HttpRoutes[F] =
+  def authF[F[_]: Async](stateRef: Ref[F, State])(cont: AuthedReq => HttpRoutes[F]): HttpRoutes[F] =
     Kleisli(req => OptionT.liftF(stateRef.get).flatMap(auth(_)(cont).run(req)))
 
-  def authOpt[F[_]: Async](state: State)(cont: Option[AuthUser] => HttpRoutes[F]): HttpRoutes[F] = {
-    val authUser: Kleisli[F, Request[F], Either[String, Option[AuthUser]]] = Kleisli { req =>
-      req.headers
-        .get[UserOAuthAccessToken]
-        .orElse(req.headers.get[PersonalAccessToken]) match {
-        case None => Option.empty[AuthUser].asRight[String].pure[F]
-        case Some(token) =>
-          GitLabStateQueries
-            .findUserByToken(token)(state)
+  def authOpt[F[_]: Async](state: State)(cont: Option[AuthedReq] => HttpRoutes[F]): HttpRoutes[F] = {
+    val authedReq: Kleisli[F, Request[F], Either[String, Option[AuthedReq]]] = Kleisli { req =>
+      maybeProjectAuthedReq(req, state) orElse maybeUserAuthedReq(req, state) match {
+        case None => Option.empty[AuthedReq].asRight[String].pure[F]
+        case someAuthReq @ Some(_) =>
+          someAuthReq
             .map(_.some)
-            .toRight("User not found")
+            .toRight("User or Project unknown")
             .pure[F]
+            .widen
       }
     }
-    val middleware = AuthMiddleware(authUser, authFail)
+    val middleware = AuthMiddleware(authedReq, authFail(Status.Forbidden))
     middleware(AuthedRoutes(authReq => cont(authReq.context).run(authReq.req)))
   }
 
-  def authOptF[F[_]: Async](stateRef: Ref[F, State])(cont: Option[AuthUser] => HttpRoutes[F]): HttpRoutes[F] =
+  def authOptF[F[_]: Async](stateRef: Ref[F, State])(cont: Option[AuthedReq] => HttpRoutes[F]): HttpRoutes[F] =
     Kleisli(req => OptionT.liftF(stateRef.get).flatMap(authOpt(_)(cont).run(req)))
 
-  def apply(user: AuthUser): Header.ToRaw =
+  def apply(user: AuthedReq): Header.ToRaw =
     user.accessToken match {
-      case t: ProjectAccessToken   => Header.ToRaw.modelledHeadersToRaw(t)
-      case t: UserOAuthAccessToken => Header.ToRaw.modelledHeadersToRaw(t)
-      case t: PersonalAccessToken  => Header.ToRaw.modelledHeadersToRaw(t)
+      case t: ProjectAccessToken   => Header.ToRaw.modelledHeadersToRaw(t.asInstanceOf[ProjectAccessToken])
+      case t: UserOAuthAccessToken => Header.ToRaw.modelledHeadersToRaw(t.asInstanceOf[UserOAuthAccessToken])
+      case t: PersonalAccessToken  => Header.ToRaw.modelledHeadersToRaw(t.asInstanceOf[PersonalAccessToken])
     }
 
-  implicit val privateTokenHeader: Header[PersonalAccessToken, Header.Single] =
+  private def maybeUserAuthedReq[F[_]](req: Request[F], state: State) =
+    (req.headers.get[UserOAuthAccessToken] orElse req.headers.get[PersonalAccessToken])
+      .flatMap(findAuthedUser(_)(state))
+
+  private def maybeProjectAuthedReq[F[_]](req: Request[F], state: State) =
+    req.headers.get[ProjectAccessToken] >>= (findAuthedProject(_)(state))
+
+  private implicit val privateTokenHeader: Header[PersonalAccessToken, Header.Single] =
     Header.create(
       ci"PRIVATE-TOKEN",
       _.value,
       value => PersonalAccessToken.from(value).leftMap(ex => ParseFailure(ex.getMessage, ""))
     )
 
-  implicit val projectAccessToken: Header[ProjectAccessToken, Header.Single] = {
+  private implicit val userOAuthAccessToken: Header[UserOAuthAccessToken, Header.Single] =
+    bearerToken(v => !ProjectAccessTokenDefaultPrefix.exists(v), UserOAuthAccessToken(_: String))
+
+  private implicit val projectAccessToken: Header[ProjectAccessToken, Header.Single] =
+    bearerToken(ProjectAccessTokenDefaultPrefix.exists, ProjectAccessToken(_: String))
+
+  private def bearerToken[T <: AccessToken](predicate: String => Boolean,
+                                                    factory:   String => T
+  ): Header[T, Header.Single] = {
     val h: Header[Authorization, Header.Single] = Header[Authorization]
     Header.create(
       h.name,
@@ -96,27 +123,15 @@ private[gitlab] object GitLabAuth {
       (h.parse _).andThen(
         _.flatMap(header =>
           header.credentials match {
-            case Credentials.Token(AuthScheme.Bearer, token) => ProjectAccessToken(token).asRight
-            case _                                           => Left(ParseFailure("Invalid token", ""))
+            case Credentials.Token(AuthScheme.Bearer, token) if predicate(token) => factory(token).asRight
+            case _ => Left(ParseFailure("Invalid token", ""))
           }
         )
       )
     )
   }
 
-  implicit val userOAuthAccessToken: Header[UserOAuthAccessToken, Header.Single] = {
-    val h: Header[Authorization, Header.Single] = Header[Authorization]
-    Header.create(
-      h.name,
-      v => h.value(Authorization(Credentials.Token(AuthScheme.Bearer, v.value))),
-      (h.parse _).andThen(
-        _.flatMap(header =>
-          header.credentials match {
-            case Credentials.Token(AuthScheme.Bearer, token) => UserOAuthAccessToken(token).asRight
-            case _                                           => Left(ParseFailure("Invalid token", ""))
-          }
-        )
-      )
-    )
+  private def authFail[F[_]: Applicative](status: Status): AuthedRoutes[String, F] = Kleisli { req =>
+    OptionT.liftF(Response[F](status).withEntity(req.context).pure[F])
   }
 }

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateUpdates.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateUpdates.scala
@@ -29,8 +29,9 @@ import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.persons.GitLabId
 import io.renku.graph.model.projects.Id
 import io.renku.graph.model.testentities.{Person, Project => RenkuProject}
-import io.renku.graph.model.{RenkuUrl, entities}
-import io.renku.http.client.AccessToken
+import io.renku.graph.model.{RenkuUrl, entities, projects}
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.http.client.UserAccessToken
 import org.http4s.Uri
 
 /** Collection of functions to update the state in [[GitLabApiStub]]. */
@@ -48,7 +49,7 @@ trait GitLabStateUpdates {
   def clearState: StateUpdate =
     _ => State.empty
 
-  def addUser(id: GitLabId, token: AccessToken): StateUpdate =
+  def addUser(id: GitLabId, token: UserAccessToken): StateUpdate =
     state => state.copy(users = state.users.updated(id, token))
 
   def addWebhook(projectId: Id, url: Uri): StateUpdate = state => {
@@ -106,6 +107,9 @@ trait GitLabStateUpdates {
     addProject(project, webhook) >>
       addCommits(project.id, commits) >>
       addPersons(EntityFunctions[RenkuProject].findAllPersons(project.entitiesProject).map(toPerson))
+
+  def addProjectAccessToken(projectId: projects.Id, token: ProjectAccessToken): StateUpdate =
+    state => state.copy(projectAccessTokens = state.projectAccessTokens.updated(projectId, token))
 
   private lazy val toPerson: entities.Person => Person = person =>
     Person(

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubIOSyntax.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStubIOSyntax.scala
@@ -26,7 +26,7 @@ import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.persons.GitLabId
 import io.renku.graph.model.projects.Id
-import io.renku.http.client.AccessToken
+import io.renku.http.client.UserAccessToken
 import io.renku.http.server.security.model.AuthUser
 import io.renku.testtools.IOSpec
 import org.http4s.Uri
@@ -42,7 +42,7 @@ trait GitLabStubIOSyntax { self: IOSpec =>
       self.update(GitLabStateUpdates.clearState).unsafeRunSync()
 
     /** Adds an authenticated gitlab user. */
-    def addAuthenticated(userId: GitLabId, token: AccessToken): Unit =
+    def addAuthenticated(userId: GitLabId, token: UserAccessToken): Unit =
       self.update(GitLabStateUpdates.addUser(userId, token)).unsafeRunSync()
 
     /** Adds an authenticated gitlab user. */

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdater.scala
@@ -46,7 +46,7 @@ private object DBUpdater {
     (_, infoRemover, execTimes) =>
       new ToTriplesStoreUpdater(infoRemover, execTimes).pure[F].widen[DBUpdater[F, ToTriplesStore]]
 
-  implicit def factoryToFailureUpdater[F[_]: Async]
+  implicit def factoryToFailureUpdater[F[_]: Async: Logger]
       : EventUpdaterFactory[F, ToFailure[ProcessingStatus, FailureStatus]] = (_, infoRemover, execTimes) =>
     new ToFailureUpdater(infoRemover, execTimes).pure[F].widen[DBUpdater[F, ToFailure[ProcessingStatus, FailureStatus]]]
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/ToFailureUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/ToFailureUpdater.scala
@@ -19,10 +19,9 @@
 package io.renku.eventlog.events.consumers.statuschange
 
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Temporal
 import cats.effect.kernel.Async
 import cats.syntax.all._
-import eu.timepit.refined.api.Refined
 import io.renku.db.implicits._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers._
@@ -32,13 +31,16 @@ import io.renku.graph.model.events.EventStatus.{FailureStatus, New, ProcessingSt
 import io.renku.graph.model.events.{EventId, EventStatus}
 import io.renku.graph.model.projects
 import io.renku.metrics.LabeledHistogram
+import org.typelevel.log4cats.Logger
+import skunk.SqlState.DeadlockDetected
 import skunk.data.Completion
 import skunk.implicits._
-import skunk.~
+import skunk.{Session, ~}
 
 import java.time.{Duration, Instant}
+import scala.concurrent.duration._
 
-private class ToFailureUpdater[F[_]: MonadCancelThrow: Async](
+private class ToFailureUpdater[F[_]: Async: Logger](
     deliveryInfoRemover: DeliveryInfoRemover[F],
     queriesExecTimes:    LabeledHistogram[F],
     now:                 () => Instant = () => Instant.now
@@ -55,8 +57,11 @@ private class ToFailureUpdater[F[_]: MonadCancelThrow: Async](
     ancestorsUpdateResult <- maybeUpdateAncestors(event, eventUpdateResult)
   } yield ancestorsUpdateResult combine eventUpdateResult
 
-  private def updateEvent(event: ToFailure[ProcessingStatus, FailureStatus]) = measureExecutionTime {
-    SqlStatement[F](name = Refined.unsafeApply(s"to_${event.newStatus.value.toLowerCase} - status update"))
+  private def updateEvent(
+      event: ToFailure[ProcessingStatus, FailureStatus]
+  ): Kleisli[F, Session[F], DBUpdateResults.ForProjects] = measureExecutionTime {
+    SqlStatement
+      .named(s"to_${event.newStatus.value.toLowerCase} - status update")
       .command[FailureStatus ~ ExecutionDate ~ EventMessage ~ EventId ~ projects.Id ~ ProcessingStatus](
         sql"""UPDATE event
               SET status = $eventFailureStatusEncoder,
@@ -86,6 +91,15 @@ private class ToFailureUpdater[F[_]: MonadCancelThrow: Async](
           new Exception(s"Could not update event ${event.eventId} to status ${event.newStatus}: $completion")
             .raiseError[F, DBUpdateResults.ForProjects]
       }
+  }.recoverWith(retryUpdating(event))
+
+  private def retryUpdating(
+      event: ToFailure[ProcessingStatus, FailureStatus]
+  ): PartialFunction[Throwable, Kleisli[F, Session[F], DBUpdateResults.ForProjects]] = { case DeadlockDetected(_) =>
+    Kleisli.liftF[F, Session[F], Unit] {
+      Logger[F].warn(show"Deadlock while updating event ${event.eventId} to ${event.newStatus}") >>
+        Temporal[F].sleep(1 second)
+    } >> updateEvent(event)
   }
 
   private def maybeUpdateAncestors(event:         ToFailure[ProcessingStatus, FailureStatus],
@@ -99,7 +113,8 @@ private class ToFailureUpdater[F[_]: MonadCancelThrow: Async](
 
   private def updateAncestorsStatus(event: ToFailure[ProcessingStatus, FailureStatus], newStatus: EventStatus) =
     measureExecutionTime {
-      SqlStatement(name = Refined.unsafeApply(s"to_${event.newStatus.value.toLowerCase} - ancestors update"))
+      SqlStatement
+        .named(s"to_${event.newStatus.value.toLowerCase} - ancestors update")
         .select[EventStatus ~ ExecutionDate ~ projects.Id ~ projects.Id ~ EventId ~ EventId, EventId](
           sql"""UPDATE event evt
                 SET status = $eventStatusEncoder, 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/ToFailureUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/ToFailureUpdaterSpec.scala
@@ -29,8 +29,9 @@ import io.renku.graph.model.events.{CompoundEventId, EventStatus}
 import EventStatus._
 import io.renku.eventlog._
 import EventContentGenerators.{eventDates, eventMessages}
+import StatusChangeEvent.{AllowedCombination, ToFailure}
 import cats.data.Kleisli
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.{AllowedCombination, ToFailure}
+import io.renku.interpreters.TestLogger
 import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
@@ -247,6 +248,7 @@ class ToFailureUpdaterSpec
     val projectId   = projectIds.generateOne
     val projectPath = projectPaths.generateOne
 
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val currentTime         = mockFunction[Instant]
     val deliveryInfoRemover = mock[DeliveryInfoRemover[IO]]
     val queriesExecTimes    = TestLabeledHistogram[SqlStatement.Name]("query_id")

--- a/graph-commons/src/main/scala/io/renku/graph/http/server/security/GitLabAuthenticator.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/http/server/security/GitLabAuthenticator.scala
@@ -21,7 +21,7 @@ package io.renku.graph.http.server.security
 import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
-import io.renku.http.client.{UserAccessToken, GitLabClient}
+import io.renku.http.client.{GitLabClient, UserAccessToken}
 import io.renku.http.server.security.EndpointSecurityException.AuthenticationFailure
 import io.renku.http.server.security.model.AuthUser
 import io.renku.http.server.security.{Authenticator, EndpointSecurityException}

--- a/graph-commons/src/main/scala/io/renku/http/client/AccessToken.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/AccessToken.scala
@@ -30,6 +30,8 @@ sealed trait AccessToken extends Any with StringTinyType with Sensitive
 
 sealed trait UserAccessToken extends Any with AccessToken
 
+sealed trait OAuthAccessToken extends Any with AccessToken
+
 object AccessToken {
 
   final class PersonalAccessToken private (val value: String) extends AnyVal with UserAccessToken
@@ -37,12 +39,12 @@ object AccessToken {
       extends TinyTypeFactory[PersonalAccessToken](new PersonalAccessToken(_))
       with NonBlank[PersonalAccessToken]
 
-  final class UserOAuthAccessToken private (val value: String) extends AnyVal with UserAccessToken
+  final class UserOAuthAccessToken private (val value: String) extends AnyVal with UserAccessToken with OAuthAccessToken
   object UserOAuthAccessToken
       extends TinyTypeFactory[UserOAuthAccessToken](new UserOAuthAccessToken(_))
       with NonBlank[UserOAuthAccessToken]
 
-  final class ProjectAccessToken private (val value: String) extends AnyVal with AccessToken
+  final class ProjectAccessToken private (val value: String) extends AnyVal with AccessToken with OAuthAccessToken
   object ProjectAccessToken
       extends TinyTypeFactory[ProjectAccessToken](new ProjectAccessToken(_))
       with NonBlank[ProjectAccessToken]

--- a/graph-commons/src/main/scala/io/renku/http/client/GitLabClient.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/GitLabClient.scala
@@ -31,7 +31,7 @@ import io.renku.graph.model.GitLabApiUrl
 import io.renku.http.client.HttpRequest.NamedRequest
 import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.metrics.{GitLabApiCallRecorder, MetricsRegistry}
-import org.http4s.Method.{DELETE, GET, POST}
+import org.http4s.Method.{DELETE, GET, HEAD, POST}
 import org.http4s.circe.{jsonEncoder, jsonEncoderOf}
 import org.http4s.{EntityEncoder, Method, Uri}
 import org.typelevel.log4cats.Logger
@@ -41,6 +41,10 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 trait GitLabClient[F[_]] {
 
   def get[ResultType](path:    Uri, endpointName: String Refined NonEmpty)(
+      mapResponse:             ResponseMappingF[F, ResultType]
+  )(implicit maybeAccessToken: Option[AccessToken]): F[ResultType]
+
+  def head[ResultType](path:   Uri, endpointName: String Refined NonEmpty)(
       mapResponse:             ResponseMappingF[F, ResultType]
   )(implicit maybeAccessToken: Option[AccessToken]): F[ResultType]
 
@@ -70,17 +74,25 @@ final class GitLabClientImpl[F[_]: Async: Logger](
     )
     with GitLabClient[F] {
 
-  def get[ResultType](path:    Uri, endpointName: String Refined NonEmpty)(
-      mapResponse:             ResponseMapping[ResultType]
-  )(implicit maybeAccessToken: Option[AccessToken]): F[ResultType] = for {
+  override def get[ResultType](path: Uri, endpointName: String Refined NonEmpty)(
+      mapResponse:                   ResponseMapping[ResultType]
+  )(implicit maybeAccessToken:       Option[AccessToken]): F[ResultType] = for {
     uri     <- validateUri(show"$gitLabApiUrl/$path")
     request <- secureNamedRequest(GET, uri, endpointName)
     result  <- super.send(request)(mapResponse)
   } yield result
 
-  def post[ResultType](path:   Uri, endpointName: String Refined NonEmpty, payload: Json)(
-      mapResponse:             ResponseMappingF[F, ResultType]
-  )(implicit maybeAccessToken: Option[AccessToken]): F[ResultType] = for {
+  override def head[ResultType](path: Uri, endpointName: String Refined NonEmpty)(
+      mapResponse:                    ResponseMapping[ResultType]
+  )(implicit maybeAccessToken:        Option[AccessToken]): F[ResultType] = for {
+    uri     <- validateUri(show"$gitLabApiUrl/$path")
+    request <- secureNamedRequest(HEAD, uri, endpointName)
+    result  <- super.send(request)(mapResponse)
+  } yield result
+
+  override def post[ResultType](path: Uri, endpointName: String Refined NonEmpty, payload: Json)(
+      mapResponse:                    ResponseMappingF[F, ResultType]
+  )(implicit maybeAccessToken:        Option[AccessToken]): F[ResultType] = for {
     uri     <- validateUri(show"$gitLabApiUrl/$path")
     request <- secureNamedRequest(uri, endpointName, payload)
     result  <- super.send(request)(mapResponse)

--- a/graph-commons/src/main/scala/io/renku/http/server/security/Authentication.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/security/Authentication.scala
@@ -21,7 +21,7 @@ package io.renku.http.server.security
 import cats.data.{Kleisli, OptionT}
 import cats.syntax.all._
 import cats.{Applicative, MonadThrow}
-import io.renku.http.client.AccessToken
+import io.renku.http.client.UserAccessToken
 import io.renku.http.client.AccessToken.{PersonalAccessToken, UserOAuthAccessToken}
 import io.renku.http.server.security.EndpointSecurityException.AuthenticationFailure
 import io.renku.http.server.security.model._
@@ -60,13 +60,13 @@ private class AuthenticationImpl[F[_]: MonadThrow](authenticator: Authenticator[
 
     import Header.Select._
 
-    lazy val getBearerToken: Option[AccessToken] =
+    lazy val getBearerToken: Option[UserAccessToken] =
       request.headers.get(singleHeaders(Authorization.headerInstance)) >>= {
         case Authorization(Token(Bearer, token)) => UserOAuthAccessToken(token).some
         case _                                   => None
       }
 
-    lazy val getPrivateAccessToken: Option[AccessToken] =
+    lazy val getPrivateAccessToken: Option[UserAccessToken] =
       request.headers.get(ci"PRIVATE-TOKEN").map(_.toList) >>= {
         case Header.Raw(_, token) :: _ => PersonalAccessToken(token).some
         case _                         => None

--- a/graph-commons/src/main/scala/io/renku/http/server/security/model.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/security/model.scala
@@ -19,11 +19,11 @@
 package io.renku.http.server.security
 
 import io.renku.graph.model.persons
-import io.renku.http.client.AccessToken
+import io.renku.http.client.UserAccessToken
 import org.http4s.Response
 
 object model {
-  final case class AuthUser(id: persons.GitLabId, accessToken: AccessToken)
+  final case class AuthUser(id: persons.GitLabId, accessToken: UserAccessToken)
 }
 
 sealed trait EndpointSecurityException extends Exception with Product with Serializable {

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -76,7 +76,7 @@ object CommonGraphGenerators {
 
   implicit val projectAccessTokens: Gen[ProjectAccessToken] = for {
     chars <- Gen.listOfN(20, Gen.oneOf(('A' to 'Z').map(_.toString) ++ ('a' to 'z').map(_.toString)))
-  } yield ProjectAccessToken(s"glpat-${chars.mkString("")}")
+  } yield ProjectAccessToken(s"$ProjectAccessTokenDefaultPrefix${chars.mkString("")}")
 
   implicit val securityExceptions: Gen[EndpointSecurityException] =
     Gen.oneOf(AuthenticationFailure, AuthorizationFailure)

--- a/graph-commons/src/test/scala/io/renku/http/client/ProjectAccessTokenDefaultPrefix.scala
+++ b/graph-commons/src/test/scala/io/renku/http/client/ProjectAccessTokenDefaultPrefix.scala
@@ -16,11 +16,20 @@
  * limitations under the License.
  */
 
-package io.renku.http.server.security
+package io.renku.http.client
 
-import io.renku.http.client.UserAccessToken
-import io.renku.http.server.security.model.AuthUser
+import cats.Show
 
-trait Authenticator[F[_]] {
-  def authenticate(accessToken: UserAccessToken): F[Either[EndpointSecurityException, AuthUser]]
+// This prefix is the default prefix for all Project and Personal Access Tokens GitLab generates.
+// The reason it cannot be used in production code either for validation or classification
+// is that it's configurable and may be different on various GL instances.
+case object ProjectAccessTokenDefaultPrefix {
+
+  val value: String = "glpat-"
+
+  override val toString: String = value
+
+  val show: Show[ProjectAccessTokenDefaultPrefix.type] = Show.show(_.value)
+
+  def exists(v: String): Boolean = v startsWith value
 }

--- a/graph-commons/src/test/scala/io/renku/testtools/GitLabClientTools.scala
+++ b/graph-commons/src/test/scala/io/renku/testtools/GitLabClientTools.scala
@@ -26,7 +26,7 @@ import io.circe.Json
 import io.renku.generators.Generators.Implicits._
 import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.http.client.{AccessToken, GitLabClient}
-import org.http4s.Method.{DELETE, GET, POST}
+import org.http4s.Method.{DELETE, GET, HEAD, POST}
 import org.http4s.{Method, Uri}
 import org.scalacheck.Gen
 import org.scalamock.matchers.ArgCapture.CaptureOne
@@ -47,6 +47,14 @@ trait GitLabClientTools[F[_]] {
       case GET =>
         (gitLabClient
           .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[F, ResultType])(
+            _: Option[AccessToken]
+          ))
+          .expects(*, *, capture(responseMapping), *)
+          .returning(resultGenerator.generateOne.pure[F])
+          .repeat(expectedNumberOfCalls)
+      case HEAD =>
+        (gitLabClient
+          .head(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[F, ResultType])(
             _: Option[AccessToken]
           ))
           .expects(*, *, capture(responseMapping), *)

--- a/helm-chart/renku-graph/templates/token-repository-deployment.yaml
+++ b/helm-chart/renku-graph/templates/token-repository-deployment.yaml
@@ -43,6 +43,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "tokenRepository.fullname" . }}
                   key: tokenRepository-tokenEncryption-secret
+            - name: PROJECT_TOKEN_TTL
+              value: "{{ .Values.tokenRepository.projectTokenTTL }}"
             - name: TOKEN_REPOSITORY_POSTGRES_HOST
               value: "{{ template "postgresql.fullname" . }}"
             - name: TOKEN_REPOSITORY_POSTGRES_PORT

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -95,6 +95,7 @@ tokenRepository:
   jvmXmx: 128M
   gitlab:
     rateLimit: 50/sec
+  projectTokenTTL: '1 year'
   connectionPool: 2
   tokenEncryption:
     ## A secret for signing access tokens stored in the database

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -95,7 +95,7 @@ tokenRepository:
   jvmXmx: 128M
   gitlab:
     rateLimit: 50/sec
-  projectTokenTTL: '1 year'
+  projectTokenTTL: '365 days'
   connectionPool: 2
   tokenEncryption:
     ## A secret for signing access tokens stored in the database

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
@@ -913,7 +913,7 @@ class DatasetsFinderSpec
   private lazy val publicProjectEntities: Gen[RenkuProject.WithoutParent] = renkuProjectEntities(visibilityPublic)
 
   implicit class PersonOps(person: Person) {
-    lazy val toAuthUser: AuthUser = AuthUser(person.maybeGitLabId.get, accessTokens.generateOne)
+    lazy val toAuthUser: AuthUser = AuthUser(person.maybeGitLabId.get, userAccessTokens.generateOne)
   }
 
   private implicit class DatasetAndProjectOps(datasetAndProject: (Dataset[Dataset.Provenance], RenkuProject)) {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
@@ -20,7 +20,7 @@ package io.renku.knowledgegraph.entities
 package finder
 
 import cats.effect.IO
-import io.renku.generators.CommonGraphGenerators.accessTokens
+import io.renku.generators.CommonGraphGenerators.userAccessTokens
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.testentities.{Entity => _, _}
 import io.renku.http.rest.SortBy
@@ -107,6 +107,6 @@ trait FinderSpecOps {
   }
 
   implicit class PersonOps(person: Person) {
-    lazy val toAuthUser: AuthUser = AuthUser(person.maybeGitLabId.get, accessTokens.generateOne)
+    lazy val toAuthUser: AuthUser = AuthUser(person.maybeGitLabId.get, userAccessTokens.generateOne)
   }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinderSpec.scala
@@ -35,7 +35,6 @@ import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.server.EndpointTester._
 import io.renku.interpreters.TestLogger
-import io.renku.stubbing.ExternalServiceStubbing
 import io.renku.testtools.{GitLabClientTools, IOSpec}
 import org.http4s.implicits._
 import org.http4s.{Request, Response, Status, Uri}
@@ -46,7 +45,6 @@ import org.scalatest.wordspec.AnyWordSpec
 class GLProjectFinderSpec
     extends AnyWordSpec
     with should.Matchers
-    with ExternalServiceStubbing
     with IOSpec
     with MockFactory
     with GitLabClientTools[IO] {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinderSpec.scala
@@ -21,7 +21,7 @@ package finder
 
 import cats.effect.IO
 import cats.syntax.all._
-import io.renku.generators.CommonGraphGenerators.{accessTokens, authUsers}
+import io.renku.generators.CommonGraphGenerators.{authUsers, userAccessTokens}
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.projects
 import io.renku.graph.model.testentities._
@@ -70,7 +70,7 @@ class TSProjectFinderSpec
 
       val authUser = personEntities(withGitLabId).generateOne
       val criteria = criterias.generateOne.copy(maybeUser =
-        AuthUser(authUser.maybeGitLabId.getOrElse(fail("AuthUser without GL id")), accessTokens.generateOne).some
+        AuthUser(authUser.maybeGitLabId.getOrElse(fail("AuthUser without GL id")), userAccessTokens.generateOne).some
       )
 
       val matchingMember = personEntities(withGitLabId).generateOne.copy(maybeGitLabId = criteria.userId.some)

--- a/token-repository/README.md
+++ b/token-repository/README.md
@@ -132,7 +132,7 @@ token-repository uses relational database as an internal storage. The DB has the
 | project_path | VARCHAR     | NOT NULL    |
 | token        | VARCHAR     | NOT NULL    |
 | created_at   | TIMESTAMPTZ | NOT NULL    |
-| expiry_date  | TIMESTAMPTZ | NOT NULL    |
+| expiry_date  | DATE        | NOT NULL    |
 
 ## Trying out
 

--- a/token-repository/README.md
+++ b/token-repository/README.md
@@ -120,6 +120,20 @@ Response body example:
 }
 ```
 
+## DB schema
+
+token-repository uses relational database as an internal storage. The DB has the following schema:
+
+`projects_tokens` table
+
+| column       | type        | constraints |
+|--------------|-------------|-------------|
+| project_id   | INT4        | PK NOT NULL |
+| project_path | VARCHAR     | NOT NULL    |
+| token        | VARCHAR     | NOT NULL    |
+| created_at   | TIMESTAMPTZ | NOT NULL    |
+| expiry_date  | TIMESTAMPTZ | NOT NULL    |
+
 ## Trying out
 
 The token-repository is a part of multi-module sbt project thus it has to be built from the root level.

--- a/token-repository/src/main/resources/application.conf
+++ b/token-repository/src/main/resources/application.conf
@@ -3,6 +3,9 @@ service-name = "token-repository"
 client-certificate = ""
 client-certificate = ${?RENKU_CLIENT_CERTIFICATE}
 
+project-token-ttl = 1 year
+project-token-ttl = ${?PROJECT_TOKEN_TTL}
+
 projects-tokens {
   // the secret has to be 16 chars base64 encoded
   secret = "Sz9DZ2E+OzhVdnEnXjNAUQ=="

--- a/token-repository/src/main/resources/application.conf
+++ b/token-repository/src/main/resources/application.conf
@@ -3,7 +3,8 @@ service-name = "token-repository"
 client-certificate = ""
 client-certificate = ${?RENKU_CLIENT_CERTIFICATE}
 
-project-token-ttl = 1 year
+// project-token-ttl cannot use unit bigger than 'day'
+project-token-ttl = 365 days
 project-token-ttl = ${?PROJECT_TOKEN_TTL}
 
 projects-tokens {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
@@ -22,6 +22,7 @@ import cats.MonadThrow
 import cats.effect.{Async, Clock, Resource}
 import cats.syntax.all._
 import io.renku.graph.http.server.binders.{ProjectId, ProjectPath}
+import io.renku.http.client.GitLabClient
 import io.renku.http.server.version
 import io.renku.metrics.{LabeledHistogram, MetricsRegistry, RoutesMetrics}
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
@@ -58,7 +59,7 @@ private class MicroserviceRoutes[F[_]: MonadThrow](
 }
 
 private object MicroserviceRoutes {
-  def apply[F[_]: Async: Logger: MetricsRegistry: SessionResource](
+  def apply[F[_]: Async: GitLabClient: Logger: MetricsRegistry: SessionResource](
       queriesExecTimes: LabeledHistogram[F]
   ): F[MicroserviceRoutes[F]] = for {
     fetchTokenEndpoint     <- FetchTokenEndpoint(queriesExecTimes)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/AccessTokenCrypto.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/AccessTokenCrypto.scala
@@ -59,7 +59,7 @@ private class AccessTokenCryptoImpl[F[_]: MonadThrow](
   } recoverWith meaningfulError
 
   private lazy val serialize: AccessToken => String = {
-    case ProjectAccessToken(token)   => Json.obj("projectAccessToken" -> Json.fromString(token)).noSpaces
+    case ProjectAccessToken(token)   => Json.obj("project" -> Json.fromString(token)).noSpaces
     case UserOAuthAccessToken(token) => Json.obj("oauth" -> Json.fromString(token)).noSpaces
     case PersonalAccessToken(token)  => Json.obj("personal" -> Json.fromString(token)).noSpaces
   }
@@ -74,7 +74,7 @@ private class AccessTokenCryptoImpl[F[_]: MonadThrow](
     def maybeExtract(field: String, as: String => Either[IllegalArgumentException, AccessToken]) =
       cursor.downField(field).as[Option[String]].flatMap(to(as))
 
-    maybeExtract("projectAccessToken", as = ProjectAccessToken.from)
+    maybeExtract("project", as = ProjectAccessToken.from)
       .flatMap {
         case token @ Some(_) => token.asRight
         case None            => maybeExtract("oauth", as = UserOAuthAccessToken.from)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/TokenRepositoryTypeSerializers.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/TokenRepositoryTypeSerializers.scala
@@ -24,7 +24,8 @@ import io.renku.graph.model.projects
 import skunk.codec.all.{int4, varchar}
 import skunk.{Decoder, Encoder}
 
-private trait TokenRepositoryTypeSerializers {
+trait TokenRepositoryTypeSerializers {
+
   val projectIdDecoder: Decoder[projects.Id] = int4.map(projects.Id.apply)
   val projectIdEncoder: Encoder[projects.Id] = int4.values.contramap(_.value)
 
@@ -32,8 +33,8 @@ private trait TokenRepositoryTypeSerializers {
   val projectPathEncoder: Encoder[projects.Path] =
     varchar.values.contramap((b: projects.Path) => b.value)
 
-  val encryptedAccessTokenDecoder: Decoder[EncryptedAccessToken] =
+  private[repository] val encryptedAccessTokenDecoder: Decoder[EncryptedAccessToken] =
     varchar.emap(s => EncryptedAccessToken.from(s).leftMap(_.getMessage))
-  val encryptedAccessTokenEncoder: Encoder[EncryptedAccessToken] =
+  private[repository] val encryptedAccessTokenEncoder: Encoder[EncryptedAccessToken] =
     varchar.values.contramap((b: EncryptedAccessToken) => b.value)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociateTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociateTokenEndpoint.scala
@@ -25,7 +25,7 @@ import cats.syntax.all._
 import io.renku.graph.model.projects.Id
 import io.renku.http.ErrorMessage
 import io.renku.http.ErrorMessage._
-import io.renku.http.client.AccessToken
+import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.metrics.LabeledHistogram
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.http4s.circe._
@@ -73,7 +73,7 @@ class AssociateTokenEndpointImpl[F[_]: Concurrent: Logger](
 
 object AssociateTokenEndpoint {
 
-  def apply[F[_]: Async: Logger: SessionResource](
+  def apply[F[_]: Async: GitLabClient: Logger: SessionResource](
       queriesExecTimes: LabeledHistogram[F]
   ): F[AssociateTokenEndpoint[F]] = TokenAssociator(queriesExecTimes).map(new AssociateTokenEndpointImpl[F](_))
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociationPersister.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociationPersister.scala
@@ -18,6 +18,7 @@
 
 package io.renku.tokenrepository.repository.association
 
+import TokenDates.{CreatedAt, ExpiryDate}
 import cats.data.Kleisli
 import cats.effect._
 import cats.syntax.all._
@@ -32,7 +33,7 @@ import skunk.data.Completion.Delete
 import skunk.implicits._
 
 private trait AssociationPersister[F[_]] {
-  def persistAssociation(projectId: Id, projectPath: Path, encryptedToken: EncryptedAccessToken): F[Unit]
+  def persistAssociation(storingInfo: TokenStoringInfo): F[Unit]
 }
 
 private class AssociationPersisterImpl[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F])
@@ -40,38 +41,41 @@ private class AssociationPersisterImpl[F[_]: MonadCancelThrow: SessionResource](
     with AssociationPersister[F]
     with TokenRepositoryTypeSerializers {
 
-  override def persistAssociation(id: Id, path: Path, token: EncryptedAccessToken): F[Unit] =
+  override def persistAssociation(storingInfo: TokenStoringInfo): F[Unit] =
     SessionResource[F].useWithTransactionK {
       Kleisli { case (_, session) =>
-        (deleteAssociation(id, path) >> insert(id, path, token)).run(session)
+        (deleteAssociation(storingInfo.project) >> insert(storingInfo)).run(session)
       }
     }
 
-  private def deleteAssociation(id: Id, path: Path) = measureExecutionTime {
+  private def deleteAssociation(project: TokenStoringInfo.Project) = measureExecutionTime {
     SqlStatement
       .named("associate token - delete")
       .command[Id ~ Path](sql"""
         DELETE FROM projects_tokens 
         WHERE project_id = $projectIdEncoder OR project_path = $projectPathEncoder
       """.command)
-      .arguments(id, path)
+      .arguments(project.id, project.path)
       .build
       .flatMapResult {
         case Delete(_) => ().pure[F]
         case completion =>
-          new Exception(s"Re-associating token for projectId = $id, projectPath = $path failed: $completion")
-            .raiseError[F, Unit]
+          new Exception(
+            s"Re-associating token for projectId = ${project.id}, projectPath = ${project.path} failed: $completion"
+          ).raiseError[F, Unit]
       }
   }
 
-  private def insert(id: Id, path: Path, token: EncryptedAccessToken) = measureExecutionTime {
+  private def insert(storingInfo: TokenStoringInfo) = measureExecutionTime {
     SqlStatement
       .named("associate token - insert")
-      .command[Id ~ Path ~ EncryptedAccessToken](sql"""
-        INSERT INTO projects_tokens (project_id, project_path, token)
-        VALUES ($projectIdEncoder, $projectPathEncoder, $encryptedAccessTokenEncoder)
+      .command[Id ~ Path ~ EncryptedAccessToken ~ CreatedAt ~ ExpiryDate](sql"""
+        INSERT INTO projects_tokens (project_id, project_path, token, created_at, expiry_date)
+        VALUES ($projectIdEncoder, $projectPathEncoder, $encryptedAccessTokenEncoder, $createdAtEncoder, $expiryDateEncoder)
       """.command)
-      .arguments(id ~ path ~ token)
+      .arguments(
+        storingInfo.project.id ~ storingInfo.project.path ~ storingInfo.encryptedToken ~ storingInfo.dates.createdAt ~ storingInfo.dates.expiryDate
+      )
       .build
       .void
   } recoverWith { case SqlState.UniqueViolation(_) => Kleisli.pure(()) }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/PersistedPathFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/PersistedPathFinder.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import cats.Id
+import cats.effect.MonadCancelThrow
+import io.renku.db.DbClient
+import io.renku.graph.model.projects
+import io.renku.metrics.LabeledHistogram
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
+import io.renku.tokenrepository.repository.TokenRepositoryTypeSerializers
+
+private trait PersistedPathFinder[F[_]] {
+  def findPersistedProjectPath(projectId: projects.Id): F[projects.Path]
+}
+
+private object PersistedPathFinder {
+  def apply[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F]): PersistedPathFinder[F] =
+    new PersistedPathFinderImpl[F](queriesExecTimes)
+}
+
+private class PersistedPathFinderImpl[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F])
+    extends DbClient[F](Some(queriesExecTimes))
+    with PersistedPathFinder[F]
+    with TokenRepositoryTypeSerializers {
+
+  import io.renku.db.SqlStatement
+  import skunk.implicits._
+
+  override def findPersistedProjectPath(projectId: projects.Id): F[projects.Path] =
+    SessionResource[F].useK(measureExecutionTime(query(projectId)))
+
+  private def query(projectId: projects.Id) =
+    SqlStatement
+      .named("find path for token")
+      .select[projects.Id, projects.Path](
+        sql"""SELECT project_path
+              FROM projects_tokens
+              WHERE project_id = $projectIdEncoder"""
+          .query(projectPathDecoder)
+      )
+      .arguments(projectId)
+      .build[Id](_.unique)
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreator.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import cats.effect.Async
+import cats.syntax.all._
+import com.typesafe.config.{Config, ConfigFactory}
+import io.renku.graph.model.projects
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.http.client.{AccessToken, GitLabClient}
+
+import java.time.{LocalDate, Period}
+
+private trait ProjectAccessTokenCreator[F[_]] {
+  def createPersonalAccessToken(projectId: projects.Id, accessToken: AccessToken): F[ProjectAccessToken]
+}
+
+private object ProjectAccessTokenCreator {
+
+  import io.renku.config.ConfigLoader._
+
+  import scala.concurrent.duration.FiniteDuration
+
+  def apply[F[_]: Async: GitLabClient](config: Config = ConfigFactory.load()): F[ProjectAccessTokenCreator[F]] =
+    find[F, FiniteDuration]("project-token-ttl", config)
+      .map(duration => Period.ofDays(duration.toDays.toInt))
+      .map(projectTokenTTL => new ProjectAccessTokenCreatorImpl[F](projectTokenTTL))
+}
+
+private class ProjectAccessTokenCreatorImpl[F[_]: Async: GitLabClient](
+    projectTokenTTL: Period,
+    currentDate:     () => LocalDate = () => LocalDate.now()
+) extends ProjectAccessTokenCreator[F] {
+
+  import cats.effect._
+  import cats.syntax.all._
+  import eu.timepit.refined.auto._
+  import io.circe.Decoder
+  import io.circe.Decoder.decodeString
+  import io.circe.literal._
+  import org.http4s.Status.Created
+  import org.http4s.circe.jsonOf
+  import org.http4s.implicits._
+  import org.http4s.{EntityDecoder, Request, Response, Status}
+
+  override def createPersonalAccessToken(projectId: projects.Id, accessToken: AccessToken): F[ProjectAccessToken] = {
+    val payload = json"""{
+      "name":       "renku",
+      "scopes":     ["api", "read_repository"],
+      "expires_at": ${currentDate().plus(projectTokenTTL)}
+    }"""
+    GitLabClient[F].post(uri"projects" / projectId.value / "access_tokens", "create-project-access-token", payload)(
+      mapResponse
+    )(accessToken.some)
+  }
+
+  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[ProjectAccessToken]] = {
+    case (Created, _, response) => response.as[ProjectAccessToken]
+  }
+
+  private implicit lazy val tokenDecoder: EntityDecoder[F, ProjectAccessToken] = {
+    val tokenDecoder = decodeString.emap { value =>
+      ProjectAccessToken.from(value).leftMap(_.getMessage)
+    }
+
+    val fieldDecoder: Decoder[ProjectAccessToken] = _.downField("token").as(tokenDecoder)
+
+    jsonOf[F, ProjectAccessToken](Sync[F], fieldDecoder)
+  }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectPathFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectPathFinder.scala
@@ -26,7 +26,7 @@ import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 import org.typelevel.log4cats.Logger
 
-trait ProjectPathFinder[F[_]] {
+private trait ProjectPathFinder[F[_]] {
   def findProjectPath(projectId: projects.Id, accessToken: AccessToken): OptionT[F, projects.Path]
 }
 
@@ -57,7 +57,7 @@ private class ProjectPathFinderImpl[F[_]: Async: GitLabClient: Logger] extends P
   }
 }
 
-object ProjectPathFinder {
+private object ProjectPathFinder {
 
   def apply[F[_]: Async: GitLabClient: Logger]: F[ProjectPathFinder[F]] =
     new ProjectPathFinderImpl[F].pure[F].widen

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectPathFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectPathFinder.scala
@@ -18,40 +18,31 @@
 
 package io.renku.tokenrepository.repository.association
 
+import cats.data.OptionT
 import cats.effect.Async
-import cats.effect.kernel.Temporal
 import cats.syntax.all._
-import io.renku.config.GitLab
-import io.renku.control.{RateLimit, Throttler}
-import io.renku.graph.config.GitLabUrlLoader
-import io.renku.graph.model.{GitLabApiUrl, projects}
-import io.renku.http.client.{AccessToken, RestClient}
-import org.http4s.circe.jsonOf
+import eu.timepit.refined.auto._
+import io.renku.graph.model.projects
+import io.renku.http.client.{AccessToken, GitLabClient}
 import org.typelevel.log4cats.Logger
 
 trait ProjectPathFinder[F[_]] {
-  def findProjectPath(projectId: projects.Id, maybeAccessToken: Option[AccessToken]): F[Option[projects.Path]]
+  def findProjectPath(projectId: projects.Id, accessToken: AccessToken): OptionT[F, projects.Path]
 }
 
-private class ProjectPathFinderImpl[F[_]: Async: Temporal: Logger](
-    gitLabUrl:       GitLabApiUrl,
-    gitLabThrottler: Throttler[F, GitLab]
-) extends RestClient(gitLabThrottler)
-    with ProjectPathFinder[F] {
+private class ProjectPathFinderImpl[F[_]: Async: GitLabClient: Logger] extends ProjectPathFinder[F] {
 
+  import org.http4s.circe.jsonOf
   import cats.effect._
   import cats.syntax.all._
   import io.circe._
-  import io.renku.tinytypes.json.TinyTypeDecoders._
-  import org.http4s.Method.GET
-  import org.http4s.Status.Unauthorized
+  import org.http4s.Status.{NotFound, Ok, Unauthorized}
   import org.http4s._
-  import org.http4s.dsl.io._
+  import org.http4s.implicits._
 
-  def findProjectPath(projectId: projects.Id, maybeAccessToken: Option[AccessToken]): F[Option[projects.Path]] = for {
-    uri     <- validateUri(s"$gitLabUrl/projects/$projectId")
-    project <- send(request(GET, uri, maybeAccessToken))(mapResponse)
-  } yield project
+  def findProjectPath(projectId: projects.Id, accessToken: AccessToken): OptionT[F, projects.Path] = OptionT {
+    GitLabClient[F].get(uri"projects" / projectId.value, "single-project")(mapResponse)(accessToken.some)
+  }
 
   private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Option[projects.Path]]] = {
     case (Ok, _, response)    => response.as[projects.Path].map(Option.apply)
@@ -60,6 +51,7 @@ private class ProjectPathFinderImpl[F[_]: Async: Temporal: Logger](
   }
 
   private implicit lazy val projectPathDecoder: EntityDecoder[F, projects.Path] = {
+    import io.renku.tinytypes.json.TinyTypeDecoders._
     lazy val decoder: Decoder[projects.Path] = _.downField("path_with_namespace").as[projects.Path]
     jsonOf[F, projects.Path](Sync[F], decoder)
   }
@@ -67,9 +59,6 @@ private class ProjectPathFinderImpl[F[_]: Async: Temporal: Logger](
 
 object ProjectPathFinder {
 
-  def apply[F[_]: Async: Temporal: Logger]: F[ProjectPathFinder[F]] = for {
-    gitLabRateLimit <- RateLimit.fromConfig[F, GitLab]("services.gitlab.rate-limit")
-    gitLabThrottler <- Throttler[F, GitLab](gitLabRateLimit)
-    gitLabUrl       <- GitLabUrlLoader[F]().map(_.apiV4)
-  } yield new ProjectPathFinderImpl(gitLabUrl, gitLabThrottler)
+  def apply[F[_]: Async: GitLabClient: Logger]: F[ProjectPathFinder[F]] =
+    new ProjectPathFinderImpl[F].pure[F].widen
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import cats.MonadThrow
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.http.client.GitLabClient
+
+private trait TokenValidator[F[_]] {
+  def checkValid(token: ProjectAccessToken): F[Boolean]
+}
+
+private object TokenValidator {
+  def apply[F[_]: MonadThrow: GitLabClient]: F[TokenValidator[F]] = new TokenValidatorImpl[F].pure[F].widen
+}
+
+private class TokenValidatorImpl[F[_]: MonadThrow: GitLabClient] extends TokenValidator[F] {
+
+  import org.http4s.Status.{NotFound, Ok, Unauthorized}
+  import org.http4s._
+  import org.http4s.implicits._
+
+  override def checkValid(token: ProjectAccessToken): F[Boolean] =
+    GitLabClient[F].head(uri"user", "user")(mapResponse)(token.some)
+
+  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Boolean]] = {
+    case (Ok, _, _)           => true.pure[F]
+    case (NotFound, _, _)     => false.pure[F]
+    case (Unauthorized, _, _) => false.pure[F]
+  }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
@@ -34,7 +34,7 @@ private object TokenValidator {
 
 private class TokenValidatorImpl[F[_]: MonadThrow: GitLabClient] extends TokenValidator[F] {
 
-  import org.http4s.Status.{NotFound, Ok, Unauthorized}
+  import org.http4s.Status.{Forbidden, NotFound, Ok, Unauthorized}
   import org.http4s._
   import org.http4s.implicits._
 
@@ -42,8 +42,7 @@ private class TokenValidatorImpl[F[_]: MonadThrow: GitLabClient] extends TokenVa
     GitLabClient[F].head(uri"user", "user")(mapResponse)(token.some)
 
   private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Boolean]] = {
-    case (Ok, _, _)           => true.pure[F]
-    case (NotFound, _, _)     => false.pure[F]
-    case (Unauthorized, _, _) => false.pure[F]
+    case (Ok, _, _)                                  => true.pure[F]
+    case (NotFound | Unauthorized | Forbidden, _, _) => false.pure[F]
   }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/model.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import io.renku.graph.model.projects
+import io.renku.graph.model.views.TinyTypeJsonLDOps
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.tinytypes.constraints.InstantNotInTheFuture
+import io.renku.tinytypes.{InstantTinyType, TinyTypeFactory}
+import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
+import io.renku.tokenrepository.repository.association.TokenDates._
+
+import java.time.Instant
+
+private final case class TokenCreationInfo(token: ProjectAccessToken, dates: TokenDates)
+
+private final case class TokenDates(createdAt: CreatedAt, expiryDate: ExpiryDate)
+
+private object TokenDates {
+  final class CreatedAt private (val value: Instant) extends AnyVal with InstantTinyType
+
+  implicit object CreatedAt
+      extends TinyTypeFactory[CreatedAt](new CreatedAt(_))
+      with InstantNotInTheFuture[CreatedAt]
+      with TinyTypeJsonLDOps[CreatedAt]
+
+  final class ExpiryDate private (val value: Instant) extends AnyVal with InstantTinyType
+  implicit object ExpiryDate extends TinyTypeFactory[ExpiryDate](new ExpiryDate(_)) with TinyTypeJsonLDOps[ExpiryDate]
+}
+
+private final case class TokenStoringInfo(project:        TokenStoringInfo.Project,
+                                          encryptedToken: EncryptedAccessToken,
+                                          dates:          TokenDates
+)
+
+private object TokenStoringInfo {
+  final case class Project(id: projects.Id, path: projects.Path)
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/model.scala
@@ -22,17 +22,17 @@ import io.renku.graph.model.projects
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.tinytypes.constraints.InstantNotInTheFuture
-import io.renku.tinytypes.{InstantTinyType, TinyTypeFactory}
+import io.renku.tinytypes.{InstantTinyType, LocalDateTinyType, TinyTypeFactory}
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.association.TokenDates._
 
-import java.time.Instant
+import java.time.{Instant, LocalDate}
 
 private final case class TokenCreationInfo(token: ProjectAccessToken, dates: TokenDates)
 
-private final case class TokenDates(createdAt: CreatedAt, expiryDate: ExpiryDate)
+final case class TokenDates(createdAt: CreatedAt, expiryDate: ExpiryDate)
 
-private object TokenDates {
+object TokenDates {
   final class CreatedAt private (val value: Instant) extends AnyVal with InstantTinyType
 
   implicit object CreatedAt
@@ -40,7 +40,7 @@ private object TokenDates {
       with InstantNotInTheFuture[CreatedAt]
       with TinyTypeJsonLDOps[CreatedAt]
 
-  final class ExpiryDate private (val value: Instant) extends AnyVal with InstantTinyType
+  final class ExpiryDate private (val value: LocalDate) extends AnyVal with LocalDateTinyType
   implicit object ExpiryDate extends TinyTypeFactory[ExpiryDate](new ExpiryDate(_)) with TinyTypeJsonLDOps[ExpiryDate]
 }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/package.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/package.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+
+import skunk.codec.all._
+import skunk.{Decoder, Encoder}
+
+import java.time.{OffsetDateTime, ZoneOffset}
+
+package object association {
+
+  import io.renku.tokenrepository.repository.association.TokenDates._
+
+  private[association] val createdAtDecoder: Decoder[CreatedAt] =
+    timestamptz.map(timestamp => CreatedAt(timestamp.toInstant))
+  private[association] val createdAtEncoder: Encoder[CreatedAt] = timestamptz.values.contramap((b: CreatedAt) =>
+    OffsetDateTime.ofInstant(b.value, b.value.atOffset(ZoneOffset.UTC).toZonedDateTime.getZone)
+  )
+
+  private[association] val expiryDateDecoder: Decoder[ExpiryDate] =
+    timestamptz.map(timestamp => ExpiryDate(timestamp.toInstant))
+  private[association] val expiryDateEncoder: Encoder[ExpiryDate] = timestamptz.values.contramap((b: ExpiryDate) =>
+    OffsetDateTime.ofInstant(b.value, b.value.atOffset(ZoneOffset.UTC).toZonedDateTime.getZone)
+  )
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/package.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/package.scala
@@ -33,9 +33,6 @@ package object association {
     OffsetDateTime.ofInstant(b.value, b.value.atOffset(ZoneOffset.UTC).toZonedDateTime.getZone)
   )
 
-  private[association] val expiryDateDecoder: Decoder[ExpiryDate] =
-    timestamptz.map(timestamp => ExpiryDate(timestamp.toInstant))
-  private[association] val expiryDateEncoder: Encoder[ExpiryDate] = timestamptz.values.contramap((b: ExpiryDate) =>
-    OffsetDateTime.ofInstant(b.value, b.value.atOffset(ZoneOffset.UTC).toZonedDateTime.getZone)
-  )
+  private[association] val expiryDateDecoder: Decoder[ExpiryDate] = date.map(date => ExpiryDate(date))
+  private[association] val expiryDateEncoder: Encoder[ExpiryDate] = date.values.contramap((b: ExpiryDate) => b.value)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRemover.scala
@@ -33,9 +33,13 @@ private[repository] trait TokenRemover[F[_]] {
   def delete(projectId: Id): F[Unit]
 }
 
-private[repository] class TokenRemoverImpl[F[_]: MonadCancelThrow: SessionResource](
-    queriesExecTimes: LabeledHistogram[F]
-) extends DbClient[F](Some(queriesExecTimes))
+private[repository] object TokenRemover {
+  def apply[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F]): TokenRemover[F] =
+    new TokenRemoverImpl[F](queriesExecTimes)
+}
+
+private class TokenRemoverImpl[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F])
+    extends DbClient[F](Some(queriesExecTimes))
     with TokenRemover[F]
     with TokenRepositoryTypeSerializers {
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
@@ -34,7 +34,12 @@ private[repository] trait PersistedTokensFinder[F[_]] {
   def findStoredToken(projectPath: Path): OptionT[F, EncryptedAccessToken]
 }
 
-private[repository] class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: SessionResource](
+private[repository] object PersistedTokensFinder {
+  def apply[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F]): PersistedTokensFinder[F] =
+    new PersistedTokensFinderImpl[F](queriesExecTimes)
+}
+
+private class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: SessionResource](
     queriesExecTimes: LabeledHistogram[F]
 ) extends DbClient[F](Some(queriesExecTimes))
     with PersistedTokensFinder[F]

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
@@ -30,8 +30,8 @@ import io.renku.tokenrepository.repository.TokenRepositoryTypeSerializers
 import skunk.implicits._
 
 private[repository] trait PersistedTokensFinder[F[_]] {
-  def findToken(projectId:   Id):   OptionT[F, EncryptedAccessToken]
-  def findToken(projectPath: Path): OptionT[F, EncryptedAccessToken]
+  def findStoredToken(projectId:   Id):   OptionT[F, EncryptedAccessToken]
+  def findStoredToken(projectPath: Path): OptionT[F, EncryptedAccessToken]
 }
 
 private[repository] class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: SessionResource](
@@ -40,7 +40,7 @@ private[repository] class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: Sess
     with PersistedTokensFinder[F]
     with TokenRepositoryTypeSerializers {
 
-  override def findToken(projectId: Id): OptionT[F, EncryptedAccessToken] = run {
+  override def findStoredToken(projectId: Id): OptionT[F, EncryptedAccessToken] = run {
     SqlStatement(name = "find token - id")
       .select[Id, EncryptedAccessToken](
         sql"""select token from projects_tokens where project_id = $projectIdEncoder"""
@@ -50,7 +50,7 @@ private[repository] class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: Sess
       .build(_.option)
   }
 
-  override def findToken(projectPath: Path): OptionT[F, EncryptedAccessToken] = run {
+  override def findStoredToken(projectPath: Path): OptionT[F, EncryptedAccessToken] = run {
     SqlStatement(name = "find token - path")
       .select[Path, EncryptedAccessToken](
         sql"select token from projects_tokens where project_path = $projectPathEncoder"

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/TokenFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/TokenFinder.scala
@@ -45,15 +45,15 @@ private class TokenFinderImpl[F[_]: MonadThrow](
   import accessTokenCrypto._
 
   override def findToken(projectPath: Path): OptionT[F, AccessToken] = for {
-    encryptedToken <- tokenInRepoFinder.findToken(projectPath)
+    encryptedToken <- tokenInRepoFinder.findStoredToken(projectPath)
     accessToken <-
-      OptionT.liftF(decrypt(encryptedToken)) recoverWith retry(() => tokenInRepoFinder.findToken(projectPath))
+      OptionT.liftF(decrypt(encryptedToken)) recoverWith retry(() => tokenInRepoFinder.findStoredToken(projectPath))
   } yield accessToken
 
   override def findToken(projectId: Id): OptionT[F, AccessToken] = for {
-    encryptedToken <- tokenInRepoFinder.findToken(projectId)
+    encryptedToken <- tokenInRepoFinder.findStoredToken(projectId)
     accessToken <-
-      OptionT.liftF(decrypt(encryptedToken)) recoverWith retry(() => tokenInRepoFinder.findToken(projectId))
+      OptionT.liftF(decrypt(encryptedToken)) recoverWith retry(() => tokenInRepoFinder.findStoredToken(projectId))
   } yield accessToken
 
   private def retry(fetchToken:      () => OptionT[F, AccessTokenCrypto.EncryptedAccessToken],

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/TokenFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/TokenFinder.scala
@@ -43,18 +43,21 @@ private class TokenFinderImpl[F[_]: MonadThrow](
 ) extends TokenFinder[F] {
 
   import accessTokenCrypto._
+  import tokenInRepoFinder._
 
-  override def findToken(projectPath: Path): OptionT[F, AccessToken] = for {
-    encryptedToken <- tokenInRepoFinder.findStoredToken(projectPath)
-    accessToken <-
-      OptionT.liftF(decrypt(encryptedToken)) recoverWith retry(() => tokenInRepoFinder.findStoredToken(projectPath))
-  } yield accessToken
+  override def findToken(projectPath: Path): OptionT[F, AccessToken] =
+    findStoredToken(projectPath) >>= { encryptedToken =>
+      OptionT
+        .liftF(decrypt(encryptedToken))
+        .recoverWith(retry(() => findStoredToken(projectPath)))
+    }
 
-  override def findToken(projectId: Id): OptionT[F, AccessToken] = for {
-    encryptedToken <- tokenInRepoFinder.findStoredToken(projectId)
-    accessToken <-
-      OptionT.liftF(decrypt(encryptedToken)) recoverWith retry(() => tokenInRepoFinder.findStoredToken(projectId))
-  } yield accessToken
+  override def findToken(projectId: Id): OptionT[F, AccessToken] =
+    findStoredToken(projectId) >>= { encryptedToken =>
+      OptionT
+        .liftF(decrypt(encryptedToken))
+        .recoverWith(retry(() => findStoredToken(projectId)))
+    }
 
   private def retry(fetchToken:      () => OptionT[F, AccessTokenCrypto.EncryptedAccessToken],
                     numberOfRetries: Int = 0

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
@@ -21,7 +21,6 @@ package io.renku.tokenrepository.repository.init
 import DbInitializer.Runnable
 import cats.effect._
 import cats.syntax.all._
-import io.renku.metrics.LabeledHistogram
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.typelevel.log4cats.Logger
 
@@ -55,9 +54,9 @@ class DbInitializerImpl[F[_]: Async: Logger](migrators: List[Runnable[F, Unit]],
 
 object DbInitializer {
 
-  def apply[F[_]: Async: Logger: SessionResource](queriesExecTimes: LabeledHistogram[F]): F[DbInitializer[F]] = for {
+  def apply[F[_]: Async: Logger: SessionResource]: F[DbInitializer[F]] = for {
     tableCreator               <- ProjectsTokensTableCreator[F].pure[F]
-    pathAdder                  <- ProjectPathAdder[F](queriesExecTimes)
+    pathAdder                  <- ProjectPathAdder[F].pure[F]
     duplicateProjectsRemover   <- DuplicateProjectsRemover[F].pure[F]
     expireAndCreatedDatesAdder <- ExpireAndCreatedDatesAdder[F].pure[F]
   } yield new DbInitializerImpl[F](

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
@@ -21,14 +21,8 @@ package io.renku.tokenrepository.repository.init
 import cats.data.Kleisli
 import cats.effect._
 import cats.syntax.all._
-import io.renku.graph.model.projects
-import io.renku.graph.model.projects.{Id, Path}
-import io.renku.metrics.LabeledHistogram
-import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
-import io.renku.tokenrepository.repository.association.ProjectPathFinder
-import io.renku.tokenrepository.repository.deletion.{TokenRemover, TokenRemoverImpl}
-import io.renku.tokenrepository.repository.{AccessTokenCrypto, TokenRepositoryTypeSerializers}
+import io.renku.tokenrepository.repository.TokenRepositoryTypeSerializers
 import org.typelevel.log4cats.Logger
 import skunk._
 import skunk.implicits._
@@ -39,86 +33,28 @@ private trait ProjectPathAdder[F[_]] {
   def run(): F[Unit]
 }
 
-private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource](
-    accessTokenCrypto: AccessTokenCrypto[F],
-    pathFinder:        ProjectPathFinder[F],
-    tokenRemover:      TokenRemover[F]
-) extends ProjectPathAdder[F]
+private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource]
+    extends ProjectPathAdder[F]
     with TokenRepositoryTypeSerializers {
 
   import MigrationTools._
-  import accessTokenCrypto._
-  import pathFinder._
 
   def run(): F[Unit] = SessionResource[F].useK {
-    checkColumnExists >>= {
-      case true  => Kleisli.liftF(Logger[F].info("'project_path' column exists"))
+    checkColumnExists("projects_tokens", "project_path") >>= {
+      case true  => Kleisli.liftF(Logger[F].info("'project_path' column existed"))
       case false => addColumn()
     }
-  }
-
-  private lazy val checkColumnExists: Kleisli[F, Session[F], Boolean] = {
-    val query: Query[skunk.Void, projects.Path] = sql"select project_path from projects_tokens limit 1"
-      .query(projectPathDecoder)
-    Kleisli(_.option(query).map(_ => true).recover { case _ => false })
   }
 
   private def addColumn(): Kleisli[F, Session[F], Unit] = Kleisli { implicit session =>
     {
       for {
         _ <- execute(sql"ALTER TABLE projects_tokens ADD COLUMN IF NOT EXISTS project_path VARCHAR".command)
-        _ <- Spawn[F] start addMissingPaths()
-      } yield ()
-    } recoverWith logging
-  }
-
-  private def addMissingPaths(): F[Unit] = SessionResource[F].useK {
-    Kleisli { implicit session =>
-      for {
-        _ <- addPathIfMissing().run(session)
         _ <- execute(sql"ALTER TABLE projects_tokens ALTER COLUMN project_path SET NOT NULL".command)
         _ <- execute(sql"CREATE INDEX IF NOT EXISTS idx_project_path ON projects_tokens(project_path)".command)
         _ <- Logger[F].info("'project_path' column added")
       } yield ()
-    }
-  }
-
-  private def addPathIfMissing(): Kleisli[F, Session[F], Unit] =
-    findEntryWithoutPath >>= {
-      case None                              => Kleisli.pure(())
-      case Some((projectId, encryptedToken)) => addPathOrRemoveRow(projectId, encryptedToken)
-    }
-
-  private def findEntryWithoutPath: Kleisli[F, Session[F], Option[(Id, EncryptedAccessToken)]] = {
-    val query: Query[Void, (Id, EncryptedAccessToken)] =
-      sql"SELECT project_id, token FROM projects_tokens WHERE project_path IS NULL LIMIT 1;"
-        .query(projectIdDecoder ~ encryptedAccessTokenDecoder)
-        .map { case id ~ token => (id, token) }
-    Kleisli(_.option(query))
-  }
-
-  private def addPathOrRemoveRow(id: Id, encryptedToken: EncryptedAccessToken) = {
-    for {
-      token            <- Kleisli.liftF(decrypt(encryptedToken))
-      maybeProjectPath <- Kleisli.liftF(findProjectPath(id, Some(token)))
-      _                <- addOrRemove(id, maybeProjectPath)
-      _                <- addPathIfMissing()
-    } yield ()
-  } recoverWith { case NonFatal(exception) =>
-    Logger[F].error(exception)(s"Error while adding Project Path for projectId = $id")
-    addPathIfMissing()
-  }
-
-  private def addOrRemove(id: Id, maybePath: Option[Path]): Kleisli[F, Session[F], Unit] =
-    maybePath match {
-      case Some(path) => addPath(id, path)
-      case None       => Kleisli.liftF(tokenRemover.delete(id))
-    }
-
-  private def addPath(id: Id, path: Path): Kleisli[F, Session[F], Unit] = {
-    val query: Command[Path ~ Id] =
-      sql"update projects_tokens set project_path = $projectPathEncoder where project_id = $projectIdEncoder".command
-    Kleisli(_.prepare(query).use(_.execute(path ~ id)).void)
+    } recoverWith logging
   }
 
   private lazy val logging: PartialFunction[Throwable, F[Unit]] = { case NonFatal(exception) =>
@@ -129,9 +65,5 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource](
 
 private object ProjectPathAdder {
 
-  def apply[F[_]: Async: Logger: SessionResource](queriesExecTimes: LabeledHistogram[F]): F[ProjectPathAdder[F]] = for {
-    accessTokenCrypto <- AccessTokenCrypto[F]()
-    pathFinder        <- ProjectPathFinder[F]
-    tokenRemover = new TokenRemoverImpl[F](queriesExecTimes)
-  } yield new ProjectPathAdderImpl[F](accessTokenCrypto, pathFinder, tokenRemover)
+  def apply[F[_]: Async: Logger: SessionResource]: ProjectPathAdder[F] = new ProjectPathAdderImpl[F]
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
@@ -30,7 +30,7 @@ import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 
-trait InMemoryProjectsTokensDb extends ForAllTestContainer {
+trait InMemoryProjectsTokensDb extends ForAllTestContainer with TokenRepositoryTypeSerializers {
   self: Suite with IOSpec =>
 
   private val dbConfig = new ProjectsTokensDbConfigProvider[IO].get().unsafeRunSync()

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
@@ -16,18 +16,27 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.association
+package io.renku.tokenrepository.repository
+package association
 
+import AccessTokenCrypto.EncryptedAccessToken
+import RepositoryGenerators._
+import association.Generators.tokenStoringInfos
+import association.TokenDates._
+import association.TokenStoringInfo.Project
+import cats.data.Kleisli
 import cats.effect.IO
+import cats.syntax.all._
 import io.renku.db.SqlStatement
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators._
+import io.renku.graph.model.projects
 import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
-import io.renku.tokenrepository.repository.InMemoryProjectsTokensDbSpec
-import io.renku.tokenrepository.repository.RepositoryGenerators._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+import skunk._
+import skunk.implicits._
 
 class AssociationPersisterSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
 
@@ -36,75 +45,79 @@ class AssociationPersisterSpec extends AnyWordSpec with IOSpec with InMemoryProj
     "insert the association " +
       "if there's no token for the given project id" in new TestCase {
 
-        val token = encryptedAccessTokens.generateOne
+        associator.persistAssociation(tokenStoringInfo).unsafeRunSync() shouldBe ()
 
-        associator.persistAssociation(projectId, projectPath, token).unsafeRunSync() shouldBe ()
-
-        findToken(projectId)   shouldBe Some(token.value)
-        findToken(projectPath) shouldBe Some(token.value)
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.some
       }
 
     "update the given token " +
       "if there's a token for the project path and id" in new TestCase {
 
-        val token = encryptedAccessTokens.generateOne
+        associator.persistAssociation(tokenStoringInfo).unsafeRunSync() shouldBe ()
 
-        associator.persistAssociation(projectId, projectPath, token).unsafeRunSync() shouldBe ()
-
-        findToken(projectId)   shouldBe Some(token.value)
-        findToken(projectPath) shouldBe Some(token.value)
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.some
 
         val newToken = encryptedAccessTokens.generateOne
-        associator.persistAssociation(projectId, projectPath, newToken).unsafeRunSync() shouldBe ()
+        associator.persistAssociation(tokenStoringInfo.copy(encryptedToken = newToken)).unsafeRunSync() shouldBe ()
 
-        findToken(projectId)   shouldBe Some(newToken.value)
-        findToken(projectPath) shouldBe Some(newToken.value)
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.copy(encryptedToken = newToken).some
       }
 
     "update the given token and project id" +
       "if there's a token for the project path but with different project id" in new TestCase {
 
-        val token = encryptedAccessTokens.generateOne
+        associator.persistAssociation(tokenStoringInfo).unsafeRunSync() shouldBe ()
 
-        associator.persistAssociation(projectId, projectPath, token).unsafeRunSync() shouldBe ()
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.some
 
-        findToken(projectId)   shouldBe Some(token.value)
-        findToken(projectPath) shouldBe Some(token.value)
+        val newStoringInfo =
+          tokenStoringInfo.copy(project = tokenStoringInfo.project.copy(id = projectIds.generateOne),
+                                encryptedToken = encryptedAccessTokens.generateOne
+          )
+        associator.persistAssociation(newStoringInfo).unsafeRunSync() shouldBe ()
 
-        val newId    = projectIds.generateOne
-        val newToken = encryptedAccessTokens.generateOne
-        associator.persistAssociation(newId, projectPath, newToken).unsafeRunSync() shouldBe ()
-
-        findToken(projectId)   shouldBe None
-        findToken(newId)       shouldBe Some(newToken.value)
-        findToken(projectPath) shouldBe Some(newToken.value)
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe None
+        findTokenInfo(newStoringInfo.project.id)   shouldBe newStoringInfo.some
       }
 
     "update the given token and project path" +
       "if there's a token for the project id but with different project path" in new TestCase {
 
-        val token = encryptedAccessTokens.generateOne
+        associator.persistAssociation(tokenStoringInfo).unsafeRunSync() shouldBe ()
 
-        associator.persistAssociation(projectId, projectPath, token).unsafeRunSync() shouldBe ()
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.some
 
-        findToken(projectId)   shouldBe Some(token.value)
-        findToken(projectPath) shouldBe Some(token.value)
+        val newStoringInfo =
+          tokenStoringInfo.copy(project = tokenStoringInfo.project.copy(path = projectPaths.generateOne),
+                                encryptedToken = encryptedAccessTokens.generateOne
+          )
+        associator.persistAssociation(newStoringInfo).unsafeRunSync() shouldBe ()
 
-        val newPath  = projectPaths.generateOne
-        val newToken = encryptedAccessTokens.generateOne
-        associator.persistAssociation(projectId, newPath, newToken).unsafeRunSync() shouldBe ()
-
-        findToken(projectPath) shouldBe None
-        findToken(projectId)   shouldBe Some(newToken.value)
-        findToken(newPath)     shouldBe Some(newToken.value)
+        findTokenInfo(tokenStoringInfo.project.id) shouldBe newStoringInfo.some
       }
   }
 
   private trait TestCase {
-    val projectId   = projectIds.generateOne
-    val projectPath = projectPaths.generateOne
+    val tokenStoringInfo = tokenStoringInfos.generateOne
 
     private val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
     val associator               = new AssociationPersisterImpl[IO](queriesExecTimes)
   }
+
+  private def findTokenInfo(projectId: projects.Id): Option[TokenStoringInfo] = sessionResource
+    .useK {
+      val query: Query[projects.Id, TokenStoringInfo] = sql"""
+      SELECT project_id, project_path, token, created_at, expiry_date
+      FROM projects_tokens
+      WHERE project_id = $projectIdEncoder"""
+        .query(
+          projectIdDecoder ~ projectPathDecoder ~ encryptedAccessTokenDecoder ~ createdAtDecoder ~ expiryDateDecoder
+        )
+        .map {
+          case (id: projects.Id) ~ (path: projects.Path) ~ (token: EncryptedAccessToken) ~ (createdAt: CreatedAt) ~ (expiryDate: ExpiryDate) =>
+            TokenStoringInfo(Project(id, path), token, TokenDates(createdAt, expiryDate))
+        }
+      Kleisli(_.prepare(query).use(_.option(projectId)))
+    }
+    .unsafeRunSync()
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
@@ -97,6 +97,39 @@ class AssociationPersisterSpec extends AnyWordSpec with IOSpec with InMemoryProj
       }
   }
 
+  "updatePath" should {
+
+    "replace the Path for the given project Id" in new TestCase {
+
+      associator.persistAssociation(tokenStoringInfo).unsafeRunSync() shouldBe ()
+
+      findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.some
+
+      val newPath = projectPaths.generateOne
+      associator.updatePath(Project(tokenStoringInfo.project.id, newPath)).unsafeRunSync() shouldBe ()
+
+      findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo
+        .copy(project = tokenStoringInfo.project.copy(path = newPath))
+        .some
+    }
+
+    "do nothing if project Path not changed" in new TestCase {
+
+      associator.persistAssociation(tokenStoringInfo).unsafeRunSync() shouldBe ()
+
+      associator.updatePath(tokenStoringInfo.project).unsafeRunSync() shouldBe ()
+
+      findTokenInfo(tokenStoringInfo.project.id) shouldBe tokenStoringInfo.some
+    }
+
+    "do nothing if no project with the given Id" in new TestCase {
+
+      associator.updatePath(tokenStoringInfo.project).unsafeRunSync() shouldBe ()
+
+      findTokenInfo(tokenStoringInfo.project.id) shouldBe None
+    }
+  }
+
   private trait TestCase {
     val tokenStoringInfo = tokenStoringInfos.generateOne
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/Generators.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/Generators.scala
@@ -21,7 +21,7 @@ package io.renku.tokenrepository.repository.association
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators.projectAccessTokens
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
+import io.renku.generators.Generators.{localDates, timestampsNotInTheFuture}
 import io.renku.graph.model.GraphModelGenerators.{projectIds, projectPaths}
 import io.renku.tokenrepository.repository.RepositoryGenerators._
 import io.renku.tokenrepository.repository.association.TokenDates._
@@ -30,7 +30,7 @@ import org.scalacheck.Gen
 private object Generators {
 
   val tokenCreatedAts:  Gen[CreatedAt]  = timestampsNotInTheFuture.toGeneratorOf(CreatedAt)
-  val tokenExpiryDates: Gen[ExpiryDate] = timestamps.toGeneratorOf(ExpiryDate)
+  val tokenExpiryDates: Gen[ExpiryDate] = localDates.toGeneratorOf(ExpiryDate)
 
   val tokenDates: Gen[TokenDates] =
     (tokenCreatedAts, tokenExpiryDates).mapN(TokenDates.apply)

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/Generators.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/Generators.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import cats.syntax.all._
+import io.renku.generators.CommonGraphGenerators.projectAccessTokens
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
+import io.renku.graph.model.GraphModelGenerators.{projectIds, projectPaths}
+import io.renku.tokenrepository.repository.RepositoryGenerators._
+import io.renku.tokenrepository.repository.association.TokenDates._
+import org.scalacheck.Gen
+
+private object Generators {
+
+  val tokenCreatedAts:  Gen[CreatedAt]  = timestampsNotInTheFuture.toGeneratorOf(CreatedAt)
+  val tokenExpiryDates: Gen[ExpiryDate] = timestamps.toGeneratorOf(ExpiryDate)
+
+  val tokenDates: Gen[TokenDates] =
+    (tokenCreatedAts, tokenExpiryDates).mapN(TokenDates.apply)
+
+  val tokenCreationInfos: Gen[TokenCreationInfo] =
+    (projectAccessTokens, tokenDates).mapN(TokenCreationInfo.apply)
+
+  private val projectInfos: Gen[TokenStoringInfo.Project] =
+    (projectIds, projectPaths).mapN(TokenStoringInfo.Project.apply)
+
+  val tokenStoringInfos: Gen[TokenStoringInfo] =
+    (projectInfos, encryptedAccessTokens, tokenDates).mapN(TokenStoringInfo.apply)
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/PersistedPathFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/PersistedPathFinderSpec.scala
@@ -42,7 +42,7 @@ class PersistedPathFinderSpec extends AnyWordSpec with IOSpec with InMemoryProje
     }
 
     "fail if there's no Path for the given Id" in new TestCase {
-      intercept[Exception]{
+      intercept[Exception] {
         (finder findPersistedProjectPath projectId).unsafeRunSync()
       }
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/PersistedPathFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/PersistedPathFinderSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import io.renku.db.SqlStatement
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators._
+import io.renku.metrics.TestLabeledHistogram
+import io.renku.testtools.IOSpec
+import io.renku.tokenrepository.repository.InMemoryProjectsTokensDbSpec
+import io.renku.tokenrepository.repository.RepositoryGenerators.encryptedAccessTokens
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class PersistedPathFinderSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
+
+  "findPersistedProjectPath" should {
+
+    "return Path for the given project Id" in new TestCase {
+
+      val projectPath = projectPaths.generateOne
+
+      insert(projectId, projectPath, encryptedAccessTokens.generateOne)
+
+      (finder findPersistedProjectPath projectId).unsafeRunSync() shouldBe projectPath
+    }
+
+    "fail if there's no Path for the given Id" in new TestCase {
+      intercept[Exception]{
+        (finder findPersistedProjectPath projectId).unsafeRunSync()
+      }
+    }
+  }
+
+  private trait TestCase {
+    val projectId = projectIds.generateOne
+
+    private val queriesExecTimes = TestLabeledHistogram[SqlStatement.Name]("query_id")
+    val finder                   = new PersistedPathFinderImpl(queriesExecTimes)
+  }
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreatorSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.collection.NonEmpty
+import io.circe.Json
+import io.circe.literal._
+import io.renku.generators.CommonGraphGenerators.{accessTokens, projectAccessTokens}
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.durations
+import io.renku.graph.model.GraphModelGenerators.projectIds
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.http.client.RestClient.ResponseMappingF
+import io.renku.http.client.{AccessToken, GitLabClient}
+import io.renku.http.server.EndpointTester._
+import io.renku.testtools.{GitLabClientTools, IOSpec}
+import org.http4s.Method.POST
+import org.http4s.Status.{Created, Unauthorized}
+import org.http4s.implicits._
+import org.http4s.{Request, Response, Uri}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.{LocalDate, Period}
+import scala.concurrent.duration._
+
+class ProjectAccessTokenCreatorSpec
+    extends AnyWordSpec
+    with MockFactory
+    with GitLabClientTools[IO]
+    with IOSpec
+    with should.Matchers {
+
+  "createPersonalAccessToken" should {
+
+    "do POST projects/:id/access_tokens with relevant payload" in new TestCase {
+
+      val endpointName: String Refined NonEmpty = "create-project-access-token"
+      val payload = json"""{
+        "name":       "renku",
+        "scopes":     ["api", "read_repository"],
+        "expires_at": ${now plus projectTokenTTL}
+      }"""
+      val projectAccessToken = projectAccessTokens.generateOne
+      (gitLabClient
+        .post(_: Uri, _: String Refined NonEmpty, _: Json)(_: ResponseMappingF[IO, ProjectAccessToken])(
+          _: Option[AccessToken]
+        ))
+        .expects(uri"projects" / projectId.value / "access_tokens", endpointName, payload, *, Option(accessToken))
+        .returning(projectAccessToken.pure[IO])
+
+      tokenCreator.createPersonalAccessToken(projectId, accessToken).unsafeRunSync() shouldBe projectAccessToken
+    }
+
+    s"retrieve the created Project Access Token from the response with $Created status" in new TestCase {
+      val createdToken = projectAccessTokens.generateOne
+      mapResponse(Created, Request[IO](), Response[IO](Created).withEntity(glResponsePayload(createdToken)))
+        .unsafeRunSync() shouldBe createdToken
+    }
+
+    s"fail for responses other than $Created" in new TestCase {
+      intercept[Exception] {
+        mapResponse(Unauthorized, Request[IO](), Response[IO](Unauthorized)).unsafeRunSync()
+      }
+    }
+  }
+
+  private trait TestCase {
+
+    val now         = LocalDate.now()
+    val projectId   = projectIds.generateOne
+    val accessToken = accessTokens.generateOne
+
+    val currentDate = mockFunction[LocalDate]
+    currentDate.expects().returning(now)
+    implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
+    val projectTokenTTL = Period.ofDays(durations(1 day, 730 days).generateOne.toDays.toInt)
+    val tokenCreator    = new ProjectAccessTokenCreatorImpl[IO](projectTokenTTL, currentDate)
+
+    lazy val mapResponse = captureMapping(tokenCreator, gitLabClient)(
+      findingMethod = _.createPersonalAccessToken(projectId, accessToken).unsafeRunSync(),
+      resultGenerator = projectAccessTokens.generateOne,
+      method = POST
+    )
+  }
+
+  private def glResponsePayload(projectAccessToken: ProjectAccessToken) = json"""{
+    "token": ${projectAccessToken.value}
+  }"""
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/TokenValidatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/TokenValidatorSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.association
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import eu.timepit.refined.collection.NonEmpty
+import io.renku.generators.CommonGraphGenerators.projectAccessTokens
+import io.renku.generators.Generators.Implicits._
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.http.client.GitLabClient
+import io.renku.http.client.RestClient.ResponseMappingF
+import io.renku.testtools.{GitLabClientTools, IOSpec}
+import org.http4s.Method.HEAD
+import org.http4s.Status.{BadRequest, NotFound, Ok, Unauthorized}
+import org.http4s.implicits._
+import org.http4s.{Request, Response, Uri}
+import org.scalacheck.Gen
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class TokenValidatorSpec
+    extends AnyWordSpec
+    with IOSpec
+    with MockFactory
+    with GitLabClientTools[IO]
+    with TableDrivenPropertyChecks
+    with should.Matchers {
+
+  "checkValid" should {
+
+    "return true if HEAD /user call to the the GL returns 200" in new TestCase {
+
+      val projectAccessToken = projectAccessTokens.generateOne
+
+      val endpointName: String Refined NonEmpty = "user"
+      val validationResult = results.generateOne
+      (gitLabClient
+        .head(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, Boolean])(
+          _: Option[ProjectAccessToken]
+        ))
+        .expects(uri"user", endpointName, *, Option(projectAccessToken))
+        .returning(validationResult.pure[IO])
+
+      validator.checkValid(projectAccessToken).unsafeRunSync() shouldBe validationResult
+    }
+
+    forAll {
+      Table(
+        "Status"     -> "Expected Result",
+        Ok           -> true,
+        NotFound     -> false,
+        Unauthorized -> false
+      )
+    } { (status, result) =>
+      s"map $status to true" in new TestCase {
+        mapResponse(status, Request[IO](), Response[IO](status)).unsafeRunSync() shouldBe result
+      }
+    }
+
+    "throw an Exception if remote responds with status different than OK, NOT_FOUND or UNAUTHORIZED" in new TestCase {
+      intercept[Exception] {
+        mapResponse(BadRequest, Request[IO](), Response[IO](BadRequest)).unsafeRunSync()
+      }
+    }
+  }
+
+  private trait TestCase {
+    implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
+    val validator = new TokenValidatorImpl[IO]
+
+    lazy val mapResponse = captureMapping(validator, gitLabClient)(
+      findingMethod = _.checkValid(projectAccessTokens.generateOne).unsafeRunSync(),
+      resultGenerator = results.generateOne,
+      method = HEAD
+    )
+  }
+
+  private lazy val results = Gen.oneOf(true, false)
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/TokenValidatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/TokenValidatorSpec.scala
@@ -30,7 +30,7 @@ import io.renku.http.client.GitLabClient
 import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.testtools.{GitLabClientTools, IOSpec}
 import org.http4s.Method.HEAD
-import org.http4s.Status.{BadRequest, NotFound, Ok, Unauthorized}
+import org.http4s.Status.{BadRequest, Forbidden, NotFound, Ok, Unauthorized}
 import org.http4s.implicits._
 import org.http4s.{Request, Response, Uri}
 import org.scalacheck.Gen
@@ -69,8 +69,9 @@ class TokenValidatorSpec
       Table(
         "Status"     -> "Expected Result",
         Ok           -> true,
-        NotFound     -> false,
-        Unauthorized -> false
+        Unauthorized -> false,
+        Forbidden    -> false,
+        NotFound     -> false
       )
     } { (status, result) =>
       s"map $status to true" in new TestCase {

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinderSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class PersistedTokensFinderSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
 
-  "findToken" should {
+  "findStoredToken" should {
 
     "return token associated with the projectId" in new TestCase {
 
@@ -38,7 +38,7 @@ class PersistedTokensFinderSpec extends AnyWordSpec with IOSpec with InMemoryPro
 
       insert(projectId, projectPath, encryptedToken)
 
-      finder.findToken(projectId).value.unsafeRunSync() shouldBe Some(encryptedToken)
+      finder.findStoredToken(projectId).value.unsafeRunSync() shouldBe Some(encryptedToken)
     }
 
     "return token associated with the projectPath" in new TestCase {
@@ -47,11 +47,11 @@ class PersistedTokensFinderSpec extends AnyWordSpec with IOSpec with InMemoryPro
 
       insert(projectId, projectPath, encryptedToken)
 
-      finder.findToken(projectPath).value.unsafeRunSync() shouldBe Some(encryptedToken)
+      finder.findStoredToken(projectPath).value.unsafeRunSync() shouldBe Some(encryptedToken)
     }
 
     "return None if there's no token associated with the projectId" in new TestCase {
-      finder.findToken(projectId).value.unsafeRunSync() shouldBe None
+      finder.findStoredToken(projectId).value.unsafeRunSync() shouldBe None
     }
   }
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/TokenFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/TokenFinderSpec.scala
@@ -46,7 +46,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       val encryptedToken = encryptedAccessTokens.generateOne
       (tokenInRepoFinder
-        .findToken(_: Id))
+        .findStoredToken(_: Id))
         .expects(projectId)
         .returning(OptionT.some(encryptedToken))
 
@@ -64,7 +64,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
       val projectId = projectIds.generateOne
 
       (tokenInRepoFinder
-        .findToken(_: Id))
+        .findStoredToken(_: Id))
         .expects(projectId)
         .returning(OptionT.none[IO, EncryptedAccessToken])
 
@@ -77,7 +77,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       val exception = exceptions.generateOne
       (tokenInRepoFinder
-        .findToken(_: Id))
+        .findStoredToken(_: Id))
         .expects(projectId)
         .returning(OptionT.liftF[IO, EncryptedAccessToken](exception.raiseError[IO, EncryptedAccessToken]))
 
@@ -98,7 +98,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
         val encryptedToken = encryptedAccessTokens.generateOne
         (tokenInRepoFinder
-          .findToken(_: Id))
+          .findStoredToken(_: Id))
           .expects(projectId)
           .returning(OptionT.some(encryptedToken))
 
@@ -109,7 +109,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
           .returning(exception.raiseError[IO, AccessToken])
 
         (tokenInRepoFinder
-          .findToken(_: Id))
+          .findStoredToken(_: Id))
           .expects(projectId)
           .returning(OptionT.some(encryptedToken))
 
@@ -131,7 +131,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       val encryptedToken = encryptedAccessTokens.generateOne
       (tokenInRepoFinder
-        .findToken(_: Id))
+        .findStoredToken(_: Id))
         .expects(projectId)
         .returning(OptionT.some(encryptedToken))
 
@@ -146,7 +146,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
     }
   }
 
-  "findToken(ProjectPath)" should {
+  "findStoredToken(ProjectPath)" should {
 
     "return Access Token if the token found for the projectPath in the db was successfully decrypted" in new TestCase {
 
@@ -154,7 +154,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       val encryptedToken = encryptedAccessTokens.generateOne
       (tokenInRepoFinder
-        .findToken(_: Path))
+        .findStoredToken(_: Path))
         .expects(projectPath)
         .returning(OptionT.some(encryptedToken))
 
@@ -172,7 +172,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
       val projectPath = projectPaths.generateOne
 
       (tokenInRepoFinder
-        .findToken(_: Path))
+        .findStoredToken(_: Path))
         .expects(projectPath)
         .returning(OptionT.none[IO, EncryptedAccessToken])
 
@@ -185,7 +185,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       val exception = exceptions.generateOne
       (tokenInRepoFinder
-        .findToken(_: Path))
+        .findStoredToken(_: Path))
         .expects(projectPath)
         .returning(OptionT.liftF[IO, EncryptedAccessToken](exception.raiseError[IO, EncryptedAccessToken]))
       intercept[Exception] {
@@ -205,7 +205,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
         val encryptedToken = encryptedAccessTokens.generateOne
         (tokenInRepoFinder
-          .findToken(_: Path))
+          .findStoredToken(_: Path))
           .expects(projectPath)
           .returning(OptionT.some(encryptedToken))
         val exception = exceptions.generateOne
@@ -215,7 +215,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
           .returning(exception.raiseError[IO, AccessToken])
 
         (tokenInRepoFinder
-          .findToken(_: Path))
+          .findStoredToken(_: Path))
           .expects(projectPath)
           .returning(OptionT.some(encryptedToken))
 
@@ -237,7 +237,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       val encryptedToken = encryptedAccessTokens.generateOne
       (tokenInRepoFinder
-        .findToken(_: Path))
+        .findStoredToken(_: Path))
         .expects(projectPath)
         .returning(OptionT.some(encryptedToken))
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/TokenFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/TokenFinderSpec.scala
@@ -142,7 +142,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       intercept[Exception] {
         tokenFinder.findToken(projectId).value.unsafeRunSync()
-      }.getMessage() shouldBe exception.getMessage
+      }.getMessage shouldBe exception.getMessage
     }
   }
 
@@ -248,7 +248,7 @@ class TokenFinderSpec extends AnyWordSpec with IOSpec with MockFactory with shou
 
       intercept[Exception] {
         tokenFinder.findToken(projectPath).value.unsafeRunSync()
-      }.getMessage() shouldBe exception.getMessage
+      }.getMessage shouldBe exception.getMessage
     }
   }
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
@@ -19,9 +19,7 @@
 package io.renku.tokenrepository.repository.init
 
 import cats.effect.IO
-import io.renku.db.SqlStatement
 import io.renku.interpreters.TestLogger
-import io.renku.metrics.{LabeledHistogram, TestLabeledHistogram}
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.InMemoryProjectsTokensDb
 
@@ -30,12 +28,10 @@ trait DbMigrations {
 
   protected type Migration = { def run(): IO[Unit] }
 
-  private lazy val queriesExecTimes: LabeledHistogram[IO] =
-    TestLabeledHistogram[SqlStatement.Name]("query_id")
   protected implicit lazy val logger: TestLogger[IO] = TestLogger[IO]()
 
   protected lazy val projectsTokensTableCreator: Migration = ProjectsTokensTableCreator[IO]
-  protected lazy val projectPathAdded:           Migration = ProjectPathAdder(queriesExecTimes).unsafeRunSync()
+  protected lazy val projectPathAdded:           Migration = ProjectPathAdder[IO]
   protected lazy val duplicateProjectsRemover:   Migration = DuplicateProjectsRemover[IO]
   protected lazy val expireAndCreatedDatesAdder: Migration = ExpireAndCreatedDatesAdder[IO]
 


### PR DESCRIPTION
This PR changes the behaviour of `PUT /projects/:id/tokens` so a Project Access Token is generated and persisted for the Project.