### PR TITLE
chore: Move image utilities into its own scope

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsApiEncoders.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsApiEncoders.scala
@@ -23,7 +23,8 @@ import io.circe.literal._
 import io.circe.{Encoder, Json}
 import io.renku.graph.acceptancetests.data._
 import io.renku.graph.acceptancetests.tooling.AcceptanceSpec
-import io.renku.graph.model.datasets.{DatePublished, Identifier, ImageUri, Title}
+import io.renku.graph.model.datasets.{DatePublished, Identifier, Title}
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.testentities.{Dataset, Person}
 import io.renku.graph.model.{GitLabUrl, projects}
 import io.renku.http.rest.Links.{Href, Rel, _links}

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetSearchResult.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetSearchResult.scala
@@ -24,7 +24,8 @@ import cats.syntax.all._
 import io.circe.literal._
 import io.circe.{Encoder, Json}
 import io.renku.config
-import io.renku.graph.model.datasets.{Date, DatePublished, Description, Identifier, ImageUri, Keyword, Name, Title}
+import io.renku.graph.model.datasets.{Date, DatePublished, Description, Identifier, Keyword, Name, Title}
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.{GitLabUrl, projects}
 import io.renku.http.rest.Links.{Href, Link, Rel, _links}
 import io.renku.json.JsonOps._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetsFinder.scala
@@ -28,8 +28,9 @@ import io.circe.DecodingFailure
 import io.circe.literal._
 import io.renku.graph.config.RenkuUrlLoader
 import io.renku.graph.model.Schemas._
-import io.renku.graph.model.datasets.{DateCreated, DatePublished, Description, Identifier, ImageUri, Keyword, Name, Title}
+import io.renku.graph.model.datasets.{DateCreated, DatePublished, Description, Identifier, Keyword, Name, Title}
 import io.renku.graph.model.entities.Person
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Visibility
 import io.renku.graph.model.{GraphClass, RenkuUrl, projects}
 import io.renku.http.rest.paging.Paging.PagedResultsFinder

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/EndpointDocs.scala
@@ -27,6 +27,7 @@ import io.circe.syntax._
 import io.renku.config.renku
 import io.renku.graph.config.GitLabUrlLoader
 import io.renku.graph.model._
+import io.renku.graph.model.images.ImageUri
 import io.renku.http.InfoMessage
 import io.renku.http.InfoMessage._
 import io.renku.knowledgegraph.docs.model.Operation.GET
@@ -121,7 +122,7 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
         ExemplarProject(projects.ResourceId(projectPath), projectPath),
         ProjectsCount(1),
         List(datasets.Keyword("key")),
-        List(datasets.ImageUri("image.png"))
+        List(ImageUri("image.png"))
       ).asJson
     )
   }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
@@ -26,8 +26,9 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.circe.{Decoder, DecodingFailure}
 import io.renku.graph.http.server.security.Authorizer.AuthContext
-import io.renku.graph.model.datasets.{Identifier, ImageUri, Keyword}
+import io.renku.graph.model.datasets.{Identifier, Keyword}
 import io.renku.graph.model.entities.Person
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Path
 import io.renku.graph.model.{GraphClass, projects, publicationEvents}
 import io.renku.http.server.security.model.AuthUser

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
@@ -28,7 +28,8 @@ import io.circe.{Encoder, Json}
 import io.renku.config.renku
 import io.renku.graph.model
 import io.renku.graph.model.GitLabUrl
-import io.renku.graph.model.datasets.{Date, DateCreated, DatePublished, DerivedFrom, Description, Identifier, ImageUri, Keyword, Name, OriginalIdentifier, PartLocation, ResourceId, SameAs, Title}
+import io.renku.graph.model.datasets._
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Visibility
 import io.renku.http.rest.Links.{Href, Link, Rel, _links}
 import io.renku.json.JsonOps._

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/DatasetFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/DatasetFinder.scala
@@ -25,7 +25,8 @@ import cats.data.NonEmptyList
 import cats.effect.{Async, Spawn}
 import cats.syntax.all._
 import io.renku.graph.http.server.security.Authorizer.AuthContext
-import io.renku.graph.model.datasets.{Identifier, ImageUri, Keyword}
+import io.renku.graph.model.datasets.{Identifier, Keyword}
+import io.renku.graph.model.images.ImageUri
 import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/EndpointDocs.scala
