### PR TITLE
fix: Fix generating composite plans with mappings

### DIFF
--- a/event-log/README.md
+++ b/event-log/README.md
@@ -7,7 +7,7 @@ This is a microservice which provides CRUD operations for Event Log DB.
 | Method | Path                                        | Description                                                                |
 |--------|---------------------------------------------|----------------------------------------------------------------------------|
 | GET    | ```/events```                               | Returns info about events                                                  |
-| GET    | ```/events/:event-id/:project-id```         | Returns info about event with the given `id` and `project-id`              |
+| GET    | ```/events/:event-id/:project-path```         | Returns info about event with the given `id` and `project-path`              |
 | GET    | ```/events/:event-id/:project-id/payload``` | Returns payload associated with the event having the `id` and `project-id` |
 | POST   | ```/events```                               | Sends an event for processing                                              |
 | GET    | ```/metrics```                              | Returns Prometheus metrics of the service                                  |
@@ -99,7 +99,7 @@ Response body example:
 }
 ```
 
-### GET /events/:event-id/:project-id/payload`
+### GET /events/:event-id/:project-path/payload`
 
 Finds event's payload.
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/PayloadTypeChangerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/PayloadTypeChangerSpec.scala
@@ -18,24 +18,12 @@
 
 package io.renku.eventlog.init
 
-import cats.data.Kleisli
 import cats.effect.IO
-import io.renku.eventlog.EventContentGenerators._
-import io.renku.eventlog.{CreatedDate, EventDate, ExecutionDate}
-import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.nonEmptyStrings
-import io.renku.graph.model.EventsGenerators.{batchDates, eventBodies, eventStatuses}
-import io.renku.graph.model.GraphModelGenerators.{projectPaths, projectSchemaVersions}
-import io.renku.graph.model.events.{BatchDate, CompoundEventId, EventBody, EventId, EventStatus}
-import io.renku.graph.model.projects
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Info
 import io.renku.testtools.IOSpec
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import skunk.codec.all._
-import skunk.implicits._
-import skunk.{Command, ~}
 
 class PayloadTypeChangerSpec extends AnyWordSpec with IOSpec with DbInitSpec with should.Matchers {
 
@@ -71,68 +59,4 @@ class PayloadTypeChangerSpec extends AnyWordSpec with IOSpec with DbInitSpec wit
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val tableRefactor = new PayloadTypeChangerImpl[IO]
   }
-
-  private def generateEvent(eventId: CompoundEventId): Unit = {
-    upsertProject(eventId.projectId)
-    insertEvent(eventId)
-    insertPayload(eventId)
-  }
-
-  private def insertEvent(eventId: CompoundEventId): Unit = execute[Unit] {
-    Kleisli { session =>
-      val query: Command[
-        EventId ~ projects.Id ~ EventStatus ~ CreatedDate ~ ExecutionDate ~ EventDate ~ EventBody ~ BatchDate
-      ] =
-        sql"""INSERT INTO 
-              event (event_id, project_id, status, created_date, execution_date, event_date, event_body, batch_date) 
-              values (
-              $eventIdEncoder, 
-              $projectIdEncoder, 
-              $eventStatusEncoder, 
-              $createdDateEncoder,
-              $executionDateEncoder, 
-              $eventDateEncoder, 
-              $eventBodyEncoder,
-              $batchDateEncoder)
-      """.command
-      session
-        .prepare(query)
-        .use(
-          _.execute(
-            eventId.id ~ eventId.projectId ~ eventStatuses.generateOne ~ createdDates.generateOne ~
-              executionDates.generateOne ~ eventDates.generateOne ~ eventBodies.generateOne ~ batchDates.generateOne
-          )
-        )
-        .void
-    }
-  }
-
-  private def insertPayload(eventId: CompoundEventId) = execute[Unit] {
-    Kleisli { session =>
-      val query: Command[EventId ~ projects.Id ~ String ~ String] =
-        sql"""INSERT INTO 
-              event_payload (event_id, project_id, payload, schema_version) 
-              values ($eventIdEncoder,$projectIdEncoder, $text, $text)""".command
-      session
-        .prepare(query)
-        .use(
-          _.execute(
-            eventId.id ~ eventId.projectId ~ nonEmptyStrings().generateOne ~ projectSchemaVersions.generateOne.value
-          )
-        )
-        .void
-    }
-  }
-
-  private def upsertProject(projectId: projects.Id): Unit = execute[Unit] {
-    Kleisli { session =>
-      val query: Command[projects.Id ~ projects.Path ~ EventDate] =
-        sql"""INSERT INTO
-                project (project_id, project_path, latest_event_date)
-                VALUES ($projectIdEncoder, $projectPathEncoder, $eventDateEncoder)
-          """.command
-      session.prepare(query).use(_.execute(projectId ~ projectPaths.generateOne ~ eventDates.generateOne)).void
-    }
-  }
-
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/Generators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/Generators.scala
@@ -149,8 +149,9 @@ private object Generators {
 
   def stepPlanGenFactory: StepPlanGenFactory =
     for {
-      params <- ProjectBasedGenFactory.liftF(commandParametersLists)
-      plan   <- stepPlanEntities(params: _*)
+      params     <- ProjectBasedGenFactory.liftF(commandParametersLists)
+      explParams <- ProjectBasedGenFactory.liftF(explicitCommandParameterObjects)
+      plan       <- stepPlanEntities((explParams :: params): _*)
     } yield plan
 
   def compositePlanGen(minChildren: Int = 3, maxChildren: Int = 6): Gen[CompositePlan] =

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -27,7 +27,7 @@ import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.Schemas.{prov, renku, schema}
 import io.renku.graph.model._
-import io.renku.graph.model.entities.Generators.{compositePlanGen, compositePlanGenFactory, stepPlanGenFactory}
+import io.renku.graph.model.entities.Generators.{compositePlanGenFactory, stepPlanGenFactory}
 import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail, ProjectMemberWithEmail}
 import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
 import io.renku.graph.model.persons.Name
@@ -438,7 +438,8 @@ class ProjectSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
     }
 
     "validate a composite plan that has references outside its children" in {
-      val testPlan = compositePlanGen()
+      val testPlan = compositePlanEntities(stepPlanGenFactory.mapF(_.toGeneratorOfList(min = 3)))
+        .mapF(_.suchThat(_.mappings.nonEmpty))
         .generateOne
         .asInstanceOf[CompositePlan.NonModified]
 


### PR DESCRIPTION
One test requires mappings in a composite plan.

```
should validate a composite plan that has references outside its children *** FAILED ***
[info]   java.util.NoSuchElementException: head of empty list
[info]   at scala.collection.immutable.Nil$.head(List.scala:662)
[info]   at scala.collection.immutable.Nil$.head(List.scala:661)
[info]   at io.renku.graph.model.entities.ProjectSpec.$anonfun$new$64(ProjectSpec.scala:446)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply(AnyWordSpecLike.scala:1239)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
```