### PR TITLE
feat: Project Access Token name to be configurable

### DIFF
--- a/helm-chart/renku-graph/templates/token-repository-deployment.yaml
+++ b/helm-chart/renku-graph/templates/token-repository-deployment.yaml
@@ -45,6 +45,8 @@ spec:
                   key: tokenRepository-tokenEncryption-secret
             - name: PROJECT_TOKEN_TTL
               value: "{{ .Values.tokenRepository.projectTokenTTL }}"
+            - name: PROJECT_TOKEN_NAME
+              value: "{{ .Values.tokenRepository.projectTokenName }}"
             - name: PROJECT_TOKEN_DUE_PERIOD
               value: "{{ .Values.tokenRepository.projectTokenDuePeriod }}"
             - name: TOKEN_REPOSITORY_POSTGRES_HOST

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -96,6 +96,8 @@ tokenRepository:
   gitlab:
     rateLimit: 50/sec
   projectTokenTTL: '365 days'
+  # name of the Project Access Tokens to be created on behalf of the user
+  projectTokenName: 'renku'
   projectTokenDuePeriod: '184 days'
   connectionPool: 2
   tokenEncryption:

--- a/token-repository/src/main/resources/application.conf
+++ b/token-repository/src/main/resources/application.conf
@@ -7,6 +7,9 @@ client-certificate = ${?RENKU_CLIENT_CERTIFICATE}
 project-token-ttl = 365 days
 project-token-ttl = ${?PROJECT_TOKEN_TTL}
 
+project-token-name = "renku"
+project-token-name = ${?PROJECT_TOKEN_NAME}
+
 project-token-due-period = 182 days
 project-token-due-period = ${?PROJECT_TOKEN_DUE_PERIOD}
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/package.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/package.scala
@@ -27,8 +27,6 @@ package object creation {
 
   import io.renku.tokenrepository.repository.creation.TokenDates._
 
-  private[creation] val renkuTokenName = "renku"
-
   private[creation] val createdAtDecoder: Decoder[CreatedAt] =
     timestamptz.map(timestamp => CreatedAt(timestamp.toInstant))
   private[creation] val createdAtEncoder: Encoder[CreatedAt] = timestamptz.values.contramap((b: CreatedAt) =>

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/modelSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/modelSpec.scala
@@ -20,14 +20,15 @@ package io.renku.tokenrepository.repository.creation
 
 import cats.syntax.all._
 import com.typesafe.config.ConfigFactory
-import io.renku.generators.Generators.ints
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{ints, nonEmptyStrings}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.time.Period
 import scala.jdk.CollectionConverters._
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class ProjectTokenDuePeriodSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
@@ -41,6 +42,24 @@ class ProjectTokenDuePeriodSpec extends AnyWordSpec with should.Matchers with Sc
 
         ProjectTokenDuePeriod[Try](config) shouldBe Period.ofDays(duration).pure[Try]
       }
+    }
+  }
+}
+
+class RenkuAccessTokenNameSpec extends AnyWordSpec with should.Matchers {
+
+  "apply" should {
+
+    "read 'project-token-name' as Period from the config" in {
+      val name = nonEmptyStrings().generateOne
+      val config = ConfigFactory.parseMap(
+        Map("project-token-name" -> name).asJava
+      )
+
+      val Success(actual) = RenkuAccessTokenName[Try](config)
+
+      actual              shouldBe a[RenkuAccessTokenName]
+      actual.value shouldBe name
     }
   }
 }


### PR DESCRIPTION
This PR introduces config value for the name of Project Access Tokens that are created on behalf of the user in GitLab.

It's to prevent different environments from using the same name tokens which could cause different environments to remove tokens from each other.