### PR TITLE
fix: Plan entity decoder not to be strict on types

### DIFF
--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
@@ -19,8 +19,8 @@
 package io.renku.graph.model
 package entities
 
-import StepPlanCommandParameter.{CommandInput, CommandOutput, CommandParameter}
 import Schemas.{prov, renku, schema}
+import StepPlanCommandParameter.{CommandInput, CommandOutput, CommandParameter}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.syntax.all._
 import io.circe.DecodingFailure
@@ -61,21 +61,15 @@ object Plan {
     }
 
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Plan] =
-    JsonLDDecoder.entity(EntityTypes.of(prov / "Plan")) { cursor =>
-      cursor.getEntityTypes
-        .flatMap {
-          case ets if ets.contains(StepPlan.entityTypes) =>
-            StepPlan.decoder.apply(cursor)
-          case ets if ets.contains(CompositePlan.Ontology.entityTypes) =>
-            CompositePlan.decoder.apply(cursor)
-          case ets =>
-            Left(
-              DecodingFailure(
-                DecodingFailure.Reason.CustomReason(show"Expected composite plan or step plan, but got: $ets"),
-                cursor.jsonLD.toJson.hcursor
-              )
-            )
-        }
+    JsonLDDecoder.entity(EntityTypes of prov / "Plan") { cursor =>
+      lazy val noMatchFailure: Either[DecodingFailure, Plan] = cursor.getEntityTypes.flatMap { ets =>
+        DecodingFailure(
+          DecodingFailure.Reason.CustomReason(show"Cannot decode entity as Plan: $ets"),
+          cursor.jsonLD.toJson.hcursor
+        ).asLeft
+      }
+
+      StepPlan.decoder.apply(cursor) orElse CompositePlan.decoder.apply(cursor) orElse noMatchFailure
     }
 
   lazy val ontology: Type =
@@ -270,11 +264,8 @@ object StepPlan {
         )
     }
 
-  private val withStrictEntityTypes: Cursor => JsonLDDecoder.Result[Boolean] =
-    _.getEntityTypes.map(_ == StepPlan.entityTypes)
-
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[StepPlan] =
-    JsonLDDecoder.cacheableEntity(entityTypes, withStrictEntityTypes) { cursor =>
+    JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       import io.renku.graph.model.views.StringTinyTypeJsonLDDecoders._
       for {
         resourceId            <- cursor.downEntityId.as[ResourceId]
@@ -460,11 +451,8 @@ object CompositePlan {
       )
     }
 
-  private val withStrictEntityTypes: Cursor => JsonLDDecoder.Result[Boolean] =
-    _.getEntityTypes.map(_ == CompositePlan.Ontology.entityTypes)
-
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDEntityDecoder[CompositePlan] =
-    JsonLDDecoder.entity(Ontology.entityTypes, withStrictEntityTypes) { cursor =>
+    JsonLDDecoder.entity(Ontology.entityTypes) { cursor =>
       import io.renku.graph.model.views.StringTinyTypeJsonLDDecoders._
       for {
         resourceId            <- cursor.downEntityId.as[ResourceId]

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -198,6 +198,33 @@ class PlanSpec
       decoded.fold(err => fail(err.message), identity) should contain theSameElementsAs List(sp, cp)
     }
 
+    "decode a Composite Plan that has additional types" in {
+      val plan = compositePlanGen().generateOne
+        .to[entities.CompositePlan]
+
+      val newJson =
+        JsonLDTools
+          .view(plan)
+          .selectByTypes(entities.CompositePlan.Ontology.entityTypes)
+          .addType(renku / "WorkflowCompositePlan")
+          .value
+
+      newJson.cursor.as[List[entities.CompositePlan]] shouldBe List(plan).asRight
+    }
+
+    "decode a Step Plan that has additional types" in {
+      val plan = plans.generateOne.to[entities.StepPlan]
+
+      val newJson =
+        JsonLDTools
+          .view(plan)
+          .selectByTypes(entities.StepPlan.entityTypes)
+          .addType(renku / "WorkflowPlan")
+          .value
+
+      newJson.cursor.as[List[entities.StepPlan]] shouldBe List(plan).asRight
+    }
+
     "fail decode if a parameter maps to itself" in {
       val plan = compositePlanNonEmptyMappings.generateOne
       val pm_  = plan.mappings.head

--- a/renku-model/src/test/scala/io/renku/graph/model/tools/JsonLDTools.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/tools/JsonLDTools.scala
@@ -19,12 +19,15 @@
 package io.renku.graph.model.tools
 
 import io.renku.graph.model.tools.JsonLDTools.JsonLDElementView.{Filter, Update}
-import io.renku.jsonld.{EntityType, EntityTypes, JsonLD, JsonLDEncoder, Property}
+import io.renku.jsonld._
 
 object JsonLDTools {
 
   def flattenedJsonLD[A: JsonLDEncoder](value: A): JsonLD =
     JsonLDEncoder[A].apply(value).flatten.fold(throw _, identity)
+
+  def flattenedJsonLDFrom(value: JsonLD, other: JsonLD*): JsonLD =
+    JsonLD.arr(value :: other.toList: _*).flatten.fold(throw _, identity)
 
   /** Create a view of the value as JsonLD in order to create a modified version. */
   def view[A: JsonLDEncoder](value: A): JsonLDElementView =


### PR DESCRIPTION
This PR takes out the strict type check predicate from both the Plan entity decoders. The reason is that introduction of `WorkflowFile` version of both the Plans does not bring significant changes to any of the non-`WorkflowFile` Plans. Moreover, not decoding `WorkflowFile` Plans causes failures during decoding Activities created as a result of `WorkflowFile` Plan execution. The option here would be to skip decoding `WorkflowFile` related Activities but this seems not to be a trivial thing to do.
I tried decoding a payload from a project using WorkflowFile feature and without the strict type check on Plan decoders all seems to be working fine.