### PR TITLE
feat: TS migration kicking-off background migration to schema V10

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/AllEventsToNewUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/AllEventsToNewUpdater.scala
@@ -18,17 +18,16 @@
 
 package io.renku.eventlog.events.consumers.statuschange
 
+import StatusChangeEvent.{AllEventsToNew, ProjectEventsToNew}
 import cats.Applicative
 import cats.data.Kleisli
 import cats.effect.Async
 import cats.syntax.all._
-import eu.timepit.refined.auto._
 import io.circe.Encoder
 import io.circe.literal._
 import io.circe.syntax._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.{AllEventsToNew, ProjectEventsToNew}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.consumers.Project
 import io.renku.events.producers.EventSender
@@ -60,7 +59,8 @@ private class AllEventsToNewUpdater[F[_]: Async: QueriesExecutionTimes](
   private def createEventsResource(
       f: Cursor[F, ProjectEventsToNew] => F[Unit]
   ): Kleisli[F, Session[F], Unit] = measureExecutionTime {
-    SqlStatement(name = "all_to_new - find projects")
+    SqlStatement
+      .named("all_to_new - find projects")
       .select[Void, ProjectEventsToNew](
         sql"""SELECT proj.project_id, proj.project_path
               FROM project proj
@@ -81,7 +81,7 @@ private class AllEventsToNewUpdater[F[_]: Async: QueriesExecutionTimes](
             EventRequestContent.NoPayload(event.asJson),
             EventSender.EventContext(
               CategoryName(ProjectEventsToNew.eventType.show),
-              show"$categoryName: Generating ${ProjectEventsToNew.eventType} for ${event.project} failed"
+              show"$categoryName: generating ${ProjectEventsToNew.eventType} for ${event.project} failed"
             )
           ) >> sendEventIfFound(cursor, areMore)
       }
@@ -89,7 +89,7 @@ private class AllEventsToNewUpdater[F[_]: Async: QueriesExecutionTimes](
 
   private implicit val encoder: Encoder[ProjectEventsToNew] = Encoder.instance { event =>
     json"""{
-      "categoryName": ${categoryName.value},
+      "categoryName": $categoryName,
       "project": {
         "id":   ${event.project.id},
         "path": ${event.project.path}

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/cleanup/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/cleanup/EventFinder.scala
@@ -157,7 +157,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: Logger: Qu
     Kleisli.liftF(transaction.commit.void)
 
   private def rollback(transaction: Transaction[F])(
-      savepoint:                    transaction.Savepoint
+      savepoint: transaction.Savepoint
   ): PartialFunction[Throwable, Kleisli[F, Session[F], Unit]] = { case err =>
     Kleisli.liftF {
       (transaction rollback savepoint).void >>

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/AllEventsToNewUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/AllEventsToNewUpdaterSpec.scala
@@ -33,7 +33,6 @@ import io.renku.graph.model.EventContentGenerators.{eventDates, eventMessages}
 import io.renku.graph.model.EventsGenerators._
 import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.events.{EventDate, EventId, EventStatus, ExecutionDate}
-import io.renku.interpreters.TestLogger
 import io.renku.metrics.TestMetricsRegistry
 import io.renku.testtools.IOSpec
 import org.scalacheck.Gen
@@ -68,7 +67,7 @@ class AllEventsToNewUpdaterSpec
           .expects(
             EventRequestContent.NoPayload(toEventJson(project)),
             EventSender.EventContext(CategoryName(ProjectEventsToNew.eventType.show),
-                                     show"$categoryName: Generating ${ProjectEventsToNew.eventType} for $project failed"
+                                     show"$categoryName: generating ${ProjectEventsToNew.eventType} for $project failed"
             )
           )
           .returning(().pure[IO])
@@ -84,7 +83,6 @@ class AllEventsToNewUpdaterSpec
 
   private trait TestCase {
 
-    implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val eventSender = mock[EventSender[IO]]
     private implicit val metricsRegistry:  TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
     private implicit val queriesExecTimes: QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()
@@ -130,9 +128,9 @@ class AllEventsToNewUpdaterSpec
   private def toEventJson(project: Project) = json"""{
     "categoryName": "EVENTS_STATUS_CHANGE",
     "project": {
-      "id":   ${project.id.value},
-      "path": ${project.path.value}
+      "id":   ${project.id},
+      "path": ${project.path}
     },
-    "newStatus": ${EventStatus.New.value}
+    "newStatus": ${EventStatus.New}
   }"""
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToV10.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToV10.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers
+package tsmigrationrequest
+package migrations
+
+import cats.data.EitherT
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.circe.literal._
+import io.renku.events.producers.EventSender
+import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.model.{Schemas, projects}
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import org.typelevel.log4cats.Logger
+import tooling.{RecordsFinder, RecoverableErrorsRecovery}
+
+private class MigrationToV10[F[_]: Async](
+    projectsFinder:   ProjectsFinder[F],
+    eventsSender:     EventSender[F],
+    recoveryStrategy: RecoverableErrorsRecovery = RecoverableErrorsRecovery
+) extends Migration[F] {
+
+  import eventsSender._
+  import fs2._
+  import projectsFinder._
+  import recoveryStrategy._
+
+  override lazy val name: Migration.Name = MigrationToV10.name
+
+  override def run(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
+    Stream
+      .iterate(1)(_ + 1)
+      .evalMap(findProjects)
+      .takeThrough(_.nonEmpty)
+      .flatMap(in => Stream.emits(in))
+      .map(toCleanUpEvent)
+      .evalMap { case (payload, ctx) => sendEvent(payload, ctx) }
+      .compile
+      .drain
+      .map(_.asRight[ProcessingRecoverableError])
+      .recoverWith(maybeRecoverableError[F, Unit])
+  }
+
+  private def toCleanUpEvent(path: projects.Path): (EventRequestContent.NoPayload, EventSender.EventContext) = {
+    val eventCategoryName = CategoryName("CLEAN_UP_REQUEST")
+    EventRequestContent.NoPayload {
+      json"""{
+          "categoryName": $eventCategoryName,
+          "project": {
+            "path": $path
+          }
+        }"""
+    } -> EventSender.EventContext(eventCategoryName, show"$categoryName: $name cannot send event for $path")
+  }
+}
+
+private object MigrationToV10 {
+  val name: Migration.Name = Migration.Name("Migration to V10")
+
+  def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder] = for {
+    projectsFinder <- ProjectsFinder[F]
+    eventsSender   <- EventSender[F]
+  } yield new MigrationToV10(projectsFinder, eventsSender)
+}
+
+private trait ProjectsFinder[F[_]] {
+  def findProjects(page: Int): F[List[projects.Path]]
+}
+
+private object ProjectsFinder {
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectsFinder[F]] =
+    ProjectsConnectionConfig[F]().map(RecordsFinder[F](_)).map(new ProjectsFinderImpl(_))
+}
+
+private class ProjectsFinderImpl[F[_]](recordsFinder: RecordsFinder[F]) extends ProjectsFinder[F] with Schemas {
+
+  import ResultsDecoder._
+  import io.renku.tinytypes.json.TinyTypeDecoders._
+
+  private val chunkSize: Int = 50
+
+  override def findProjects(page: Int): F[List[projects.Path]] =
+    recordsFinder.findRecords(query(page))
+
+  private def query(page: Int) = SparqlQuery.of(
+    MigrationToV10.name.asRefined,
+    Prefixes of (schema -> "schema", renku -> "renku"),
+    s"""|SELECT DISTINCT ?path
+        |WHERE {
+        |  GRAPH ?id {
+        |    ?id a schema:Project;
+        |        renku:projectPath ?path
+        |  }
+        |}
+        |ORDER BY ?path
+        |LIMIT $chunkSize
+        |OFFSET ${(page - 1) * chunkSize}
+        |""".stripMargin
+  )
+
+  private implicit lazy val decoder: Decoder[List[projects.Path]] = ResultsDecoder[List, projects.Path] {
+    implicit cur =>
+      extract[projects.Path]("path")
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -41,6 +41,7 @@ private[tsmigrationrequest] object Migrations {
     compositePlan                  <- CompositePlanProvision.create[F]
     fixMultipleProjectCreatedDates <- FixMultipleProjectCreatedDates[F]
     addRenkuPlanWhereMissing       <- AddRenkuPlanWhereMissing[F]
+    migrationToV10                 <- MigrationToV10[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -49,7 +50,8 @@ private[tsmigrationrequest] object Migrations {
                     fixPlansYoungerThanActivities,
                     compositePlan,
                     fixMultipleProjectCreatedDates,
-                    addRenkuPlanWhereMissing
+                    addRenkuPlanWhereMissing,
+                    migrationToV10
                   )
   } yield migrations
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/TSCleanerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/TSCleanerSpec.scala
@@ -472,7 +472,7 @@ class TSCleanerSpec
         upload(to = projectsDataset, topProject, middleProject, middleProjectFork, bottomProject1, bottomProject2)
 
         givenProjectIdFindingSucceeds(middleProject)
-      givenDatasetsGraphCleaningSucceeds(middleProject)
+        givenDatasetsGraphCleaningSucceeds(middleProject)
 
         cleaner.removeTriples(middleProject.path).unsafeRunSync()
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToV10Spec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToV10Spec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.circe.literal._
+import io.renku.events.producers.EventSender
+import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import GraphModelGenerators.projectPaths
+import cats.MonadThrow
+import io.renku.generators.Generators.{exceptions, positiveInts}
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.generators.ErrorGenerators.processingRecoverableErrors
+import io.renku.triplesstore._
+import org.scalacheck.Gen
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import tooling.{RecordsFinder, RecoverableErrorsRecovery}
+
+class MigrationToV10Spec extends AnyWordSpec with should.Matchers with IOSpec with MockFactory {
+
+  "query" should {
+
+    "find all projects that exists in the Default Graph but not in the Named Graphs dataset" in new TestCase {
+
+      val allProjects = projectPaths.generateList(min = chunkSize, max = chunkSize * 2)
+
+      val projectsChunks = allProjects
+        .sliding(chunkSize, chunkSize)
+        .toList
+      projectsChunks.zipWithIndex foreach givenProjectsChunkReturned
+      givenProjectsChunkReturned(List.empty[projects.Path] -> projectsChunks.size)
+
+      allProjects map toCleanUpRequestEvent foreach givenEventIsSent
+
+      migration.run().value.unsafeRunSync() shouldBe ().asRight
+    }
+
+    "return a Recoverable Error if in case of an exception while finding projects " +
+      "the given strategy returns one" in new TestCase {
+
+        val exception = exceptions.generateOne
+
+        (projectsFinder.findProjects _)
+          .expects(1)
+          .returning(exception.raiseError[IO, List[projects.Path]])
+
+        migration.run().value.unsafeRunSync() shouldBe recoverableError.asLeft
+      }
+  }
+
+  private trait TestCase {
+    val chunkSize = positiveInts(max = 100).generateOne.value
+
+    private val eventCategoryName = CategoryName("CLEAN_UP_REQUEST")
+    val projectsFinder            = mock[ProjectsFinder[IO]]
+    private val eventSender       = mock[EventSender[IO]]
+    val recoverableError          = processingRecoverableErrors.generateOne
+    private val recoveryStrategy = new RecoverableErrorsRecovery {
+      override def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = { _ =>
+        recoverableError.asLeft[OUT].pure[F]
+      }
+    }
+    val migration = new MigrationToV10[IO](projectsFinder, eventSender, recoveryStrategy)
+
+    def givenProjectsChunkReturned: ((List[projects.Path], Int)) => Unit = { case (chunk, idx) =>
+      (projectsFinder.findProjects _)
+        .expects(idx + 1)
+        .returning(chunk.pure[IO])
+      ()
+    }
+
+    def toCleanUpRequestEvent(projectPath: projects.Path) = projectPath -> EventRequestContent.NoPayload {
+      json"""{
+        "categoryName": $eventCategoryName,
+        "project": {
+          "path": $projectPath
+        }
+      }"""
+    }
+
+    lazy val givenEventIsSent: ((projects.Path, EventRequestContent.NoPayload)) => Unit = { case (path, event) =>
+      (eventSender
+        .sendEvent(_: EventRequestContent.NoPayload, _: EventSender.EventContext))
+        .expects(event,
+                 EventSender.EventContext(eventCategoryName,
+                                          show"$categoryName: ${migration.name} cannot send event for $path"
+                 )
+        )
+        .returning(().pure[IO])
+      ()
+    }
+  }
+}
+
+class ProjectsFinderSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset {
+
+  private val chunkSize = 50
+
+  "findProjects" should {
+
+    "find requested page of projects existing in the TS" in new TestCase {
+
+      val projects = anyProjectEntities
+        .generateList(min = chunkSize + 1, max = Gen.choose(chunkSize + 1, (2 * chunkSize) - 1).generateOne)
+        .map(_.to[entities.Project])
+        .sortBy(_.path)
+
+      upload(to = projectsDataset, projects: _*)
+
+      val (page1, page2) = projects splitAt chunkSize
+      finder.findProjects(page = 1).unsafeRunSync() shouldBe page1.map(_.path)
+      finder.findProjects(page = 2).unsafeRunSync() shouldBe page2.map(_.path)
+      finder.findProjects(page = 3).unsafeRunSync() shouldBe Nil
+    }
+  }
+
+  private trait TestCase {
+    private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
+    private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    val finder = new ProjectsFinderImpl[IO](RecordsFinder(projectsDSConnectionInfo))
+  }
+}


### PR DESCRIPTION
This PR brings a migration that will effectively re-provision all the Projects found in the TS. The process doesn't wipe out the TS but rather redoes each Project one by one. As a result, API users will be able to find the relevant data throughout the duration of the operation. At a single point in time, a maximum of (number of TGs running on an environment) Projects will be unavailable.