### PR TITLE
feat: Allow multiple sort parameters

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -22,6 +22,7 @@ import Criteria._
 import io.circe.Decoder
 import io.renku.graph.model.{persons, projects}
 import io.renku.http.rest.SortBy.Direction
+import io.renku.http.rest.Sorting
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.server.security.model.AuthUser
 import io.renku.tinytypes.constraints.{LocalDateNotInTheFuture, NonBlank}
@@ -31,7 +32,7 @@ import io.renku.tinytypes.{LocalDateTinyType, StringTinyType, TinyTypeFactory}
 import java.time.LocalDate
 
 final case class Criteria(filters:   Filters = Filters(),
-                          sorting:   Sorting.By = Sorting.default,
+                          sorting:   Sorting[Criteria.Sort.type] = Criteria.Sort.default,
                           paging:    PagingRequest = PagingRequest.default,
                           maybeUser: Option[AuthUser] = None
 )
@@ -78,7 +79,7 @@ object Criteria {
     object Until extends TinyTypeFactory[Until](new Until(_)) with LocalDateNotInTheFuture[Until]
   }
 
-  object Sorting extends io.renku.http.rest.SortBy {
+  object Sort extends io.renku.http.rest.SortBy {
 
     type PropertyType = SortProperty
 
@@ -88,7 +89,9 @@ object Criteria {
     final case object ByMatchingScore extends Property("matchingScore") with SortProperty
     final case object ByDate          extends Property("date") with SortProperty
 
-    lazy val default: Sorting.By = Sorting.By(ByName, Direction.Asc)
+    val byNameAsc = Sort.By(ByName, Direction.Asc)
+
+    val default: Sorting[Sort.type] = Sorting(byNameAsc)
 
     override lazy val properties: Set[SortProperty] = Set(ByName, ByMatchingScore, ByDate)
   }

--- a/entities-search/src/test/scala/io/renku/entities/search/DatasetsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/DatasetsEntitiesFinderSpec.scala
@@ -18,14 +18,14 @@
 
 package io.renku.entities.search
 
-import Criteria.{Filters, Sorting}
+import Criteria.{Filters, Sort}
 import EntityConverters._
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model._
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
-import io.renku.http.rest.SortBy
+import io.renku.http.rest.{SortBy, Sorting}
 import io.renku.testtools.IOSpec
 import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
 import org.scalatest.matchers.should
@@ -105,7 +105,7 @@ class DatasetsEntitiesFinderSpec
       finder
         .findEntities(
           Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Dataset)),
-                   sorting = Sorting.By(Sorting.ByDate, SortBy.Direction.Asc)
+                   sorting = Sorting(Sort.By(Sort.ByDate, SortBy.Direction.Asc))
           )
         )
         .unsafeRunSync()

--- a/event-log/src/main/scala/io/renku/eventlog/MicroserviceRoutes.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/MicroserviceRoutes.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog
 
 import cats.NonEmptyParallel
-import cats.data.{Validated, ValidatedNel}
+import cats.data.ValidatedNel
 import cats.effect.kernel.{Ref, Sync}
 import cats.effect.{Async, Resource}
 import cats.syntax.all._
@@ -34,6 +34,7 @@ import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.graph.http.server.binders._
 import io.renku.graph.model.events.{CompoundEventId, EventDate, EventStatus}
 import io.renku.graph.model.projects
+import io.renku.http.rest.Sorting
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.rest.paging.PagingRequest.Decoders.{page, perPage}
 import io.renku.http.rest.paging.model.{Page, PerPage}
