### PR TITLE
chore: introduce converters from test to cli entitiies

### DIFF
--- a/renku-model/src/test/scala/io/renku/graph/model/cli/CliDatasetConverters.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/cli/CliDatasetConverters.scala
@@ -20,7 +20,10 @@ package io.renku.graph.model.cli
 
 import cats.syntax.all._
 import io.renku.cli.model._
-import io.renku.graph.model.{datasets, entities}
+import io.renku.graph.model.testentities.Dataset.DatasetImagesOps
+import io.renku.graph.model.testentities.HavingInvalidationTime
+import io.renku.jsonld.syntax._
+import io.renku.graph.model.{RenkuUrl, datasets, entities, publicationEvents, testentities}
 
 trait CliDatasetConverters extends CliCommonConverters {
 
@@ -57,6 +60,41 @@ trait CliDatasetConverters extends CliCommonConverters {
       dataset.publicationEvents.map(from)
     )
 
+  def from(dataset: testentities.Dataset[testentities.Dataset.Provenance])(implicit renkuUrl: RenkuUrl): CliDataset = {
+    val id = datasets.ResourceId(dataset.asEntityId.show)
+    CliDataset(
+      resourceId = id,
+      identifier = dataset.identification.identifier,
+      title = dataset.identification.title,
+      name = dataset.identification.name,
+      createdOrPublished = dataset.provenance.date,
+      dateModified = datasets.DateModified(dataset.provenance.date),
+      creators = dataset.provenance.creators.map(from),
+      description = dataset.additionalInfo.maybeDescription,
+      keywords = dataset.additionalInfo.keywords,
+      images = dataset.additionalInfo.images.toEntitiesImages(id).toList,
+      license = dataset.additionalInfo.maybeLicense,
+      version = dataset.additionalInfo.maybeVersion,
+      datasetFiles = dataset.parts.map(from),
+      sameAs = dataset.provenance match {
+        case p: testentities.Dataset.Provenance.ImportedExternal => p.sameAs.some
+        case p: testentities.Dataset.Provenance.ImportedInternal => p.sameAs.some
+        case _: testentities.Dataset.Provenance.Internal         => None
+        case _: testentities.Dataset.Provenance.Modified         => None
+      },
+      derivedFrom = dataset.provenance match {
+        case m: testentities.Dataset.Provenance.Modified => m.derivedFrom.some
+        case _ => None
+      },
+      originalIdentifier = dataset.provenance.originalIdentifier.some,
+      invalidationTime = dataset.provenance match {
+        case m: testentities.Dataset.Provenance.Modified => m.maybeInvalidationTime
+        case _ => None
+      },
+      dataset.publicationEvents.map(from)
+    )
+  }
+
   def from(part: entities.DatasetPart): CliDatasetFile =
     CliDatasetFile(part.resourceId,
                    part.external,
@@ -66,8 +104,29 @@ trait CliDatasetConverters extends CliCommonConverters {
                    part.maybeInvalidationTime
     )
 
+  def from(part: testentities.DatasetPart)(implicit renkuUrl: RenkuUrl): CliDatasetFile =
+    CliDatasetFile(
+      datasets.PartResourceId(part.asEntityId.show),
+      part.external,
+      from(part.entity),
+      part.dateCreated,
+      part.maybeSource,
+      part match {
+        case p: HavingInvalidationTime =>
+          p.invalidationTime.some
+        case _ => None
+      }
+    )
+
   def from(pe: entities.PublicationEvent): CliPublicationEvent =
     CliPublicationEvent(pe.resourceId, pe.about, pe.datasetResourceId, pe.maybeDescription, pe.name, pe.startDate)
+
+  def from(pe: testentities.PublicationEvent)(implicit renkuUrl: RenkuUrl): CliPublicationEvent = {
+    val id    = publicationEvents.ResourceId(pe.asEntityId.show)
+    val about = publicationEvents.About((renkuUrl / "urls" / "datasets" / pe.dataset.identification.identifier).show)
+    val resId = datasets.ResourceId(pe.dataset.asEntityId.show)
+    CliPublicationEvent(id, about, resId, pe.maybeDescription, pe.name, pe.startDate)
+  }
 }
 
 object CliDatasetConverters extends CliDatasetConverters

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
@@ -19,8 +19,10 @@
 package io.renku.graph.model.testentities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliActivity
 import io.renku.graph.model._
 import io.renku.graph.model.activities.{EndTime, StartTime}
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.entityModel._
 import io.renku.graph.model.testentities.Activity._
 import io.renku.graph.model.testentities.Entity.OutputEntity
@@ -102,6 +104,9 @@ object Activity {
       activity.generations.map(_.to[entities.Generation]),
       activity.parameters.map(_.to[entities.ParameterValue])
     )
+
+  implicit def toCliActivity(implicit renkuUrl: RenkuUrl): Activity => CliActivity =
+    CliConverters.from(_)
 
   implicit def encoder(implicit
       renkuUrl:     RenkuUrl,

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Agent.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Agent.scala
@@ -19,7 +19,9 @@
 package io.renku.graph.model.testentities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliSoftwareAgent
 import io.renku.graph.model.agents.Name
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.versions.CliVersion
 import io.renku.graph.model.{agents, entities}
 
@@ -32,6 +34,9 @@ object Agent {
 
   implicit lazy val toEntitiesAgent: Agent => entities.Agent = agent =>
     entities.Agent(agents.ResourceId(agent.asEntityId.show), Name(s"renku ${agent.cliVersion}"))
+
+  implicit def toCliAgent: Agent => CliSoftwareAgent =
+    CliConverters.from(_)
 
   implicit lazy val encoder: JsonLDEncoder[Agent] = JsonLDEncoder.instance {
     _.to[entities.Agent].asJsonLD

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
@@ -27,15 +27,20 @@ sealed trait Association {
   val activity: Activity
   val agent:    AgentType
   val plan:     StepPlan
+
+  def agentOrPerson: Either[Agent, Person]
 }
 
 object Association {
 
   final case class WithRenkuAgent(activity: Activity, agent: Agent, plan: StepPlan) extends Association {
     type AgentType = Agent
+
+    def agentOrPerson: Either[Agent, Person] = Left(agent)
   }
   final case class WithPersonAgent(activity: Activity, agent: Person, plan: StepPlan) extends Association {
     type AgentType = Person
+    def agentOrPerson: Either[Agent, Person] = Right(agent)
   }
 
   def factory(agent: Agent, plan: StepPlan): Activity => Association = Association.WithRenkuAgent(_, agent, plan)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Association.scala
@@ -19,7 +19,9 @@
 package io.renku.graph.model.testentities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliAssociation
 import io.renku.graph.model._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.jsonld._
 
 sealed trait Association {
@@ -59,6 +61,9 @@ object Association {
                                            plan.to[entities.StepPlan].resourceId
       )
   }
+
+  implicit def toCliAssociation(implicit renkuUrl: RenkuUrl): Association => CliAssociation =
+    CliConverters.from(_)
 
   implicit def encoder(implicit renkuUrl: RenkuUrl, graph: GraphClass): JsonLDEncoder[Association] =
     JsonLDEncoder.instance(_.to[entities.Association].asJsonLD)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/CompositePlan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/CompositePlan.scala
@@ -20,7 +20,9 @@ package io.renku.graph.model.testentities
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.syntax.all._
+import io.renku.cli.model.CliCompositePlan
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.{GitLabApiUrl, GraphClass, InvalidationTime, RenkuUrl, entities, plans}
 import io.renku.graph.model.plans.{Command, DateCreated, DerivedFrom, Description, Identifier, Keyword, Name}
 import io.renku.jsonld.JsonLDEncoder
@@ -134,6 +136,9 @@ object CompositePlan {
             )
           )
           .fold(errors => sys.error(errors.intercalate("; ")), _.asInstanceOf[entities.CompositePlan.NonModified])
+
+    implicit def toCliCompositePlan[P <: NonModified](implicit renkuUrl: RenkuUrl): P => CliCompositePlan =
+      CliConverters.from(_)
   }
 
   case class Modified(
@@ -244,12 +249,18 @@ object CompositePlan {
             )
           )
           .fold(errors => sys.error(errors.intercalate("; ")), _.asInstanceOf[entities.CompositePlan.Modified])
+
+    def toCliCompositePlan(implicit renkuUrl: RenkuUrl): Modified => CliCompositePlan =
+      CliConverters.from(_)
   }
 
   implicit def toEntitiesCompositePlan(implicit renkuUrl: RenkuUrl): CompositePlan => entities.CompositePlan = {
     case p: NonModified => NonModified.toEntitiesCompositePlan(renkuUrl)(p)
     case p: Modified    => Modified.toEntitiesCompositePlan(renkuUrl)(p)
   }
+
+  implicit def toCliCompositePlan(implicit renkuUrl: RenkuUrl): CompositePlan => CliCompositePlan =
+    CliConverters.from(_)
 
   // maybe just use the project encoder on the production entities
   implicit def jsonLDEncoder(implicit

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Dataset.scala
@@ -354,8 +354,7 @@ object Dataset {
   }
 
   implicit def toCliDataset[TP <: Provenance](implicit renkuUrl: RenkuUrl): Dataset[TP] => CliDataset =
-    ((_: Dataset[Dataset.Provenance]).to[entities.Dataset[entities.Dataset.Provenance]]) andThen
-      (CliConverters.from(_: entities.Dataset[entities.Dataset.Provenance]))
+    CliConverters.from(_)
 
   implicit def functions[P <: Provenance]: EntityFunctions[Dataset[P]] =
     EntityFunctions[entities.Dataset[entities.Dataset.Provenance]]

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/DatasetPart.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/DatasetPart.scala
@@ -60,7 +60,7 @@ object DatasetPart {
   }
 
   implicit def toCliDatasetFile(implicit renkuUrl: RenkuUrl): DatasetPart => CliDatasetFile =
-    ((_: DatasetPart).to[entities.DatasetPart]) andThen (CliConverters.from(_: entities.DatasetPart))
+    CliConverters.from(_)
 
   implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[DatasetPart] =
     JsonLDEncoder.instance(_.to[entities.DatasetPart].asJsonLD)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Entity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Entity.scala
@@ -47,8 +47,8 @@ object Entity {
     case e: OutputEntity => toOutputEntity(renkuUrl)(e)
   }
 
-  implicit def toCliEntity(implicit renkuUrl: RenkuUrl): Entity => CliEntity = e =>
-    CliConverters.from(e.to[entities.Entity])
+  implicit def toCliEntity(implicit renkuUrl: RenkuUrl): Entity => CliEntity =
+    CliConverters.from(_)
 
   implicit def toInputEntity(implicit renkuUrl: RenkuUrl): InputEntity => entities.Entity.InputEntity =
     entity =>

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Generation.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Generation.scala
@@ -21,7 +21,9 @@ package io.renku.graph.model.testentities
 import Entity.OutputEntity
 import Generation.Id
 import cats.syntax.all._
+import io.renku.cli.model.CliGeneration
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.{activities, entities, generations}
 import io.renku.tinytypes.constraints.UUID
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
@@ -48,6 +50,9 @@ object Generation {
         activities.ResourceId(generation.activity.asEntityId.show),
         generation.entity.to[entities.Entity.OutputEntity]
       )
+
+  implicit def toCliGeneration(implicit renkuUrl: RenkuUrl): Generation => CliGeneration =
+    CliConverters.from(_)
 
   def factory(entityFactory: Generation => OutputEntity): Activity => Generation =
     activity => Generation(Id.generate, activity, entityFactory)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/NonRenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/NonRenkuProject.scala
@@ -18,7 +18,9 @@
 
 package io.renku.graph.model.testentities
 
+import io.renku.cli.model.CliProject
 import io.renku.graph.model._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.{DateCreated, Description, ForksCount, Keyword, Name, Path, Visibility}
 import io.renku.jsonld.JsonLDEncoder
@@ -111,6 +113,9 @@ object NonRenkuProject {
         projects.ResourceId(project.parent.asEntityId),
         convertImageUris(project.asEntityId)(project.images)
       )
+
+  implicit def toCliNonRenkuProject(implicit renkuUrl: RenkuUrl): NonRenkuProject => CliProject =
+    CliConverters.from(_)
 
   implicit def encoder[P <: NonRenkuProject](implicit
       renkuUrl:     RenkuUrl,

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterLink.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterLink.scala
@@ -20,6 +20,8 @@ package io.renku.graph.model.testentities
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import io.renku.cli.model.CliParameterLink
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.{RenkuUrl, commandParameters, entities, parameterLinks}
 import io.renku.graph.model.testentities.StepPlanCommandParameter.{CommandInput, CommandOutput, CommandParameter}
 import io.renku.jsonld.{EntityIdEncoder, JsonLDEncoder}
@@ -59,6 +61,9 @@ object ParameterLink {
       source = commandParameters.ResourceId(p.source.asEntityId.show),
       sinks = p.sinks.map(s => commandParameters.ResourceId(s.asEntityId.show))
     )
+
+  implicit def toCliParameterLink(implicit renkuUrl: RenkuUrl): ParameterLink => CliParameterLink =
+    CliConverters.from(_)
 
   implicit def jsonLDEncoder: JsonLDEncoder[ParameterLink] =
     JsonLDEncoder.instance(toEntitiesParameterLink(_).asJsonLD)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterMapping.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterMapping.scala
@@ -20,7 +20,9 @@ package io.renku.graph.model.testentities
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import io.renku.cli.model.CliParameterMapping
 import io.renku.graph.model._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.commandParameters.{Description, Name}
 import io.renku.jsonld.syntax._
 import io.renku.jsonld.{EntityIdEncoder, JsonLDEncoder}
@@ -56,6 +58,9 @@ object ParameterMapping {
       name = m.name,
       mappedParameter = m.mappedParam.map(c => commandParameters.ResourceId(c.asEntityId.show))
     )
+
+  implicit def toCliParameterMapping(implicit renkuUrl: RenkuUrl): ParameterMapping => CliParameterMapping =
+    CliConverters.from(_)
 
   implicit def jsonLDEncoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[ParameterMapping] =
     JsonLDEncoder.instance(toEntitiesParameterMapping(_).asJsonLD)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterValue.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ParameterValue.scala
@@ -19,8 +19,10 @@
 package io.renku.graph.model.testentities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliParameterValue
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.noDashUuid
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.entityModel.LocationLike
 import io.renku.graph.model.parameterValues.ValueOverride
 import io.renku.graph.model.testentities.StepPlanCommandParameter._
@@ -67,6 +69,9 @@ object ParameterValue {
                                                 p.valueReference.to[entities.StepPlanCommandParameter.CommandInput]
       )
   }
+
+  implicit def toCliParameterValue(implicit renkuUrl: RenkuUrl): ParameterValue => CliParameterValue =
+    CliConverters.from(_)
 
   object LocationParameterValue {
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Person.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Person.scala
@@ -67,8 +67,7 @@ object Person {
       )
   }
 
-  implicit def toCliPerson(implicit renkuUrl: RenkuUrl): Person => CliPerson = p =>
-    CliConverters.from(p.to[entities.Person])
+  implicit def toCliPerson(implicit renkuUrl: RenkuUrl): Person => CliPerson = CliConverters.from(_)
 
   implicit def toMaybeEntitiesPersonWithGitLabId(implicit
       renkuUrl: RenkuUrl

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
@@ -20,9 +20,11 @@ package io.renku.graph.model.testentities
 
 import cats.data.{Validated, ValidatedNel}
 import cats.syntax.all._
+import io.renku.cli.model.CliPlan
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestampsNotInTheFuture
 import io.renku.graph.model._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.commandParameters.Position
 import io.renku.graph.model.plans._
 
@@ -103,6 +105,9 @@ object Plan {
     case p: CompositePlan.NonModified => p.to[entities.Plan](CompositePlan.NonModified.toEntitiesCompositePlan)
     case p: CompositePlan.Modified    => p.to[entities.Plan](CompositePlan.Modified.toEntitiesCompositePlan)
   }
+
+  implicit def toCliPlan[P <: Plan](implicit renkuUrl: RenkuUrl): P => CliPlan =
+    CliConverters.from(_)
 
   implicit def encoder[P <: Plan](implicit
       renkuUrl:     RenkuUrl,

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Project.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Project.scala
@@ -19,6 +19,8 @@
 package io.renku.graph.model
 package testentities
 
+import io.renku.cli.model.CliProject
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.entities.EntityFunctions
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.{DateCreated, Description, ForksCount, Keyword, Name, Path, Visibility}
@@ -72,6 +74,9 @@ object Project {
       toEntitiesNonRenkuProjectWithParent(renkuUrl),
       toEntitiesNonRenkuProjectWithoutParent(renkuUrl)
     )
+
+  implicit def toCliProject(implicit renkuUrl: RenkuUrl): Project => CliProject =
+    CliConverters.from(_)
 
   implicit def toProjectIdentification(implicit renkuUrl: RenkuUrl): Project => entities.ProjectIdentification =
     project => entities.ProjectIdentification(projects.ResourceId(project.asEntityId), project.path)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/PublicationEvent.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/PublicationEvent.scala
@@ -19,7 +19,9 @@
 package io.renku.graph.model.testentities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliPublicationEvent
 import io.renku.graph.model._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.publicationEvents._
 import io.renku.graph.model.testentities.Dataset.Provenance
 
@@ -45,6 +47,9 @@ object PublicationEvent {
       publicationEvent.name,
       publicationEvent.startDate
     )
+
+  implicit def toCliPublicationEvent(implicit renkuUrl: RenkuUrl): PublicationEvent => CliPublicationEvent =
+    CliConverters.from(_)
 
   implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[PublicationEvent] =
     JsonLDEncoder.instance(_.to[entities.PublicationEvent].asJsonLD)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
@@ -20,9 +20,11 @@ package io.renku.graph.model.testentities
 
 import cats.data.ValidatedNel
 import cats.syntax.all._
+import io.renku.cli.model.CliProject
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model
 import io.renku.graph.model._
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects._
 import io.renku.graph.model.testentities.RenkuProject.CreateCompositePlan
@@ -236,6 +238,9 @@ object RenkuProject {
     case p: RenkuProject.WithoutParent => toEntitiesRenkuProjectWithoutParent(renkuUrl)(p)
     case p: RenkuProject.WithParent    => toEntitiesRenkuProjectWithParent(renkuUrl)(p)
   }
+
+  implicit def toCliRenkuProject(implicit renkuUrl: RenkuUrl): RenkuProject => CliProject =
+    CliConverters.from(_)
 
   implicit def toEntitiesRenkuProjectWithoutParent(implicit
       renkuUrl: RenkuUrl

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlan.scala
@@ -24,6 +24,8 @@ import cats.data.{Validated, ValidatedNel}
 import cats.syntax.all._
 import commandParameters.Position
 import entityModel.Location
+import io.renku.cli.model.CliStepPlan
+import io.renku.graph.model.cli.CliConverters
 import plans.{Command, DateCreated, DerivedFrom, Description, Identifier, Keyword, Name, ProgrammingLanguage, ResourceId, SuccessCode}
 
 trait StepPlan extends Plan {
@@ -89,6 +91,9 @@ object StepPlan {
         plan.outputs.map(_.to[entities.StepPlanCommandParameter.CommandOutput]),
         plan.successCodes
       )
+
+    implicit def toCliStepPlan(implicit renkuUrl: RenkuUrl): NonModified => CliStepPlan =
+      CliConverters.from(_)
   }
 
   trait NonModifiedAlg extends PlanAlg {
@@ -203,6 +208,9 @@ object StepPlan {
           maybeInvalidationTime
         )
       }
+
+    implicit def toCliStepPlan[P <: Modified](implicit renkuUrl: RenkuUrl): P => CliStepPlan =
+      CliConverters.from(_)
   }
 
   trait ModifiedAlg extends PlanAlg {
@@ -294,6 +302,9 @@ object StepPlan {
     case p: StepPlan.NonModified => StepPlan.NonModified.toEntitiesStepPlan(renkuUrl)(p)
     case p: StepPlan.Modified    => StepPlan.Modified.toEntitiesStepPlan(renkuUrl)(p)
   }
+
+  implicit def toCliStepPlan(implicit renkuUrl: RenkuUrl): StepPlan => CliStepPlan =
+    CliConverters.from(_)
 
   object CommandParameters {
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlanCommandParameter.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/StepPlanCommandParameter.scala
@@ -20,6 +20,8 @@ package io.renku.graph.model.testentities
 
 import cats.syntax.all._
 import eu.timepit.refined.auto._
+import io.renku.cli.model.{CliCommandInput, CliCommandOutput}
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.commandParameters.IOStream.{StdErr, StdIn, StdOut}
 import io.renku.graph.model.commandParameters._
 import io.renku.graph.model.entityModel.Location
@@ -209,6 +211,9 @@ object StepPlanCommandParameter {
         )
     }
 
+    implicit def toCliCommandInput(implicit renkuUrl: RenkuUrl): CommandInput => CliCommandInput =
+      CliConverters.from(_)
+
     implicit def commandInputEncoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[CommandInput] =
       JsonLDEncoder.instance(_.to[entities.StepPlanCommandParameter.CommandInput].asJsonLD)
 
@@ -333,6 +338,9 @@ object StepPlanCommandParameter {
           parameter.maybeEncodingFormat
         )
     }
+
+    implicit def toCliCommandOutput(implicit renkuUrl: RenkuUrl): CommandOutput => CliCommandOutput =
+      CliConverters.from(_)
 
     implicit def commandOutputEncoder[O <: CommandOutput](implicit renkuUrl: RenkuUrl): JsonLDEncoder[O] =
       JsonLDEncoder.instance(_.to[entities.StepPlanCommandParameter.CommandOutput].asJsonLD)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Usage.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Usage.scala
@@ -20,8 +20,10 @@ package io.renku.graph.model.testentities
 
 import Usage.Id
 import cats.syntax.all._
+import io.renku.cli.model.CliUsage
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.noDashUuid
+import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.{RenkuUrl, entities, usages}
 import io.renku.tinytypes.constraints.UUID
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
@@ -43,6 +45,9 @@ object Usage {
 
   implicit def toEntitiesUsage(implicit renkuUrl: RenkuUrl): Usage => entities.Usage = usage =>
     entities.Usage(usages.ResourceId(usage.asEntityId.show), usage.entity.to[entities.Entity])
+
+  implicit def toCliUsage(implicit renkuUrl: RenkuUrl): Usage => CliUsage =
+    CliConverters.from(_)
 
   implicit def encoder(implicit renkuUrl: RenkuUrl): JsonLDEncoder[Usage] =
     JsonLDEncoder.instance(_.to[entities.Usage].asJsonLD)


### PR DESCRIPTION
This PR adds conversions from our test entities to the cli model. This will be used in subsequent PRs to generate values that support testing the decoders - which always decode a cli generated payload. 

Issue: #1168 