### PR TITLE
fix: Fix python build in TG dockerfile

### DIFF
--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -28,7 +28,7 @@ ENV TZ UTC
 
 # Installing Renku and other dependencies
 RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py3-pip py3-wheel openssl-dev libffi-dev linux-headers gcc g++ make libxml2-dev libxslt-dev libc-dev yaml-dev 'rust>1.41.0' cargo tini && \
-    python3 -m pip install --ignore-installed packaging && \
+    python3 -m pip install --ignore-installed 'packaging==21.3 '&& \
     python3 -m pip install --upgrade 'pip==22.3.1' && \
     python3 -m pip install jinja2 && \
     python3 -m pip install 'renku==1.10.0' 'sentry-sdk==1.5.11'  && \


### PR DESCRIPTION
A new version of `packaging` introduces some incompatibility, pinning it to the previous version to have a successful build.

/deploy