### PR TITLE
feat: Migrate project created dates

### DIFF
--- a/tiny-types/src/test/scala/io/renku/tinytypes/syntax/InstantTinyTypeSyntax.scala
+++ b/tiny-types/src/test/scala/io/renku/tinytypes/syntax/InstantTinyTypeSyntax.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tinytypes.syntax
+
+import io.renku.tinytypes.{InstantTinyType, TinyTypeFactory}
+import scala.concurrent.duration.FiniteDuration
+
+trait InstantTinyTypeSyntax {
+
+  final implicit class InstantTinyTypeOps[A <: InstantTinyType](self: A) {
+    def +(duration: FiniteDuration)(implicit tf: TinyTypeFactory[A]): A =
+      tf.apply(self.value.plusMillis(duration.toMillis))
+
+    def -(duration: FiniteDuration)(implicit tf: TinyTypeFactory[A]): A =
+      tf.apply(self.value.minusMillis(duration.toMillis))
+  }
+}
+
+object InstantTinyTypeSyntax extends InstantTinyTypeSyntax

--- a/tiny-types/src/test/scala/io/renku/tinytypes/syntax/all.scala
+++ b/tiny-types/src/test/scala/io/renku/tinytypes/syntax/all.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tinytypes.syntax
+
+object all extends InstantTinyTypeSyntax

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/FixMultipleProjectCreatedDates.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/FixMultipleProjectCreatedDates.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.Schemas.schema
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling.UpdateQueryMigration
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import org.typelevel.log4cats.Logger
+
+private object FixMultipleProjectCreatedDates {
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    UpdateQueryMigration[F](name, query).widen
+
+  private lazy val name = Migration.Name("Remove too many project createdDates")
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of schema -> "schema",
+    s"""|DELETE { Graph ?g { ?id schema:dateCreated ?date } }
+        |WHERE {
+        |  Graph ?g {
+        |    {
+        |      SELECT ?id (min(?cdate) as ?minDate)
+        |      WHERE {
+        |        ?id a schema:Project;
+        |            schema:dateCreated ?cdate.
+        |      }
+        |      GROUP BY ?id
+        |      HAVING (COUNT(?cdate) > 1)
+        |    }
+        |    ?id schema:dateCreated ?date.
+        |    FILTER ( ?date != ?minDate )
+        |  }
+        |}
+        |""".stripMargin
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -33,19 +33,21 @@ private[tsmigrationrequest] object Migrations {
   def apply[F[_]: Async: ReProvisioningStatus: Logger: MetricsRegistry: SparqlQueryTimeRecorder](
       config: Config
   ): F[List[Migration[F]]] = for {
-    datasetsCreator               <- DatasetsCreator[F]
-    datasetsRemover               <- DatasetsRemover[F]
-    reProvisioning                <- ReProvisioning[F](config)
-    removeNotLinkedPersons        <- RemoveNotLinkedPersons[F]
-    fixPlansYoungerThanActivities <- FixPlansYoungerThanActivities[F]
-    compositePlan                 <- CompositePlanProvision.create[F]
+    datasetsCreator                <- DatasetsCreator[F]
+    datasetsRemover                <- DatasetsRemover[F]
+    reProvisioning                 <- ReProvisioning[F](config)
+    removeNotLinkedPersons         <- RemoveNotLinkedPersons[F]
+    fixPlansYoungerThanActivities  <- FixPlansYoungerThanActivities[F]
+    compositePlan                  <- CompositePlanProvision.create[F]
+    fixMultipleProjectCreatedDates <- FixMultipleProjectCreatedDates[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
                     reProvisioning,
                     removeNotLinkedPersons,
                     fixPlansYoungerThanActivities,
-                    compositePlan
+                    compositePlan,
+                    fixMultipleProjectCreatedDates
                   )
   } yield migrations
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/FixMultipleProjectCreatedDatesSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/FixMultipleProjectCreatedDatesSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.graph.model.{GraphClass, entities, projects}
+import io.renku.graph.model.testentities._
+import io.renku.generators.Generators.Implicits._
+import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore._
+import io.renku.tinytypes.syntax.all._
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.typelevel.log4cats.Logger
+import eu.timepit.refined.auto._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+
+import java.time.Instant
+import scala.concurrent.duration._
+
+class FixMultipleProjectCreatedDatesSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset {
+
+  implicit val logger: Logger[IO] = TestLogger()
+
+  "run" should {
+    "remove obsolete project created dates when multiple exist" in {
+      val data = anyRenkuProjectEntities
+        .modify(replaceProjectCreator(personEntities.generateSome))
+        .addDataset(datasetEntities(provenanceInternal))
+        .generateList(min = 2, max = 2)
+        .map(_.bimap(identity, _.to[entities.Project]))
+
+      upload(to = projectsDataset, data.map(_._2): _*)
+      val moreDates = List.range(1, 3)
+      moreDates
+        .flatMap(n => data.map(_._2).map(project => (project.resourceId, project.dateCreated - n.days)))
+        .foreach { case (id, date) =>
+          val graphId = GraphClass.Project.id(id)
+          insert(to = projectsDataset, Quad(graphId, id, schema / "dateCreated", date))
+        }
+
+      val datesBefore = findProjectDateCreated
+      datesBefore.size           shouldBe 2
+      datesBefore.map(_._2.size) shouldBe List.fill(2)(1 + moreDates.size)
+
+      runUpdate(projectsDataset, FixMultipleProjectCreatedDates.query).unsafeRunSync()
+
+      val datesAfter = findProjectDateCreated
+      datesAfter.size           shouldBe 2
+      datesAfter.map(_._2.size) shouldBe List(1, 1)
+    }
+  }
+
+  def findProjectDateCreated: Map[projects.ResourceId, List[Instant]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.of(
+        "find dates",
+        Prefixes.of(schema -> "schema"),
+        """
+          |SELECT ?projectId ?dateCreated
+          |WHERE {
+          |  graph ?g {
+          |    ?projectId a schema:Project;
+          |       schema:dateCreated ?dateCreated
+          |  }
+          |}
+          |""".stripMargin
+      )
+    ).unsafeRunSync()
+      .map(row => projects.ResourceId(row("projectId")) -> Instant.parse(row("dateCreated")))
+      .groupMap(_._1)(_._2)
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
@@ -30,9 +30,9 @@ import io.renku.graph.model.testentities._
 import io.renku.graph.model.{GraphClass, entities, projects}
 import io.renku.jsonld.syntax._
 import io.renku.testtools.IOSpec
-import io.renku.tinytypes.{InstantTinyType, TinyTypeFactory}
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
+import io.renku.tinytypes.syntax.all._
 import monocle.Lens
 import org.scalacheck.Gen
 import org.scalatest.matchers.should
@@ -405,12 +405,4 @@ class UpdatesCreatorSpec
         case p: entities.RenkuProject.WithoutParent    => p.copy(dateCreated = created)
       }
     }
-
-  final implicit class InstantTinyTypeOps[A <: InstantTinyType](self: A) {
-    def +(duration: FiniteDuration)(implicit tf: TinyTypeFactory[A]): A =
-      tf.apply(self.value.plusMillis(duration.toMillis))
-
-    def -(duration: FiniteDuration)(implicit tf: TinyTypeFactory[A]): A =
-      tf.apply(self.value.minusMillis(duration.toMillis))
-  }
 }


### PR DESCRIPTION
Adds a migration to remove `dateCreated` properties from projects that have more than one.

closes #1231 