@@ -60,7 +61,7 @@ private class MicroserviceRoutes[F[_]: Sync](
 ) extends Http4sDsl[F] {
 
   import EventStatusParameter._
-  import EventsEndpoint.Criteria.Sorting.sort
+  import EventsEndpoint.Criteria.Sort.sort
   import ProjectIdParameter._
   import ProjectPathParameter._
   import eventDetailsEndpoint._
@@ -73,7 +74,15 @@ private class MicroserviceRoutes[F[_]: Sync](
 
   // format: off
   lazy val routes: Resource[F, HttpRoutes[F]] = HttpRoutes.of[F] {
-    case request @ GET  -> Root / "events" :? `project-id`(validatedProjectId) +& `project-path`(validatedProjectPath) +& status(status) +& since(since) +& until(until) +& page(page) +& perPage(perPage) +& sort(sortBy) => respond503IfMigrating(maybeFindEvents(validatedProjectId, validatedProjectPath, status, since, until, page, perPage, sortBy, request))
+    case request @ GET  -> Root / "events" :? `project-id`(validatedProjectId) +&
+      `project-path`(validatedProjectPath) +&
+      status(status) +&
+      since(since) +&
+      until(until) +&
+      page(page) +&
+      perPage(perPage) +&
+      sort(sortBy) => 
+      respond503IfMigrating(maybeFindEvents(validatedProjectId, validatedProjectPath, status, since, until, page, perPage, sortBy, request))
     case request @ POST -> Root / "events"                                            => respond503IfMigrating(processEvent(request))
     case           GET  -> Root / "events" / EventId(eventId) / ProjectId(projectId)  => respond503IfMigrating(getDetails(CompoundEventId(eventId, projectId)))
     case           GET  -> Root / "events" / EventId(eventId) / ProjectPath(projectPath) / "payload"  => respond503IfMigrating(eventPayloadEndpoint.getEventPayload(eventId, projectPath))
@@ -157,7 +166,7 @@ private class MicroserviceRoutes[F[_]: Sync](
                               maybeUntil:       Option[ValidatedNel[ParseFailure, EventDate]],
                               maybePage:        Option[ValidatedNel[ParseFailure, Page]],
                               maybePerPage:     Option[ValidatedNel[ParseFailure, PerPage]],
-                              maybeSortBy:      Option[ValidatedNel[ParseFailure, EventsEndpoint.Criteria.Sorting.By]],
+                              maybeSortBy:      ValidatedNel[ParseFailure, List[EventsEndpoint.Criteria.Sort.By]],
                               request:          Request[F]
   ): F[Response[F]] = {
     import EventsEndpoint.Criteria._
@@ -177,31 +186,37 @@ private class MicroserviceRoutes[F[_]: Sync](
           validatedIdentifier,
           maybeStatus.sequence,
           maybeDates.sequence,
-          maybeSortBy getOrElse Validated.validNel(EventsEndpoint.Criteria.Sorting.default),
+          maybeSortBy,
           PagingRequest(maybePage, maybePerPage)
         ).mapN { case (path, maybeStatus, maybeDates, sorting, paging) =>
-          findEvents(EventsEndpoint.Criteria(Filters.ProjectEvents(path, maybeStatus, maybeDates), sorting, paging),
-                     request
+          val sortOrDefault = Sorting.fromList(sorting).getOrElse(EventsEndpoint.Criteria.Sort.default)
+          findEvents(
+            EventsEndpoint.Criteria(Filters.ProjectEvents(path, maybeStatus, maybeDates), sortOrDefault, paging),
+            request
           )
         }.fold(toBadRequest, identity)
       case (None, Some(validatedStatus), maybeDates) =>
         (
           validatedStatus,
           maybeDates.sequence,
-          maybeSortBy getOrElse Validated.validNel(EventsEndpoint.Criteria.Sorting.default),
+          maybeSortBy,
           PagingRequest(maybePage, maybePerPage)
         ).mapN { case (status, maybeDates, sorting, paging) =>
-          findEvents(EventsEndpoint.Criteria(Filters.EventsWithStatus(status, maybeDates), sorting, paging), request)
+          val sortOrDefault = Sorting.fromList(sorting).getOrElse(EventsEndpoint.Criteria.Sort.default)
+          findEvents(EventsEndpoint.Criteria(Filters.EventsWithStatus(status, maybeDates), sortOrDefault, paging),
+                     request
+          )
         }.fold(toBadRequest, identity)
       case (None, None, Some(validatedDates)) =>
-        (validatedDates,
-         maybeSortBy getOrElse Validated.validNel(EventsEndpoint.Criteria.Sorting.default),
-         PagingRequest(maybePage, maybePerPage)
-        ).mapN { case (dates, sorting, paging) =>
-          findEvents(EventsEndpoint.Criteria(dates, sorting, paging), request)
-        }.fold(toBadRequest, identity)
+        (validatedDates, maybeSortBy, PagingRequest(maybePage, maybePerPage))
+          .mapN { case (dates, sorting, paging) =>
+            val sortOrDefault = Sorting.fromList(sorting).getOrElse(EventsEndpoint.Criteria.Sort.default)
+            findEvents(EventsEndpoint.Criteria(dates, sortOrDefault, paging), request)
+          }
+          .fold(toBadRequest, identity)
     }
   }
+
 }
 
 private object MicroserviceRoutes {

--- a/event-log/src/main/scala/io/renku/eventlog/events/EventsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/EventsEndpoint.scala
@@ -30,6 +30,7 @@ import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.{EventDate, EventInfo, EventStatus, StatusProcessingTime}
 import io.renku.graph.model.projects
 import io.renku.http.ErrorMessage
+import io.renku.http.rest.Sorting
 import io.renku.http.rest.paging.PagingRequest
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{Request, Response}
@@ -71,7 +72,7 @@ object EventsEndpoint {
 
   final case class Criteria(
       filters: Criteria.Filters,
-      sorting: Criteria.Sorting.By = Sorting.default,
+      sorting: Sorting[Criteria.Sort.type] = Criteria.Sort.default,
       paging:  PagingRequest = PagingRequest.default
   )
 
@@ -91,7 +92,7 @@ object EventsEndpoint {
       final case class EventsSinceAndUntil(since: EventsSince, until: EventsUntil)              extends FiltersOnDate
     }
 
-    object Sorting extends io.renku.http.rest.SortBy {
+    object Sort extends io.renku.http.rest.SortBy {
       import io.renku.http.rest.SortBy.Direction
 
       type PropertyType = SortProperty
@@ -100,7 +101,7 @@ object EventsEndpoint {
 
       final case object EventDate extends Property("eventDate") with SortProperty
 
-      lazy val default: Sorting.By = Sorting.By(EventDate, Direction.Desc)
+      lazy val default: Sorting[Sort.type] = Sorting(Sort.By(EventDate, Direction.Desc))
 
       override lazy val properties: Set[SortProperty] = Set(EventDate)
     }

--- a/event-log/src/test/scala/io/renku/eventlog/MicroserviceRoutesSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/MicroserviceRoutesSpec.scala
@@ -33,6 +33,7 @@ import io.renku.generators.Generators.{jsons, nonEmptyStrings}
 import io.renku.graph.model.EventContentGenerators._
 import io.renku.graph.model.EventsGenerators.{compoundEventIds, eventIds, eventStatuses}
 import io.renku.graph.model.GraphModelGenerators._
+import io.renku.http.rest.Sorting
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.server.EndpointTester._
 import io.renku.http.server.version
@@ -68,7 +69,7 @@ class MicroserviceRoutesSpec
 
   "GET /events" should {
     import EventsEndpoint.Criteria
-    import EventsEndpoint.Criteria.Sorting._
+    import EventsEndpoint.Criteria.Sort._
     import EventsEndpoint.Criteria._
 
     forAll {
@@ -151,7 +152,7 @@ class MicroserviceRoutesSpec
         (eventStatuses -> sortingDirections).mapN { (status, dir) =>
           uri"/events" +? ("status" -> status.value) +? ("sort" -> s"eventDate:$dir") -> Criteria(
             Filters.EventsWithStatus(status, maybeDates = None),
-            Sorting.By(EventDate, dir)
+            Sorting(Sort.By(EventDate, dir))
           )
         }.generateOne,
         (eventStatuses -> pages).mapN { (status, page) =>

--- a/event-log/src/test/scala/io/renku/eventlog/events/EventsEndpointSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/EventsEndpointSpec.scala
@@ -120,18 +120,18 @@ class EventsEndpointSpec extends AnyWordSpec with IOSpec with MockFactory with s
         projectPath <- projectPaths
         maybeStatus <- eventStatuses.toGeneratorOfOptions
         maybeDates  <- filtersOnDates.toGeneratorOfOptions
-        sorting     <- sortBys(Criteria.Sorting)
+        sorting     <- sortBys(Criteria.Sort)
         paging      <- pagingRequests
       } yield Criteria(Filters.ProjectEvents(projectPath, maybeStatus, maybeDates), sorting, paging),
       for {
         status     <- eventStatuses
         maybeDates <- filtersOnDates.toGeneratorOfOptions
-        sorting    <- sortBys(Criteria.Sorting)
+        sorting    <- sortBys(Criteria.Sort)
         paging     <- pagingRequests
       } yield Criteria(Filters.EventsWithStatus(status, maybeDates), sorting, paging),
       for {
         dates   <- filtersOnDates
-        sorting <- sortBys(Criteria.Sorting)
+        sorting <- sortBys(Criteria.Sort)
         paging  <- pagingRequests
       } yield Criteria(dates, sorting, paging)
     )

--- a/event-log/src/test/scala/io/renku/eventlog/events/EventsFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/EventsFinderSpec.scala
@@ -30,7 +30,7 @@ import io.renku.graph.model.EventContentGenerators._
 import io.renku.graph.model.EventsGenerators._
 import io.renku.graph.model.GraphModelGenerators.{projectIds, projectPaths}
 import io.renku.graph.model.events.CompoundEventId
-import io.renku.http.rest.SortBy
+import io.renku.http.rest.{SortBy, Sorting}
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.rest.paging.model.{Page, PerPage}
 import io.renku.metrics.TestMetricsRegistry
@@ -143,7 +143,7 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
       val pagedResults = eventsFinder
         .findEvents(
           Criteria(Filters.ProjectEvents(projectPath, maybeStatus = None, maybeDates = None),
-                   Sorting.By(Sorting.EventDate, SortBy.Direction.Asc),
+                   Sorting(Sort.By(Sort.EventDate, SortBy.Direction.Asc)),
                    pagingRequest
           )
         )
@@ -155,9 +155,10 @@ class EventsFinderSpec extends AnyWordSpec with IOSpec with InMemoryEventLogDbSp
 
       val ascPagedResults = eventsFinder
         .findEvents(
-          Criteria(Filters.ProjectEvents(projectPath, maybeStatus = None, maybeDates = None),
-                   Sorting.By(Sorting.EventDate, SortBy.Direction.Desc),
-                   pagingRequest
+          Criteria(
+            Filters.ProjectEvents(projectPath, maybeStatus = None, maybeDates = None),
+            Sorting(Sort.By(Sort.EventDate, SortBy.Direction.Desc)),
+            pagingRequest
           )
         )
         .unsafeRunSync()

--- a/graph-commons/src/main/scala/io/renku/http/rest/Sorting.scala
+++ b/graph-commons/src/main/scala/io/renku/http/rest/Sorting.scala
@@ -1,0 +1,38 @@
+package io.renku.http.rest
+
+import cats.Semigroup
+import cats.data.NonEmptyList
+import io.renku.triplesstore.client.model.OrderBy
+
+/** Combines multiple [[SortBy.By]]s. */
+final case class Sorting[S <: SortBy](sortBy: NonEmptyList[S#By]) {
+
+  def toOrderBy(pm: S#PropertyType => OrderBy.Property): OrderBy =
+    OrderBy(sortBy.map(e => OrderBy.Sort(pm(e.property), e.direction.toOrderByDirection)))
+
+  lazy val asOrderBy: OrderBy = toOrderBy(p => OrderBy.Property(p.name))
+
+  def :+(next: S#By): Sorting[S] =
+    new Sorting(sortBy.append(next))
+
+  def ++(next: Sorting[S]): Sorting[S] =
+    new Sorting(this.sortBy.concatNel(next.sortBy))
+}
+
+object Sorting {
+  def apply[E <: SortBy](e: E#By, more: E#By*): Sorting[E] =
+    apply[E](NonEmptyList(e, more.toList))
+
+  def apply[E <: SortBy](sorts: NonEmptyList[E#By]): Sorting[E] =
+    new Sorting[E](sorts)
+
+  def fromList[E <: SortBy](list: List[E#By]): Option[Sorting[E]] =
+    NonEmptyList.fromList(list).map(Sorting(_))
+
+  def fromListOrDefault[E <: SortBy](list: List[E#By], default: => Sorting[E]): Sorting[E] =
+    fromList(list).getOrElse(default)
+
+  implicit def sortingSemigroup[A <: SortBy]: Semigroup[Sorting[A]] =
+    Semigroup.instance(_ ++ _)
+
+}

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -38,7 +38,7 @@ import io.renku.http.client._
 import io.renku.http.rest.Links.{Href, Link, Rel}
 import io.renku.http.rest.paging.model.Total
 import io.renku.http.rest.paging.{PagingRequest, PagingResponse}
-import io.renku.http.rest.{Links, SortBy, paging}
+import io.renku.http.rest.{Links, SortBy, Sorting, paging}
 import io.renku.http.server.security.EndpointSecurityException
 import io.renku.http.server.security.EndpointSecurityException.{AuthenticationFailure, AuthorizationFailure}
 import io.renku.http.server.security.model.AuthUser
@@ -189,10 +189,10 @@ object CommonGraphGenerators {
 
   implicit lazy val sortingDirections: Gen[SortBy.Direction] = Gen.oneOf(SortBy.Direction.Asc, SortBy.Direction.Desc)
 
-  def sortBys[T <: SortBy](sortBy: T): Gen[T#By] = for {
+  def sortBys[T <: SortBy](sortBy: T): Gen[Sorting[T]] = for {
     property  <- Gen.oneOf(sortBy.properties.toList)
     direction <- sortingDirections
-  } yield sortBy.By(property, direction)
+  } yield Sorting(sortBy.By(property, direction))
 
   object TestSort extends SortBy {
     type PropertyType = TestProperty
@@ -203,7 +203,7 @@ object CommonGraphGenerators {
     override val properties: Set[TestProperty] = Set(Name, Email)
   }
 
-  def testSortBys: Gen[TestSort.By] = sortBys(TestSort)
+  def testSortBys: Gen[Sorting[TestSort.type]] = sortBys(TestSort)
 
   implicit val pages: Gen[paging.model.Page] = positiveInts(max = 100) map (_.value) map paging.model.Page.apply
   implicit val perPages: Gen[paging.model.PerPage] =

--- a/graph-commons/src/test/scala/io/renku/http/rest/SortBySpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/rest/SortBySpec.scala
@@ -35,7 +35,7 @@ class SortBySpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
 
     "return the valid Sort.By instance for a valid name and direction" in {
       forAll(testSortBys) { sort =>
-        TestSort.from(serialize(sort)) shouldBe Right(sort)
+        TestSort.from(serialize(sort.sortBy.head)) shouldBe Right(sort.sortBy.head)
       }
     }
 
@@ -67,8 +67,8 @@ class SortBySpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
 
     "decode a valid sort query parameter" in {
       forAll(testSortBys) { sort =>
-        Map("sort" -> Seq(serialize(sort))) match {
-          case TestSort.sort(actual) => actual shouldBe Some(Validated.validNel(sort))
+        Map("sort" -> Seq(serialize(sort.sortBy.head))) match {
+          case TestSort.sort(actual) => actual shouldBe Validated.validNel(sort.sortBy.toList)
         }
       }
     }
@@ -76,15 +76,15 @@ class SortBySpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
     "fail to decode an invalid sort query parameter" in {
       Map("sort" -> Seq(s"invalid:$Desc")) match {
         case TestSort.sort(actual) =>
-          actual shouldBe Some(Validated.invalidNel {
+          actual shouldBe Validated.invalidNel {
             ParseFailure(TestSort.Property.from("invalid").swap.getOrElse(throw new Exception("ERROR!")).getMessage, "")
-          })
+          }
       }
     }
 
     "return None when no sort query parameter" in {
       Map.empty[String, List[String]] match {
-        case TestSort.sort(actual) => actual shouldBe None
+        case TestSort.sort(actual) => actual shouldBe Validated.valid(Nil)
       }
     }
   }
@@ -96,7 +96,7 @@ class SortBySpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
 
       val sort = testSortBys.generateOne
 
-      convert(sort).value shouldBe urlEncode(serialize(sort))
+      convert(sort.sortBy.head).value shouldBe urlEncode(serialize(sort.sortBy.head))
     }
   }
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
@@ -28,6 +28,7 @@ import io.renku.graph.model.projects.Visibility
 import io.renku.graph.model.testentities.{Dataset, Person, RenkuProject}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
 import io.renku.http.rest.SortBy.Direction
+import io.renku.http.rest.Sorting
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.rest.paging.model.{Page, PerPage, Total}
 import io.renku.http.server.security.model.AuthUser
@@ -66,7 +67,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2, project3)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           val expectedResults = List(
@@ -92,7 +93,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, projects: _*)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe projects
@@ -113,7 +114,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2, project3)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -135,7 +136,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project2Updated)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -156,7 +157,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2, project2Fork)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -180,7 +181,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(dataset1Modified -> project1, dataset2Modified -> project2)
@@ -199,7 +200,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, projectWithAllDatasets)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List((modification2, projectWithAllDatasets).toDatasetSearchResult(projectsCount = 1))
@@ -217,7 +218,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -238,7 +239,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2Updated)
 
           val result = datasetsFinder
-            .findDatasets(None, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(None, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -259,7 +260,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project, fork)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -278,7 +279,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, projectUpdated, fork)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -303,7 +304,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project, forkUpdated)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List(
@@ -323,7 +324,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project1, project2)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List((dataset1, project1).toDatasetSearchResult(projectsCount = 1))
@@ -339,7 +340,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, project, forkUpdated)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List((dataset, project).toDatasetSearchResult(projectsCount = 1))
@@ -355,7 +356,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, afterForkingUpdated, fork)
 
           val result = datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
 
           result.results shouldBe List((dataset, fork).toDatasetSearchResult(projectsCount = 1))
@@ -371,7 +372,7 @@ class DatasetsFinderSpec
           upload(to = projectsDataset, projectUpdated)
 
           datasetsFinder
-            .findDatasets(maybePhrase, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+            .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
             .unsafeRunSync()
             .results shouldBe Nil
         }
@@ -405,7 +406,7 @@ class DatasetsFinderSpec
         upload(to = projectsDataset, project1, project2, project3, project4, project5, projectWithoutPhrase)
 
         val result = datasetsFinder
-          .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+          .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
           .unsafeRunSync()
 
         result.results shouldBe List((dataset1, project1),
@@ -424,7 +425,11 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project)
 
       datasetsFinder
-        .findDatasets(Some(phrases.generateOne), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrases.generateOne),
+                      Sorting(Sort.By(TitleProperty, Direction.Asc)),
+                      PagingRequest.default,
+                      None
+        )
         .unsafeRunSync()
         .results shouldBe Nil
     }
@@ -439,7 +444,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project)
 
       datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results shouldBe Nil
     }
@@ -459,7 +464,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project1, project2)
 
       datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results shouldBe List((dataset1, project1).toDatasetSearchResult(projectsCount = 1))
     }
@@ -477,7 +482,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project1, project2Updated)
 
       datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results shouldBe List((dataset2Modified, project2Updated).toDatasetSearchResult(projectsCount = 1))
     }
@@ -493,7 +498,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, projectUpdate2)
 
       datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results shouldBe Nil
     }
