### PR TITLE
fix: processes limiting event handlers to continue on scheduling failure

### DIFF
--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/events/consumers/globalcommitsync/EventHandlerSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/events/consumers/globalcommitsync/EventHandlerSpec.scala
@@ -100,8 +100,6 @@ class EventHandlerSpec
       }
 
       handler.createHandlingProcess(request).unsafeRunSync().process.value.unsafeRunSync() shouldBe BadRequest.asLeft
-
-      logger.expectNoLogs()
     }
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/projectsync/EventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/projectsync/EventHandlerSpec.scala
@@ -92,8 +92,6 @@ class EventHandlerSpec
       }
 
       handler.createHandlingProcess(request).unsafeRunSync().process.value.unsafeRunSync() shouldBe BadRequest.asLeft
-
-      logger.expectNoLogs()
     }
   }
 

--- a/graph-commons/src/main/scala/io/renku/events/consumers/model.scala
+++ b/graph-commons/src/main/scala/io/renku/events/consumers/model.scala
@@ -18,12 +18,13 @@
 
 package io.renku.events.consumers
 
-import cats.Show
 import cats.data.EitherT
 import cats.effect.Concurrent
 import cats.effect.kernel.Deferred
 import cats.syntax.all._
+import cats.{MonadThrow, Show}
 import io.renku.graph.model.projects
+import org.typelevel.log4cats.Logger
 
 final case class Project(id: projects.GitLabId, path: projects.Path)
 
