### PR TITLE
chore: services' images to extend eclipse-temurin:17-jre-alpine

### DIFF
--- a/commit-event-service/Dockerfile
+++ b/commit-event-service/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM openjdk:17-jdk-alpine as builder
+FROM eclipse-temurin:17-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project commit-event-service" stage  && \
     apk del .build-dependencies
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /opt/commit-event-service
 

--- a/event-log/Dockerfile
+++ b/event-log/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM openjdk:17-jdk-alpine as builder
+FROM eclipse-temurin:17-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project event-log" stage && \
     apk del .build-dependencies
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /opt/event-log
 

--- a/knowledge-graph/Dockerfile
+++ b/knowledge-graph/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM openjdk:17-jdk-alpine as builder
+FROM eclipse-temurin:17-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project knowledge-graph" stage && \
     apk del .build-dependencies
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /opt/knowledge-graph
 

--- a/token-repository/Dockerfile
+++ b/token-repository/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM openjdk:17-jdk-alpine as builder
+FROM eclipse-temurin:17-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project token-repository" stage && \
     apk del .build-dependencies
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /opt/token-repository
 

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM openjdk:17-jdk-alpine as builder
+FROM eclipse-temurin:17-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project triples-generator" stage && \
     apk del .build-dependencies
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /opt/triples-generator
 

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM openjdk:17-jdk-alpine as builder
+FROM eclipse-temurin:17-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project webhook-service" stage  && \
     apk del .build-dependencies
 
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /opt/webhook-service
 


### PR DESCRIPTION
This PR addresses vulnerabilities found on graph services' images. It replaces the problematic base image with [eclipse-temurin:17-jre-alpine](https://hub.docker.com/layers/library/eclipse-temurin/17-jre-alpine/images/sha256-e1506ba20f0cb2af6f23e24c7f8855b417f0b085708acd9b85344a884ba77767?context=explore) which extends `alpine:3.17` (see [here](https://github.com/adoptium/containers/blob/main/17/jre/alpine/Dockerfile.releases.full))

/deploy #persist