### PR TITLE
fix: lucene query escape tool to treat phrases as strings

### DIFF
--- a/generators/src/main/scala/io/renku/generators/Generators.scala
+++ b/generators/src/main/scala/io/renku/generators/Generators.scala
@@ -86,8 +86,8 @@ object Generators {
   }
 
   def sentenceContaining(phrase: NonBlank): Gen[String] = for {
-    prefix <- nonEmptyStrings()
-    suffix <- nonEmptyStrings()
+    prefix <- nonEmptyStrings(minLength = 3)
+    suffix <- nonEmptyStrings(minLength = 3)
   } yield s"$prefix $phrase $suffix"
 
   def blankStrings(maxLength: Int = 10): Gen[String] = for {

--- a/graph-commons/build.sbt
+++ b/graph-commons/build.sbt
@@ -24,9 +24,9 @@ val pureConfigVersion = "0.17.2"
 libraryDependencies += "com.github.pureconfig" %% "pureconfig"      % pureConfigVersion
 libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % pureConfigVersion
 
-libraryDependencies += "eu.timepit"   %% "refined-pureconfig" % "0.10.1"
-libraryDependencies += "io.sentry"     % "sentry-logback"     % "6.9.2"
-libraryDependencies += "org.tpolecat" %% "skunk-core"         % "0.3.2"
+libraryDependencies += "eu.timepit"       %% "refined-pureconfig" % "0.10.1"
+libraryDependencies += "io.sentry"         % "sentry-logback"     % "6.9.2"
+libraryDependencies += "org.apache.lucene" % "lucene-queryparser" % "9.4.2"
 
 val http4sVersion           = "0.23.16"
 val http4sBlazeVersion      = "0.23.12"
@@ -38,6 +38,7 @@ libraryDependencies += "org.http4s" %% "http4s-dsl"                % http4sVersi
 libraryDependencies += "org.http4s" %% "http4s-prometheus-metrics" % http4sPrometheusVersion
 libraryDependencies += "org.http4s" %% "http4s-server"             % http4sVersion
 
+libraryDependencies += "org.tpolecat"  %% "skunk-core"    % "0.3.2"
 libraryDependencies += "org.typelevel" %% "cats-effect"   % "3.4.2"
 libraryDependencies += "org.typelevel" %% "log4cats-core" % "2.5.0"
 

--- a/graph-commons/src/main/scala/io/renku/triplesstore/LuceneQueryEncoder.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/LuceneQueryEncoder.scala
@@ -18,37 +18,9 @@
 
 package io.renku.triplesstore
 
+import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil
+
 object LuceneQueryEncoder {
 
-  private val specialCharactersEscape =
-    List("+",
-         "-",
-         "&",
-         "&&",
-         "|",
-         "||",
-         "!",
-         "(",
-         ")",
-         "{",
-         "}",
-         "[",
-         "]",
-         "^",
-         """"""",
-         "~",
-         "*",
-         "?",
-         ":",
-         """\""",
-         "/"
-    ).map {
-      case c if c == "}" || c == "]" || c == "*" || c == """\""" => c -> s"""\\$c"""
-      case c                                                     => c -> s"""\\\\$c"""
-    }.toMap
-
-  def queryAsString(v: String): String =
-    specialCharactersEscape.foldLeft(v) { case (escaped, (specialChar, replacement)) =>
-      escaped.replace(specialChar, replacement)
-    }
+  def queryAsString(v: String): String = QueryParserUtil.escape(v).replace("\\", "\\\\")
 }

--- a/graph-commons/src/main/scala/io/renku/triplesstore/LuceneQueryEncoder.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/LuceneQueryEncoder.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesstore
+
+object LuceneQueryEncoder {
+
+  private val specialCharactersEscape =
+    List("+",
+         "-",
+         "&",
+         "&&",
+         "|",
+         "||",
+         "!",
+         "(",
+         ")",
+         "{",
+         "}",
+         "[",
+         "]",
+         "^",
+         """"""",
+         "~",
+         "*",
+         "?",
+         ":",
+         """\""",
+         "/"
+    ).map {
+      case c if c == "}" || c == "]" || c == "*" || c == """\""" => c -> s"""\\$c"""
+      case c                                                     => c -> s"""\\\\$c"""
+    }.toMap
+
+  def queryAsString(v: String): String =
+    specialCharactersEscape.foldLeft(v) { case (escaped, (specialChar, replacement)) =>
+      escaped.replace(specialChar, replacement)
+    }
+}

--- a/graph-commons/src/main/scala/io/renku/triplesstore/TSClient.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/TSClient.scala
@@ -43,7 +43,7 @@ abstract class TSClient[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     maxRetries:             Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeoutOverride:    Option[Duration] = None,
     requestTimeoutOverride: Option[Duration] = None,
-    printQueries:             Boolean = false
+    printQueries:           Boolean = false
 ) extends RestClient(Throttler.noThrottling,
                      Some(implicitly[SparqlQueryTimeRecorder[F]].instance),
                      retryInterval,

--- a/graph-commons/src/main/scala/io/renku/triplesstore/TSClient.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/TSClient.scala
@@ -43,7 +43,7 @@ abstract class TSClient[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     maxRetries:             Int Refined NonNegative = MaxRetriesAfterConnectionTimeout,
     idleTimeoutOverride:    Option[Duration] = None,
     requestTimeoutOverride: Option[Duration] = None,
-    logQueries:             Boolean = false
+    printQueries:             Boolean = false
 ) extends RestClient(Throttler.noThrottling,
                      Some(implicitly[SparqlQueryTimeRecorder[F]].instance),
                      retryInterval,
@@ -113,7 +113,7 @@ abstract class TSClient[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     result <- send(sparqlQueryRequest(uri, queryType, query))(mapResponse)
   } yield result
 
-  private def log(query: SparqlQuery) = whenA(logQueries)(Logger[F] info query.show)
+  private def log(query: SparqlQuery) = whenA(printQueries)(println(query.show).pure[F])
 
   private def sparqlQueryRequest(uri: Uri, queryType: SparqlQueryType, query: SparqlQuery) = HttpRequest(
     request(POST, uri, triplesStoreConfig.authCredentials)

--- a/graph-commons/src/test/scala/io/renku/triplesstore/LuceneQueryEncoderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/LuceneQueryEncoderSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesstore
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{NonBlank, nonEmptyStrings, sentenceContaining}
+import io.renku.graph.model.projects
+import io.renku.graph.model.testentities._
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class LuceneQueryEncoderSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with should.Matchers {
+
+  import LuceneQueryEncoder._
+
+  "queryAsString" should {
+
+    List[NonBlank]("""\""",
+                   "+",
+                   "-",
+                   "&&",
+                   "||",
+                   "&",
+                   "|",
+                   "!",
+                   "(",
+                   ")",
+                   "{",
+                   "}",
+                   "[",
+                   "]",
+                   "^",
+                   """"""",
+                   "~",
+                   "*",
+                   "?",
+                   ":",
+                   "/"
+    ) foreach { specialChar =>
+      s"escape '$specialChar' so it can be used as a string in the Lucene search" in {
+
+        val query = s"$specialChar${nonEmptyStrings(minLength = 3).generateOne}"
+        val name  = sentenceContaining(Refined.unsafeApply(query)).generateAs(projects.Name)
+        val project = renkuProjectEntities(visibilityPublic)
+          .modify(replaceProjectName(name))
+          .generateOne
+
+        upload(to = projectsDataset, project)
+
+        runSelect(
+          on = projectsDataset,
+          SparqlQuery.of(
+            "lucene test query",
+            Prefixes of (schema -> "schema", text -> "text"),
+            s"""SELECT ?name
+            WHERE {
+              GRAPH ?g {
+                ?id text:query (schema:name '${queryAsString(query)}');
+                    schema:name ?name
+              }
+            }
+            """.stripMargin
+          )
+        ).unsafeRunSync() shouldBe List(Map("name" -> name.value))
+      }
+    }
+  }
+}

--- a/graph-commons/src/test/scala/io/renku/triplesstore/LuceneQueryEncoderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/LuceneQueryEncoderSpec.scala
@@ -40,11 +40,9 @@ class LuceneQueryEncoderSpec
 
   "queryAsString" should {
 
-    List[NonBlank]("""\""",
+    List[NonBlank]("\\",
                    "+",
                    "-",
-                   "&&",
-                   "||",
                    "&",
                    "|",
                    "!",
@@ -55,7 +53,7 @@ class LuceneQueryEncoderSpec
                    "[",
                    "]",
                    "^",
-                   """"""",
+                   "\"",
                    "~",
                    "*",
                    "?",

--- a/graph-commons/src/test/scala/io/renku/triplesstore/Quad.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/Quad.scala
@@ -20,7 +20,7 @@ package io.renku.triplesstore
 
 import cats.Show
 import cats.syntax.all._
-import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
+import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
 import io.renku.jsonld.{EntityId, EntityIdEncoder, Property}
 import io.renku.tinytypes.{StringTinyType, TinyType}
 

--- a/graph-commons/src/test/scala/io/renku/triplesstore/Triple.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/Triple.scala
@@ -20,7 +20,7 @@ package io.renku.triplesstore
 
 import cats.Show
 import cats.syntax.all._
-import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
+import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
 import io.renku.jsonld.{EntityId, EntityIdEncoder, Property}
 import io.renku.tinytypes.{StringTinyType, TinyType}
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/package.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/package.scala
@@ -53,10 +53,11 @@ package object finder {
 
   private[finder] implicit class FiltersOps(filters: Filters) {
 
-    import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
+    import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
+    import io.renku.triplesstore.LuceneQueryEncoder.queryAsString
 
     private val queryAll: String = "*"
-    lazy val query:       String = filters.maybeQuery.map(_.value).getOrElse(queryAll)
+    lazy val query:       String = filters.maybeQuery.map(q => queryAsString(q.value)).getOrElse(queryAll)
 
     def whenRequesting(entityType: Filters.EntityType, predicates: Boolean*)(query: => String): Option[String] = {
       val typeMatching = filters.entityTypes match {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/EntitiesFinderSpec.scala
@@ -95,7 +95,7 @@ class EntitiesFinderSpec
           )
         )
         .generateOne
-      val plan :: Nil = planProject.plans.toList
+      val plan :: Nil = planProject.plans
 
       val notMatchingProject = renkuProjectEntities(visibilityPublic)
         .withActivities(activityEntities(stepPlanEntities()))
@@ -147,7 +147,7 @@ class EntitiesFinderSpec
           )
         )
         .generateOne
-      val plan :: Nil = planProject.plans.toList
+      val plan :: Nil = planProject.plans
 
       upload(to = projectsDataset, soleProject, dsProject, planProject, projectEntities(visibilityPublic).generateOne)
 
@@ -185,7 +185,7 @@ class EntitiesFinderSpec
           )
         )
         .generateOne
-      val plan :: Nil = planProject.plans.toList
+      val plan :: Nil = planProject.plans
 
       upload(to = projectsDataset, soleProject, dsProject, planProject, projectEntities(visibilityPublic).generateOne)
 
@@ -288,7 +288,7 @@ class EntitiesFinderSpec
       finder
         .findEntities(Criteria(Filters(entityTypes = Set(EntityType.Workflow))))
         .unsafeRunSync()
-        .results shouldBe project.plans.map(_ -> project).map(_.to[model.Entity.Workflow]).toList.sortBy(_.name.value)
+        .results shouldBe project.plans.map(_ -> project).map(_.to[model.Entity.Workflow]).sortBy(_.name.value)
     }
 
     "return entities of many types when multiple types given" in new TestCase {
@@ -556,7 +556,7 @@ class EntitiesFinderSpec
             )
         )
         .generateOne
-      val plan :: _ = project.plans.toList
+      val plan :: _ = project.plans
 
       upload(to = projectsDataset, project)
 
@@ -685,7 +685,7 @@ class EntitiesFinderSpec
             )
         )
         .generateOne
-      val plan :: _ = project.plans.toList
+      val plan :: _ = project.plans
 
       upload(to = projectsDataset, project)
 
@@ -845,7 +845,7 @@ class EntitiesFinderSpec
             )
         )
         .generateOne
-      val plan :: _ = project.plans.toList
+      val plan :: _ = project.plans
 
       upload(to = projectsDataset, project)
 

--- a/renku-model/src/main/scala/io/renku/graph/model/views/SparqlLiteralEncoder.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/views/SparqlLiteralEncoder.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model.views
 
-object SparqlValueEncoder {
+object SparqlLiteralEncoder {
 
   def sparqlEncode(string: String): String =
     string

--- a/renku-model/src/test/scala/io/renku/graph/model/views/SparqlLiteralEncoderSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/views/SparqlLiteralEncoderSpec.scala
@@ -23,9 +23,9 @@ import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class SparqlValueEncoderSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
+class SparqlLiteralEncoderSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Matchers {
 
-  import io.renku.graph.model.views.SparqlValueEncoder._
+  import SparqlLiteralEncoder._
 
   "iriEncode" should {
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/modelSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/modelSpec.scala
@@ -58,7 +58,7 @@ class RenkuAccessTokenNameSpec extends AnyWordSpec with should.Matchers {
 
       val Success(actual) = RenkuAccessTokenName[Try](config)
 
-      actual              shouldBe a[RenkuAccessTokenName]
+      actual       shouldBe a[RenkuAccessTokenName]
       actual.value shouldBe name
     }
   }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/TSCleaner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/TSCleaner.scala
@@ -63,7 +63,7 @@ private class TSCleanerImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
   import SameAsHierarchyFixer._
   import eu.timepit.refined.auto._
   import io.renku.graph.model.Schemas._
-  import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
+  import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
   import io.renku.triplesstore.SparqlQuery
   import io.renku.triplesstore.SparqlQuery.Prefixes
   private implicit val tsConnection: ProjectsConnectionConfig = connectionConfig

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/UpdatesCreator.scala
@@ -28,7 +28,7 @@ import io.renku.graph.model._
 import io.renku.graph.model.entities.Person
 import io.renku.graph.model.persons.GitLabId
 import io.renku.graph.model.views.RdfResource
-import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
+import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/persons/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/persons/UpdatesCreator.scala
@@ -24,7 +24,7 @@ import io.renku.graph.model.GraphClass
 import io.renku.graph.model.Schemas._
 import io.renku.graph.model.entities.Person
 import io.renku.graph.model.views.RdfResource
-import io.renku.graph.model.views.SparqlValueEncoder.sparqlEncode
+import io.renku.graph.model.views.SparqlLiteralEncoder.sparqlEncode
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
 


### PR DESCRIPTION
This PR escapes search phrases passed to the Cross-Entity Search API so they are treated as strings.

The escape characters are taken from [here](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html)

/deploy #persist