### PR TITLE
refactor: datasets.Date tiny type renamed to CreatedOrPublished

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/model.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/model.scala
@@ -62,7 +62,7 @@ object model {
         identifier:          datasets.Identifier,
         name:                datasets.Name,
         visibility:          projects.Visibility,
-        date:                datasets.Date,
+        date:                datasets.CreatedOrPublished,
         creators:            List[persons.Name],
         keywords:            List[datasets.Keyword],
         maybeDescription:    Option[datasets.Description],
@@ -70,7 +70,7 @@ object model {
         exemplarProjectPath: projects.Path
     ) extends Entity {
       override type Name = datasets.Name
-      override type Date = datasets.Date
+      override type Date = datasets.CreatedOrPublished
     }
 
     final case class Workflow(

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/SearchInfo.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/SearchInfo.scala
@@ -28,7 +28,7 @@ import io.renku.graph.model.{datasets, persons, projects}
 private final case class SearchInfo(topmostSameAs:      datasets.TopmostSameAs,
                                     name:               datasets.Name,
                                     visibility:         projects.Visibility,
-                                    createdOrPublished: datasets.Date,
+                                    createdOrPublished: datasets.CreatedOrPublished,
                                     maybeDateModified:  Option[datasets.DateModified],
                                     creators:           NonEmptyList[PersonInfo],
                                     keywords:           List[datasets.Keyword],

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/SearchInfoExtractor.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/SearchInfoExtractor.scala
@@ -44,19 +44,19 @@ private object SearchInfoExtractor {
 
   private def findDateOriginal[F[_]: MonadThrow](prov:    Dataset.Provenance.Modified,
                                                  project: Project
-  ): F[datasets.Date] =
+  ): F[datasets.CreatedOrPublished] =
     project.datasets
       .find(_.identification.resourceId.value == prov.topmostDerivedFrom.value)
-      .map(_.provenance.date.pure[F].widen[datasets.Date])
+      .map(_.provenance.date.pure[F].widen[datasets.CreatedOrPublished])
       .getOrElse(
         new Exception(
           show"Cannot find original Dataset ${prov.topmostDerivedFrom} for project ${project.resourceId}"
-        ).raiseError[F, datasets.Date]
+        ).raiseError[F, datasets.CreatedOrPublished]
       )
       .widen
 
   private def createSearchInfo(ds:                 Dataset[Dataset.Provenance],
-                               createdOrPublished: datasets.Date,
+                               createdOrPublished: datasets.CreatedOrPublished,
                                maybeDateModified:  Option[datasets.DateModified],
                                project:            Project
   ) = SearchInfo(

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/commands/SearchInfoFetcher.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/commands/SearchInfoFetcher.scala
@@ -195,7 +195,7 @@ private class SearchInfoFetcherImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder
 
       def toCreatedOrPublished(maybeDateCreated:   Option[datasets.DateCreated],
                                maybeDatePublished: Option[datasets.DatePublished]
-      )(implicit topSameAs: TopmostSameAs): Either[DecodingFailure, datasets.Date] = Either.fromOption(
+      )(implicit topSameAs: TopmostSameAs): Either[DecodingFailure, datasets.CreatedOrPublished] = Either.fromOption(
         maybeDateCreated orElse maybeDatePublished,
         ifNone = DecodingFailure(
           DecodingFailure.Reason.CustomReason(s"neither dateCreated nor datePublished for $topSameAs"),

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/Generators.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/Generators.scala
@@ -36,7 +36,7 @@ private object Generators {
   implicit lazy val searchInfoObjectsGen: Gen[SearchInfo] = for {
     topmostSameAs      <- datasetTopmostSameAs
     name               <- datasetNames
-    createdOrPublished <- datasetDates
+    createdOrPublished <- datasetCreatedOrPublished
     visibility         <- projectVisibilities
     maybeDateModified  <- datasetModifiedDates(notYoungerThan = createdOrPublished).toGeneratorOfOptions
     creators           <- personInfos.toGeneratorOfNonEmptyList(max = 2)

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/commands/EncodersSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/commands/EncodersSpec.scala
@@ -121,7 +121,7 @@ class EncodersSpec extends AnyWordSpec with should.Matchers {
     }
   }
 
-  private def createdOrPublishedToQuad(topmostSameAs: datasets.TopmostSameAs): datasets.Date => Quad = {
+  private def createdOrPublishedToQuad(topmostSameAs: datasets.TopmostSameAs): datasets.CreatedOrPublished => Quad = {
     case d: datasets.DateCreated =>
       DatasetsQuad(topmostSameAs, SearchInfoOntology.dateCreatedProperty.id, d.asObject)
     case d: datasets.DatePublished =>

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetSearchResult.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetSearchResult.scala
@@ -24,7 +24,7 @@ import cats.syntax.all._
 import io.circe.literal._
 import io.circe.{Encoder, Json}
 import io.renku.config
-import io.renku.graph.model.datasets.{Date, DatePublished, Description, Identifier, Keyword, Name, Title}
+import io.renku.graph.model.datasets.{CreatedOrPublished, DatePublished, Description, Identifier, Keyword, Name, Title}
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.{GitLabUrl, projects}
 import io.renku.http.rest.Links.{Href, Link, Rel, _links}
@@ -33,16 +33,16 @@ import io.renku.tinytypes.constraints.NonNegativeInt
 import io.renku.tinytypes.{IntTinyType, TinyTypeFactory}
 
 final case class DatasetSearchResult(
-    id:               Identifier,
-    title:            Title,
-    name:             Name,
-    maybeDescription: Option[Description],
-    creators:         List[DatasetCreator],
-    date:             Date,
-    exemplarProject:  ExemplarProject,
-    projectsCount:    ProjectsCount,
-    keywords:         List[Keyword],
-    images:           List[ImageUri]
+    id:                 Identifier,
+    title:              Title,
+    name:               Name,
+    maybeDescription:   Option[Description],
+    creators:           List[DatasetCreator],
+    createdOrPublished: CreatedOrPublished,
+    exemplarProject:    ExemplarProject,
+    projectsCount:      ProjectsCount,
+    keywords:           List[Keyword],
+    images:             List[ImageUri]
 )
 
 object DatasetSearchResult {
@@ -76,7 +76,7 @@ object DatasetSearchResult {
           .deepMerge(_links(Link(Rel("details") -> datasets.details.Endpoint.href(renkuApiUrl, id))))
     }
 
-  private implicit lazy val publishingEncoder: Encoder[(List[DatasetCreator], Date)] = Encoder.instance {
+  private implicit lazy val publishingEncoder: Encoder[(List[DatasetCreator], CreatedOrPublished)] = Encoder.instance {
     case (creators, DatePublished(date)) => json"""{
     "creator":       $creators,
     "datePublished": $date

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
@@ -213,7 +213,7 @@ private object BaseDetailsFinderImpl {
                                    Option[DerivedFrom],
                                    SameAs,
                                    OriginalIdentifier,
-                                   Date,
+                                   CreatedOrPublished,
                                    Option[Description],
                                    DatasetProject
   ) => Result[Dataset] = {
@@ -228,7 +228,7 @@ private object BaseDetailsFinderImpl {
         maybeInitialTag = None,
         maybeDesc,
         creators = List.empty,
-        date = dates,
+        createdOrPublished = dates,
         parts = List.empty,
         project = project,
         usedIn = List.empty,
@@ -246,7 +246,7 @@ private object BaseDetailsFinderImpl {
         maybeInitialTag = None,
         maybeDescription,
         creators = List.empty,
-        date = date,
+        createdOrPublished = date,
         parts = List.empty,
         project = project,
         usedIn = List.empty,
@@ -270,16 +270,16 @@ private object BaseDetailsFinderImpl {
         maybeDerivedFrom <- extract[Option[DerivedFrom]]("maybeDerivedFrom")
         sameAs           <- extract[SameAs]("topmostSameAs")
         initialVersion   <- extract[OriginalIdentifier]("initialVersion")
-        date <- maybeDerivedFrom match {
-                  case Some(_) => extract[DateCreated]("maybeDateCreated").widen[Date]
-                  case _ =>
-                    extract[Option[DatePublished]]("maybeDatePublished")
-                      .flatMap {
-                        case Some(published) => published.asRight
-                        case None            => extract[DateCreated]("maybeDateCreated")
-                      }
-                      .widen[Date]
-                }
+        createdOrPublished <- maybeDerivedFrom match {
+                                case Some(_) => extract[DateCreated]("maybeDateCreated").widen[CreatedOrPublished]
+                                case _ =>
+                                  extract[Option[DatePublished]]("maybeDatePublished")
+                                    .flatMap {
+                                      case Some(published) => published.asRight
+                                      case None            => extract[DateCreated]("maybeDateCreated")
+                                    }
+                                    .widen[CreatedOrPublished]
+                              }
         maybeDescription <- extract[Option[Description]]("description")
 
         project <- (extract[projects.ResourceId]("projectId"),
@@ -295,7 +295,7 @@ private object BaseDetailsFinderImpl {
                                  maybeDerivedFrom,
                                  sameAs,
                                  initialVersion,
-                                 date,
+                                 createdOrPublished,
                                  maybeDescription,
                                  project
                    )

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
@@ -35,56 +35,56 @@ import io.renku.http.rest.Links.{Href, Link, Rel, _links}
 import io.renku.json.JsonOps._
 
 private sealed trait Dataset extends Product with Serializable {
-  val resourceId:       ResourceId
-  val id:               Identifier
-  val title:            Title
-  val name:             Name
-  val versions:         DatasetVersions
-  val maybeInitialTag:  Option[Tag]
-  val maybeDescription: Option[Description]
-  val creators:         List[DatasetCreator]
-  val date:             Date
-  val parts:            List[DatasetPart]
-  val project:          DatasetProject
-  val usedIn:           List[DatasetProject]
-  val keywords:         List[Keyword]
-  val images:           List[ImageUri]
+  val resourceId:         ResourceId
+  val id:                 Identifier
+  val title:              Title
+  val name:               Name
+  val versions:           DatasetVersions
+  val maybeInitialTag:    Option[Tag]
+  val maybeDescription:   Option[Description]
+  val creators:           List[DatasetCreator]
+  val createdOrPublished: CreatedOrPublished
+  val parts:              List[DatasetPart]
+  val project:            DatasetProject
+  val usedIn:             List[DatasetProject]
+  val keywords:           List[Keyword]
+  val images:             List[ImageUri]
 }
 
 private object Dataset {
 
-  final case class NonModifiedDataset(resourceId:       ResourceId,
-                                      id:               Identifier,
-                                      title:            Title,
-                                      name:             Name,
-                                      sameAs:           SameAs,
-                                      versions:         DatasetVersions,
-                                      maybeInitialTag:  Option[Tag],
-                                      maybeDescription: Option[Description],
-                                      creators:         List[DatasetCreator],
-                                      date:             Date,
-                                      parts:            List[DatasetPart],
-                                      project:          DatasetProject,
-                                      usedIn:           List[DatasetProject],
-                                      keywords:         List[Keyword],
-                                      images:           List[ImageUri]
+  final case class NonModifiedDataset(resourceId:         ResourceId,
+                                      id:                 Identifier,
+                                      title:              Title,
+                                      name:               Name,
+                                      sameAs:             SameAs,
+                                      versions:           DatasetVersions,
+                                      maybeInitialTag:    Option[Tag],
+                                      maybeDescription:   Option[Description],
+                                      creators:           List[DatasetCreator],
+                                      createdOrPublished: CreatedOrPublished,
+                                      parts:              List[DatasetPart],
+                                      project:            DatasetProject,
+                                      usedIn:             List[DatasetProject],
+                                      keywords:           List[Keyword],
+                                      images:             List[ImageUri]
   ) extends Dataset
 
-  final case class ModifiedDataset(resourceId:       ResourceId,
-                                   id:               Identifier,
-                                   title:            Title,
-                                   name:             Name,
-                                   derivedFrom:      DerivedFrom,
-                                   versions:         DatasetVersions,
-                                   maybeInitialTag:  Option[Tag],
-                                   maybeDescription: Option[Description],
-                                   creators:         List[DatasetCreator],
-                                   date:             DateCreated,
-                                   parts:            List[DatasetPart],
-                                   project:          DatasetProject,
-                                   usedIn:           List[DatasetProject],
-                                   keywords:         List[Keyword],
-                                   images:           List[ImageUri]
+  final case class ModifiedDataset(resourceId:         ResourceId,
+                                   id:                 Identifier,
+                                   title:              Title,
+                                   name:               Name,
+                                   derivedFrom:        DerivedFrom,
+                                   versions:           DatasetVersions,
+                                   maybeInitialTag:    Option[Tag],
+                                   maybeDescription:   Option[Description],
+                                   creators:           List[DatasetCreator],
+                                   createdOrPublished: DateCreated,
+                                   parts:              List[DatasetPart],
+                                   project:            DatasetProject,
+                                   usedIn:             List[DatasetProject],
+                                   keywords:           List[Keyword],
+                                   images:             List[ImageUri]
   ) extends Dataset
 
   final case class DatasetPart(location: PartLocation)
@@ -112,8 +112,8 @@ private object Dataset {
         ("versions" -> dataset.versions.asJson).some,
         dataset.maybeInitialTag.map(tag => "tags" -> json"""{"initial": ${tag.asJson}}"""),
         dataset.maybeDescription.map(description => "description" -> description.asJson),
-        ("published" -> (dataset.creators -> dataset.date).asJson).some,
-        dataset.date match {
+        ("published" -> (dataset.creators -> dataset.createdOrPublished).asJson).some,
+        dataset.createdOrPublished match {
           case DatePublished(_)  => Option.empty[(String, Json)]
           case DateCreated(date) => ("created" -> date.asJson).some
         },
@@ -131,7 +131,7 @@ private object Dataset {
   }
   // format: on
 
-  private implicit lazy val publishingEncoder: Encoder[(List[DatasetCreator], Date)] = Encoder.instance {
+  private implicit lazy val publishingEncoder: Encoder[(List[DatasetCreator], CreatedOrPublished)] = Encoder.instance {
     case (creators, DatePublished(date)) => json"""{
       "datePublished": $date,
       "creator"      : $creators

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
@@ -614,7 +614,7 @@ class DatasetsFinderSpec
 
       results shouldBe List((dataset1, project1), (dataset2, project2), (dataset3, project3))
         .map(_.toDatasetSearchResult(projectsCount = 1))
-        .sortBy(_.date.instant)
+        .sortBy(_.createdOrPublished.instant)
         .reverse
     }
 
@@ -644,7 +644,7 @@ class DatasetsFinderSpec
 
       results shouldBe List((dataset1, project1), (dataset2, project2), (dataset3, project3))
         .map(_.toDatasetSearchResult(projectsCount = 1))
-        .sortBy(_.date.instant)
+        .sortBy(_.createdOrPublished.instant)
         .reverse
     }
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
@@ -172,8 +172,8 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
         }""" addIfDefined "description" -> maybeDescription
     }
 
-    private implicit lazy val publishingEncoder: Encoder[(List[DatasetCreator], Date)] =
-      Encoder.instance[(List[DatasetCreator], Date)] {
+    private implicit lazy val publishingEncoder: Encoder[(List[DatasetCreator], CreatedOrPublished)] =
+      Encoder.instance[(List[DatasetCreator], CreatedOrPublished)] {
         case (creators, DatePublished(date)) => json"""{
           "creator":       $creators,
           "datePublished": $date
@@ -223,7 +223,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
     name              <- datasetNames
     maybeDescription  <- datasetDescriptions.toGeneratorOfOptions
     creators          <- personEntities.toGeneratorOfNonEmptyList(max = 4)
-    dates             <- datasetDates
+    dates             <- datasetCreatedOrPublished
     exemplarProjectId <- projectResourceIds
     projectsCount     <- nonNegativeInts() map (_.value) map ProjectsCount.apply
     keywords          <- datasetKeywords.toGeneratorOfList()

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
@@ -213,7 +213,7 @@ class EndpointSpec
       date <-
         maybeDateCreated
           .orElse(published._2)
-          .widen[Date]
+          .widen[CreatedOrPublished]
           .map(_.asRight)
           .getOrElse(DecodingFailure("No date found", Nil).asLeft)
     } yield (maybeSameAs, maybeDateCreated, maybeDerivedFrom) match {

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliDataset.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliDataset.scala
@@ -33,7 +33,7 @@ final case class CliDataset(
     identifier:         Identifier,
     title:              Title,
     name:               Name,
-    createdOrPublished: Date,
+    createdOrPublished: CreatedOrPublished,
     dateModified:       Option[DateModified],
     creators:           NonEmptyList[CliPerson],
     description:        Option[Description],

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliDatasetProvenance.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliDatasetProvenance.scala
@@ -24,7 +24,7 @@ import io.renku.graph.model.datasets._
 /** View on the dataset focusing on provenance properties.
  */
 final case class CliDatasetProvenance(
-    createdOrPublished: Date,
+    createdOrPublished: CreatedOrPublished,
     dateModified:       Option[DateModified],
     sameAs:             Option[SameAs],
     derivedFrom:        Option[DerivedFrom],

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/generators/DatasetGenerators.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/generators/DatasetGenerators.scala
@@ -32,7 +32,7 @@ trait DatasetGenerators {
       resourceId         <- RenkuTinyTypeGenerators.datasetResourceIds(identifier)
       title              <- RenkuTinyTypeGenerators.datasetTitles
       name               <- RenkuTinyTypeGenerators.datasetNames
-      createdOrPublished <- RenkuTinyTypeGenerators.datasetDates
+      createdOrPublished <- RenkuTinyTypeGenerators.datasetCreatedOrPublished
       creators           <- PersonGenerators.cliPersonGen.toGeneratorOfNonEmptyList(max = 3)
       descr              <- RenkuTinyTypeGenerators.datasetDescriptions.toGeneratorOfOptions
       keywords           <- RenkuTinyTypeGenerators.datasetKeywords.toGeneratorOfList(max = 3)

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
@@ -237,24 +237,23 @@ object datasets {
       with UrlConstraint[PartResourceId]
       with EntityIdJsonLDOps[PartResourceId]
 
-  sealed trait Date extends Any with TinyType {
+  sealed trait CreatedOrPublished extends Any with TinyType {
     def instant: Instant
   }
-
-  object Date {
-    implicit val encoder: Encoder[Date] = Encoder.instance {
+  object CreatedOrPublished {
+    implicit val encoder: Encoder[CreatedOrPublished] = Encoder.instance {
       case d: DateCreated   => d.asJson
       case d: DatePublished => d.asJson
     }
 
-    implicit val show: Show[Date] =
+    implicit val show: Show[CreatedOrPublished] =
       Show.show {
         case d: DateCreated   => d.show
         case d: DatePublished => d.show
       }
   }
 
-  final class DateCreated private (val value: Instant) extends AnyVal with Date with InstantTinyType {
+  final class DateCreated private (val value: Instant) extends AnyVal with CreatedOrPublished with InstantTinyType {
     override def instant: Instant = value
   }
   implicit object DateCreated
@@ -265,7 +264,10 @@ object datasets {
       Show.show(d => s"DateCreated(${d.value})")
   }
 
-  final class DatePublished private (val value: LocalDate) extends AnyVal with Date with LocalDateTinyType {
+  final class DatePublished private (val value: LocalDate)
+      extends AnyVal
+      with CreatedOrPublished
+      with LocalDateTinyType {
     override def instant: Instant = value.atStartOfDay().toInstant(ZoneOffset.UTC)
   }
   implicit object DatePublished
@@ -282,7 +284,7 @@ object datasets {
       with InstantNotInTheFuture[DateModified]
       with TinyTypeJsonLDOps[DateModified] {
 
-    def apply(date: datasets.Date): DateModified = DateModified(date.instant)
+    def apply(date: datasets.CreatedOrPublished): DateModified = DateModified(date.instant)
   }
 
   final class PartId private (val value: String) extends AnyVal with StringTinyType

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/RenkuTinyTypeGenerators.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/RenkuTinyTypeGenerators.scala
@@ -190,10 +190,10 @@ trait RenkuTinyTypeGenerators {
   def datasetCreatedDates(min: Instant = Instant.EPOCH): Gen[datasets.DateCreated] =
     Generators.timestamps(min, max = Instant.now()).map(datasets.DateCreated.apply)
 
-  lazy val datasetDates: Gen[datasets.Date] =
+  lazy val datasetCreatedOrPublished: Gen[datasets.CreatedOrPublished] =
     Gen.oneOf(datasetCreatedDates(), datasetPublishedDates(datasets.DatePublished(LocalDate.EPOCH)))
 
-  def datasetModifiedDates(notYoungerThan: datasets.Date): Gen[datasets.DateModified] =
+  def datasetModifiedDates(notYoungerThan: datasets.CreatedOrPublished): Gen[datasets.DateModified] =
     timestampsNotInTheFuture(notYoungerThan.instant).generateAs(datasets.DateModified(_))
 
   implicit val datasetKeywords: Gen[datasets.Keyword] =

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/datasetsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/datasetsSpec.scala
@@ -233,23 +233,23 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
     }
   }
 
-  "Date" should {
+  "CreatedOrPublished" should {
 
     "provide encoder if it's a DateCreated" in {
       val date: DateCreated = datasetCreatedDates().generateOne
-      date.asInstanceOf[Date].asJson shouldBe date.value.asJson
+      date.asInstanceOf[CreatedOrPublished].asJson shouldBe date.value.asJson
     }
 
     "provide encoder if it's a DatePublished" in {
       val date: DatePublished = datasetPublishedDates().generateOne
-      date.asInstanceOf[Date].asJson shouldBe date.value.asJson
+      date.asInstanceOf[CreatedOrPublished].asJson shouldBe date.value.asJson
     }
   }
 
-  "DateModified.apply(DateCreated)" should {
+  "DateModified.apply(CreatedOrPublished)" should {
 
     "instantiate DateModified from a Dataset Date" in {
-      val created = datasetDates.generateOne
+      val created = datasetCreatedOrPublished.generateOne
       DateModified(created).value shouldBe created.instant
     }
   }

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/ModelTinyTypesDiffInstances.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/ModelTinyTypesDiffInstances.scala
@@ -26,7 +26,8 @@ trait ModelTinyTypesDiffInstances extends TinyTypeDiffInstances {
 
   implicit val imageUriDiff: Diff[ImageUri] = Diff.diffForString.contramap(_.value)
 
-  implicit val datasetsDateDiff: Diff[datasets.Date] = Diff.derived[datasets.Date]
+  implicit val datasetsCreatedOrPublishedDiff: Diff[datasets.CreatedOrPublished] =
+    Diff.derived[datasets.CreatedOrPublished]
 
   implicit val datasetsSameAsDiff: Diff[datasets.SameAs] = Diff.diffForString.contramap {
     case sa: datasets.InternalSameAs => sa.value

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Dataset.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Dataset.scala
@@ -138,7 +138,7 @@ object Dataset {
   }
 
   sealed trait Provenance extends Product with Serializable {
-    type D <: Date
+    type D <: CreatedOrPublished
     val topmostSameAs:      TopmostSameAs
     val originalIdentifier: OriginalIdentifier
     val topmostDerivedFrom: TopmostDerivedFrom

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/DatasetSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/DatasetSpec.scala
@@ -223,7 +223,7 @@ class DatasetSpec
 
       assume(modelDs.identification.identifier.value != modelDs.provenance.originalIdentifier.value)
 
-      val cliDs = modelDs.toCliEntity.copy(createdOrPublished = datasetDates.generateOne)
+      val cliDs = modelDs.toCliEntity.copy(createdOrPublished = datasetCreatedOrPublished.generateOne)
 
       encodeAndDecodeToModel(cliDs) shouldBe List(modelDs).asRight
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
@@ -53,7 +53,7 @@ object Dataset {
   )
 
   sealed trait Provenance extends Product with Serializable {
-    type D <: Date
+    type D <: CreatedOrPublished
     val topmostSameAs:      TopmostSameAs
     val originalIdentifier: OriginalIdentifier
     val topmostDerivedFrom: TopmostDerivedFrom

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/SameAsHierarchyFixer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/namedgraphs/SameAsHierarchyFixer.scala
@@ -120,12 +120,12 @@ private class SameAsHierarchyFixer[F[_]: Async: Logger: SparqlQueryTimeRecorder]
     }
   }
 
-  private case class DirectDescendantInfo(graphId:       EntityId,
-                                          dsId:          datasets.ResourceId,
-                                          topmostSameAs: TopmostSameAs,
-                                          sameAs:        SameAs,
-                                          date:          Date,
-                                          modified:      Boolean
+  private case class DirectDescendantInfo(graphId:            EntityId,
+                                          dsId:               datasets.ResourceId,
+                                          topmostSameAs:      TopmostSameAs,
+                                          sameAs:             SameAs,
+                                          createdOrPublished: CreatedOrPublished,
+                                          modified:           Boolean
   )
 
   private def collectDirectDescendants(dsInfo: DSInfo): Nested[F, List, DirectDescendantInfo] = Nested {


### PR DESCRIPTION
This PR renames `datasets.Date` tiny type to `datasets.CreatedOrPublished` for improved expressiveness and reduced confusion with `DateModified`.

closes #1280 