@@ -27,6 +27,7 @@ import io.circe.syntax._
 import io.renku.config.renku
 import io.renku.graph.config.GitLabUrlLoader
 import io.renku.graph.model._
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Visibility
 import io.renku.http.InfoMessage
 import io.renku.http.InfoMessage._
@@ -90,7 +91,7 @@ private class EndpointDocsImpl(implicit gitLabUrl: GitLabUrl, renkuApiUrl: renku
         DatasetProject(projects.ResourceId(projectPath), projectPath, projects.Name("name"), Visibility.Public),
         List(DatasetProject(projects.ResourceId(projectPath), projectPath, projects.Name("name"), Visibility.Public)),
         List(datasets.Keyword("key")),
-        List(datasets.ImageUri("image.png"))
+        List(ImageUri("image.png"))
       ): Dataset
   }.asJson
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -25,6 +25,7 @@ import io.circe.syntax._
 import io.renku.config.renku
 import io.renku.graph.config.GitLabUrlLoader
 import io.renku.graph.model._
+import io.renku.graph.model.images.ImageUri
 import io.renku.http.InfoMessage
 import io.renku.http.InfoMessage._
 import io.renku.knowledgegraph.docs
@@ -158,7 +159,7 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
       List(persons.Name("Jan Kowalski")),
       List(datasets.Keyword("key")),
       datasets.Description("Some project").some,