@@ -510,7 +515,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project, forkUpdated)
 
       datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results shouldBe List((dataset, project).toDatasetSearchResult(projectsCount = 1))
     }
@@ -526,7 +531,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project, forkUpdated)
 
       datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results shouldBe List((datasetModified, forkUpdated).toDatasetSearchResult(projectsCount = 1))
     }
@@ -542,7 +547,7 @@ class DatasetsFinderSpec
         upload(to = projectsDataset, project)
 
         datasetsFinder
-          .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+          .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
           .unsafeRunSync()
           .results shouldBe Nil
       }
@@ -569,7 +574,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, project1, project2, project3, projectNonPhrased)
 
       val results = datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results
 
@@ -599,7 +604,11 @@ class DatasetsFinderSpec
       )
 
       val results = datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(DatePublishedProperty, Direction.Desc), PagingRequest.default, None)
+        .findDatasets(Some(phrase),
+                      Sorting(Sort.By(DatePublishedProperty, Direction.Desc)),
+                      PagingRequest.default,
+                      None
+        )
         .unsafeRunSync()
         .results
 
@@ -629,7 +638,7 @@ class DatasetsFinderSpec
       )
 
       val results = datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(DateProperty, Direction.Desc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(DateProperty, Direction.Desc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results
 
@@ -662,7 +671,7 @@ class DatasetsFinderSpec
       upload(to = projectsDataset, publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2)
 
       val results = datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(ProjectsCountProperty, Direction.Asc), PagingRequest.default, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(ProjectsCountProperty, Direction.Asc)), PagingRequest.default, None)
         .unsafeRunSync()
         .results
 
