### PR TITLE
fix: deduplicate project created dates after transformation

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/persons/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/persons/UpdatesCreator.scala
@@ -24,7 +24,6 @@ import io.renku.graph.model.GraphClass
 import io.renku.graph.model.Schemas._
 import io.renku.graph.model.entities.Person
 import io.renku.graph.model.views.RdfResource
-import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
 
@@ -87,7 +86,7 @@ private trait UpdatesCreator {
           |WHERE {
           |  GRAPH <${GraphClass.Persons.id.show}> {
           |    {
-          |      SELECT ?id
+          |      SELECT ?id (max(?e) as ?name)
           |      WHERE {
           |        BIND ($resource AS ?id)
           |        ?id a schema:Person;
@@ -96,15 +95,13 @@ private trait UpdatesCreator {
           |      GROUP BY ?id
           |      HAVING (COUNT(?e) > 1)
           |    }
-          |    ?id schema:name ?name.
-          |    FILTER (?name != '${sparqlEncode(person.name.show)}')
           |  }
           |}
           |""".stripMargin
     )
   }
 
-  private def deduplicateEmail(person: Person) = person.maybeEmail.map { email =>
+  private def deduplicateEmail(person: Person) = person.maybeEmail.map { _ =>
     val resource = person.resourceId.showAs[RdfResource]
     SparqlQuery.of(
       name = "transformation - person email deduplicate",
@@ -113,7 +110,7 @@ private trait UpdatesCreator {
           |WHERE {
           |  GRAPH <${GraphClass.Persons.id.show}> {
           |    {
-          |      SELECT ?id
+          |      SELECT ?id (max(?e) as ?email)
           |      WHERE {
           |        BIND ($resource AS ?id)
           |        ?id a schema:Person;
@@ -122,15 +119,13 @@ private trait UpdatesCreator {
           |      GROUP BY ?id
           |      HAVING (COUNT(?e) > 1)
           |    }
-          |    ?id schema:email ?email.
-          |    FILTER (?email != '${sparqlEncode(email.show)}')
           |  }
           |}
           |""".stripMargin
     )
   }
 
-  private def deduplicateAffiliation(person: Person) = person.maybeAffiliation.map { affiliation =>
+  private def deduplicateAffiliation(person: Person) = person.maybeAffiliation.map { _ =>
     val resource = person.resourceId.showAs[RdfResource]
     SparqlQuery.of(
       name = "transformation - person affiliation deduplicate",
@@ -139,7 +134,7 @@ private trait UpdatesCreator {
           |WHERE {
           |  GRAPH <${GraphClass.Persons.id.show}> {
           |    {
-          |      SELECT ?id
+          |      SELECT ?id (max(?e) as ?affiliation)
           |      WHERE {
           |        BIND ($resource AS ?id)
           |        ?id a schema:Person;
@@ -148,8 +143,6 @@ private trait UpdatesCreator {
           |      GROUP BY ?id
           |      HAVING (COUNT(?e) > 1)
           |    }
-          |    ?id schema:affiliation ?affiliation.
-          |    FILTER (?affiliation != '${sparqlEncode(affiliation.show)}')
           |  }
           |}
           |""".stripMargin

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/DateCreatedUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/DateCreatedUpdater.scala
@@ -35,14 +35,15 @@ private class DateCreatedUpdaterImpl(updatesCreator: UpdatesCreator) extends Dat
   import updatesCreator._
 
   override def updateDateCreated(kgData: ProjectMutableData): ((Project, Queries)) => (Project, Queries) = {
-    case (project, queries) if (project.dateCreated compareTo kgData.dateCreated) < 0 =>
+    case (project, queries) if project.dateCreated < kgData.earliestDateCreated =>
       project -> (queries |+| preDataQueriesOnly(dateCreatedDeletion(project, kgData)))
-    case (project, queries) if (project.dateCreated compareTo kgData.dateCreated) > 0 =>
+    case (project, queries) if project.dateCreated > kgData.earliestDateCreated =>
+      val kgDataCreated = kgData.earliestDateCreated
       val updatedProj = project match {
-        case p: RenkuProject.WithoutParent    => p.copy(dateCreated = kgData.dateCreated)
-        case p: RenkuProject.WithParent       => p.copy(dateCreated = kgData.dateCreated)
-        case p: NonRenkuProject.WithoutParent => p.copy(dateCreated = kgData.dateCreated)
-        case p: NonRenkuProject.WithParent    => p.copy(dateCreated = kgData.dateCreated)
+        case p: RenkuProject.WithoutParent    => p.copy(dateCreated = kgDataCreated)
+        case p: RenkuProject.WithParent       => p.copy(dateCreated = kgDataCreated)
+        case p: NonRenkuProject.WithoutParent => p.copy(dateCreated = kgDataCreated)
+        case p: NonRenkuProject.WithParent    => p.copy(dateCreated = kgDataCreated)
       }
       updatedProj -> queries
     case (project, queries) => project -> queries

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/ProjectMutableData.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/ProjectMutableData.scala
@@ -18,14 +18,23 @@
 
 package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation.namedgraphs.projects
 
+import cats.data.{NonEmptyList => Nel}
 import io.renku.graph.model.{CliVersion, persons, projects}
 
-private final case class ProjectMutableData(name:             projects.Name,
-                                            dateCreated:      projects.DateCreated,
-                                            maybeParentId:    Option[projects.ResourceId],
-                                            visibility:       projects.Visibility,
-                                            maybeDescription: Option[projects.Description],
-                                            keywords:         Set[projects.Keyword],
-                                            maybeAgent:       Option[CliVersion],
-                                            maybeCreatorId:   Option[persons.ResourceId]
-)
+private final case class ProjectMutableData(
+    name:             projects.Name,
+    dateCreated:      Nel[projects.DateCreated],
+    maybeParentId:    Option[projects.ResourceId],
+    visibility:       projects.Visibility,
+    maybeDescription: Option[projects.Description],
+    keywords:         Set[projects.Keyword],
+    maybeAgent:       Option[CliVersion],
+    maybeCreatorId:   Option[persons.ResourceId]
+) {
+
+  lazy val earliestDateCreated: projects.DateCreated =
+    dateCreated.toList.min
+
+  def selectEarliestDateCreated: ProjectMutableData =
+    copy(dateCreated = Nel.one(earliestDateCreated))
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/ProjectTransformer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/ProjectTransformer.scala
@@ -25,7 +25,6 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.graph.model.entities.Project
 import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
-import io.renku.triplesgenerator.events.consumers.tsprovisioning.TransformationStep.Queries.preDataQueriesOnly
 import io.renku.triplesgenerator.events.consumers.tsprovisioning.TransformationStep.{Queries, Transformation}
 import io.renku.triplesgenerator.events.consumers.tsprovisioning.{RecoverableErrorsRecovery, TransformationStep}
 import io.renku.triplesstore.SparqlQueryTimeRecorder
@@ -65,7 +64,7 @@ private class ProjectTransformerImpl[F[_]: MonadThrow](
 
   private def addOtherUpdates(kgData: ProjectMutableData): ((Project, Queries)) => (Project, Queries) = {
     case (project, queries) =>
-      (project, queries |+| preDataQueriesOnly(prepareUpdates(project, kgData)))
+      (project, queries ++ Queries(prepareUpdates(project, kgData), postUpdates(project)))
   }
 }
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreator.scala
@@ -182,15 +182,17 @@ private object UpdatesCreator extends UpdatesCreator {
       name = "transformation - project date created deduplicate",
       Prefixes.of(schema -> "schema"),
       s"""|WITH $resource 
-          |DELETE { ?s schema:dateCreated ?date }
+          |DELETE { ?p schema:dateCreated ?date }
           |WHERE {
           |  {
-          |    SELECT (min(?date) as ?minDate)
+          |    SELECT (min(?cdate) as ?minDate)
           |    WHERE {
-          |      ?s schema:dateCreated ?date
+          |      ?_s a schema:Project;
+          |          schema:dateCreated ?cdate.
           |    }
           |  }
-          |  ?s schema:dateCreated ?date.
+          |  ?p a schema:Project;
+          |     schema:dateCreated ?date.
           |  FILTER ( ?date != ?minDate )
           |}
           |""".stripMargin

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/DateCreatedUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/DateCreatedUpdaterSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation
 package namedgraphs.projects
 
+import cats.data.{NonEmptyList => Nel}
 import Generators.queriesGen
 import TestDataTools._
 import io.renku.generators.CommonGraphGenerators.sparqlQueries
@@ -41,7 +42,7 @@ class DateCreatedUpdaterSpec extends AnyWordSpec with should.Matchers with MockF
       "if project dateCreated on the model is < dateCreated currently in KG" in new TestCase {
         val project = anyProjectEntities.generateOne.to[entities.Project]
         val kgData = toProjectMutableData(project).copy(dateCreated =
-          timestampsNotInTheFuture(butYoungerThan = project.dateCreated.value).generateAs(DateCreated)
+          Nel.of(timestampsNotInTheFuture(butYoungerThan = project.dateCreated.value).generateAs(DateCreated))
         )
 
         val updateQueries = sparqlQueries.generateList()
@@ -58,7 +59,7 @@ class DateCreatedUpdaterSpec extends AnyWordSpec with should.Matchers with MockF
       "if project dateCreated on the model is > dateCreated currently in KG" in new TestCase {
         val project       = anyProjectEntities.generateOne.to[entities.Project]
         val kgDateCreated = timestamps(max = project.dateCreated.value.minusMillis(1)).generateAs(DateCreated)
-        val kgData        = toProjectMutableData(project).copy(dateCreated = kgDateCreated)
+        val kgData        = toProjectMutableData(project).copy(dateCreated = Nel.of(kgDateCreated))
 
         val updatedProject -> queries = updater.updateDateCreated(kgData)(project -> initialQueries)
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/KGProjectFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/KGProjectFinderSpec.scala
@@ -47,7 +47,8 @@ class KGProjectFinderSpec
       forAll(anyProjectEntities.map(_.to[entities.Project])) { project =>
         upload(to = projectsDataset, project)
 
-        finder.find(project.resourceId).unsafeRunSync() shouldBe toProjectMutableData(project).some
+        val projectData = finder.find(project.resourceId).unsafeRunSync()
+        projectData.map(_.selectEarliestDateCreated) shouldBe toProjectMutableData(project).some
       }
     }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/ProjectTransformerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/ProjectTransformerSpec.scala
@@ -20,6 +20,7 @@ package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation
 package namedgraphs.projects
 
 import Generators._
+import cats.data.{NonEmptyList => Nel}
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators.sparqlQueries
 import io.renku.generators.Generators.Implicits._
@@ -139,7 +140,7 @@ class ProjectTransformerSpec extends AnyWordSpec with MockFactory with should.Ma
     maybeAgent     <- cliVersions.toGeneratorOfOptions
     maybeCreatorId <- personResourceIds.toGeneratorOfOptions
   } yield ProjectMutableData(name,
-                             dateCreated,
+                             Nel.of(dateCreated),
                              maybeParentId,
                              visibility,
                              maybeDesc,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/TestDataTools.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/TestDataTools.scala
@@ -18,6 +18,7 @@
 
 package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation.namedgraphs.projects
 
+import cats.data.{NonEmptyList => Nel}
 import cats.syntax.all._
 import io.renku.graph.model.entities
 
@@ -25,7 +26,7 @@ private object TestDataTools {
 
   def toProjectMutableData(project: entities.Project): ProjectMutableData = ProjectMutableData(
     project.name,
-    project.dateCreated,
+    Nel.of(project.dateCreated),
     findParent(project),
     project.visibility,
     project.maybeDescription,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
@@ -48,7 +48,6 @@ class UpdatesCreatorSpec
     with IOSpec
     with should.Matchers
     with InMemoryJenaForSpec
-    // with ExternalJenaForSpec
     with ProjectsDataset
     with TableDrivenPropertyChecks
     with ScalaCheckPropertyChecks {
@@ -299,7 +298,9 @@ class UpdatesCreatorSpec
 
       upload(to = projectsDataset, project)
 
-      dateCreatedDeletion(project, toProjectMutableData(project).copy(dateCreated = projectCreatedDates().generateOne))
+      dateCreatedDeletion(project,
+                          toProjectMutableData(project).copy(dateCreated = projectCreatedDates().generateNonEmptyList())
+      )
         .runAll(on = projectsDataset)
         .unsafeRunSync()
 


### PR DESCRIPTION
When events are processed concurrently it may happen that different project created dates get into the KG. With the "eventual consistency" requirements, we check for this situation after transformation and remove all but the earliest one.

/deploy #persist