-      List(datasets.ImageUri("image.png")),
+      List(ImageUri("image.png")),
       projects.Path("group/subgroup/name")
     ).asJson,
     Workflow(

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/DatasetsQuery.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/finder/DatasetsQuery.scala
@@ -23,6 +23,7 @@ import cats.data.NonEmptyList
 import cats.syntax.all._
 import io.circe.{Decoder, DecodingFailure}
 import io.renku.graph.model._
+import io.renku.graph.model.images.ImageUri
 import io.renku.knowledgegraph.entities.Endpoint.Criteria.Filters.EntityType
 import io.renku.knowledgegraph.entities.model.{Entity, MatchingScore}
 
@@ -214,7 +215,7 @@ private case object DatasetsQuery extends EntityQuery[model.Entity.Dataset] {
         extract[Option[String]]("keywords") >>= toListOf[datasets.Keyword, datasets.Keyword.type](datasets.Keyword)
       maybeDesc <- extract[Option[datasets.Description]]("maybeDescription")
       images <- extract[Option[String]]("images") >>=
-                  toListOfImageUris[datasets.ImageUri, datasets.ImageUri.type](datasets.ImageUri)
+                  toListOfImageUris[ImageUri, ImageUri.type](ImageUri)
     } yield Entity.Dataset(matchingScore,
                            idPathAndVisibility._1,
                            name,

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/model.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/model.scala
@@ -26,6 +26,7 @@ import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
 import io.renku.config.renku
 import io.renku.graph.model._
+import io.renku.graph.model.images.ImageUri
 import io.renku.http.rest.Links.{Href, Link, Rel, _links}
 import io.renku.json.JsonOps._
 import io.renku.knowledgegraph
@@ -111,7 +112,7 @@ private object model {
         creators:            List[persons.Name],
         keywords:            List[datasets.Keyword],
         maybeDescription:    Option[datasets.Description],
-        images:              List[datasets.ImageUri],
+        images:              List[ImageUri],
         exemplarProjectPath: projects.Path
     ) extends Entity {
       override type Name = datasets.Name
@@ -124,16 +125,16 @@ private object model {
           renkuApiUrl: renku.ApiUrl
       ): Encoder[model.Entity.Dataset] = {
 
-        implicit lazy val imagesEncoder: Encoder[(List[datasets.ImageUri], projects.Path)] =
-          Encoder.instance[(List[datasets.ImageUri], projects.Path)] { case (imageUris, exemplarProjectPath) =>
+        implicit lazy val imagesEncoder: Encoder[(List[ImageUri], projects.Path)] =
+          Encoder.instance[(List[ImageUri], projects.Path)] { case (imageUris, exemplarProjectPath) =>
             Json.arr(imageUris.map {
-              case uri: datasets.ImageUri.Relative =>
+              case uri: ImageUri.Relative =>
                 json"""{
                   "location": $uri
                 }""" deepMerge _links(
                   Link(Rel("view") -> Href(gitLabUrl / exemplarProjectPath / "raw" / "master" / uri))
                 )
-              case uri: datasets.ImageUri.Absolute =>
+              case uri: ImageUri.Absolute =>
                 json"""{
                   "location": $uri
                 }""" deepMerge _links(Link(Rel("view") -> Href(uri.show)))

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/EndpointDocs.scala
@@ -27,6 +27,7 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import io.renku.config.renku
 import io.renku.graph.config.GitLabUrlLoader
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.{GitLabUrl, datasets, projects}
 import io.renku.http.InfoMessage
 import io.renku.http.InfoMessage._
@@ -81,14 +82,14 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
        datasets.Title("dataset"),
        datasets.Name("dataset"),
        datasets.SameAs("http://datasets-repo/abcd").asLeft[datasets.DerivedFrom],
-       List(datasets.ImageUri("image.png"))
+       List(ImageUri("image.png"))
       ).asJson,
       (datasets.Identifier("123"),
        datasets.OriginalIdentifier("123"),
        datasets.Title("dataset"),
        datasets.Name("dataset"),
        datasets.DerivedFrom("http://datasets-repo/abcd").asRight[datasets.SameAs],
-       List(datasets.ImageUri("image.png"))
+       List(ImageUri("image.png"))
       ).asJson
     )
   }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetEncoder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetEncoder.scala
@@ -23,7 +23,8 @@ import io.circe.literal._
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import io.renku.config.renku
-import io.renku.graph.model.datasets.{DerivedFrom, ImageUri, SameAs}
+import io.renku.graph.model.datasets.{DerivedFrom, SameAs}
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.{GitLabUrl, projects}
 import io.renku.http.rest.Links.{Href, Link, Rel, _links}
 import io.renku.knowledgegraph

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetsFinder.scala
@@ -22,7 +22,8 @@ import ProjectDatasetsFinder.{ProjectDataset, SameAsOrDerived}
 import cats.MonadThrow
 import cats.effect.kernel.Async
 import io.renku.graph.model.RenkuUrl
-import io.renku.graph.model.datasets.{DerivedFrom, Identifier, ImageUri, Name, OriginalIdentifier, SameAs, Title}
+import io.renku.graph.model.datasets.{DerivedFrom, Identifier, Name, OriginalIdentifier, SameAs, Title}
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.{Path, ResourceId}
 import io.renku.graph.model.views.RdfResource
 import io.renku.triplesstore.SparqlQuery.Prefixes

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
@@ -34,6 +34,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.datasets._
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.http.ErrorMessage
@@ -228,7 +229,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
     exemplarProjectId <- projectResourceIds
     projectsCount     <- nonNegativeInts() map (_.value) map ProjectsCount.apply
     keywords          <- datasetKeywords.toGeneratorOfList()
-    images            <- datasetImageUris.toGeneratorOfList()
+    images            <- imageUris.toGeneratorOfList()
   } yield DatasetSearchResult(
     id,
     title,

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
@@ -32,6 +32,7 @@ import io.renku.generators.Generators._
 import io.renku.graph.http.server.security.Authorizer.AuthContext
 import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.datasets._
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.persons.{Affiliation, Email, Name => UserName}
 import io.renku.graph.model.projects.Path
 import io.renku.graph.model.testentities.{Dataset => _, _}

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
@@ -30,6 +30,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators.{gitLabUrls, renkuUrls}
 import io.renku.graph.model._
+import io.renku.graph.model.images.ImageUri
 import io.renku.http.ErrorMessage
 import io.renku.http.ErrorMessage._
 import io.renku.http.rest.Links
@@ -146,16 +147,16 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
   )(implicit gitLabUrl: GitLabUrl): Decoder[model.Entity] = cursor => {
     import io.renku.tinytypes.json.TinyTypeDecoders._
 
-    def imagesDecoder(projectPath: projects.Path): Decoder[datasets.ImageUri] = Decoder.instance { cursor =>
-      cursor.downField("location").as[datasets.ImageUri] >>= {
-        case uri: datasets.ImageUri.Relative =>
+    def imagesDecoder(projectPath: projects.Path): Decoder[ImageUri] = Decoder.instance { cursor =>
+      cursor.downField("location").as[ImageUri] >>= {
+        case uri: ImageUri.Relative =>
           cursor._links >>= {
             _.get(Rel("view")) match {
               case Some(link) if link.href.value == s"$gitLabUrl/$projectPath/raw/master/$uri" => uri.asRight
               case maybeLink => DecodingFailure(s"'$maybeLink' is not expected absolute DS image view link", Nil).asLeft
             }
           }
-        case uri: datasets.ImageUri.Absolute =>
+        case uri: ImageUri.Absolute =>
           cursor._links >>= {
             _.get(Rel("view")) match {
               case Some(link) if link.href.value == uri.show => uri.asRight

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/EndpointSpec.scala
@@ -27,7 +27,8 @@ import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators._
-import io.renku.graph.model.datasets.{Identifier, ImageUri, Name, OriginalIdentifier, Title}
+import io.renku.graph.model.datasets.{Identifier, Name, OriginalIdentifier, Title}
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Path
 import io.renku.http.ErrorMessage
 import io.renku.http.InfoMessage._
@@ -191,6 +192,6 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
     title                   <- datasetTitles
     name                    <- datasetNames
     sameAsEitherDerivedFrom <- Gen.oneOf(datasetSameAs map (Left(_)), datasetDerivedFroms map (Right(_)))
-    images                  <- listOf(datasetImageUris)
+    images                  <- listOf(imageUris)
   } yield (id, originalIdentifier, title, name, sameAsEitherDerivedFrom, images)
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/datasets.scala
@@ -32,7 +32,7 @@ import io.renku.jsonld._
 import io.renku.jsonld.ontology.{Class, ObjectProperty, Type}
 import io.renku.jsonld.syntax._
 import io.renku.tinytypes._
-import io.renku.tinytypes.constraints.{InstantNotInTheFuture, LocalDateNotInTheFuture, NonBlank, NonNegativeInt, UUID, Url => UrlConstraint}
+import io.renku.tinytypes.constraints.{InstantNotInTheFuture, LocalDateNotInTheFuture, NonBlank, UUID, Url => UrlConstraint}
 
 import java.time.{Instant, LocalDate, ZoneOffset}
 
@@ -95,46 +95,6 @@ object datasets {
       extends TinyTypeFactory[Keyword](new Keyword(_))
       with NonBlank[Keyword]
       with TinyTypeJsonLDOps[Keyword]
-
-  class ImageResourceId private (val value: String) extends AnyVal with StringTinyType
-  implicit object ImageResourceId
-      extends TinyTypeFactory[ImageResourceId](new ImageResourceId(_))
-      with UrlConstraint[ImageResourceId]
-      with EntityIdJsonLDOps[ImageResourceId]
-
-  final class ImagePosition private (val value: Int) extends AnyVal with IntTinyType
-  implicit object ImagePosition
-      extends TinyTypeFactory[ImagePosition](new ImagePosition(_))
-      with NonNegativeInt[ImagePosition]
-      with TinyTypeJsonLDOps[ImagePosition]
-
-  trait ImageUri extends Any with TinyType { type V = String }
-  object ImageUri extends From[ImageUri] with TinyTypeJsonLDOps[ImageUri] {
-
-    def apply(value: String): ImageUri = from(value).fold(throw _, identity)
-
-    override def from(value: String): Either[IllegalArgumentException, ImageUri] =
-      Relative.from(value) orElse Absolute.from(value)
-
-    final class Relative private (val value: String) extends AnyVal with ImageUri with RelativePathTinyType {
-      override type V = String
-    }
-    object Relative extends TinyTypeFactory[Relative](new Relative(_)) with constraints.RelativePath[Relative]
-
-    final class Absolute private (val value: String) extends AnyVal with ImageUri with UrlTinyType {
-      override type V = String
-    }
-    object Absolute extends TinyTypeFactory[Absolute](new Absolute(_)) with constraints.Url[Absolute]
-
-    implicit lazy val encoder: Encoder[ImageUri] = Encoder.instance {
-      case uri: Relative => Json.fromString(uri.value)
-      case uri: Absolute => uri.asJson
-    }
-
-    implicit lazy val decoder: Decoder[ImageUri] = Decoder.decodeString.emap { value =>
-      (Relative.from(value) orElse Absolute.from(value)).leftMap(_ => s"Cannot decode $value to $ImageUri")
-    }
-  }
 
   final class PartLocation private (val value: String) extends AnyVal with StringTinyType
   implicit object PartLocation

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Dataset.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Dataset.scala
@@ -25,6 +25,7 @@ import io.renku.graph.model._
 import io.renku.graph.model.datasets._
 import io.renku.graph.model.entities.Dataset.Provenance._
 import io.renku.graph.model.entities.Dataset._
+import io.renku.graph.model.images.Image
 import io.renku.jsonld.JsonLDEncoder
 
 import java.time.Instant
@@ -438,37 +439,6 @@ object Dataset {
           maybeVersion <- cursor.downField(schema / "version").as[Option[Version]]
         } yield AdditionalInfo(maybeDescription, keywords, images, maybeLicense, maybeVersion)
     }
-  }
-
-  final case class Image(resourceId: ImageResourceId, uri: ImageUri, position: ImagePosition)
-
-  object Image {
-    private val imageEntityTypes = EntityTypes of schema / "ImageObject"
-
-    private[Dataset] implicit val jsonLDEncoder: JsonLDEncoder[Image] = JsonLDEncoder.instance {
-      case Image(resourceId, uri, position) =>
-        JsonLD.entity(
-          resourceId.asEntityId,
-          imageEntityTypes,
-          (schema / "contentUrl") -> uri.asJsonLD,
-          (schema / "position")   -> position.asJsonLD
-        )
-    }
-
-    private[Dataset] implicit lazy val decoder: JsonLDDecoder[Image] = JsonLDDecoder.entity(imageEntityTypes) {
-      cursor =>
-        for {
-          resourceId <- cursor.downEntityId.as[ImageResourceId]
-          uri        <- cursor.downField(schema / "contentUrl").as[ImageUri]
-          position   <- cursor.downField(schema / "position").as[ImagePosition]
-        } yield Image(resourceId, uri, position)
-    }
-
-    val ontology: Type = Type.Def(
-      Class(schema / "ImageObject"),
-      DataProperty(schema / "contentUrl", xsd / "string"),
-      DataProperty(schema / "position", xsd / "int")
-    )
   }
 
   val entityTypes: EntityTypes = EntityTypes of (schema / "Dataset", prov / "Entity")

--- a/renku-model/src/main/scala/io/renku/graph/model/images/Image.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/images/Image.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.images
+
+import io.renku.graph.model.Schemas.schema
+import io.renku.jsonld.ontology._
+import io.renku.jsonld.syntax._
+import io.renku.jsonld.{EntityTypes, JsonLD, JsonLDDecoder, JsonLDEncoder}
+
+final case class Image(resourceId: ImageResourceId, uri: ImageUri, position: ImagePosition)
+
+object Image {
+  private val imageEntityTypes = EntityTypes of schema / "ImageObject"
+
+  implicit val jsonLDEncoder: JsonLDEncoder[Image] = JsonLDEncoder.instance { case Image(resourceId, uri, position) =>
+    JsonLD.entity(
+      resourceId.asEntityId,
+      imageEntityTypes,
+      (schema / "contentUrl") -> uri.asJsonLD,
+      (schema / "position")   -> position.asJsonLD
+    )
+  }
+
+  implicit lazy val decoder: JsonLDDecoder[Image] = JsonLDDecoder.entity(imageEntityTypes) { cursor =>
+    for {
+      resourceId <- cursor.downEntityId.as[ImageResourceId]
+      uri        <- cursor.downField(schema / "contentUrl").as[ImageUri]
+      position   <- cursor.downField(schema / "position").as[ImagePosition]
+    } yield Image(resourceId, uri, position)
+  }
+
+  val ontology: Type = Type.Def(
+    Class(schema / "ImageObject"),
+    DataProperty(schema / "contentUrl", xsd / "string"),
+    DataProperty(schema / "position", xsd / "int")
+  )
+}

--- a/renku-model/src/main/scala/io/renku/graph/model/images/ImagePosition.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/images/ImagePosition.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.images
+
+import io.renku.graph.model.views.TinyTypeJsonLDOps
+import io.renku.tinytypes._
+import io.renku.tinytypes.constraints.NonNegativeInt
+
+final class ImagePosition private (val value: Int) extends AnyVal with IntTinyType
+
+object ImagePosition
+    extends TinyTypeFactory[ImagePosition](new ImagePosition(_))
+    with NonNegativeInt[ImagePosition]
+    with TinyTypeJsonLDOps[ImagePosition]

--- a/renku-model/src/main/scala/io/renku/graph/model/images/ImageResourceId.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/images/ImageResourceId.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.images
+
+import io.renku.graph.model.views.EntityIdJsonLDOps
+import io.renku.tinytypes._
+import io.renku.tinytypes.constraints.{Url => UrlConstraint}
+
+final class ImageResourceId private (val value: String) extends AnyVal with StringTinyType
+
+object ImageResourceId
+    extends TinyTypeFactory[ImageResourceId](new ImageResourceId(_))
+    with UrlConstraint[ImageResourceId]
+    with EntityIdJsonLDOps[ImageResourceId]

--- a/renku-model/src/main/scala/io/renku/graph/model/images/ImageUri.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/images/ImageUri.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.images
+
+import cats.syntax.all._
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.syntax._
+import io.renku.graph.model.views.TinyTypeJsonLDOps
+import io.renku.tinytypes._
+
+trait ImageUri extends Any with TinyType {
+  type V = String
+}
+
+object ImageUri extends From[ImageUri] with TinyTypeJsonLDOps[ImageUri] {
+
+  def apply(value: String): ImageUri = from(value).fold(throw _, identity)
+
+  override def from(value: String): Either[IllegalArgumentException, ImageUri] =
+    Relative.from(value) orElse Absolute.from(value)
+
+  final class Relative private (val value: String) extends AnyVal with ImageUri with RelativePathTinyType {
+    override type V = String
+  }
+  object Relative extends TinyTypeFactory[Relative](new Relative(_)) with constraints.RelativePath[Relative]
+
+  final class Absolute private (val value: String) extends AnyVal with ImageUri with UrlTinyType {
+    override type V = String
+  }
+  object Absolute extends TinyTypeFactory[Absolute](new Absolute(_)) with constraints.Url[Absolute]
+
+  implicit lazy val encoder: Encoder[ImageUri] = Encoder.instance {
+    case uri: Relative => Json.fromString(uri.value)
+    case uri: Absolute => uri.asJson
+  }
+
+  implicit lazy val decoder: Decoder[ImageUri] = Decoder.decodeString.emap { value =>
+    (Relative.from(value) orElse Absolute.from(value)).leftMap(_ => s"Cannot decode $value to $ImageUri")
+  }
+}

--- a/renku-model/src/test/scala/io/renku/graph/model/GraphModelGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/GraphModelGenerators.scala
@@ -22,6 +22,7 @@ import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.datasets._
+import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.persons.{Affiliation, Email, Name, Username}
 import io.renku.graph.model.projects.{FilePath, GitLabId, Path, ResourceId, Visibility}
 import org.scalacheck.Gen
@@ -139,7 +140,7 @@ object GraphModelGenerators {
   implicit val datasetTitles:       Gen[datasets.Title] = nonEmptyStrings(minLength = 4) map datasets.Title.apply
   implicit val datasetNames:        Gen[datasets.Name]  = nonEmptyStrings(minLength = 4) map datasets.Name.apply
   implicit val datasetDescriptions: Gen[Description]    = paragraphs() map (_.value) map Description.apply
-  implicit val datasetImageUris:    Gen[ImageUri]       = Gen.oneOf(relativePaths(), httpUrls()) map ImageUri.apply
+  implicit val imageUris:           Gen[ImageUri]       = Gen.oneOf(relativePaths(), httpUrls()) map ImageUri.apply
   implicit val datasetExternalSameAs: Gen[ExternalSameAs] =
     validatedUrls map SameAs.external map (_.fold(throw _, identity))
   def datasetInternalSameAsFrom(renkuUrlGen:  Gen[RenkuUrl] = renkuUrls,

--- a/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/datasetsSpec.scala
@@ -26,6 +26,7 @@ import io.circe.syntax._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.datasets._
+import io.renku.graph.model.images._
 import io.renku.graph.model.views.RdfResource
 import io.renku.jsonld.EntityId
 import io.renku.jsonld.syntax._
@@ -80,13 +81,13 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     }
 
     "provide an implicit Json encoder" in {
-      forAll(datasetImageUris) { uri =>
+      forAll(imageUris) { uri =>
         uri.asJson shouldBe Json.fromString(uri.value)
       }
     }
 
     "provide an implicit Json decoder" in {
-      forAll(datasetImageUris) { uri =>
+      forAll(imageUris) { uri =>
         Json.fromString(uri.value).as[ImageUri] shouldBe uri.asRight
       }
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/DatasetSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/DatasetSpec.scala
@@ -29,6 +29,7 @@ import io.renku.graph.model.Schemas.schema
 import io.renku.graph.model._
 import io.renku.graph.model.entities.Dataset.Provenance
 import io.renku.graph.model.entities.Dataset.Provenance.{ImportedInternalAncestorExternal, ImportedInternalAncestorInternal}
+import io.renku.graph.model.images.Image
 import io.renku.graph.model.testentities._
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.DatasetGenFactory
 import io.renku.jsonld.parser._
@@ -336,14 +337,13 @@ class DatasetSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
 
   "encode" should {
 
-    implicit val jsonLDEncoder: JsonLDEncoder[entities.Dataset.Image] = JsonLDEncoder.instance {
-      case entities.Dataset.Image(resourceId, uri, position) =>
-        JsonLD.entity(
-          resourceId.asEntityId,
-          EntityTypes of schema / "ImageObject",
-          schema / "contentUrl" -> uri.asJsonLD,
-          schema / "position"   -> position.asJsonLD
-        )
+    implicit val jsonLDEncoder: JsonLDEncoder[Image] = JsonLDEncoder.instance { case Image(resourceId, uri, position) =>
+      JsonLD.entity(
+        resourceId.asEntityId,
+        EntityTypes of schema / "ImageObject",
+        schema / "contentUrl" -> uri.asJsonLD,
+        schema / "position"   -> position.asJsonLD
+      )
     }
 
     "produce JsonLD with all the relevant properties and only links to Person entities " +

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
@@ -24,6 +24,7 @@ import cats.syntax.all._
 import io.renku.graph.model._
 import io.renku.graph.model.datasets._
 import io.renku.graph.model.entities.EntityFunctions
+import io.renku.graph.model.images.{Image, ImagePosition, ImageResourceId, ImageUri}
 import io.renku.graph.model.testentities.Dataset.Provenance._
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
@@ -343,7 +344,7 @@ object Dataset {
         dataset.additionalInfo.keywords.sorted,
         dataset.additionalInfo.images.zipWithIndex.map { case (url, idx) =>
           val imagePosition = ImagePosition(idx)
-          entities.Dataset.Image(
+          Image(
             ImageResourceId(imageEntityId((dataset: Dataset[Provenance]).asEntityId, imagePosition).show),
             url,
             imagePosition

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/DatasetEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/DatasetEntitiesGenerators.scala
@@ -24,7 +24,7 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{fixed, nonBlankStrings, positiveInts, sentences, timestamps, timestampsNotInTheFuture}
-import io.renku.graph.model.GraphModelGenerators.{datasetCreatedDates, datasetDescriptions, datasetExternalSameAs, datasetIdentifiers, datasetImageUris, datasetInternalSameAs, datasetKeywords, datasetLicenses, datasetNames, datasetOriginalIdentifiers, datasetPartExternals, datasetPartIds, datasetPartSources, datasetPublishedDates, datasetTitles, datasetVersions, projectCreatedDates}
+import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model._
 import io.renku.graph.model.datasets.{DerivedFrom, ExternalSameAs, Identifier, InternalSameAs, OriginalIdentifier, TopmostSameAs}
 import io.renku.graph.model.testentities.Dataset.{AdditionalInfo, Identification, Provenance}
@@ -217,7 +217,7 @@ trait DatasetEntitiesGenerators {
   val datasetAdditionalInfos: Gen[Dataset.AdditionalInfo] = for {
     maybeDescription <- datasetDescriptions.toGeneratorOfOptions
     keywords         <- datasetKeywords.toGeneratorOfList()
-    images           <- datasetImageUris.toGeneratorOfList()
+    images           <- imageUris.toGeneratorOfList()
     maybeLicense     <- datasetLicenses.toGeneratorOfOptions
     maybeVersion     <- datasetVersions.toGeneratorOfOptions
   } yield Dataset.AdditionalInfo(maybeDescription, keywords, images, maybeLicense, maybeVersion)


### PR DESCRIPTION
Images were tight to datasets, but are now going to be used for projects as well.

issue: #1242 