@@ -701,7 +710,7 @@ class DatasetsFinderSpec
       val pagingRequest = PagingRequest(Page(2), PerPage(1))
 
       val result = datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), pagingRequest, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), pagingRequest, None)
         .unsafeRunSync()
 
       result.results shouldBe List((dataset1, project1), (dataset2, project2), (dataset3, project3))
@@ -731,7 +740,7 @@ class DatasetsFinderSpec
       val pagingRequest = PagingRequest(Page(2), PerPage(3))
 
       val result = datasetsFinder
-        .findDatasets(Some(phrase), Sort.By(TitleProperty, Direction.Asc), pagingRequest, None)
+        .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), pagingRequest, None)
         .unsafeRunSync()
 
       result.results                  shouldBe Nil
@@ -752,7 +761,7 @@ class DatasetsFinderSpec
         upload(to = projectsDataset, publicProject, privateProject)
 
         val result = datasetsFinder
-          .findDatasets(None, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, maybeUser = None)
+          .findDatasets(None, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, maybeUser = None)
           .unsafeRunSync()
 
         result.results          shouldBe List((publicDataset, publicProject).toDatasetSearchResult(projectsCount = 1))
@@ -769,7 +778,7 @@ class DatasetsFinderSpec
         upload(to = projectsDataset, publicProject, privateProjectWithPublicDataset)
 
         val result = datasetsFinder