@@ -66,11 +67,33 @@ class EventHandlingProcess[F[_]: Concurrent] private (
 
 object EventHandlingProcess {
 
-  def withWaitingForCompletion[F[_]: Concurrent](
+  def withWaitingForCompletion[F[_]: Concurrent: Logger](
       process:        Deferred[F, Unit] => EitherT[F, EventSchedulingResult, Accepted],
       releaseProcess: F[Unit]
   ): F[EventHandlingProcess[F]] =
-    Deferred[F, Unit].map(deferred => new EventHandlingProcess[F](deferred, process(deferred), releaseProcess.some))
+    Deferred[F, Unit].map(deferred =>
+      new EventHandlingProcess[F](
+        deferred,
+        EitherT(process(deferred).recoverWith(onLeftComplete(deferred)).value recoverWith onErrorComplete(deferred)),
+        releaseProcess.some
+      )
+    )
+
+  private def onLeftComplete[F[_]: MonadThrow: Logger](
+      deferred: Deferred[F, Unit]
+  ): PartialFunction[EventSchedulingResult, EitherT[F, EventSchedulingResult, Accepted]] = { case result =>
+    EitherT.left {
+      (deferred.complete(()) >> Logger[F].error(show"Failure during event scheduling: $result"))
+        .map(_ => result)
+    }
+  }
+
+  private def onErrorComplete[F[_]: MonadThrow: Logger](
+      deferred: Deferred[F, Unit]
+  ): PartialFunction[Throwable, F[Either[EventSchedulingResult, Accepted]]] = { case exception =>
+    (deferred.complete(()) >> Logger[F].error(exception)("Failure during event scheduling"))
+      .map(_ => EventSchedulingResult.SchedulingError(exception).asLeft[Accepted])
+  }
 
   def apply[F[_]: Concurrent](process: EitherT[F, EventSchedulingResult, Accepted]): F[EventHandlingProcess[F]] = for {
     deferred <- Deferred[F, Unit]

--- a/graph-commons/src/test/scala/io/renku/events/consumers/ConcurrentProcessesLimiterSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/events/consumers/ConcurrentProcessesLimiterSpec.scala
@@ -26,6 +26,7 @@ import cats.syntax.all._
 import io.renku.events.consumers.EventSchedulingResult._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{exceptions, positiveInts}
+import io.renku.interpreters.TestLogger
 import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
@@ -186,11 +187,12 @@ class ConcurrentProcessesLimiterSpec
 
   private trait TestCase {
 
+    private implicit val logger: TestLogger[IO] = TestLogger()
     val processesCount = positiveInts().generateOne
     val semaphore      = mock[TestSemaphore]
 
-    val limiter      = new ConcurrentProcessesLimiterImpl[IO](processesCount, semaphore)
-    val withoutLimit = ConcurrentProcessesLimiter.withoutLimit[IO]
+    private val limiter = new ConcurrentProcessesLimiterImpl[IO](processesCount, semaphore)
+    val withoutLimit    = ConcurrentProcessesLimiter.withoutLimit[IO]
 
     def resultWithoutLimit(result: EitherT[IO, EventSchedulingResult, Accepted]): EventHandlingProcess[IO] =
       EventHandlingProcess[IO](result).unsafeRunSync()

--- a/graph-commons/src/test/scala/io/renku/events/consumers/EventHandlingProcessSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/events/consumers/EventHandlingProcessSpec.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.events.consumers
+
+import cats.data.EitherT
+import cats.effect.{Deferred, IO, Ref}
+import cats.syntax.all._
+import io.renku.events.consumers.EventSchedulingResult.Accepted
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.exceptions
+import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class EventHandlingProcessSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with Eventually
+    with IntegrationPatience {
+
+  "withWaitingForCompletion" should {
+
+    "complete the deferred process flag in case of success" in new TestCase {
+
+      val underlyingProcess = givenProcess(returning = EitherT.rightT[IO, EventSchedulingResult](Accepted))
+
+      val handlingProcess = EventHandlingProcess
+        .withWaitingForCompletion[IO](underlyingProcess, releaseProcess = ().pure[IO])
+        .unsafeRunSync()
+
+      handlingProcess.process.value.unsafeRunAndForget()
+
+      givenProcessFinishedFlagSet(onCompletionOf = handlingProcess)
+
+      eventually {
+        processFinished.get.unsafeRunSync() shouldBe true
+      }
+    }
+
+    "complete the deferred process flag in case of a Left" in new TestCase {
+
+      val underlyingProcess = givenProcess(
+        returning = EitherT.leftT[IO, Accepted](EventSchedulingResult.SchedulingError(exceptions.generateOne))
+      )
+
+      val handlingProcess = EventHandlingProcess
+        .withWaitingForCompletion[IO](underlyingProcess, releaseProcess = ().pure[IO])
+        .unsafeRunSync()
+
+      handlingProcess.process.value.unsafeRunAndForget()
+
+      givenProcessFinishedFlagSet(onCompletionOf = handlingProcess)
+
+      eventually {
+        processFinished.get.unsafeRunSync() shouldBe true
+      }
+    }
+
+    "complete the deferred process flag in case of a failure" in new TestCase {
+
+      val underlyingProcess = givenProcess(
+        returning = EitherT.right[EventSchedulingResult](exceptions.generateOne.raiseError[IO, Accepted])
+      )
+
+      val handlingProcess = EventHandlingProcess
+        .withWaitingForCompletion[IO](underlyingProcess, releaseProcess = ().pure[IO])
+        .unsafeRunSync()
+
+      handlingProcess.process.value.unsafeRunAndForget()
+
+      givenProcessFinishedFlagSet(onCompletionOf = handlingProcess)
+
+      eventually {
+        processFinished.get.unsafeRunSync() shouldBe true
+      }
+    }
+
+    "turn failure occurring during process execution to SchedulingError" in new TestCase {
+
+      val exception = exceptions.generateOne
+      val underlyingProcess = givenProcess(
+        returning = EitherT.right[EventSchedulingResult](exception.raiseError[IO, Accepted])
+      )
+
+      val handlingProcess = EventHandlingProcess
+        .withWaitingForCompletion[IO](underlyingProcess, releaseProcess = ().pure[IO])
+        .unsafeRunSync()
+
+      handlingProcess.process.value.unsafeRunSync() shouldBe EventSchedulingResult.SchedulingError(exception).asLeft
+    }
+  }
+
+  private trait TestCase {
+
+    implicit val logger: TestLogger[IO] = TestLogger()
+
+    val processFinished = Ref.unsafe[IO, Boolean](false)
+
+    def givenProcess(returning: EitherT[IO, EventSchedulingResult, Accepted]) = { (dfrd: Deferred[IO, Unit]) =>
+      returning
+        .semiflatTap(_ => dfrd.complete(()))
+    }
+
+    def givenProcessFinishedFlagSet(onCompletionOf: EventHandlingProcess[IO]): Unit =
+      (onCompletionOf.waitToFinish() >> processFinished.set(true)).unsafeRunAndForget()
+  }
+}

--- a/renku-model/src/test/scala/io/renku/graph/model/tools/JsonLDTools.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/tools/JsonLDTools.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.graph.model.tools
 
 import io.renku.graph.model.tools.JsonLDTools.JsonLDElementView.{Filter, Update}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/TSReadinessForEventsChecker.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/TSReadinessForEventsChecker.scala
@@ -29,8 +29,6 @@ import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
 
-import scala.util.control.NonFatal
-
 private trait TSReadinessForEventsChecker[F[_]] {
   def verifyTSReady: EitherT[F, EventSchedulingResult, Accepted]
 }
@@ -50,7 +48,7 @@ private class TSReadinessForEventsCheckerImpl[F[_]: MonadThrow](tsStateChecker: 
         case state @ (TSState.MissingDatasets | TSState.ReProvisioning) =>
           ServiceUnavailable(state.show).asLeft.leftWiden[EventSchedulingResult]
       }
-      .recover { case NonFatal(exception) =>
+      .recover { case exception =>
         SchedulingError(exception).asLeft[Accepted].leftWiden[EventSchedulingResult]
       }
   }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/EventHandlerSpec.scala
@@ -87,8 +87,6 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
         .returning(exceptions.generateOne.raiseError[IO, CommitEvent])
 
       handler.createHandlingProcess(request).unsafeRunSyncProcess() shouldBe Left(BadRequest)
-
-      logger.expectNoLogs()
     }
 
     s"return $BadRequest if event body is not present" in new TestCase {
@@ -98,8 +96,6 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
       val request = EventRequestContent.NoPayload(compoundEventIds.generateOne.asJson(eventEncoder))
 
       handler.createHandlingProcess(request).unsafeRunSyncProcess() shouldBe Left(BadRequest)
-
-      logger.expectNoLogs()
     }
 
     s"return $Accepted and release the processing flag when event processor fails while processing the event" in new TestCase {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/cleanup/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/cleanup/EventHandlerSpec.scala
@@ -75,7 +75,7 @@ class EventHandlerSpec extends AnyWordSpec with MockFactory with IOSpec with sho
       val eventJson: Json = json"""{
         "categoryName": "CLEAN_UP",
         "project": {
-          "path" :      ${projectPaths.generateOne.value}
+          "path": ${projectPaths.generateOne.value}
         }
       }"""
       val request   = requestContent(eventJson)
@@ -83,8 +83,6 @@ class EventHandlerSpec extends AnyWordSpec with MockFactory with IOSpec with sho
       (eventBodyDeserializer.toCleanUpEvent _).expects(eventJson).returns(exception.raiseError[IO, CleanUpEvent])
 
       handler.createHandlingProcess(request).unsafeRunSyncProcess() shouldBe Left(BadRequest)
-
-      logger.expectNoLogs()
     }
 
     s"return $Accepted and release the processing flag when event processor fails while processing the event" in new TestCase {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandlerSpec.scala
@@ -160,8 +160,6 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
         .createHandlingProcess(EventRequestContent.NoPayload(json"""{"categoryName": ${categoryName.value}}"""))
         .flatMap(_.process.merge)
         .unsafeRunSync() shouldBe BadRequest
-
-      logger.expectNoLogs()
     }
 
     "decode an event from the request, " +
@@ -175,7 +173,7 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
           .flatMap(_.process.merge)
           .unsafeRunSync() shouldBe BadRequest
 
-        logger.loggedOnly(
+        logger.logged(
           Info(show"$categoryName: $requestedVersion -> $BadRequest service in version '$serviceVersion'")
         )
       }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EventHandlerSpec.scala
@@ -78,8 +78,6 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
       val request = EventRequestContent.NoPayload((event.compoundEventId, event.project).asJson)
 
       handler.createHandlingProcess(request).unsafeRunSyncProcess() shouldBe Left(BadRequest)
-
-      logger.expectNoLogs()
     }
 
     s"return $BadRequest if event payload is malformed" in new TestCase {
@@ -89,11 +87,8 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
       val request =
         EventRequestContent.WithPayload((event.compoundEventId, event.project).asJson, jsons.generateOne.noSpaces)
 
-      handler.createHandlingProcess(request).unsafeRunSync().process.value.unsafeRunSync() shouldBe Left(
-        BadRequest
-      )
-
-      logger.expectNoLogs()
+      handler.createHandlingProcess(request).unsafeRunSync().process.value.unsafeRunSync() shouldBe
+        BadRequest.asLeft
     }
 
     s"return $Accepted and release the processing flag when event processor fails processing the event" in new TestCase {


### PR DESCRIPTION
It was observed that concurrent processes limiting handlers stop accepting new events in some situations. It was identified that on failures during process scheduling, the deferred flag signalling the process completion wasn't set. This PR ensures the flag is set in such circumstances.