### PR TITLE
feat: DB migration replacing existing non-PAT to PAT tokens

### DIFF
--- a/graph-commons/src/test/scala/io/renku/db/DbSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/db/DbSpec.scala
@@ -18,10 +18,10 @@
 
 package io.renku.db
 
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, TestSuite}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
 
 trait DbSpec extends BeforeAndAfterAll with BeforeAndAfter {
-  self: TestSuite =>
+  self: Suite =>
 
   protected def initDb():           Unit
   protected def prepareDbForTest(): Unit

--- a/token-repository/src/main/scala/io/renku/tokenrepository/Microservice.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/Microservice.scala
@@ -50,8 +50,8 @@ object Microservice extends IOMicroservice {
       implicit0(gc: GitLabClient[IO])    <- GitLabClient[IO]()
       certificateLoader                  <- CertificateLoader[IO]
       sentryInitializer                  <- SentryInitializer[IO]
-      dbInitializer                      <- DbInitializer[IO]
       queriesExecTimes                   <- QueriesExecutionTimes[IO]
+      dbInitializer                      <- DbInitializer[IO](queriesExecTimes)
       microserviceRoutes                 <- MicroserviceRoutes[IO](queriesExecTimes)
       exitCode <- microserviceRoutes.routes.use { routes =>
                     new MicroserviceRunner(

--- a/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
@@ -19,7 +19,7 @@
 package io.renku.tokenrepository
 
 import cats.MonadThrow
-import cats.effect.{Async, Clock, Resource}
+import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.http.server.binders.{ProjectId, ProjectPath}
 import io.renku.http.client.GitLabClient
@@ -30,32 +30,49 @@ import io.renku.tokenrepository.repository.association.AssociateTokenEndpoint
 import io.renku.tokenrepository.repository.deletion.DeleteTokenEndpoint
 import io.renku.tokenrepository.repository.fetching.FetchTokenEndpoint
 import org.http4s.dsl.Http4sDsl
+import org.http4s.{HttpRoutes, Response}
 import org.typelevel.log4cats.Logger
 
-private class MicroserviceRoutes[F[_]: MonadThrow](
+private trait MicroserviceRoutes[F[_]] {
+  def notifyDBReady(): F[Unit]
+  def routes:          Resource[F, HttpRoutes[F]]
+}
+
+private class MicroserviceRoutesImpl[F[_]: MonadThrow](
     fetchTokenEndpoint:     FetchTokenEndpoint[F],
     associateTokenEndpoint: AssociateTokenEndpoint[F],
     deleteTokenEndpoint:    DeleteTokenEndpoint[F],
     routesMetrics:          RoutesMetrics[F],
-    versionRoutes:          version.Routes[F]
+    versionRoutes:          version.Routes[F],
+    dbReady:                Ref[F, Boolean]
 )(implicit clock:           Clock[F])
-    extends Http4sDsl[F] {
+    extends Http4sDsl[F]
+    with MicroserviceRoutes[F] {
 
   import associateTokenEndpoint._
   import deleteTokenEndpoint._
   import fetchTokenEndpoint._
+  import io.renku.http.InfoMessage
+  import io.renku.http.InfoMessage._
   import org.http4s.HttpRoutes
   import routesMetrics._
 
+  override def notifyDBReady(): F[Unit] = dbReady.set(true)
+
   // format: off
-  lazy val routes: Resource[F, HttpRoutes[F]] = HttpRoutes.of[F] {
-    case           GET    -> Root / "ping"                                           => Ok("pong")
-    case           GET    -> Root / "projects" / ProjectId(projectId) / "tokens"     => fetchToken(projectId)
-    case           GET    -> Root / "projects" / ProjectPath(projectPath) / "tokens" => fetchToken(projectPath)
-    case request @ POST   -> Root / "projects" / ProjectId(projectId) / "tokens"     => associateToken(projectId, request)
-    case           DELETE -> Root / "projects" / ProjectId(projectId) / "tokens"     => deleteToken(projectId)
+  override lazy val routes: Resource[F, HttpRoutes[F]] = HttpRoutes.of[F] {
+    case       GET    -> Root / "ping"                                           => Ok("pong")
+    case       GET    -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(fetchToken(projectId))
+    case       GET    -> Root / "projects" / ProjectPath(projectPath) / "tokens" => whenDBReady(fetchToken(projectPath))
+    case req @ POST   -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(associateToken(projectId, req))
+    case       DELETE -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(deleteToken(projectId))
   }.withMetrics.map(_ <+> versionRoutes())
   // format: on
+
+  private def whenDBReady(thunk: => F[Response[F]]): F[Response[F]] = dbReady.get >>= {
+    case true  => thunk
+    case false => ServiceUnavailable(InfoMessage("DB migration running"))
+  }
 }
 
 private object MicroserviceRoutes {
@@ -66,10 +83,12 @@ private object MicroserviceRoutes {
     associateTokenEndpoint <- AssociateTokenEndpoint(queriesExecTimes)
     deleteTokenEndpoint    <- DeleteTokenEndpoint(queriesExecTimes)
     versionRoutes          <- version.Routes[F]
-  } yield new MicroserviceRoutes(fetchTokenEndpoint,
-                                 associateTokenEndpoint,
-                                 deleteTokenEndpoint,
-                                 new RoutesMetrics[F],
-                                 versionRoutes
+    dbReady                <- Ref.of(false)
+  } yield new MicroserviceRoutesImpl(fetchTokenEndpoint,
+                                     associateTokenEndpoint,
+                                     deleteTokenEndpoint,
+                                     new RoutesMetrics[F],
+                                     versionRoutes,
+                                     dbReady
   )
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociationPersister.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/AssociationPersister.scala
@@ -33,12 +33,12 @@ import skunk.data.Completion
 import skunk.data.Completion.Delete
 import skunk.implicits._
 
-private trait AssociationPersister[F[_]] {
+private[repository] trait AssociationPersister[F[_]] {
   def persistAssociation(storingInfo: TokenStoringInfo):         F[Unit]
   def updatePath(project:             TokenStoringInfo.Project): F[Unit]
 }
 
-private object AssociationPersister {
+private[repository] object AssociationPersister {
   def apply[F[_]: MonadCancelThrow: SessionResource](queriesExecTimes: LabeledHistogram[F]): AssociationPersister[F] =
     new AssociationPersisterImpl[F](queriesExecTimes)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreator.scala
@@ -24,11 +24,12 @@ import com.typesafe.config.{Config, ConfigFactory}
 import io.renku.graph.model.projects
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.{AccessToken, GitLabClient}
+import org.http4s.Status.{Forbidden, NotFound}
 
 import java.time.{LocalDate, Period}
 
 private[tokenrepository] trait ProjectAccessTokenCreator[F[_]] {
-  def createPersonalAccessToken(projectId: projects.Id, accessToken: AccessToken): F[TokenCreationInfo]
+  def createPersonalAccessToken(projectId: projects.Id, accessToken: AccessToken): F[Option[TokenCreationInfo]]
 }
 
 private[tokenrepository] object ProjectAccessTokenCreator {
@@ -59,7 +60,9 @@ private class ProjectAccessTokenCreatorImpl[F[_]: Async: GitLabClient](
   import org.http4s.implicits._
   import org.http4s.{EntityDecoder, Request, Response, Status}
 
-  override def createPersonalAccessToken(projectId: projects.Id, accessToken: AccessToken): F[TokenCreationInfo] = {
+  override def createPersonalAccessToken(projectId:   projects.Id,
+                                         accessToken: AccessToken
+  ): F[Option[TokenCreationInfo]] = {
     val payload = json"""{
       "name":       "renku",
       "scopes":     ["api", "read_repository"],
@@ -70,8 +73,9 @@ private class ProjectAccessTokenCreatorImpl[F[_]: Async: GitLabClient](
     )(accessToken.some)
   }
 
-  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[TokenCreationInfo]] = {
-    case (Created, _, response) => response.as[TokenCreationInfo]
+  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Option[TokenCreationInfo]]] = {
+    case (Created, _, response)       => response.as[TokenCreationInfo].map(Option.apply)
+    case (Forbidden | NotFound, _, _) => Option.empty[TokenCreationInfo].pure[F]
   }
 
   private implicit lazy val tokenDecoder: EntityDecoder[F, TokenCreationInfo] = {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/ProjectAccessTokenCreator.scala
@@ -27,11 +27,11 @@ import io.renku.http.client.{AccessToken, GitLabClient}
 
 import java.time.{LocalDate, Period}
 
-private trait ProjectAccessTokenCreator[F[_]] {
+private[tokenrepository] trait ProjectAccessTokenCreator[F[_]] {
   def createPersonalAccessToken(projectId: projects.Id, accessToken: AccessToken): F[TokenCreationInfo]
 }
 
-private object ProjectAccessTokenCreator {
+private[tokenrepository] object ProjectAccessTokenCreator {
 
   import io.renku.config.ConfigLoader._
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
@@ -21,14 +21,13 @@ package io.renku.tokenrepository.repository.association
 import cats.MonadThrow
 import cats.syntax.all._
 import eu.timepit.refined.auto._
-import io.renku.http.client.AccessToken.ProjectAccessToken
-import io.renku.http.client.GitLabClient
+import io.renku.http.client.{AccessToken, GitLabClient}
 
-private trait TokenValidator[F[_]] {
-  def checkValid(token: ProjectAccessToken): F[Boolean]
+private[tokenrepository] trait TokenValidator[F[_]] {
+  def checkValid(token: AccessToken): F[Boolean]
 }
 
-private object TokenValidator {
+private[tokenrepository] object TokenValidator {
   def apply[F[_]: MonadThrow: GitLabClient]: F[TokenValidator[F]] = new TokenValidatorImpl[F].pure[F].widen
 }
 
@@ -38,7 +37,7 @@ private class TokenValidatorImpl[F[_]: MonadThrow: GitLabClient] extends TokenVa
   import org.http4s._
   import org.http4s.implicits._
 
-  override def checkValid(token: ProjectAccessToken): F[Boolean] =
+  override def checkValid(token: AccessToken): F[Boolean] =
     GitLabClient[F].head(uri"user", "user")(mapResponse)(token.some)
 
   private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Boolean]] = {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/TokenValidator.scala
@@ -42,6 +42,6 @@ private class TokenValidatorImpl[F[_]: MonadThrow: GitLabClient] extends TokenVa
 
   private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Boolean]] = {
     case (Ok, _, _)                                  => true.pure[F]
-    case (NotFound | Unauthorized | Forbidden, _, _) => false.pure[F]
+    case (Unauthorized | Forbidden | NotFound, _, _) => false.pure[F]
   }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/association/model.scala
@@ -18,6 +18,7 @@
 
 package io.renku.tokenrepository.repository.association
 
+import cats.Show
 import io.renku.graph.model.projects
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.http.client.AccessToken.ProjectAccessToken
@@ -28,11 +29,11 @@ import io.renku.tokenrepository.repository.association.TokenDates._
 
 import java.time.{Instant, LocalDate}
 
-private final case class TokenCreationInfo(token: ProjectAccessToken, dates: TokenDates)
+private[repository] final case class TokenCreationInfo(token: ProjectAccessToken, dates: TokenDates)
 
-final case class TokenDates(createdAt: CreatedAt, expiryDate: ExpiryDate)
+private[repository] final case class TokenDates(createdAt: CreatedAt, expiryDate: ExpiryDate)
 
-object TokenDates {
+private[repository] object TokenDates {
   final class CreatedAt private (val value: Instant) extends AnyVal with InstantTinyType
 
   implicit object CreatedAt
@@ -44,11 +45,17 @@ object TokenDates {
   implicit object ExpiryDate extends TinyTypeFactory[ExpiryDate](new ExpiryDate(_)) with TinyTypeJsonLDOps[ExpiryDate]
 }
 
-private final case class TokenStoringInfo(project:        TokenStoringInfo.Project,
-                                          encryptedToken: EncryptedAccessToken,
-                                          dates:          TokenDates
+private[repository] final case class TokenStoringInfo(project:        TokenStoringInfo.Project,
+                                                      encryptedToken: EncryptedAccessToken,
+                                                      dates:          TokenDates
 )
 
-private object TokenStoringInfo {
+private[repository] object TokenStoringInfo {
   final case class Project(id: projects.Id, path: projects.Path)
+
+  object Project {
+    implicit lazy val show: Show[Project] = Show.show { case Project(id, path) =>
+      s"projectId = $id, projectPath = $path"
+    }
+  }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DBMigration.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DBMigration.scala
@@ -18,15 +18,6 @@
 
 package io.renku.tokenrepository.repository.init
 
-import cats.effect.IO
-import io.renku.interpreters.TestLogger
-import io.renku.testtools.IOSpec
-import io.renku.tokenrepository.repository.InMemoryProjectsTokensDb
-
-trait DbMigrations {
-  self: InMemoryProjectsTokensDb with IOSpec =>
-
-  protected implicit lazy val logger: TestLogger[IO] = TestLogger[IO]()
-
-  protected lazy val allMigrations: List[DBMigration[IO]] = DbInitializer.migrations[IO]
+trait DBMigration[F[_]] {
+  def run(): F[Unit]
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
@@ -60,7 +60,7 @@ object DbInitializer {
     ProjectsTokensTableCreator[F].pure[F],
     ProjectPathAdder[F].pure[F],
     DuplicateProjectsRemover[F].pure[F],
-    ExpireAndCreatedDatesAdder[F].pure[F],
+    ExpiryAndCreatedDatesAdder[F].pure[F],
     TokensMigrator[F](queriesExecTimes)
   ).sequence
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
@@ -61,7 +61,8 @@ object DbInitializer {
     ProjectPathAdder[F].pure[F],
     DuplicateProjectsRemover[F].pure[F],
     ExpiryAndCreatedDatesAdder[F].pure[F],
-    TokensMigrator[F](queriesExecTimes)
+    TokensMigrator[F](queriesExecTimes),
+    ExpiryAndCreatedDatesNotNull[F].pure[F]
   ).sequence
 
   def apply[F[_]: Async: GitLabClient: Logger: SessionResource](

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemover.scala
@@ -26,17 +26,12 @@ import org.typelevel.log4cats.Logger
 import skunk.implicits._
 import skunk.{Command, Session}
 
-private trait DuplicateProjectsRemover[F[_]] {
-  def run(): F[Unit]
-}
-
 private object DuplicateProjectsRemover {
-  def apply[F[_]: MonadCancelThrow: Logger: SessionResource]: DuplicateProjectsRemover[F] =
-    new DuplicateProjectsRemoverImpl[F]
+  def apply[F[_]: MonadCancelThrow: Logger: SessionResource]: DBMigration[F] =
+    new DuplicateProjectsRemover[F]
 }
 
-private class DuplicateProjectsRemoverImpl[F[_]: MonadCancelThrow: Logger: SessionResource]
-    extends DuplicateProjectsRemover[F] {
+private class DuplicateProjectsRemover[F[_]: MonadCancelThrow: Logger: SessionResource] extends DBMigration[F] {
 
   override def run(): F[Unit] = SessionResource[F].useK {
     for {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdder.scala
@@ -25,17 +25,11 @@ import cats.effect.Spawn
 import cats.syntax.all._
 import org.typelevel.log4cats.Logger
 
-private trait ExpireAndCreatedDatesAdder[F[_]] {
-  def run(): F[Unit]
-}
-
 private object ExpireAndCreatedDatesAdder {
-  def apply[F[_]: Spawn: Logger: SessionResource]: ExpireAndCreatedDatesAdder[F] =
-    new ExpireAndCreatedDatesAdderImpl[F]
+  def apply[F[_]: Spawn: Logger: SessionResource]: DBMigration[F] = new ExpireAndCreatedDatesAdder[F]
 }
 
-private class ExpireAndCreatedDatesAdderImpl[F[_]: Spawn: Logger: SessionResource]
-    extends ExpireAndCreatedDatesAdder[F] {
+private class ExpireAndCreatedDatesAdder[F[_]: Spawn: Logger: SessionResource] extends DBMigration[F] {
 
   import MigrationTools._
   import skunk._

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdder.scala
@@ -25,11 +25,11 @@ import cats.effect.Spawn
 import cats.syntax.all._
 import org.typelevel.log4cats.Logger
 
-private object ExpireAndCreatedDatesAdder {
-  def apply[F[_]: Spawn: Logger: SessionResource]: DBMigration[F] = new ExpireAndCreatedDatesAdder[F]
+private object ExpiryAndCreatedDatesAdder {
+  def apply[F[_]: Spawn: Logger: SessionResource]: DBMigration[F] = new ExpiryAndCreatedDatesAdder[F]
 }
 
-private class ExpireAndCreatedDatesAdder[F[_]: Spawn: Logger: SessionResource] extends DBMigration[F] {
+private class ExpiryAndCreatedDatesAdder[F[_]: Spawn: Logger: SessionResource] extends DBMigration[F] {
 
   import MigrationTools._
   import skunk._

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNull.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNull.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.init
+
+import cats.data.Kleisli
+import cats.effect.Spawn
+import cats.syntax.all._
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
+import org.typelevel.log4cats.Logger
+
+private object ExpiryAndCreatedDatesNotNull {
+  def apply[F[_]: Spawn: Logger: SessionResource]: DBMigration[F] = new ExpiryAndCreatedDatesNotNull[F]
+}
+
+private class ExpiryAndCreatedDatesNotNull[F[_]: Spawn: Logger: SessionResource] extends DBMigration[F] {
+
+  import MigrationTools._
+
+  override def run(): F[Unit] = SessionResource[F].useK {
+    ensureNotNullable("expiry_date") >> ensureNotNullable("created_at")
+  }
+
+  private def ensureNotNullable(column: String) =
+    checkColumnNullable("projects_tokens", column) >>= {
+      case true =>
+        madeColumnNullable("projects_tokens", column)
+          .flatMapF(_ => Logger[F].info(s"'$column' column made NOT NULL"))
+      case false =>
+        Kleisli.liftF(Logger[F].info(s"'$column' column already NOT NULL"))
+    }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNull.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNull.scala
@@ -19,16 +19,16 @@
 package io.renku.tokenrepository.repository.init
 
 import cats.data.Kleisli
-import cats.effect.Spawn
+import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import org.typelevel.log4cats.Logger
 
 private object ExpiryAndCreatedDatesNotNull {
-  def apply[F[_]: Spawn: Logger: SessionResource]: DBMigration[F] = new ExpiryAndCreatedDatesNotNull[F]
+  def apply[F[_]: MonadCancelThrow: Logger: SessionResource]: DBMigration[F] = new ExpiryAndCreatedDatesNotNull[F]
 }
 
-private class ExpiryAndCreatedDatesNotNull[F[_]: Spawn: Logger: SessionResource] extends DBMigration[F] {
+private class ExpiryAndCreatedDatesNotNull[F[_]: MonadCancelThrow: Logger: SessionResource] extends DBMigration[F] {
 
   import MigrationTools._
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
@@ -22,9 +22,9 @@ import cats.MonadThrow
 import cats.data.Kleisli
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
+import skunk._
 import skunk.codec.all._
 import skunk.implicits._
-import skunk._
 
 private object MigrationTools {
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
@@ -33,15 +33,38 @@ private object MigrationTools {
 
   def checkColumnExists[F[_]: MonadCancelThrow](table: String, column: String): Kleisli[F, Session[F], Boolean] =
     Kleisli { session =>
-      val query: Query[String ~ String, Boolean] =
-        sql"""SELECT EXISTS (
-            SELECT *
-            FROM information_schema.columns
-            WHERE table_name = $varchar AND column_name = $varchar
-          )""".query(bool)
+      val query: Query[String ~ String, Boolean] = sql"""
+        SELECT EXISTS (
+          SELECT *
+          FROM information_schema.columns
+          WHERE table_name = $varchar AND column_name = $varchar
+        )""".query(bool)
       session
         .prepare(query)
         .use(_.unique(table ~ column))
         .recover { case _ => false }
+    }
+
+  def checkColumnNullable[F[_]: MonadCancelThrow](table: String, column: String): Kleisli[F, Session[F], Boolean] =
+    Kleisli { session =>
+      val query: Query[String ~ String, Boolean] = sql"""
+        SELECT is_nullable
+        FROM information_schema.columns
+        WHERE table_name = $varchar AND column_name = $varchar"""
+        .query(varchar(3))
+        .map {
+          case "YES" => true
+          case "NO"  => false
+          case other => throw new Exception(s"is_nullable for $table.$column has value $other")
+        }
+      session
+        .prepare(query)
+        .use(_.unique(table ~ column))
+        .recover { case _ => false }
+    }
+
+  def madeColumnNullable[F[_]: MonadCancelThrow](table: String, column: String): Kleisli[F, Session[F], Unit] =
+    Kleisli { implicit session =>
+      execute(sql"ALTER TABLE #$table ALTER COLUMN #$column SET NOT NULL".command)
     }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
@@ -29,12 +29,12 @@ import skunk.implicits._
 
 import scala.util.control.NonFatal
 
-private trait ProjectPathAdder[F[_]] {
-  def run(): F[Unit]
+private object ProjectPathAdder {
+  def apply[F[_]: Async: Logger: SessionResource]: DBMigration[F] = new ProjectPathAdder[F]
 }
 
-private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource]
-    extends ProjectPathAdder[F]
+private class ProjectPathAdder[F[_]: Spawn: Logger: SessionResource]
+    extends DBMigration[F]
     with TokenRepositoryTypeSerializers {
 
   import MigrationTools._
@@ -61,9 +61,4 @@ private class ProjectPathAdderImpl[F[_]: Spawn: Logger: SessionResource]
     Logger[F].error(exception)("'project_path' column adding failure")
     exception.raiseError[F, Unit]
   }
-}
-
-private object ProjectPathAdder {
-
-  def apply[F[_]: Async: Logger: SessionResource]: ProjectPathAdder[F] = new ProjectPathAdderImpl[F]
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+package init
+
+import AccessTokenCrypto.EncryptedAccessToken
+import ProjectsTokensDB.SessionResource
+import association.TokenStoringInfo.Project
+import association._
+import cats.effect.{Async, Temporal}
+import cats.syntax.all._
+import deletion.TokenRemover
+import io.renku.db.DbClient
+import io.renku.graph.model.projects
+import io.renku.http.client.{AccessToken, GitLabClient}
+import io.renku.metrics.LabeledHistogram
+import org.typelevel.log4cats.Logger
+import skunk.~
+
+import scala.concurrent.duration._
+
+private object TokensMigrator {
+  def apply[F[_]: Async: GitLabClient: SessionResource: Logger](
+      queriesExecTimes: LabeledHistogram[F]
+  ): F[DBMigration[F]] = for {
+    accessTokenCrypto         <- AccessTokenCrypto[F]()
+    tokenValidator            <- TokenValidator[F]
+    tokenRemover              <- TokenRemover[F](queriesExecTimes).pure[F]
+    projectAccessTokenCreator <- ProjectAccessTokenCreator[F]()
+    associationPersister      <- AssociationPersister[F](queriesExecTimes).pure[F]
+  } yield new TokensMigrator[F](accessTokenCrypto,
+                                tokenValidator,
+                                tokenRemover,
+                                projectAccessTokenCreator,
+                                associationPersister,
+                                queriesExecTimes
+  )
+}
+
+private class TokensMigrator[F[_]: Async: SessionResource: Logger](
+    tokenCrypto:               AccessTokenCrypto[F],
+    tokenValidator:            TokenValidator[F],
+    tokenRemover:              TokenRemover[F],
+    projectAccessTokenCreator: ProjectAccessTokenCreator[F],
+    associationPersister:      AssociationPersister[F],
+    queriesExecTimes:          LabeledHistogram[F],
+    retryInterval:             Duration = 5 seconds
+) extends DbClient[F](Some(queriesExecTimes))
+    with DBMigration[F]
+    with TokenRepositoryTypeSerializers {
+
+  private val logPrefix = "token migration:"
+
+  import associationPersister._
+  import fs2.Stream
+  import io.renku.db.SqlStatement
+  import projectAccessTokenCreator._
+  import skunk.Void
+  import skunk.implicits._
+  import tokenCrypto._
+  import tokenRemover._
+  import tokenValidator._
+
+  override def run(): F[Unit] =
+    Stream
+      .emit(())
+      .repeat
+      .evalMap(_ => findTokenWithoutDates)
+      .takeThrough(_.nonEmpty)
+      .flatMap(maybeProjectAndToken => Stream.emits(maybeProjectAndToken.toList))
+      .evalMap { case (proj, encToken) => decryptOrDelete(proj, encToken) }
+      .flatMap(maybeProjectAndToken => Stream.emits(maybeProjectAndToken.toList))
+      .evalMap { case (proj, token) => deleteWhenInvalidWithRetry(proj, token) }
+      .flatMap(maybeProjectAndToken => Stream.emits(maybeProjectAndToken.toList))
+      .evalMap { case (proj, token) => createTokenWithRetry(proj, token) }
+      .evalMap { case (proj, newTokenInfo) => encrypt(newTokenInfo.token).map(enc => (proj, newTokenInfo, enc)) }
+      .evalTap { case (proj, newTokenInfo, encToken) => persistWithRetry(proj, newTokenInfo, encToken) }
+      .evalMap { case (proj, _, _) => Logger[F].info(show"$logPrefix $proj token created") }
+      .compile
+      .drain
+
+  private def findTokenWithoutDates: F[Option[(Project, EncryptedAccessToken)]] = SessionResource[F].useK {
+    measureExecutionTime {
+      findTokenQuery.build(_.option)
+    }
+  }
+
+  private def findTokenQuery: SqlStatement.Select[F, Void, (Project, EncryptedAccessToken)] =
+    SqlStatement
+      .named[F]("find non-migrated token")
+      .select[Void, Project ~ EncryptedAccessToken](
+        sql"""
+        SELECT project_id, project_path, token
+        FROM projects_tokens
+        WHERE expiry_date IS NULL"""
+          .query(projectIdDecoder ~ projectPathDecoder ~ encryptedAccessTokenDecoder)
+          .map { case (id: projects.Id) ~ (path: projects.Path) ~ (token: EncryptedAccessToken) =>
+            Project(id, path) -> token
+          }
+      )
+      .arguments(Void)
+
+  private def decryptOrDelete(project: Project, encToken: EncryptedAccessToken): F[Option[(Project, AccessToken)]] =
+    decrypt(encToken)
+      .map(t => Option(project -> t))
+      .recoverWith { case ex: Throwable =>
+        Logger[F].error(ex)(show"$logPrefix $project token decryption failed; deleting") >>
+          delete(project.id) >>
+          Option.empty[(Project, AccessToken)].pure[F]
+      }
+
+  private def deleteWhenInvalidWithRetry(project: Project, token: AccessToken): F[Option[(Project, AccessToken)]] = {
+    checkValid(token) >>= {
+      case true => (project, token).some.pure[F]
+      case false =>
+        Logger[F].warn(show"$logPrefix $project token invalid; deleting") >>
+          delete(project.id) >>
+          Option.empty[(Project, AccessToken)].pure[F]
+    }
+  }.recoverWith(retry(deleteWhenInvalidWithRetry(project, token))(project))
+
+  private def createTokenWithRetry(project: Project, token: AccessToken): F[(Project, TokenCreationInfo)] =
+    createPersonalAccessToken(project.id, token)
+      .map(project -> _)
+      .recoverWith(retry(createTokenWithRetry(project, token))(project))
+
+  private def persistWithRetry(project:        Project,
+                               newTokenInfo:   TokenCreationInfo,
+                               encryptedToken: EncryptedAccessToken
+  ): F[Unit] =
+    persistAssociation(TokenStoringInfo(project, encryptedToken, newTokenInfo.dates))
+      .recoverWith(retry(persistWithRetry(project, newTokenInfo, encryptedToken))(project))
+
+  private def retry[O](thunk: => F[O])(project: Project): PartialFunction[Throwable, F[O]] = { case ex: Exception =>
+    Logger[F].error(ex)(show"$logPrefix $project failure; retrying") >>
+      Temporal[F].delayBy(thunk, retryInterval)
+  }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
@@ -79,8 +79,7 @@ private class TokensMigrator[F[_]: Async: SessionResource: Logger](
   override def run(): F[Unit] =
     Stream
       .repeatEval(findTokenWithoutDates)
-      .takeThrough(_.nonEmpty)
-      .flatMap(maybeProjectAndToken => Stream.emits(maybeProjectAndToken.toList))
+      .unNoneTerminate
       .evalMap { case (proj, encToken) => decryptOrDelete(proj, encToken) }
       .flatMap(maybeProjectAndToken => Stream.emits(maybeProjectAndToken.toList))
       .evalMap { case (proj, token) => deleteWhenInvalidWithRetry(proj, token) }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRoutesSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRoutesSpec.scala
@@ -19,7 +19,7 @@
 package io.renku.tokenrepository
 
 import cats.data.OptionT
-import cats.effect.IO
+import cats.effect.{IO, Ref}
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators.httpStatuses
 import io.renku.generators.Generators.Implicits._
@@ -50,23 +50,31 @@ class MicroserviceRoutesSpec
     with ScalaCheckPropertyChecks
     with should.Matchers {
 
-  "routes" should {
+  "GET /ping" should {
 
-    "define a GET /ping endpoint returning OK with 'pong' body" in new TestCase {
+    "return OK with 'pong' body" in new TestCase {
       val response = routes.call(Request(GET, uri"/ping"))
 
       response.status       shouldBe Ok
       response.body[String] shouldBe "pong"
     }
+  }
 
-    "define a GET /metrics endpoint returning OK with some prometheus metrics" in new TestCase {
+  "GET /metrics" should {
+
+    "return OK with some prometheus metrics" in new TestCase {
       val response = routes.call(Request(GET, uri"/metrics"))
 
       response.status     shouldBe Ok
       response.body[String] should include("server_response_duration_seconds")
     }
+  }
 
-    s"define a GET /projects/:id/tokens endpoint returning $Ok when a valid projectId is given" in new TestCase {
+  "GET /projects/:id/tokens" should {
+
+    s"return $Ok when a valid projectId is given" in new TestCase {
+
+      givenDBReady()
 
       val projectId = projectIds.generateOne
 
@@ -78,7 +86,15 @@ class MicroserviceRoutesSpec
       routes.call(Request(GET, uri"/projects" / projectId.toString / "tokens")).status shouldBe Ok
     }
 
-    s"define a GET /projects/:id/tokens endpoint returning $Ok when a valid projectPath is given" in new TestCase {
+    s"return $ServiceUnavailable for a valid projectId when DB migration is ongoing" in new TestCase {
+      routes
+        .call(Request(GET, uri"/projects" / projectIds.generateOne.toString / "tokens"))
+        .status shouldBe ServiceUnavailable
+    }
+
+    s"return $Ok when a valid projectPath is given" in new TestCase {
+
+      givenDBReady()
 
       val projectPath = projectPaths.generateOne
 
@@ -90,7 +106,18 @@ class MicroserviceRoutesSpec
       routes.call(Request(GET, uri"/projects" / projectPath.toString / "tokens")).status shouldBe Ok
     }
 
-    s"define a POST /projects/:id/tokens endpoint returning $Ok when a valid projectId given" in new TestCase {
+    s"return $ServiceUnavailable for a valid Project Path when DB migration is ongoing" in new TestCase {
+      routes
+        .call(Request(GET, uri"/projects" / projectPaths.generateOne.toString / "tokens"))
+        .status shouldBe ServiceUnavailable
+    }
+  }
+
+  "POST /projects/:id/tokens" should {
+
+    s"return $Ok when a valid projectId given" in new TestCase {
+
+      givenDBReady()
 
       val projectId = projectIds.generateOne
       val request   = Request[IO](POST, uri"/projects" / projectId.toString / "tokens")
@@ -103,7 +130,18 @@ class MicroserviceRoutesSpec
       (routes call request).status shouldBe NoContent
     }
 
-    s"define a DELETE /projects/:id/tokens endpoint returning $Ok when a valid projectId given" in new TestCase {
+    s"return $ServiceUnavailable for a valid projectId when DB migration is ongoing" in new TestCase {
+      routes
+        .call(Request(POST, uri"/projects" / projectIds.generateOne.toString / "tokens"))
+        .status shouldBe ServiceUnavailable
+    }
+  }
+
+  "DELETE /projects/:id/tokens" should {
+
+    s"return $Ok when a valid projectId given" in new TestCase {
+
+      givenDBReady()
 
       val projectId = projectIds.generateOne
       (deleteEndpoint
@@ -112,6 +150,12 @@ class MicroserviceRoutesSpec
         .returning(IO.pure(Response[IO](NoContent)))
 
       (routes call Request[IO](DELETE, uri"/projects" / projectId.toString / "tokens")).status shouldBe NoContent
+    }
+
+    s"return $ServiceUnavailable for a valid projectId when DB migration is ongoing" in new TestCase {
+      routes
+        .call(Request(DELETE, uri"/projects" / projectIds.generateOne.toString / "tokens"))
+        .status shouldBe ServiceUnavailable
     }
   }
 
@@ -128,13 +172,15 @@ class MicroserviceRoutesSpec
     val deleteEndpoint    = mock[deletion.DeleteTokenEndpoint[IO]]
     val routesMetrics     = TestRoutesMetrics()
     val versionRoutes     = mock[version.Routes[IO]]
-    val routes = new MicroserviceRoutes[IO](
+    private val microserviceRoutes = new MicroserviceRoutesImpl[IO](
       fetchEndpoint,
       associateEndpoint,
       deleteEndpoint,
       routesMetrics,
-      versionRoutes
-    ).routes.map(_.or(notAvailableResponse))
+      versionRoutes,
+      Ref.unsafe[IO, Boolean](false)
+    )
+    val routes = microserviceRoutes.routes.map(_.or(notAvailableResponse))
 
     val versionEndpointResponse = Response[IO](httpStatuses.generateOne)
     (versionRoutes.apply _)
@@ -143,5 +189,8 @@ class MicroserviceRoutesSpec
         import org.http4s.dsl.io.{GET => _, _}
         HttpRoutes.of[IO] { case GET -> Root / "version" => versionEndpointResponse.pure[IO] }
       }
+
+    def givenDBReady(): Unit =
+      microserviceRoutes.notifyDBReady().unsafeRunSync()
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
@@ -23,11 +23,11 @@ import cats.data.Kleisli
 import cats.effect.IO
 import cats.syntax.all._
 import io.renku.db.DbSpec
+import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.localDates
 import io.renku.graph.model.projects.{Id, Path}
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.association.TokenDates.ExpiryDate
-import io.renku.generators.Generators.Implicits._
 import io.renku.tokenrepository.repository.init.DbMigrations
 import org.scalatest.TestSuite
 import skunk._
@@ -36,7 +36,6 @@ import skunk.data.Completion
 import skunk.implicits._
 
 import java.time.{LocalDate, OffsetDateTime}
-import scala.language.reflectiveCalls
 
 trait InMemoryProjectsTokensDbSpec extends DbSpec with InMemoryProjectsTokensDb with DbMigrations {
   self: TestSuite with IOSpec =>

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
@@ -29,7 +29,8 @@ import io.renku.graph.model.projects.{Id, Path}
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.association.TokenDates.ExpiryDate
 import io.renku.tokenrepository.repository.init.DbMigrations
-import org.scalatest.TestSuite
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.Suite
 import skunk._
 import skunk.codec.all._
 import skunk.data.Completion
@@ -38,7 +39,7 @@ import skunk.implicits._
 import java.time.{LocalDate, OffsetDateTime}
 
 trait InMemoryProjectsTokensDbSpec extends DbSpec with InMemoryProjectsTokensDb with DbMigrations {
-  self: TestSuite with IOSpec =>
+  self: Suite with IOSpec with MockFactory =>
 
   protected def initDb(): Unit =
     allMigrations.map(_.run()).sequence.void.unsafeRunSync()

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/AssociationPersisterSpec.scala
@@ -33,12 +33,18 @@ import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.projects
 import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import skunk._
 import skunk.implicits._
 
-class AssociationPersisterSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
+class AssociationPersisterSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryProjectsTokensDbSpec
+    with should.Matchers
+    with MockFactory {
 
   "persistAssociation" should {
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/PersistedPathFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/association/PersistedPathFinderSpec.scala
@@ -25,10 +25,16 @@ import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.InMemoryProjectsTokensDbSpec
 import io.renku.tokenrepository.repository.RepositoryGenerators.encryptedAccessTokens
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class PersistedPathFinderSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
+class PersistedPathFinderSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryProjectsTokensDbSpec
+    with should.Matchers
+    with MockFactory {
 
   "findPersistedProjectPath" should {
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
@@ -25,10 +25,16 @@ import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.InMemoryProjectsTokensDbSpec
 import io.renku.tokenrepository.repository.RepositoryGenerators.encryptedAccessTokens
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class TokenRemoverSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
+class TokenRemoverSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryProjectsTokensDbSpec
+    with should.Matchers
+    with MockFactory {
 
   "delete" should {
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinderSpec.scala
@@ -25,10 +25,16 @@ import io.renku.metrics.TestLabeledHistogram
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.InMemoryProjectsTokensDbSpec
 import io.renku.tokenrepository.repository.RepositoryGenerators._
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class PersistedTokensFinderSpec extends AnyWordSpec with IOSpec with InMemoryProjectsTokensDbSpec with should.Matchers {
+class PersistedTokensFinderSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryProjectsTokensDbSpec
+    with should.Matchers
+    with MockFactory {
 
   "findStoredToken" should {
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.tokenrepository.repository.init
 
 import cats.data.Kleisli
+import cats.effect.IO
 import cats.syntax.all._
 import io.renku.graph.model.projects.{Id, Path}
 import io.renku.testtools.IOSpec
@@ -29,12 +30,10 @@ import skunk.data.Completion
 import skunk.implicits._
 import skunk.{Query, Void}
 
-import scala.language.reflectiveCalls
-
 trait DbInitSpec extends InMemoryProjectsTokensDb with DbMigrations with BeforeAndAfter {
   self: Suite with IOSpec =>
 
-  protected val migrationsToRun: List[Migration]
+  protected val migrationsToRun: List[DBMigration[IO]]
 
   before {
     findAllTables() foreach dropTable

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitializerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitializerSpec.scala
@@ -37,8 +37,6 @@ class DbInitializerSpec
     with should.Matchers
     with MockedRunnableCollaborators {
 
-  import DbInitializer.Runnable
-
   "run" should {
 
     "run all the migrations" in new TestCase {
@@ -70,11 +68,8 @@ class DbInitializerSpec
 
   private trait TestCase {
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
-    val migrator1 = mock[ProjectsTokensTableCreator[IO]]
-    val migrator2 = mock[ProjectPathAdder[IO]]
-    val initializer = new DbInitializerImpl(
-      List[Runnable[IO, Unit]](migrator1, migrator2),
-      retrySleepDuration = 500 millis
-    )
+    val migrator1   = mock[DBMigration[IO]]
+    val migrator2   = mock[DBMigration[IO]]
+    val initializer = new DbInitializerImpl(List(migrator1, migrator2), retrySleepDuration = 500 millis)
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
@@ -29,13 +29,19 @@ import io.renku.interpreters.TestLogger.Level.Info
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.RepositoryGenerators.encryptedAccessTokens
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import skunk.codec.all.{int4, varchar}
 import skunk.implicits._
 import skunk.{Command, Session, ~}
 
-class DuplicateProjectsRemoverSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
+class DuplicateProjectsRemoverSpec
+    extends AnyWordSpec
+    with IOSpec
+    with DbInitSpec
+    with should.Matchers
+    with MockFactory {
 
   protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
     case _: DuplicateProjectsRemover[IO] => false

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
@@ -37,8 +37,8 @@ import skunk.{Command, Session, ~}
 
 class DuplicateProjectsRemoverSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
 
-  protected override lazy val migrationsToRun: List[Migration] = allMigrations.takeWhile {
-    case _: DuplicateProjectsRemoverImpl[_] => false
+  protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
+    case _: DuplicateProjectsRemover[IO] => false
     case _ => true
   }
 
@@ -73,7 +73,7 @@ class DuplicateProjectsRemoverSpec extends AnyWordSpec with IOSpec with DbInitSp
 
   private trait TestCase {
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
-    val deduplicator = new DuplicateProjectsRemoverImpl[IO]
+    val deduplicator = new DuplicateProjectsRemover[IO]
   }
 
   protected def insert(projectId: Id, projectPath: Path, encryptedToken: EncryptedAccessToken): Unit =

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
@@ -26,8 +26,8 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
 
-  protected override lazy val migrationsToRun: List[Migration] = allMigrations.takeWhile {
-    case _: ExpireAndCreatedDatesAdder[_] => false
+  protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
+    case _: ExpireAndCreatedDatesAdder[IO] => false
     case _ => true
   }
 
@@ -56,6 +56,6 @@ class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInit
   }
 
   private trait TestCase {
-    val datesAdder = new ExpireAndCreatedDatesAdderImpl[IO]
+    val datesAdder = new ExpireAndCreatedDatesAdder[IO]
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpireAndCreatedDatesAdderSpec.scala
@@ -21,10 +21,11 @@ package io.renku.tokenrepository.repository.init
 import cats.effect.IO
 import io.renku.interpreters.TestLogger.Level.Info
 import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
+class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers with MockFactory{
 
   protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
     case _: ExpireAndCreatedDatesAdder[IO] => false

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdderSpec.scala
@@ -25,10 +25,15 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers with MockFactory{
+class ExpiryAndCreatedDatesAdderSpec
+    extends AnyWordSpec
+    with IOSpec
+    with DbInitSpec
+    with should.Matchers
+    with MockFactory {
 
   protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
-    case _: ExpireAndCreatedDatesAdder[IO] => false
+    case _: ExpiryAndCreatedDatesAdder[IO] => false
     case _ => true
   }
 
@@ -57,6 +62,6 @@ class ExpireAndCreatedDatesAdderSpec extends AnyWordSpec with IOSpec with DbInit
   }
 
   private trait TestCase {
-    val datesAdder = new ExpireAndCreatedDatesAdder[IO]
+    val datesAdder = new ExpiryAndCreatedDatesAdder[IO]
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNullSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNullSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.init
+
+import cats.effect.IO
+import io.renku.interpreters.TestLogger.Level.Info
+import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class ExpiryAndCreatedDatesNotNullSpec
+    extends AnyWordSpec
+    with IOSpec
+    with DbInitSpec
+    with should.Matchers
+    with MockFactory {
+
+  protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
+    case _: ExpiryAndCreatedDatesNotNull[IO] => false
+    case _ => true
+  }
+
+  "run" should {
+
+    "make the expiry_date and created_at NOT NULL" in new TestCase {
+
+      verifyColumnNullable("projects_tokens", "expiry_date") shouldBe true
+      verifyColumnNullable("projects_tokens", "created_at")  shouldBe true
+
+      migration.run().unsafeRunSync() shouldBe ()
+
+      verifyColumnNullable("projects_tokens", "expiry_date") shouldBe false
+      verifyColumnNullable("projects_tokens", "created_at")  shouldBe false
+
+      logger.loggedOnly(Info("'expiry_date' column made NOT NULL"), Info("'created_at' column made NOT NULL"))
+
+      logger.reset()
+
+      migration.run().unsafeRunSync() shouldBe ()
+
+      logger.loggedOnly(Info("'expiry_date' column already NOT NULL"), Info("'created_at' column already NOT NULL"))
+    }
+  }
+
+  private trait TestCase {
+    logger.reset()
+
+    val migration = new ExpiryAndCreatedDatesNotNull[IO]
+  }
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
@@ -35,8 +35,8 @@ class ProjectPathAdderSpec
     with IntegrationPatience
     with should.Matchers {
 
-  protected override lazy val migrationsToRun: List[Migration] = allMigrations.takeWhile {
-    case _: ProjectPathAdderImpl[_] => false
+  protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
+    case _: ProjectPathAdder[IO] => false
     case _ => true
   }
 
@@ -62,6 +62,6 @@ class ProjectPathAdderSpec
   private trait TestCase {
     logger.reset()
 
-    val projectPathAdder = new ProjectPathAdderImpl[IO]
+    val projectPathAdder = new ProjectPathAdder[IO]
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
@@ -30,10 +30,10 @@ class ProjectPathAdderSpec
     extends AnyWordSpec
     with IOSpec
     with DbInitSpec
-    with MockFactory
     with Eventually
     with IntegrationPatience
-    with should.Matchers {
+    with should.Matchers
+    with MockFactory {
 
   protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
     case _: ProjectPathAdder[IO] => false

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
@@ -21,10 +21,16 @@ package io.renku.tokenrepository.repository.init
 import cats.effect._
 import io.renku.interpreters.TestLogger.Level.Info
 import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class ProjectsTokensTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
+class ProjectsTokensTableCreatorSpec
+    extends AnyWordSpec
+    with IOSpec
+    with DbInitSpec
+    with should.Matchers
+    with MockFactory {
 
   protected override val migrationsToRun: List[DBMigration[IO]] = List.empty
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class ProjectsTokensTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
 
-  protected override val migrationsToRun: List[Migration] = List.empty
+  protected override val migrationsToRun: List[DBMigration[IO]] = List.empty
 
   "run" should {
 
@@ -46,6 +46,6 @@ class ProjectsTokensTableCreatorSpec extends AnyWordSpec with IOSpec with DbInit
   }
 
   private trait TestCase {
-    val tableCreator = new ProjectsTokensTableCreatorImpl[IO]
+    val tableCreator = new ProjectsTokensTableCreator[IO]
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+package init
+
+import cats.data.Kleisli
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.generators.CommonGraphGenerators.{accessTokens, projectAccessTokens}
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{exceptions, localDates, timestampsNotInTheFuture}
+import io.renku.graph.model.GraphModelGenerators.{projectIds, projectPaths}
+import io.renku.graph.model.projects
+import io.renku.http.client.AccessToken
+import io.renku.http.client.AccessToken.ProjectAccessToken
+import io.renku.interpreters.TestLogger
+import io.renku.interpreters.TestLogger.Level.{Error, Info, Warn}
+import io.renku.testtools.IOSpec
+import io.renku.tokenrepository.repository.AccessTokenCrypto
+import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
+import io.renku.tokenrepository.repository.RepositoryGenerators.encryptedAccessTokens
+import io.renku.tokenrepository.repository.association.TokenDates.{CreatedAt, ExpiryDate}
+import io.renku.tokenrepository.repository.association.TokenStoringInfo.Project
+import io.renku.tokenrepository.repository.association._
+import io.renku.tokenrepository.repository.deletion.TokenRemover
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import skunk._
+import skunk.implicits._
+
+import java.time.{Instant, LocalDate}
+import scala.concurrent.duration._
+
+class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers with MockFactory {
+
+  protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
+    case _: TokensMigrator[IO] => false
+    case _ => true
+  }
+
+  "run" should {
+
+    "go through all the stored tokens that does not have the 'expiry_date' " +
+      "and generate and store a new Project Access Token if the existing token is valid" in new TestCase {
+
+        insert(validTokenProject, validTokenEncrypted)
+
+        insertNonMigrated(oldTokenProject, oldTokenEncrypted)
+
+        val oldToken = accessTokens.generateOne
+        givenDecryption(oldTokenEncrypted, returning = oldToken.pure[IO])
+
+        givenTokenValidation(oldToken, returning = true.pure[IO])
+
+        val projectToken = projectAccessTokens.generateOne
+        val creationInfo = TokenCreationInfo(projectToken,
+                                             TokenDates(CreatedAt(Instant.now()),
+                                                        localDates(min = LocalDate.now()).generateAs(ExpiryDate)
+                                             )
+        )
+
+        givenProjectTokenCreator(oldTokenProject.id, oldToken, returning = creationInfo.pure[IO])
+
+        val projectTokenEncrypted = encryptedAccessTokens.generateOne
+        givenEncryption(projectToken, returning = projectTokenEncrypted.pure[IO])
+
+        migration.run().unsafeRunSync() shouldBe ()
+
+        findToken(validTokenProject.id)    shouldBe validTokenEncrypted.value.some
+        findToken(oldTokenProject.id)      shouldBe projectTokenEncrypted.value.some
+        findExpiryDate(oldTokenProject.id) shouldBe creationInfo.dates.expiryDate.some
+
+        logger.loggedOnly(Info(show"$logPrefix $oldTokenProject token created"))
+      }
+
+    "remove the existing token if found token is invalid" in new TestCase {
+
+      insert(validTokenProject, validTokenEncrypted)
+
+      insertNonMigrated(oldTokenProject, oldTokenEncrypted)
+
+      val oldToken = accessTokens.generateOne
+      givenDecryption(oldTokenEncrypted, returning = oldToken.pure[IO])
+
+      givenTokenValidation(oldToken, returning = false.pure[IO])
+
+      migration.run().unsafeRunSync() shouldBe ()
+
+      findToken(validTokenProject.id) shouldBe validTokenEncrypted.value.some
+      findToken(oldTokenProject.id)   shouldBe None
+
+      logger.loggedOnly(Warn(show"$logPrefix $oldTokenProject token invalid; deleting"))
+    }
+
+    "log an error and remove the token if decryption fails" in new TestCase {
+
+      insertNonMigrated(oldTokenProject, oldTokenEncrypted)
+
+      val exception = exceptions.generateOne
+      givenDecryption(oldTokenEncrypted, returning = exception.raiseError[IO, AccessToken])
+
+      migration.run().unsafeRunSync() shouldBe ()
+
+      findToken(oldTokenProject.id) shouldBe None
+
+      logger.loggedOnly(Error(show"$logPrefix $oldTokenProject token decryption failed; deleting", exception))
+    }
+
+    "retry for exceptions on token validation check" in new TestCase {
+
+      insertNonMigrated(oldTokenProject, oldTokenEncrypted)
+
+      val oldToken = accessTokens.generateOne
+      givenDecryption(oldTokenEncrypted, returning = oldToken.pure[IO])
+
+      val exception = exceptions.generateOne
+      givenTokenValidation(oldToken, returning = exception.raiseError[IO, Boolean])
+      givenTokenValidation(oldToken, returning = true.pure[IO])
+
+      val projectToken = projectAccessTokens.generateOne
+      val creationInfo =
+        TokenCreationInfo(projectToken,
+                          TokenDates(CreatedAt(Instant.now()), localDates(min = LocalDate.now()).generateAs(ExpiryDate))
+        )
+
+      givenProjectTokenCreator(oldTokenProject.id, oldToken, returning = creationInfo.pure[IO])
+
+      val projectTokenEncrypted = encryptedAccessTokens.generateOne
+      givenEncryption(projectToken, returning = projectTokenEncrypted.pure[IO])
+
+      migration.run().unsafeRunSync() shouldBe ()
+
+      findToken(oldTokenProject.id) shouldBe projectTokenEncrypted.value.some
+
+      logger.loggedOnly(
+        Error(show"$logPrefix $oldTokenProject failure; retrying", exception),
+        Info(show"$logPrefix $oldTokenProject token created")
+      )
+    }
+
+    "retry for exceptions on token creation" in new TestCase {
+
+      insertNonMigrated(oldTokenProject, oldTokenEncrypted)
+
+      val oldToken = accessTokens.generateOne
+      givenDecryption(oldTokenEncrypted, returning = oldToken.pure[IO])
+
+      givenTokenValidation(oldToken, returning = true.pure[IO])
+
+      val exception = exceptions.generateOne
+      givenProjectTokenCreator(oldTokenProject.id, oldToken, returning = exception.raiseError[IO, TokenCreationInfo])
+      val projectToken = projectAccessTokens.generateOne
+      val creationInfo =
+        TokenCreationInfo(projectToken,
+                          TokenDates(CreatedAt(Instant.now()), localDates(min = LocalDate.now()).generateAs(ExpiryDate))
+        )
+
+      givenProjectTokenCreator(oldTokenProject.id, oldToken, returning = creationInfo.pure[IO])
+
+      val projectTokenEncrypted = encryptedAccessTokens.generateOne
+      givenEncryption(projectToken, returning = projectTokenEncrypted.pure[IO])
+
+      migration.run().unsafeRunSync() shouldBe ()
+
+      findToken(oldTokenProject.id) shouldBe projectTokenEncrypted.value.some
+
+      logger.loggedOnly(
+        Error(show"$logPrefix $oldTokenProject failure; retrying", exception),
+        Info(show"$logPrefix $oldTokenProject token created")
+      )
+    }
+  }
+
+  private trait TestCase {
+
+    val validTokenProject   = Project(projectIds.generateOne, projectPaths.generateOne)
+    val validTokenEncrypted = encryptedAccessTokens.generateOne
+
+    val oldTokenProject   = Project(projectIds.generateOne, projectPaths.generateOne)
+    val oldTokenEncrypted = encryptedAccessTokens.generateOne
+
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val tokenCrypto               = mock[AccessTokenCrypto[IO]]
+    val tokenValidator            = mock[TokenValidator[IO]]
+    val tokenRemover              = TokenRemover[IO](queriesExecTimes)
+    val projectAccessTokenCreator = mock[ProjectAccessTokenCreator[IO]]
+    val associationPersister      = AssociationPersister[IO](queriesExecTimes)
+    val migration = new TokensMigrator[IO](tokenCrypto,
+                                           tokenValidator,
+                                           tokenRemover,
+                                           projectAccessTokenCreator,
+                                           associationPersister,
+                                           queriesExecTimes,
+                                           retryInterval = 500 millis
+    )
+
+    val logPrefix = "token migration:"
+
+    def insert(project: Project, encryptedToken: EncryptedAccessToken) =
+      associationPersister
+        .persistAssociation(
+          TokenStoringInfo(project,
+                           encryptedToken,
+                           TokenDates(timestampsNotInTheFuture.generateAs(CreatedAt), localDates.generateAs(ExpiryDate))
+          )
+        )
+        .unsafeRunSync()
+
+    def insertNonMigrated(project: Project, encryptedToken: EncryptedAccessToken) = execute[Unit] {
+      Kleisli[IO, Session[IO], Unit] { session =>
+        val command: Command[projects.Id ~ projects.Path ~ EncryptedAccessToken] =
+          sql"""
+          INSERT INTO projects_tokens (project_id, project_path, token)
+          VALUES ($projectIdEncoder, $projectPathEncoder, $encryptedAccessTokenEncoder)
+        """.command
+        session
+          .prepare(command)
+          .use(_.execute(project.id ~ project.path ~ encryptedToken))
+          .void
+      }
+    }
+
+    def givenDecryption(encryptedToken: EncryptedAccessToken, returning: IO[AccessToken]) =
+      (tokenCrypto
+        .decrypt(_: EncryptedAccessToken))
+        .expects(encryptedToken)
+        .returning(returning)
+
+    def givenEncryption(token: ProjectAccessToken, returning: IO[EncryptedAccessToken]) =
+      (tokenCrypto.encrypt _)
+        .expects(token)
+        .returning(returning)
+
+    def givenTokenValidation(token: AccessToken, returning: IO[Boolean]) =
+      (tokenValidator.checkValid _)
+        .expects(token)
+        .returning(returning)
+
+    def givenProjectTokenCreator(projectId:       projects.Id,
+                                 userAccessToken: AccessToken,
+                                 returning:       IO[TokenCreationInfo]
+    ) = (projectAccessTokenCreator.createPersonalAccessToken _)
+      .expects(projectId, userAccessToken)
+      .returning(returning)
+  }
+}


### PR DESCRIPTION
This PR adds a DB migration replacing existing non-Project Access Tokens with Project Access Tokens. It also makes the DB Migrations run asynchronously.