-          .findDatasets(None, Sort.By(TitleProperty, Direction.Asc), PagingRequest.default, None)
+          .findDatasets(None, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
           .unsafeRunSync()
 
         result.results          shouldBe List((publicDataset, publicProject).toDatasetSearchResult(projectsCount = 1))
@@ -802,7 +811,7 @@ class DatasetsFinderSpec
 
       val result = datasetsFinder
         .findDatasets(maybePhrase = None,
-                      Sort.By(TitleProperty, Direction.Asc),
+                      Sorting(Sort.By(TitleProperty, Direction.Asc)),
                       PagingRequest.default,
                       userWithGitlabId.toAuthUser.some
         )
@@ -827,7 +836,7 @@ class DatasetsFinderSpec
 
       datasetsFinder
         .findDatasets(maybePhrase = None,
-                      Sort.By(TitleProperty, Direction.Asc),
+                      Sorting(Sort.By(TitleProperty, Direction.Asc)),
                       PagingRequest.default,
                       authUsers.generateSome
         )
@@ -846,7 +855,7 @@ class DatasetsFinderSpec
 
       datasetsFinder
         .findDatasets(maybePhrase = None,
-                      Sort.By(TitleProperty, Direction.Asc),
+                      Sorting(Sort.By(TitleProperty, Direction.Asc)),
                       PagingRequest.default,
                       authUsers.generateSome
         )
@@ -884,7 +893,7 @@ class DatasetsFinderSpec
 
         val result = datasetsFinder
           .findDatasets(maybePhrase = None,
-                        Sort.By(TitleProperty, Direction.Asc),
+                        Sorting(Sort.By(TitleProperty, Direction.Asc)),
                         PagingRequest.default,
                         userWithGitlabId.toAuthUser.some
           )

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
@@ -137,7 +137,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
 
     private val renkuApiUrl = renkuApiUrls.generateOne
     implicit val renkuResourceUrl: renku.ResourceUrl =
-      (renkuApiUrl / "datasets") ? (page.parameterName -> pagingRequest.page) & (perPage.parameterName -> pagingRequest.perPage) & (Sort.sort.parameterName -> sort) && (query.parameterName -> maybePhrase)
+      (renkuApiUrl / "datasets") ? (page.parameterName -> pagingRequest.page) & (perPage.parameterName -> pagingRequest.perPage) && (Sort.sort.parameterName -> sort.sortBy.toList) && (query.parameterName -> maybePhrase)
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val datasetsFinder        = mock[DatasetsFinder[IO]]

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/EndpointSpec.scala
@@ -119,7 +119,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
 
   private lazy val criterias: Gen[Criteria] = for {
     maybeQuery    <- nonEmptyStrings().toGeneratorOf(Filters.Query).toGeneratorOfOptions
-    sortingBy     <- sortBys(Criteria.Sorting)
+    sortingBy     <- sortBys(Criteria.Sort)
     paging        <- pagingRequests
     maybeAuthUser <- authUsers.toGeneratorOfOptions
   } yield Criteria(Filters(maybeQuery), sortingBy, paging, maybeAuthUser)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
@@ -100,7 +100,10 @@ trait ModelOps extends Dataset.ProvenanceOps {
     }
 
     private def newChildGen(parentProject: RenkuProject) =
-      renkuProjectEntities(fixed(parentProject.visibility), minDateCreated = parentProject.dateCreated).map(child =>
+      renkuProjectEntities(
+        fixed(parentProject.visibility),
+        projectDateCreatedGen = projectCreatedDates(parentProject.dateCreated.value)
+      ).map(child =>
         RenkuProject.WithParent(
           child.path,
           child.name,

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ActivityGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ActivityGenerators.scala
@@ -97,6 +97,20 @@ trait ActivityGenerators extends RenkuTinyTypeGenerators {
     } yield Plan.of(name, maybeCommand, dateCreated, creators, CommandParameters.of(parameterFactories: _*))
   )
 
+  def stepPlanEntities(
+      planDateCreatedGen: Gen[plans.DateCreated],
+      parameterFactories: Seq[CommandParameterFactory] = Seq.empty[CommandParameterFactory]
+  )(implicit
+      planCommandsGen: Gen[Command]
+  ): StepPlanGenFactory = Kleisli(_ =>
+    for {
+      name         <- planNames
+      maybeCommand <- planCommandsGen.toGeneratorOfOptions
+      dateCreated  <- planDateCreatedGen
+      creators     <- personEntities.toGeneratorOfList(max = 2)
+    } yield Plan.of(name, maybeCommand, dateCreated, creators, CommandParameters.of(parameterFactories: _*))
+  )
+
   def compositePlanEntities(childGen: ProjectBasedGenFactory[List[Plan]]): CompositePlanGenFactory =
     (planDatesCreatedK, childGen).flatMapN { (dateCreated, childPlans) =>
       for {

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -62,17 +62,17 @@ trait RenkuProjectEntitiesGenerators {
       )
 
   def renkuProjectEntities(
-      visibilityGen:     Gen[Visibility],
-      minDateCreated:    projects.DateCreated = projects.DateCreated(Instant.EPOCH),
-      activityFactories: List[ActivityGenFactory] = Nil,
-      datasetFactories:  List[DatasetGenFactory[Dataset.Provenance]] = Nil,
-      forksCountGen:     Gen[ForksCount] = anyForksCount
+      visibilityGen:         Gen[Visibility],
+      projectDateCreatedGen: Gen[projects.DateCreated] = projectCreatedDates(Instant.EPOCH),
+      activityFactories:     List[ActivityGenFactory] = Nil,
+      datasetFactories:      List[DatasetGenFactory[Dataset.Provenance]] = Nil,
+      forksCountGen:         Gen[ForksCount] = anyForksCount
   ): Gen[RenkuProject.WithoutParent] = for {
     path             <- projectPaths
     name             <- Gen.const(path.toName)
     maybeDescription <- projectDescriptions.toGeneratorOfOptions
     agent            <- cliVersions
-    dateCreated      <- projectCreatedDates(minDateCreated.value)
+    dateCreated      <- projectDateCreatedGen
     maybeCreator     <- personEntities(withGitLabId).toGeneratorOfOptions
     visibility       <- visibilityGen
     forksCount       <- forksCountGen

--- a/tiny-types/src/main/scala/io/renku/tinytypes/constraints/Url.scala
+++ b/tiny-types/src/main/scala/io/renku/tinytypes/constraints/Url.scala
@@ -78,18 +78,21 @@ trait UrlOps[T <: UrlTinyType] {
 
     def &[Value](keyAndValue: (String, Value))(implicit convert: Value => QueryParamValue): UrlWithQueryParam =
       keyAndValue match {
-        case (key, value) => add(key, value)
+        case (key, value) => add(url, key, value)
       }
 
     def &&[Value](
-        keyAndValue: (String, Option[Value])
-    )(implicit convert: Value => QueryParamValue): UrlWithQueryParam =
-      keyAndValue match {
-        case (_, None)          => url
-        case (key, Some(value)) => add(key, value)
+        keyAndValue: (String, IterableOnce[Value])
+    )(implicit convert: Value => QueryParamValue): UrlWithQueryParam = {
+      val (key, values) = keyAndValue
+      values.iterator.foldLeft(url) { (current, value) =>
+        add(current, key, value)
       }
+    }
 
-    private def add[Value](key: String, value: Value)(implicit convert: Value => QueryParamValue) =
+    private def add[Value](url: UrlWithQueryParam, key: String, value: Value)(implicit
+        convert: Value => QueryParamValue
+    ) =
       UrlWithQueryParam {
         apply {
           if (url.toString contains s"$key=")

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/model/OrderBy.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/model/OrderBy.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesstore.client.model
+
+import cats.Semigroup
+import cats.data.NonEmptyList
+import io.renku.triplesstore.client.model.OrderBy.Sort
+import io.renku.triplesstore.client.sparql.{Fragment, SparqlEncoder}
+
+final case class OrderBy(sorting: NonEmptyList[Sort]) {
+  def ++(other: OrderBy): OrderBy =
+    OrderBy(sorting.concatNel(other.sorting))
+}
+
+object OrderBy {
+
+  sealed trait Direction extends Product {
+    final val name: String = productPrefix.toUpperCase
+    def apply(property: Property): Sort = Sort(property, this)
+  }
+  object Direction {
+    case object Asc  extends Direction
+    case object Desc extends Direction
+
+    val all: NonEmptyList[Direction] = NonEmptyList.of(Asc, Desc)
+  }
+
+  final class Property(val name: String) extends AnyVal
+  object Property {
+    def apply(name: String): Property = new Property(name)
+  }
+
+  final case class Sort(property: Property, direction: Direction)
+
+  def apply(property: Property, direction: Direction): OrderBy =
+    OrderBy(NonEmptyList.of(Sort(property, direction)))
+
+  def apply(p: (Property, Direction), more: (Property, Direction)*): OrderBy =
+    OrderBy(NonEmptyList(p, more.toList).map((Sort.apply _).tupled))
+
+  def apply(p: Sort, more: Sort*): OrderBy =
+    OrderBy(NonEmptyList(p, more.toList))
+
+  implicit val orderBySemigroup: Semigroup[OrderBy] =
+    Semigroup.instance(_ ++ _)
+
+  implicit val sparqlFragmentEncoder: SparqlEncoder[OrderBy] =
+    SparqlEncoder.instance { orderBy =>
+      val props = orderBy.sorting.map(s => s"${s.direction.name.toUpperCase}(${s.property.name})").toList.mkString(" ")
+      Fragment(s"ORDER BY $props")
+    }
+}

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/model/OrderBySpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/model/OrderBySpec.scala
@@ -16,20 +16,24 @@
  * limitations under the License.
  */
 
-package io.renku.knowledgegraph
+package io.renku.triplesstore.client.model
 
-import io.renku.generators.CommonGraphGenerators.sortBys
-import io.renku.generators.Generators.nonBlankStrings
-import io.renku.graph.model.testentities.Person
-import io.renku.http.rest.Sorting
-import io.renku.knowledgegraph.datasets.Endpoint.Query.Phrase
-import org.scalacheck.Gen
+import io.renku.triplesstore.client.model.OrderBy.{Direction, Property}
+import io.renku.triplesstore.client.sparql.{Fragment, SparqlEncoder}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 
-package object datasets {
+class OrderBySpec extends AnyWordSpec with should.Matchers {
 
-  val phrases: Gen[Phrase] = nonBlankStrings(minLength = 5) map (_.value) map Phrase.apply
-  implicit val searchEndpointSorts: Gen[Sorting[Endpoint.Sort.type]] = sortBys(Endpoint.Sort)
+  "OrderBy" should {
 
-  implicit lazy val personToCreator: Person => DatasetCreator =
-    person => DatasetCreator(person.maybeEmail, person.name, person.maybeAffiliation)
+    "encode to valid sparql" in {
+      val order = OrderBy(
+        Direction.Asc(Property("?date")),
+        Direction.Desc(Property("?name"))
+      )
+      val sparql = SparqlEncoder[OrderBy].apply(order)
+      sparql shouldBe Fragment("ORDER BY ASC(?date) DESC(?name)")
+    }
+  }
 }


### PR DESCRIPTION
This adds support for specifying multiple `sort` query parameters for the cross entity search.

There is a new type introduced to capture multiple sort parameters (based on a non-empty list). It is `Sorting` in the rest utility package and `OrderBy` for the triples store client. To lower confusion about names, the subtypes of `rest.SortBy`that were named `Sorting`are renamed to `Sort`.

The change is also applied to the find events endpoint, because it uses most of the same machinery and I kind of converted it automatically :).

closes #1278 