### PR TITLE
fix: added API to GL stub to support project access token revoke flow

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookCreationSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookCreationSpec.scala
@@ -81,7 +81,7 @@ class WebhookCreationSpec extends AcceptanceSpec with ModelImplicits with Applic
       tokenRepositoryClient
         .GET(s"projects/${project.id}/tokens")
         .jsonBody shouldBe gitLabStub
-        .query(_.projectAccessTokens(project.id))
+        .query(_.projectAccessTokens(project.id).token)
         .unsafeRunSync()
         .asInstanceOf[AccessToken]
         .asJson

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
@@ -91,7 +91,7 @@ class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServi
       tokenRepositoryClient
         .GET(s"projects/${project.id}/tokens")
         .jsonBody shouldBe gitLabStub
-        .query(_.projectAccessTokens(project.id))
+        .query(_.projectAccessTokens(project.id).token)
         .unsafeRunSync()
         .asInstanceOf[AccessToken]
         .asJson

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateQueries.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateQueries.scala
@@ -62,6 +62,9 @@ trait GitLabStateQueries {
   def projectCommits(projectId: Id): StateQuery[List[CommitData]] =
     _.commits.get(projectId).map(_.toList).getOrElse(Nil)
 
+  def findProjectAccessTokens(projectId: Id): StateQuery[List[ProjectAccessTokenInfo]] =
+    _.projectAccessTokens.get(projectId).toList
+
   def commitsFor(projectId: Id, maybeAuthedReq: Option[AuthedReq]): StateQuery[List[CommitData]] =
     for {
       project <- findProjectById(projectId, maybeAuthedReq)
@@ -75,7 +78,9 @@ trait GitLabStateQueries {
     commitsFor(projectId, maybeAuthedReq).andThen(_.map(_.toPushEvent(projectId)))
 
   def findAuthedProject(token: ProjectAccessToken): StateQuery[Option[AuthedProject]] =
-    _.projectAccessTokens.find(_._2 == token).map(AuthedProject.tupled)
+    _.projectAccessTokens.find(_._2.token == token).map { case (projectId, tokenInfo) =>
+      AuthedProject(projectId, tokenInfo.token)
+    }
 
   def findAuthedUser(token: UserAccessToken): StateQuery[Option[AuthedUser]] =
     _.users.find(_._2 == token).map(AuthedUser.tupled)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateUpdates.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateUpdates.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.acceptancetests.stubs.gitlab
 
-import GitLabApiStub.{CommitData, State, Webhook}
+import GitLabApiStub._
 import GitLabStateGenerators._
 import cats.Monoid
 import cats.data.NonEmptyList
@@ -30,7 +30,6 @@ import io.renku.graph.model.persons.GitLabId
 import io.renku.graph.model.projects.Id
 import io.renku.graph.model.testentities.{Person, Project => RenkuProject}
 import io.renku.graph.model.{RenkuUrl, entities, projects}
-import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.UserAccessToken
 import org.http4s.Uri
 
@@ -108,7 +107,7 @@ trait GitLabStateUpdates {
       addCommits(project.id, commits) >>
       addPersons(EntityFunctions[RenkuProject].findAllPersons(project.entitiesProject).map(toPerson))
 
-  def addProjectAccessToken(projectId: projects.Id, token: ProjectAccessToken): StateUpdate =
+  def addProjectAccessToken(projectId: projects.Id, token: ProjectAccessTokenInfo): StateUpdate =
     state => state.copy(projectAccessTokens = state.projectAccessTokens.updated(projectId, token))
 
   private lazy val toPerson: entities.Person => Person = person =>

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/Http4sDslUtils.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/Http4sDslUtils.scala
@@ -60,6 +60,10 @@ private[gitlab] trait Http4sDslUtils {
       } yield pid
   }
 
+  object ProjectAccessTokenId {
+    def unapply(str: String): Option[Int] = str.toIntOption
+  }
+
   def OkOrNotFound[F[_]: Applicative, A](payload: Option[A])(implicit enc: EntityEncoder[F, A]): F[Response[F]] = {
     val dsl = new Http4sDsl[F] {}
     import dsl._

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/JsonEncoders.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/JsonEncoders.scala
@@ -24,14 +24,13 @@ import io.circe.syntax._
 import io.renku.graph.acceptancetests.data.Project
 import io.renku.graph.acceptancetests.data.Project.Permissions._
 import io.renku.graph.acceptancetests.data.Project.{Permissions, Statistics}
-import io.renku.graph.acceptancetests.stubs.gitlab.GitLabApiStub.{CommitData, PushEvent, Webhook}
+import io.renku.graph.acceptancetests.stubs.gitlab.GitLabApiStub._
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabAuth.AuthedReq
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabAuth.AuthedReq.{AuthedProject, AuthedUser}
 import io.renku.graph.model.testentities.{Parent, Person}
-import io.renku.http.client.AccessToken.ProjectAccessToken
 import org.http4s.Uri
 
-import java.time.{Instant, LocalDate}
+import java.time.Instant
 
 trait JsonEncoders {
   implicit val uriEncoder: Encoder[Uri] =
@@ -71,9 +70,11 @@ trait JsonEncoders {
       )
     }
 
-  implicit val personalAccessTokenCreationEncoder: Encoder[(ProjectAccessToken, LocalDate)] =
-    Encoder.instance { case (token, expiryDate) =>
+  implicit val personalAccessTokenCreationEncoder: Encoder[ProjectAccessTokenInfo] =
+    Encoder.instance { case ProjectAccessTokenInfo(tokenId, name, token, expiryDate) =>
       json"""{
+        "id":         $tokenId,
+        "name":       $name,
         "token":      ${token.value},
         "created_at": ${Instant.now()},
         "expires_at": $expiryDate


### PR DESCRIPTION
This PR adds missing APIs on GL stub to support Project Access Token revoking functionality