### PR TITLE
fix: Fix selecting workflows when modified ones exist

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/package.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/package.scala
@@ -68,8 +68,11 @@ package object finder {
     }
 
     def onQuery(snippet: String, matchingScoreVariableName: String = "?matchingScore"): String =
-      if (query.trim != queryAll) snippet
-      else s"BIND (xsd:float(1.0) AS $matchingScoreVariableName)"
+      foldQuery(_ => snippet, s"BIND (xsd:float(1.0) AS $matchingScoreVariableName)")
+
+    def foldQuery[A](ifPresent: String => A, ifMissing: => A): A =
+      if (query.trim != queryAll) ifPresent(query)
+      else ifMissing
 
     lazy val withNoOrPublicVisibility: Boolean = filters.visibilities match {
       case v if v.isEmpty => true

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/finder/FinderSpecOps.scala
@@ -88,7 +88,7 @@ trait FinderSpecOps {
     }.distinct
 
     def addAllPlansFrom(project: RenkuProject): List[model.Entity] = {
-      project.plans.toList.map(_ -> project).map(_.to[model.Entity.Workflow]) ::: entities
+      project.plans.map(_ -> project).map(_.to[model.Entity.Workflow]) ::: entities
     }.distinct
 
     def addAllPersonsFrom(project: RenkuProject): List[model.Entity] =


### PR DESCRIPTION
When a fulltext search query is given, the entities that have a plan are selected, but without this query, the selection was missing. This resulted in not returning any plans.