### PR TITLE
feat: Add ts migration for composite plans

### DIFF
--- a/event-log/README.md
+++ b/event-log/README.md
@@ -53,13 +53,21 @@ Response body example:
 [
   {
     "id":              "df654c3b1bd105a29d658f78f6380a842feac879",
+    "project":         {
+      "id":   123,
+      "path": "namespace/project-name"
+    },
     "status":          "NEW",
     "processingTimes": [],
     "date":            "2001-09-04T10:48:29.457Z",
     "executionDate":   "2001-09-04T10:48:29.457Z"
   },
   {
-    "id":      "df654c3b1bd105a29d658f78f6380a842feac879",
+    "id":      "df654c3b1bd105a29d658f78f6380a842feac878",
+    "project":         {
+      "id":   1234,
+      "path": "namespace2/project-name"
+    },
     "status":  "TRANSFORMATION_NON_RECOVERABLE_FAILURE",
     "message": "detailed info about the cause of the failure",
     "processingTimes": [

--- a/graph-commons/src/main/scala/io/renku/graph/model/events.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/model/events.scala
@@ -273,7 +273,13 @@ object events {
     object ProjectIds {
       implicit val jsonDecoder: Decoder[ProjectIds] =
         io.circe.generic.semiauto.deriveDecoder[ProjectIds]
+
+      implicit val show: Show[ProjectIds] =
+        a => show"${a.id}/${a.path}"
     }
+
+    implicit val show: Show[EventInfo] =
+      Show.show(info => s"${info.eventId.show}/${info.project.show}/${info.status}")
 
     implicit val jsonDecoder: Decoder[EventInfo] =
       Decoder.instance { cursor =>

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/CompositePlanProvision.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/CompositePlanProvision.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.Show
+import cats.data.{EitherT, OptionT}
+import cats.effect._
+import cats.kernel.Monoid
+import cats.syntax.all._
+import fs2.Stream
+import io.circe.Json
+import io.circe.syntax._
+import io.renku.compression.Zip
+import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.events.producers.EventSender
+import io.renku.graph.config.EventLogUrl
+import io.renku.graph.eventlog.EventLogClient
+import io.renku.graph.eventlog.EventLogClient.{EventPayload, SearchCriteria}
+import io.renku.graph.model.events.{EventInfo, EventStatus}
+import io.renku.graph.model.projects.{Path => ProjectPath}
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.CompositePlanProvision.{Context, Result}
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling.{AllProjects, MigrationExecutionRegister, RecoverableErrorsRecovery, RegisteredMigration}
+import io.renku.triplesstore.SparqlQueryTimeRecorder
+import org.typelevel.log4cats.Logger
+
+private[migrations] class CompositePlanProvision[F[_]: Sync: Logger](
+    override val name: Migration.Name,
+    allProjects:       AllProjects[F],
+    eventSender:       EventSender[F],
+    eventLogClient:    EventLogClient[F],
+    executionRegister: MigrationExecutionRegister[F],
+    recoveryStrategy:  RecoverableErrorsRecovery = RecoverableErrorsRecovery
+) extends RegisteredMigration[F](name, executionRegister, recoveryStrategy) {
+
+  protected override def migrate(): EitherT[F, ProcessingRecoverableError, Unit] =
+    EitherT(
+      (Stream.eval(Logger[F].info("Starting composite plan migration")).drain ++ allProjects
+        .findAll(50))
+        .ifEmpty(Stream.eval(Logger[F].info("No projects found")).drain)
+        .map(_.path)
+        .evalMap(findLatestEvent)
+        .unNone
+        .evalMap(Context.create(getEventPayload))
+        .evalMap {
+          case Some(ctx) => sendStatusChange(ctx).as(Result.sendEvent)
+          case None      => Result.skip.pure[F]
+        }
+        .compile
+        .foldMonoid
+        .flatTap(result => Logger[F].info(result.show))
+        .void
+        .map(_.asRight[ProcessingRecoverableError])
+        .recoverWith(recoveryStrategy.maybeRecoverableError[F, Unit])
+    )
+
+  def sendStatusChange(ctx: Context): F[Unit] = {
+    val categoryName = CategoryName("EVENTS_STATUS_CHANGE")
+    val eventData    = CompositePlanProvision.createStatusChangeEvent(ctx)
+    Logger[F].info(show"Send status change to ${EventStatus.TriplesGenerated} for project ${ctx.event.project}") *>
+      eventSender.sendEvent(
+        EventRequestContent.NoPayload(eventData),
+        EventSender.EventContext(categoryName, "Migration loading CompositePlans")
+      )
+  }
+
+  def findLatestEvent(path: ProjectPath): F[Option[EventInfo]] =
+    eventLogClient
+      .getEvents(
+        SearchCriteria
+          .forProject(path)
+          .withPerPage(1)
+          .sortBy(SearchCriteria.Sort.EventDateDesc)
+      )
+      .map(_.toEither)
+      .rethrow
+      .map(_.headOption)
+      .flatTap(optEvent => Logger[F].info(show"Project $path has latest event $optEvent"))
+
+  def getEventPayload(event: EventInfo): F[Option[EventPayload]] =
+    eventLogClient
+      .getEventPayload(event.eventId, event.project.path)
+      .map(_.toEither)
+      .rethrow
+}
+
+object CompositePlanProvision {
+  def create[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[CompositePlanProvision[F]] =
+    for {
+      allProjects <- AllProjects.create[F]
+      eventSender <- EventSender[F]
+      eventLogUrl <- EventLogUrl()
+      elClient = EventLogClient(eventLogUrl)
+      executionRegister <- MigrationExecutionRegister[F]
+      name = Migration.Name("CompositePlanProvision")
+    } yield new CompositePlanProvision[F](name, allProjects, eventSender, elClient, executionRegister)
+
+  final case class Context(event: EventInfo, payload: Option[EventPayload], uncompressed: String)
+
+  object Context {
+    private[this] val eligibleEventStatus: Set[EventStatus] =
+      EventStatus.all.diff(
+        Set(
+          EventStatus.New,
+          EventStatus.Skipped,
+          EventStatus.GeneratingTriples,
+          EventStatus.GenerationRecoverableFailure,
+          EventStatus.TriplesGenerated,
+          EventStatus.TransformingTriples,
+          EventStatus.TransformationRecoverableFailure,
+          EventStatus.AwaitingDeletion,
+          EventStatus.Deleting
+        )
+      )
+
+    def create[F[_]: Logger: Sync](
+        getEventPayload: EventInfo => F[Option[EventPayload]]
+    )(ev:                EventInfo): F[Option[Context]] =
+      OptionT
+        .pure(ev)
+        .filter(event => eligibleEventStatus.contains(event.status))
+        .semiflatMap { event =>
+          for {
+            payload <- getEventPayload(event)
+            plain <- payload match {
+                       case Some(data) => Zip.unzip(data.data.toArray).attempt
+                       case None       => Right("").pure[F]
+                     }
+            text <- plain.fold(
+                      ex =>
+                        Logger[F]
+                          .warn(ex)(s"Unable to unzip event payload for ${event.eventId}")
+                          .as("CompositePlan"), // send the event in this case
+                      _.pure[F]
+                    )
+          } yield Context(event, payload, text)
+        }
+        .filter(ctx => ctx.payload.isEmpty || ctx.uncompressed.contains("CompositePlan"))
+        .value
+
+    implicit val show: Show[Context] =
+      Show.show(ctx => s"${ctx.event.show}/payload:${ctx.payload.isDefined}")
+  }
+
+  final case class Result(skippedCount: Int, sendEvent: Int) {
+    def total: Int = skippedCount + sendEvent
+    def +(other: Result): Result = Result(skippedCount + other.skippedCount, sendEvent + other.sendEvent)
+  }
+  object Result {
+    val zero: Result = Result(0, 0)
+
+    def skip:      Result = Result(1, 0)
+    def sendEvent: Result = Result(0, 1)
+
+    implicit val monoid: Monoid[Result] =
+      Monoid.instance(zero, _ + _)
+
+    implicit val show: Show[Result] =
+      Show.show(r =>
+        s"Processed ${r.total} projects, ${r.skippedCount} skipped and ${r.sendEvent} changed status to ${EventStatus.TriplesGenerated.value}"
+      )
+  }
+
+  def createStatusChangeEvent(ctx: Context): Json =
+    Json.obj(
+      "categoryName" -> "EVENTS_STATUS_CHANGE".asJson,
+      "project" -> Json.obj(
+        "id"   -> ctx.event.project.id.asJson,
+        "path" -> ctx.event.project.path.asJson
+      ),
+      "newStatus" -> EventStatus.TriplesGenerated.asJson
+    )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -38,12 +38,14 @@ private[tsmigrationrequest] object Migrations {
     reProvisioning                <- ReProvisioning[F](config)
     removeNotLinkedPersons        <- RemoveNotLinkedPersons[F]
     fixPlansYoungerThanActivities <- FixPlansYoungerThanActivities[F]
+    compositePlan                 <- CompositePlanProvision.create[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
                     reProvisioning,
                     removeNotLinkedPersons,
-                    fixPlansYoungerThanActivities
+                    fixPlansYoungerThanActivities,
+                    compositePlan
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/AllProjects.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/AllProjects.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling
+
+import cats.effect._
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import fs2.Stream
+import io.circe.Decoder
+import io.renku.graph.model.Schemas
+import io.renku.graph.model.projects.{Path => ProjectPath}
+import io.renku.tinytypes.json.TinyTypeDecoders._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.{DatasetConnectionConfig, ProjectsConnectionConfig, SparqlQuery, SparqlQueryTimeRecorder, TSClient}
+import org.typelevel.log4cats.Logger
+
+trait AllProjects[F[_]] {
+  def findAll(chunkSize: Int): Stream[F, AllProjects.ProjectMetadata]
+}
+
+object AllProjects {
+  def create[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[AllProjects[F]] =
+    ProjectsConnectionConfig[F]().map(apply[F])
+
+  final case class ProjectMetadata(path: ProjectPath)
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      tsConfig: DatasetConnectionConfig
+  ): AllProjects[F] =
+    new TSClient[F](tsConfig) with AllProjects[F] {
+      def findAll(chunkSize: Int): Stream[F, AllProjects.ProjectMetadata] =
+        findFrom(0, chunkSize)
+
+      def findFrom(offset: Int, chunkSize: Int): Stream[F, ProjectMetadata] =
+        loadAllChunks(offset, chunkSize).takeWhile(_.nonEmpty).flatMap(Stream.emits(_))
+
+      def loadAllChunks(offset: Int, chunkSize: Int): Stream[F, List[ProjectMetadata]] =
+        Stream.eval(loadChunk(offset, chunkSize)) ++ loadAllChunks(offset + chunkSize, chunkSize)
+
+      def loadChunk(offset: Int, chunkSize: Int): F[List[ProjectMetadata]] =
+        queryExpecting[List[ProjectMetadata]](projectsQuery(offset, chunkSize))
+
+      def projectsQuery(offset: Int, limit: Int): SparqlQuery =
+        SparqlQuery.of(
+          "TS migration: find projects",
+          Prefixes.of(Schemas.schema -> "schema", Schemas.renku -> "renku"),
+          s"""
+             |SELECT DISTINCT ?projectPath
+             |WHERE {
+             |  Graph ?g {
+             |    ?projectId a schema:Project;
+             |      renku:projectPath ?projectPath.
+             |  }
+             |}
+             |ORDER BY ?projectId
+             |OFFSET $offset
+             |LIMIT $limit
+             |""".stripMargin
+        )
+
+      implicit val decoder: Decoder[List[ProjectMetadata]] =
+        ResultsDecoder[List, ProjectMetadata] { implicit cursor =>
+          for {
+            path <- extract[ProjectPath]("projectPath")
+          } yield ProjectMetadata(path)
+        }
+    }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/CompositePlanProvisionSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/CompositePlanProvisionSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.effect._
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.eventlog.EventLogClient.EventPayload
+import io.renku.graph.model.EventContentGenerators
+import io.renku.graph.model.events.{EventInfo, EventStatus}
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.CompositePlanProvisionSpec.TestData
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import scodec.bits.ByteVector
+
+class CompositePlanProvisionSpec extends AnyWordSpec with IOSpec with should.Matchers {
+
+  implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  "loadContext" should {
+    "create context when event is in an eligible status" in {
+      for (status <- TestData.Status.eligible) {
+        val ev = EventContentGenerators
+          .eventInfos()
+          .generateOne
+          .copy(status = status)
+
+        val makeContext = CompositePlanProvision.Context.create[IO](eventPayload(TestData.Payload.withCompositePlan)) _
+
+        val ctx = makeContext(ev)
+          .unsafeRunSync()
+          .getOrElse(sys.error("Expected a context to be created"))
+
+        ctx.event        shouldBe ev
+        ctx.payload      shouldBe Some(TestData.Payload.withCompositePlan)
+        ctx.uncompressed shouldBe "hello CompositePlan world"
+      }
+    }
+
+    "create context if there is no payload" in {
+      for (status <- TestData.Status.eligible) {
+        val ev = EventContentGenerators
+          .eventInfos()
+          .generateOne
+          .copy(status = status)
+
+        val makeContext = CompositePlanProvision.Context.create[IO](noEventPayload) _
+
+        val ctx = makeContext(ev)
+          .unsafeRunSync()
+          .getOrElse(sys.error("Expected a context to be created"))
+
+        ctx.event        shouldBe ev
+        ctx.payload      shouldBe None
+        ctx.uncompressed shouldBe ""
+      }
+    }
+
+    "create context if the payload cannot be unzipped" in {
+      val ev = EventContentGenerators
+        .eventInfos()
+        .generateOne
+        .copy(status = TestData.Status.eligible.head)
+
+      val makeContext = CompositePlanProvision.Context.create[IO](eventPayload(TestData.Payload.invalid)) _
+
+      val ctx = makeContext(ev)
+        .unsafeRunSync()
+        .getOrElse(sys.error("Expected a context to be created"))
+
+      ctx.event        shouldBe ev
+      ctx.payload      shouldBe Some(TestData.Payload.invalid)
+      ctx.uncompressed shouldBe "CompositePlan"
+    }
+
+    "not create context when event status is not eligible" in {
+      for (status <- TestData.Status.nonEligible) {
+        val ev = EventContentGenerators
+          .eventInfos()
+          .generateOne
+          .copy(status = status)
+
+        val makeContext = CompositePlanProvision.Context.create[IO](eventPayload(TestData.Payload.withCompositePlan)) _
+
+        makeContext(ev).unsafeRunSync() shouldBe None
+      }
+    }
+
+    "not create context if the payload exist but not contains 'CompositePlan'" in {
+      val ev = EventContentGenerators
+        .eventInfos()
+        .generateOne
+        .copy(status = TestData.Status.eligible.head)
+
+      val makeContext = CompositePlanProvision.Context.create[IO](eventPayload(TestData.Payload.withoutCompositePlan)) _
+
+      makeContext(ev).unsafeRunSync() shouldBe None
+    }
+
+    "not calling getEventPayload if event has a non-eligible status" in {
+      val ev = EventContentGenerators
+        .eventInfos()
+        .generateOne
+        .copy(status = TestData.Status.nonEligible.head)
+
+      val makeContext = CompositePlanProvision.Context.create[IO](_ => IO.raiseError(new Exception("payload called"))) _
+
+      makeContext(ev).unsafeRunSync() shouldBe None
+    }
+  }
+
+  def eventPayload(data: EventPayload): EventInfo => IO[Option[EventPayload]] =
+    _ => IO.pure(Some(data))
+
+  def noEventPayload: EventInfo => IO[Option[EventPayload]] =
+    _ => IO.pure(None)
+}
+
+object CompositePlanProvisionSpec {
+
+  object TestData {
+    object Payload {
+      val withoutCompositePlan = EventPayload(
+        ByteVector.fromValidBase64("H4sIAPaxiGMAA8tIzcnJVyjPL8pJ4QIALTsIrwwAAAA=")
+      )
+      val withCompositePlan = EventPayload(
+        ByteVector.fromValidBase64("H4sIAIm0iGMAA8tIzcnJV3DOzy3IL84sSQ3IScxTKM8vykkBAKlyYxoZAAAA")
+      )
+      val invalid = EventPayload(ByteVector.view("not gzipped".getBytes))
+    }
+
+    object Status {
+      val eligible: Set[EventStatus] = Set(
+        EventStatus.TriplesStore,
+        EventStatus.GenerationNonRecoverableFailure,
+        EventStatus.GenerationNonRecoverableFailure,
+        EventStatus.TransformationNonRecoverableFailure
+      )
+      val nonEligible = EventStatus.all.diff(eligible)
+    }
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/AllProjectsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/AllProjectsSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling
+
+import cats.effect._
+import io.renku.graph.model.testentities.generators.EntitiesGenerators
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQueryTimeRecorder}
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.{GitLabApiUrl, RenkuUrl}
+import io.renku.graph.model.testentities.Project
+import io.renku.interpreters.TestLogger
+import io.renku.metrics.TestMetricsRegistry
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling.AllProjects.ProjectMetadata
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.typelevel.log4cats.Logger
+
+class AllProjectsSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with should.Matchers {
+
+  implicit val renkuUrl:  RenkuUrl     = EntitiesGenerators.renkuUrl
+  implicit val gitlabUrl: GitLabApiUrl = EntitiesGenerators.gitLabApiUrl
+  implicit val logger:    Logger[IO]   = TestLogger[IO]()
+  implicit lazy val timeRecorder: SparqlQueryTimeRecorder[IO] =
+    SparqlQueryTimeRecorder(TestMetricsRegistry[IO]).unsafeRunSync()
+
+  def allProjects: AllProjects[IO] = AllProjects[IO](projectsDSConnectionInfo)
+
+  "find" should {
+    "find all projects" in {
+      val projectGen = EntitiesGenerators.anyProjectEntities
+      val projects   = projectGen.generateFixedSizeList(32)
+
+      upload(to = projectsDataset, projects.map(a => a: Project): _*)
+      val result = allProjects.findAll(10).compile.toList.unsafeRunSync()
+
+      result shouldBe projects.map(p => ProjectMetadata(p.path)).sortBy(_.path.value)
+    }
+  }
+}


### PR DESCRIPTION
Adds a migration to change the status to NEW for projects to read in their composite plan. Projects are skipped that are known to not include a composite plan.

/deploy #persist

closes #721 