### PR TITLE
feat: creator names only for the requested page of User's Projects

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
@@ -84,15 +84,15 @@ final class GitLabApiStub[F[_]: Async: Logger](private val stateRef: Ref[F, Stat
       HttpRoutes.of {
         case GET -> Root / UserGitLabId(id) =>
           query(findPersonById(id)).flatMap(OkOrNotFound(_))
-        case GET -> Root / UserGitLabId(id) / "projects" =>
+        case req @ GET -> Root / UserGitLabId(id) / "projects" =>
           maybeAuthedReq match {
             case Some(AuthedUser(userId, _)) =>
-              if (id == userId) query(projectsFor(id.some)).flatMap(Ok(_))
-              else Ok(List.empty[Project])
+              if (id == userId) query(projectsFor(id.some)).flatMap(OkWithTotalHeader(req))
+              else OkWithTotalHeader(req)(List.empty[Project])
             case Some(AuthedProject(projectId, _)) =>
-              query(findProjectById(projectId)).map(_.toList).flatMap(Ok(_))
+              query(findProjectById(projectId)).map(_.toList).flatMap(OkWithTotalHeader(req))
             case None =>
-              query(projectsFor(id.some)).flatMap(Ok(_))
+              query(projectsFor(id.some)).flatMap(OkWithTotalHeader(req))
           }
       }
     }

--- a/graph-commons/src/main/scala/io/renku/http/client/GitLabClient.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/GitLabClient.scala
@@ -31,7 +31,7 @@ import io.renku.graph.config.GitLabUrlLoader
 import io.renku.graph.model.GitLabApiUrl
 import io.renku.http.client.HttpRequest.NamedRequest
 import io.renku.http.client.RestClient.ResponseMappingF
-import io.renku.http.rest.paging.model.Page
+import io.renku.http.rest.paging.model.{Page, Total}
 import io.renku.metrics.{GitLabApiCallRecorder, MetricsRegistry}
 import org.http4s.Method.{DELETE, GET, HEAD, POST}
 import org.http4s.circe.{jsonEncoder, jsonEncoderOf}
@@ -152,4 +152,14 @@ object GitLabClient {
       .map(Page.from)
       .map(MonadThrow[F].fromEither(_))
       .sequence
+
+  def maybeTotalPages[F[_]: MonadThrow](response: Response[F]): F[Option[Total]] = {
+    val header = ci"X-Total-Pages"
+    response.headers
+      .get(header)
+      .flatMap(_.head.value.toIntOption)
+      .map(Total.from)
+      .map(MonadThrow[F].fromEither(_))
+      .sequence
+  }
 }

--- a/graph-commons/src/main/scala/io/renku/http/rest/paging/PagingResponse.scala
+++ b/graph-commons/src/main/scala/io/renku/http/rest/paging/PagingResponse.scala
@@ -27,6 +27,13 @@ import io.renku.tinytypes.constraints.UrlOps
 import org.http4s.Header
 
 final class PagingResponse[Result] private (val results: List[Result], val pagingInfo: PagingInfo) {
+
+  def flatMap[F[_]: MonadThrow](f: List[Result] => F[List[Result]]): F[PagingResponse[Result]] =
+    f(results) >>= {
+      case r if r.size == results.size => new PagingResponse[Result](r, pagingInfo).pure[F]
+      case _ => new Exception("Paging response mapping changed page size").raiseError[F, PagingResponse[Result]]
+    }
+
   override lazy val toString: String = s"PagingResponse(pagingInfo: $pagingInfo, results: $results)"
 }
 

--- a/graph-commons/src/main/scala/io/renku/http/rest/paging/PagingResponse.scala
+++ b/graph-commons/src/main/scala/io/renku/http/rest/paging/PagingResponse.scala
@@ -28,7 +28,7 @@ import org.http4s.Header
 
 final class PagingResponse[Result] private (val results: List[Result], val pagingInfo: PagingInfo) {
 
-  def flatMap[F[_]: MonadThrow](f: List[Result] => F[List[Result]]): F[PagingResponse[Result]] =
+  def flatMapResults[F[_]: MonadThrow](f: List[Result] => F[List[Result]]): F[PagingResponse[Result]] =
     f(results) >>= {
       case r if r.size == results.size => new PagingResponse[Result](r, pagingInfo).pure[F]
       case _ => new Exception("Paging response mapping changed page size").raiseError[F, PagingResponse[Result]]

--- a/graph-commons/src/test/scala/io/renku/http/client/GitLabClientSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/client/GitLabClientSpec.scala
@@ -272,7 +272,7 @@ class GitLabClientSpec
     }
   }
 
-  "maybeTotal" should {
+  "maybeTotalPages" should {
 
     "return the value from the 'X-Total-Pages' response header" in {
 

--- a/graph-commons/src/test/scala/io/renku/http/rest/paging/PagingResponseSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/rest/paging/PagingResponseSpec.scala
@@ -201,13 +201,13 @@ class PagingResponseSpec
     }
   }
 
-  "flatMap" should {
+  "flatMapResults" should {
 
     "execute the given function on the results" in {
 
       val response = PagingResponse.from[Try, Int](1 :: 2 :: Nil, PagingRequest.default)
 
-      val result = response.success.value.flatMap(_.map(_ + 1).pure[Try])
+      val result = response.success.value.flatMapResults(_.map(_ + 1).pure[Try])
 
       result.success.value.results    shouldBe 2 :: 3 :: Nil
       result.success.value.pagingInfo shouldBe response.success.value.pagingInfo
@@ -217,7 +217,7 @@ class PagingResponseSpec
 
       val response = PagingResponse.from[Try, Int](1 :: 2 :: Nil, PagingRequest.default)
 
-      val result = response.success.value.flatMap(_ => List(1).pure[Try])
+      val result = response.success.value.flatMapResults(_ => List(1).pure[Try])
 
       result.failure.exception.getMessage shouldBe "Paging response mapping changed page size"
     }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/Endpoint.scala
@@ -19,6 +19,7 @@
 package io.renku.knowledgegraph.users.projects
 
 import Endpoint._
+import cats.Parallel
 import cats.effect.Async
 import cats.syntax.all._
 import finder._
@@ -91,7 +92,7 @@ object Endpoint {
       }
   }
 
-  def apply[F[_]: Async: GitLabClient: Logger: SparqlQueryTimeRecorder]: F[Endpoint[F]] = for {
+  def apply[F[_]: Async: Parallel: GitLabClient: Logger: SparqlQueryTimeRecorder]: F[Endpoint[F]] = for {
     projectsFinder <- ProjectsFinder[F]
     renkuUrl       <- RenkuUrlLoader()
     renkuApiUrl    <- renku.ApiUrl()

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/EndpointDocs.scala
@@ -106,6 +106,7 @@ private class EndpointDocsImpl()(implicit renkuUrl: RenkuUrl, renkuApiUrl: renku
         projects.Path("group/subgroup/name"),
         projects.Visibility.Public,
         projects.DateCreated(Instant.parse("2012-11-15T10:00:00.000Z")),
+        persons.GitLabId(1).some,
         persons.Name("Jan Kowalski").some,
         List(projects.Keyword("key")),
         projects.Description("Some project").some

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/GLCreatorsNamesAdder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/GLCreatorsNamesAdder.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.knowledgegraph.users.projects.finder
+
+import cats.MonadThrow
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.model.persons
+import io.renku.http.client.GitLabClient
+import io.renku.knowledgegraph.users.projects.Endpoint.Criteria
+import io.renku.knowledgegraph.users.projects.model.Project
+import org.typelevel.log4cats.Logger
+
+private trait GLCreatorsNamesAdder[F[_]] {
+  def addCreatorsNames(criteria: Criteria)(projects: List[Project]): F[List[Project]]
+}
+
+private object GLCreatorsNamesAdder {
+  def apply[F[_]: Async: GitLabClient: Logger]: F[GLCreatorsNamesAdder[F]] =
+    GLCreatorFinder[F].map(new GLCreatorsNamesAdderImpl[F](_))
+}
+
+private class GLCreatorsNamesAdderImpl[F[_]: MonadThrow](creatorFinder: GLCreatorFinder[F])
+    extends GLCreatorsNamesAdder[F] {
+
+  override def addCreatorsNames(criteria: Criteria)(projects: List[Project]): F[List[Project]] =
+    findDistinctCreatorIds(projects)
+      .map(fetchCreatorName(criteria))
+      .sequence
+      .map(updateProjects(projects))
+
+  private val findDistinctCreatorIds: List[Project] => List[persons.GitLabId] =
+    _.flatMap {
+      case _: Project.Activated    => None
+      case p: Project.NotActivated => p.maybeCreatorId
+    }.distinct
+
+  private type CreatorInfo = (persons.GitLabId, Option[persons.Name])
+
+  private def fetchCreatorName(criteria: Criteria)(id: persons.GitLabId): F[CreatorInfo] =
+    creatorFinder.findCreatorName(id)(criteria.maybeUser.map(_.accessToken)).map(id -> _)
+
+  private def updateProjects(projects: List[Project]): List[CreatorInfo] => List[Project] = creators =>
+    projects.map {
+      case proj @ Project.NotActivated(_, _, _, _, _, Some(creatorId), _, _, _) =>
+        creators
+          .find(_._1 == creatorId)
+          .map { case (_, maybeName) => proj.copy(maybeCreator = maybeName) }
+          .getOrElse(proj)
+      case proj => proj
+    }
+}

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinder.scala
@@ -24,7 +24,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.GitLabClient
-import io.renku.http.rest.paging.model.{Page, PerPage}
+import io.renku.http.rest.paging.model.Page
 import io.renku.knowledgegraph.users.projects.model.Project
 import org.typelevel.log4cats.Logger
 
@@ -36,7 +36,7 @@ private object GLProjectFinder {
   def apply[F[_]: Async: GitLabClient: Logger]: F[GLProjectFinder[F]] =
     new GLProjectFinderImpl[F].pure[F].widen
 
-  val requestPageSize: PerPage = PerPage(100)
+  val requestPageSize: Int = 2000
 }
 
 private class GLProjectFinderImpl[F[_]: Async: GitLabClient: Logger] extends GLProjectFinder[F] {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinder.scala
@@ -67,7 +67,6 @@ private class GLProjectFinderImpl[F[_]: Async: Parallel: GitLabClient: Logger] e
       .map(p => findProjects(criteria, Page(p)).map(_._1))
       .parSequence
       .map(_.reduce(_ ::: _))
-      .flatTap(results => println(s"TS ${results.size}").pure[F])
 
   private def findProjects(criteria: Criteria,
                            page:     Page = Page.first

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinder.scala
@@ -21,7 +21,7 @@ package finder
 
 import Endpoint.Criteria.Filters._
 import Endpoint._
-import cats.MonadThrow
+import cats.{MonadThrow, Parallel}
 import cats.effect.Async
 import cats.syntax.all._
 import io.renku.graph.model.projects
@@ -36,7 +36,7 @@ private[projects] trait ProjectsFinder[F[_]] {
 }
 
 private[projects] object ProjectsFinder {
-  def apply[F[_]: Async: GitLabClient: Logger: SparqlQueryTimeRecorder]: F[ProjectsFinder[F]] =
+  def apply[F[_]: Async: Parallel: GitLabClient: Logger: SparqlQueryTimeRecorder]: F[ProjectsFinder[F]] =
     (TSProjectFinder[F], GLProjectFinder[F], GLCreatorsNamesAdder[F]).mapN(new ProjectsFinderImpl(_, _, _))
 
   implicit val nameOrdering: Ordering[projects.Name] = Ordering.by(_.value.toLowerCase)

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinder.scala
@@ -58,7 +58,7 @@ private class ProjectsFinderImpl[F[_]: MonadThrow](
       .map(filterBy(criteria.filters.state))
       .map(_.sortBy(_.name))
       .flatMap(PagingResponse.from[F, model.Project](_, criteria.paging))
-      .flatMap(_.flatMap(addCreatorsNames(criteria)))
+      .flatMap(_.flatMapResults(addCreatorsNames(criteria)))
 
   private def queryProjects(criteria: Criteria): F[List[Project]] =
     criteria.filters.state match {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/model.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/model.scala
@@ -73,14 +73,15 @@ private object model {
     }
 
     final case class NotActivated(
-        id:           projects.GitLabId,
-        name:         projects.Name,
-        path:         projects.Path,
-        visibility:   projects.Visibility,
-        dateCreated:  projects.DateCreated,
-        maybeCreator: Option[persons.Name],
-        keywords:     List[projects.Keyword],
-        maybeDesc:    Option[projects.Description]
+        id:             projects.GitLabId,
+        name:           projects.Name,
+        path:           projects.Path,
+        visibility:     projects.Visibility,
+        dateCreated:    projects.DateCreated,
+        maybeCreatorId: Option[persons.GitLabId],
+        maybeCreator:   Option[persons.Name],
+        keywords:       List[projects.Keyword],
+        maybeDesc:      Option[projects.Description]
     ) extends Project
 
     object NotActivated {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/EndpointSpec.scala
@@ -61,7 +61,7 @@ class EndpointSpec extends AnyWordSpec with should.Matchers with IOSpec with Moc
         response.status        shouldBe Ok
         response.contentType   shouldBe Some(`Content-Type`(application.json))
         response.headers.headers should contain allElementsOf PagingHeaders.from[ResourceUrl](results)
-        response.as[List[model.Project]].unsafeRunSync() shouldBe results.results.map(sortKeywords)
+        response.as[List[model.Project]].unsafeRunSync() shouldBe results.results.map(sortKeywords).map(removeCreatorId)
       }
     }
 
@@ -158,7 +158,16 @@ class EndpointSpec extends AnyWordSpec with should.Matchers with IOSpec with Moc
                                     DecodingFailure(s"$link not equal $expected", Nil)
                    )
                  }
-        } yield model.Project.NotActivated(id, name, path, visibility, date, maybeCreator, keywords, maybeDesc)
+        } yield model.Project.NotActivated(id,
+                                           name,
+                                           path,
+                                           visibility,
+                                           date,
+                                           maybeCreatorId = None,
+                                           maybeCreator,
+                                           keywords,
+                                           maybeDesc
+        )
       case _ => fail("Neither 'details' nor 'activation' link in the response")
     }
   }
@@ -166,5 +175,10 @@ class EndpointSpec extends AnyWordSpec with should.Matchers with IOSpec with Moc
   private lazy val sortKeywords: model.Project => model.Project = {
     case p: model.Project.Activated    => p.copy(keywords = p.keywords.sorted)
     case p: model.Project.NotActivated => p.copy(keywords = p.keywords.sorted)
+  }
+
+  private lazy val removeCreatorId: model.Project => model.Project = {
+    case p: model.Project.Activated    => p.copy(keywords = p.keywords.sorted)
+    case p: model.Project.NotActivated => p.copy(maybeCreatorId = None)
   }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/GLCreatorsNamesAdderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/GLCreatorsNamesAdderSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.knowledgegraph.users.projects
+package finder
+
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.exceptions
+import io.renku.graph.model.RenkuTinyTypeGenerators._
+import io.renku.graph.model.persons
+import io.renku.http.client.AccessToken
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.TryValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
+
+class GLCreatorsNamesAdderSpec extends AnyWordSpec with should.Matchers with MockFactory with TryValues {
+
+  "find names of all the distinct creators found among the non activated projects " +
+    "and add them to the projects" in new TestCase {
+
+      val commonCreatorId        = personGitLabIds.generateOne
+      val nonActivated1          = notActivatedProjects.generateOne.copy(maybeCreatorId = commonCreatorId.some)
+      val nonActivated2          = notActivatedProjects.generateOne.copy(maybeCreatorId = commonCreatorId.some)
+      val nonActivated3          = notActivatedProjects.generateOne.copy(maybeCreatorId = None, maybeCreator = None)
+      val nonActivated4CreatorId = personGitLabIds.generateOne
+      val nonActivated4          = notActivatedProjects.generateOne.copy(maybeCreatorId = nonActivated4CreatorId.some)
+      val activated              = activatedProjects.generateOne
+
+      val commonCreatorName = personNames.generateSome
+      givenCreatorFinding(commonCreatorId, returning = commonCreatorName.pure[Try])
+      val nonActivated4CreatorName = personNames.generateSome
+      givenCreatorFinding(nonActivated4CreatorId, returning = nonActivated4CreatorName.pure[Try])
+
+      adder
+        .addCreatorsNames(criteria)(
+          nonActivated1 :: nonActivated2 :: nonActivated3 :: nonActivated4 :: activated :: Nil
+        )
+        .success
+        .value shouldBe nonActivated1.copy(maybeCreator = commonCreatorName) ::
+        nonActivated2.copy(maybeCreator = commonCreatorName) ::
+        nonActivated3 ::
+        nonActivated4.copy(maybeCreator = nonActivated4CreatorName) ::
+        activated :: Nil
+    }
+
+  "fail if finding names fails" in new TestCase {
+
+    val creatorId = personGitLabIds.generateOne
+    val project   = notActivatedProjects.generateOne.copy(maybeCreatorId = creatorId.some)
+
+    val exception = exceptions.generateOne
+    givenCreatorFinding(creatorId, returning = exception.raiseError[Try, Option[persons.Name]])
+
+    adder
+      .addCreatorsNames(criteria)(project :: Nil)
+      .failure
+      .exception shouldBe exception
+  }
+
+  private trait TestCase {
+
+    val criteria = criterias.generateOne
+
+    private val glCreatorFinder = mock[GLCreatorFinder[Try]]
+    val adder                   = new GLCreatorsNamesAdderImpl[Try](glCreatorFinder)
+
+    def givenCreatorFinding(creatorId: persons.GitLabId, returning: Try[Option[persons.Name]]) =
+      (glCreatorFinder
+        .findCreatorName(_: persons.GitLabId)(_: Option[AccessToken]))
+        .expects(creatorId, criteria.maybeUser.map(_.accessToken))
+        .returning(returning)
+  }
+}

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/GLProjectFinderSpec.scala
@@ -30,8 +30,8 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import io.renku.generators.CommonGraphGenerators.pages
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.GraphModelGenerators.{personGitLabIds, personNames}
-import io.renku.graph.model.{persons, projects}
+import io.renku.graph.model.GraphModelGenerators.personGitLabIds
+import io.renku.graph.model.projects
 import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.rest.paging.model.Page
@@ -53,8 +53,7 @@ class GLProjectFinderSpec
     with MockFactory
     with GitLabClientTools[IO] {
 
-  private type ResultItem   = (model.Project.NotActivated, Option[persons.GitLabId])
-  private type ResultsChunk = (List[ResultItem], Option[Page])
+  private type ResultsChunk = (List[model.Project.NotActivated], Option[Page])
 
   "findProjectsInGL" should {
 
@@ -62,42 +61,31 @@ class GLProjectFinderSpec
 
       val criteria = criterias.generateOne
 
-      val projectsAndCreators = notActivatedProjects
+      val projects = notActivatedProjects
         .generateNonEmptyList(max = pageSize)
         .toList
-        .map(p => p -> p.maybeCreator.map(_ => personGitLabIds.generateOne))
 
       (gitLabClient
         .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, ResultsChunk])(_: Option[AccessToken]))
         .expects(uri(criteria, Page.first), endpointName, *, criteria.maybeUser.map(_.accessToken))
-        .returning((projectsAndCreators -> Option.empty[Page]).pure[IO])
+        .returning((projects -> Option.empty[Page]).pure[IO])
 
-      projectsAndCreators.foreach {
-        case (project, Some(creatorId)) =>
-          (glCreatorFinder
-            .findCreatorName(_: persons.GitLabId)(_: Option[AccessToken]))
-            .expects(creatorId, criteria.maybeUser.map(_.accessToken))
-            .returning(project.maybeCreator.pure[IO])
-        case (_, None) => ()
-      }
-
-      finder.findProjectsInGL(criteria).unsafeRunSync() shouldBe projectsAndCreators.map(_._1)
+      finder.findProjectsInGL(criteria).unsafeRunSync() shouldBe projects
     }
 
     "read the data from all pages" in new TestCase {
 
       val criteria = criterias.generateOne
 
-      val projectsAndCreators = notActivatedProjects
+      val projects = notActivatedProjects
         .generateNonEmptyList(min = pageSize + 1, max = pageSize * 3)
         .toList
-        .map(p => p -> p.maybeCreator.map(_ => personGitLabIds.generateOne))
 
-      def maybeNextPage(resultsPage: List[ResultItem], currentPage: Page): Option[Page] =
-        if (resultsPage.last._1.id == projectsAndCreators.last._1.id) Option.empty[Page]
+      def maybeNextPage(resultsPage: List[model.Project.NotActivated], currentPage: Page): Option[Page] =
+        if (resultsPage.last.id == projects.last.id) Option.empty[Page]
         else Page(currentPage.value + 1).some
 
-      projectsAndCreators.sliding(pageSize, pageSize).zipWithIndex foreach { case (resultsPage, idx) =>
+      projects.sliding(pageSize, pageSize).zipWithIndex foreach { case (resultsPage, idx) =>
         val currentPage = Page(idx + 1)
         (gitLabClient
           .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, ResultsChunk])(_: Option[AccessToken]))
@@ -105,66 +93,19 @@ class GLProjectFinderSpec
           .returning((resultsPage -> maybeNextPage(resultsPage, currentPage)).pure[IO])
       }
 
-      projectsAndCreators foreach {
-        case (project, Some(creatorId)) =>
-          (glCreatorFinder
-            .findCreatorName(_: persons.GitLabId)(_: Option[AccessToken]))
-            .expects(creatorId, criteria.maybeUser.map(_.accessToken))
-            .returning(project.maybeCreator.pure[IO])
-        case (_, None) => ()
-      }
-
-      finder.findProjectsInGL(criteria).unsafeRunSync() shouldBe projectsAndCreators.map(_._1)
-    }
-
-    "reach to GL once for the same creator id" in new TestCase {
-
-      val criteria = criterias.generateOne
-
-      val projectsAndCreators = {
-        val commonCreatorName = personNames.generateOne
-        val commonCreatorId   = personGitLabIds.generateOne
-        List(
-          notActivatedProjects.map(p => p.copy(maybeCreator = commonCreatorName.some) -> commonCreatorId.some),
-          notActivatedProjects.map(p => p.copy(maybeCreator = commonCreatorName.some) -> commonCreatorId.some),
-          notActivatedProjects.map(p => p -> p.maybeCreator.map(_ => personGitLabIds.generateOne))
-        ).map(_.generateOne)
-      }
-
-      (gitLabClient
-        .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, ResultsChunk])(_: Option[AccessToken]))
-        .expects(uri(criteria, Page.first), endpointName, *, criteria.maybeUser.map(_.accessToken))
-        .returning((projectsAndCreators -> Option.empty[Page]).pure[IO])
-
-      val distinctCreators = projectsAndCreators.flatMap { case (proj, maybeCreatorId) =>
-        (proj.maybeCreator -> maybeCreatorId).mapN(_ -> _)
-      }.distinct
-
-      distinctCreators.size should be <= 2
-
-      distinctCreators foreach { case (creatorName, creatorId) =>
-        (glCreatorFinder
-          .findCreatorName(_: persons.GitLabId)(_: Option[AccessToken]))
-          .expects(creatorId, criteria.maybeUser.map(_.accessToken))
-          .returning(creatorName.some.pure[IO])
-      }
-
-      finder.findProjectsInGL(criteria).unsafeRunSync() shouldBe projectsAndCreators.map(_._1)
+      finder.findProjectsInGL(criteria).unsafeRunSync() shouldBe projects
     }
 
     "map OK response from GitLab to list of NotActivated" in new TestCase {
 
-      val project        = notActivatedProjects.generateOne.copy(visibility = projects.Visibility.Public)
-      val maybeCreatorId = project.maybeCreator.map(_ => personGitLabIds.generateOne)
-      val maybeNextPage  = pages.generateOption
+      val project       = notActivatedProjects.generateOne.copy(visibility = projects.Visibility.Public)
+      val maybeNextPage = pages.generateOption
 
       val response = Response[IO](Status.Ok)
-        .withEntity(List(project -> maybeCreatorId).asJson)
+        .withEntity(List(project).asJson)
         .withHeaders(maybeNextPage.map(p => Header.Raw(ci"X-Next-Page", p.show)).toSeq)
 
-      val expected = List(
-        project.copy(maybeCreator = None, keywords = project.keywords.sorted) -> maybeCreatorId
-      ) -> maybeNextPage
+      val expected = List(project.copy(maybeCreator = None, keywords = project.keywords.sorted)) -> maybeNextPage
 
       mapResponse(Status.Ok, Request[IO](), response).unsafeRunSync() shouldBe expected
     }
@@ -191,20 +132,10 @@ class GLProjectFinderSpec
     val pageSize = GLProjectFinder.requestPageSize.value
     implicit val logger:       TestLogger[IO]   = TestLogger[IO]()
     implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
-    val glCreatorFinder = mock[GLCreatorFinder[IO]]
-    val finder          = new GLProjectFinderImpl[IO](glCreatorFinder)
+    val finder = new GLProjectFinderImpl[IO]
 
     lazy val mapResponse = captureMapping(gitLabClient)(
-      {
-        (glCreatorFinder
-          .findCreatorName(_: persons.GitLabId)(_: Option[AccessToken]))
-          .expects(*, *)
-          .returning(Option.empty[persons.Name].pure[IO])
-          .anyNumberOfTimes()
-
-        val criteria = criterias.generateOne
-        finder.findProjectsInGL(criteria).unsafeRunSync()
-      },
+      finder.findProjectsInGL(criterias.generateOne).unsafeRunSync(),
       (notActivatedProjects
          .map(p => p.maybeCreator.map(_ => p -> personGitLabIds.generateOption).getOrElse(p -> None))
          .toGeneratorOfList(),
@@ -218,7 +149,7 @@ class GLProjectFinderSpec
       .withQueryParam("page", page)
       .withQueryParam("per_page", GLProjectFinder.requestPageSize)
 
-  private implicit lazy val projectEncoder: Encoder[ResultItem] = Encoder.instance { case (project, maybeCreatorId) =>
+  private implicit lazy val projectEncoder: Encoder[model.Project.NotActivated] = Encoder.instance { project =>
     json"""{
         "id":                  ${project.id},
         "description":         ${project.maybeDesc.map(_.asJson).getOrElse(Json.Null)},
@@ -226,7 +157,7 @@ class GLProjectFinderSpec
         "name":                ${project.name},
         "path_with_namespace": ${project.path},
         "created_at":          ${project.dateCreated},
-        "creator_id":          ${maybeCreatorId.map(_.asJson).getOrElse(Json.Null)}
+        "creator_id":          ${project.maybeCreatorId.map(_.asJson).getOrElse(Json.Null)}
       }"""
       .addIfDefined("visibility" -> Option.when(project.visibility != projects.Visibility.Public)(project.visibility))
   }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/ProjectsFinderSpec.scala
@@ -23,20 +23,19 @@ import Endpoint.Criteria
 import Endpoint.Criteria.Filters
 import Endpoint.Criteria.Filters._
 import ProjectsFinder.nameOrdering
+import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
 import io.renku.graph.model.projects
 import io.renku.http.rest.paging.model._
 import io.renku.http.rest.paging.{PagingRequest, PagingResponse}
+import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.TryValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFactory with TryValues {
+class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFactory with IOSpec {
 
   "findProjects" should {
 
@@ -46,19 +45,19 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val commonProject = notActivatedProjects.generateOne
 
       val tsProjects = commonProject.toActivated :: activatedProjects.generateList(max = 4)
-      givenTSFinding(criteria, returning = tsProjects.pure[Try])
+      givenTSFinding(criteria, returning = tsProjects.pure[IO])
 
       val glProjects = notActivatedProjects.generateList(max = 4)
-      givenGLFinding(criteria, returning = (commonProject :: glProjects).pure[Try])
+      givenGLFinding(criteria, returning = (commonProject :: glProjects).pure[IO])
 
       val allSortedProjects = (tsProjects ::: glProjects).sortBy(_.name)
       val expectedProjects  = modelProjects.generateFixedSizeList(allSortedProjects.size)
-      givenGLCreatorsNamesAdding(criteria, allSortedProjects, returning = expectedProjects.pure[Try])
+      givenGLCreatorsNamesAdding(criteria, allSortedProjects, returning = expectedProjects.pure[IO])
 
-      val actualResults = finder.findProjects(criteria)
+      val actualResults = finder.findProjects(criteria).unsafeRunSync()
 
-      actualResults.success.value.results          shouldBe expectedProjects
-      actualResults.success.value.pagingInfo.total shouldBe Total(expectedProjects.size)
+      actualResults.results          shouldBe expectedProjects
+      actualResults.pagingInfo.total shouldBe Total(expectedProjects.size)
     }
 
     "return not activated projects only if ActivationState is set to 'NotActivated'" in new TestCase {
@@ -67,19 +66,19 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val commonProject = notActivatedProjects.generateOne
 
       val tsProjects = commonProject.toActivated :: activatedProjects.generateList(max = 4)
-      givenTSFinding(criteria, returning = tsProjects.pure[Try])
+      givenTSFinding(criteria, returning = tsProjects.pure[IO])
 
       val glProjects = notActivatedProjects.generateNonEmptyList(max = 4).toList
-      givenGLFinding(criteria, returning = (commonProject :: glProjects).pure[Try])
+      givenGLFinding(criteria, returning = (commonProject :: glProjects).pure[IO])
 
       val allSortedProjects = glProjects.sortBy(_.name)
       val expectedProjects  = modelProjects.generateFixedSizeList(allSortedProjects.size)
-      givenGLCreatorsNamesAdding(criteria, allSortedProjects, returning = expectedProjects.pure[Try])
+      givenGLCreatorsNamesAdding(criteria, allSortedProjects, returning = expectedProjects.pure[IO])
 
-      val actualResults = finder.findProjects(criteria)
+      val actualResults = finder.findProjects(criteria).unsafeRunSync()
 
-      actualResults.success.value.results          shouldBe expectedProjects
-      actualResults.success.value.pagingInfo.total shouldBe Total(expectedProjects.size)
+      actualResults.results          shouldBe expectedProjects
+      actualResults.pagingInfo.total shouldBe Total(expectedProjects.size)
     }
 
     "return activated projects only if ActivationState is set to 'Activated'" in new TestCase {
@@ -88,16 +87,16 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val commonProject = notActivatedProjects.generateOne
 
       val tsProjects = commonProject.toActivated :: activatedProjects.generateList(max = 4)
-      givenTSFinding(criteria, returning = tsProjects.pure[Try])
+      givenTSFinding(criteria, returning = tsProjects.pure[IO])
 
       val allSortedProjects = tsProjects.sortBy(_.name)
       val expectedProjects  = modelProjects.generateFixedSizeList(allSortedProjects.size)
-      givenGLCreatorsNamesAdding(criteria, allSortedProjects, returning = expectedProjects.pure[Try])
+      givenGLCreatorsNamesAdding(criteria, allSortedProjects, returning = expectedProjects.pure[IO])
 
-      val actualResults = finder.findProjects(criteria)
+      val actualResults = finder.findProjects(criteria).unsafeRunSync()
 
-      actualResults.success.value.results          shouldBe expectedProjects
-      actualResults.success.value.pagingInfo.total shouldBe Total(expectedProjects.size)
+      actualResults.results          shouldBe expectedProjects
+      actualResults.pagingInfo.total shouldBe Total(expectedProjects.size)
     }
 
     "add person names only to the requested page" in new TestCase {
@@ -110,21 +109,20 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       )
 
       val tsProjects = projects.collect { case p: model.Project.Activated => p }
-      givenTSFinding(criteria, returning = tsProjects.pure[Try])
+      givenTSFinding(criteria, returning = tsProjects.pure[IO])
 
       val glProjects = projects.collect { case p: model.Project.NotActivated => p }
-      givenGLFinding(criteria, returning = glProjects.pure[Try])
+      givenGLFinding(criteria, returning = glProjects.pure[IO])
 
       val allSortedProjects = (tsProjects ::: glProjects).sortBy(_.name)
-      val pageProjects =
-        PagingResponse.from[Try, model.Project](allSortedProjects, paging).fold(throw _, identity).results
+      val pageProjects      = PagingResponse.from[IO, model.Project](allSortedProjects, paging).unsafeRunSync().results
       val enrichedPageProjects = modelProjects.generateFixedSizeList(pageProjects.size)
-      givenGLCreatorsNamesAdding(criteria, pageProjects, returning = enrichedPageProjects.pure[Try])
+      givenGLCreatorsNamesAdding(criteria, pageProjects, returning = enrichedPageProjects.pure[IO])
 
-      val actualResults = finder.findProjects(criteria)
+      val actualResults = finder.findProjects(criteria).unsafeRunSync()
 
-      actualResults.success.value.results          shouldBe enrichedPageProjects
-      actualResults.success.value.pagingInfo.total shouldBe Total(allSortedProjects.size)
+      actualResults.results          shouldBe enrichedPageProjects
+      actualResults.pagingInfo.total shouldBe Total(allSortedProjects.size)
     }
 
     "fail if finding projects in TS fails" in new TestCase {
@@ -132,37 +130,41 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
       val criteria = criterias.generateOne.copy(filters = Filters(ActivationState.All))
 
       val exception = exceptions.generateOne
-      givenTSFinding(criteria, returning = exception.raiseError[Try, List[model.Project.Activated]])
+      givenTSFinding(criteria, returning = exception.raiseError[IO, List[model.Project.Activated]])
 
-      givenGLFinding(criteria, returning = List.empty.pure[Try])
+      givenGLFinding(criteria, returning = List.empty.pure[IO])
 
-      finder.findProjects(criteria) shouldBe exception.raiseError[Try, List[model.Project]]
+      intercept[Exception] {
+        finder.findProjects(criteria).unsafeRunSync()
+      } shouldBe exception
     }
 
     "fail if finding projects in GL fails" in new TestCase {
 
       val criteria = criterias.generateOne.copy(filters = Filters(ActivationState.All))
 
-      givenTSFinding(criteria, returning = List.empty.pure[Try])
+      givenTSFinding(criteria, returning = List.empty.pure[IO])
 
       val exception = exceptions.generateOne
-      givenGLFinding(criteria, returning = exception.raiseError[Try, List[model.Project.NotActivated]])
+      givenGLFinding(criteria, returning = exception.raiseError[IO, List[model.Project.NotActivated]])
 
-      finder.findProjects(criteria) shouldBe exception.raiseError[Try, List[model.Project]]
+      intercept[Exception] {
+        finder.findProjects(criteria).unsafeRunSync()
+      } shouldBe exception
     }
 
     "return an empty List if no projects found" in new TestCase {
 
       val criteria = criterias.generateOne.copy(filters = Filters(ActivationState.All))
 
-      givenTSFinding(criteria, returning = List.empty.pure[Try])
-      givenGLFinding(criteria, returning = List.empty.pure[Try])
-      givenGLCreatorsNamesAdding(criteria, List.empty, returning = List.empty.pure[Try])
+      givenTSFinding(criteria, returning = List.empty.pure[IO])
+      givenGLFinding(criteria, returning = List.empty.pure[IO])
+      givenGLCreatorsNamesAdding(criteria, List.empty, returning = List.empty.pure[IO])
 
-      val actualResults = finder.findProjects(criteria)
+      val actualResults = finder.findProjects(criteria).unsafeRunSync()
 
-      actualResults.success.value.results          shouldBe Nil
-      actualResults.success.value.pagingInfo.total shouldBe Total(0)
+      actualResults.results          shouldBe Nil
+      actualResults.pagingInfo.total shouldBe Total(0)
     }
   }
 
@@ -176,24 +178,24 @@ class ProjectsFinderSpec extends AnyWordSpec with should.Matchers with MockFacto
   }
 
   private trait TestCase {
-    private val tsProjectsFinder     = mock[TSProjectFinder[Try]]
-    private val glProjectsFinder     = mock[GLProjectFinder[Try]]
-    private val glCreatorsNamesAdder = mock[GLCreatorsNamesAdder[Try]]
-    val finder = new ProjectsFinderImpl[Try](tsProjectsFinder, glProjectsFinder, glCreatorsNamesAdder)
+    private val tsProjectsFinder     = mock[TSProjectFinder[IO]]
+    private val glProjectsFinder     = mock[GLProjectFinder[IO]]
+    private val glCreatorsNamesAdder = mock[GLCreatorsNamesAdder[IO]]
+    val finder = new ProjectsFinderImpl[IO](tsProjectsFinder, glProjectsFinder, glCreatorsNamesAdder)
 
-    def givenTSFinding(criteria: Criteria, returning: Try[List[model.Project.Activated]]) =
+    def givenTSFinding(criteria: Criteria, returning: IO[List[model.Project.Activated]]) =
       (tsProjectsFinder.findProjectsInTS _)
         .expects(criteria)
         .returning(returning)
 
-    def givenGLFinding(criteria: Criteria, returning: Try[List[model.Project.NotActivated]]) =
+    def givenGLFinding(criteria: Criteria, returning: IO[List[model.Project.NotActivated]]) =
       (glProjectsFinder.findProjectsInGL _)
         .expects(criteria)
         .returning(returning)
 
     def givenGLCreatorsNamesAdding(criteria:  Criteria,
                                    projects:  List[model.Project],
-                                   returning: Try[List[model.Project]]
+                                   returning: IO[List[model.Project]]
     ) = (glCreatorsNamesAdder
       .addCreatorsNames(_: Criteria)(_: List[model.Project]))
       .expects(criteria, projects)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/package.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/package.scala
@@ -41,15 +41,25 @@ package object projects {
     anyProjectEntities.map(_.to[model.Project.Activated])
 
   private[projects] val notActivatedProjects: Gen[model.Project.NotActivated] = for {
-    id           <- projectIds
-    path         <- projectPaths
-    name         <- projectNames
-    visibility   <- projectVisibilities
-    dateCreated  <- projectCreatedDates()
-    maybeCreator <- personEntities(withGitLabId).toGeneratorOfOptions.map(_.map(_.name))
-    keywords     <- projectKeywords.toGeneratorOfList()
-    maybeDesc    <- projectDescriptions.toGeneratorOfOptions
-  } yield model.Project.NotActivated(id, name, path, visibility, dateCreated, maybeCreator, keywords, maybeDesc)
+    id             <- projectIds
+    path           <- projectPaths
+    name           <- projectNames
+    visibility     <- projectVisibilities
+    dateCreated    <- projectCreatedDates()
+    maybeCreatorId <- personGitLabIds.toGeneratorOfOptions
+    maybeCreator   <- maybeCreatorId.map(_ => personNames.toGeneratorOfSomes).getOrElse(personNames.toGeneratorOfNones)
+    keywords       <- projectKeywords.toGeneratorOfList()
+    maybeDesc      <- projectDescriptions.toGeneratorOfOptions
+  } yield model.Project.NotActivated(id,
+                                     name,
+                                     path,
+                                     visibility,
+                                     dateCreated,
+                                     maybeCreatorId,
+                                     maybeCreator,
+                                     keywords,
+                                     maybeDesc
+  )
 
   private[projects] val modelProjects: Gen[model.Project] = Gen.oneOf(activatedProjects, notActivatedProjects)
 

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/RenkuTinyTypeGenerators.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/RenkuTinyTypeGenerators.scala
@@ -139,10 +139,10 @@ trait RenkuTinyTypeGenerators {
   def projectResourceIds()(implicit renkuUrl: RenkuUrl): Gen[projects.ResourceId] =
     projectPaths map (path => projects.ResourceId.from(s"$renkuUrl/projects/$path").fold(throw _, identity))
 
-  def projectImageResourceIds(project: projects.ResourceId, max: Int = 5): Gen[List[ImageResourceId]] =
+  def projectImageResourceIds(projectId: projects.ResourceId, max: Int = 5): Gen[List[ImageResourceId]] =
     Gen
       .chooseNum(0, max)
-      .map(n => (0 until n).map(i => ImageResourceId((project / "images" / i.toString).value)).toList)
+      .map(n => (0 until n).map(i => ImageResourceId((projectId / "images" / i.toString).value)).toList)
 
   implicit val projectKeywords: Gen[projects.Keyword] =
     Generators.nonBlankStrings(minLength = 5).map(v => projects.Keyword(v.value))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreator.scala
@@ -165,8 +165,18 @@ private object UpdatesCreator extends UpdatesCreator {
       SparqlQuery.of(
         name = "transformation - delete project images",
         Prefixes.of(schema -> "schema"),
-        s"""|DELETE { Graph $resource { $resource schema:image ?img } }
-            |WHERE  { Graph $resource { $resource schema:image ?img } }
+        s"""|DELETE {
+            |  GRAPH $resource {
+            |    $resource schema:image ?img.
+            |    ?img ?p ?s
+            |  } 
+            |}
+            |WHERE  {
+            |  GRAPH $resource {
+            |    $resource schema:image ?img.
+            |    ?img ?p ?s
+            |  }
+            |}
             |""".stripMargin
       )
     }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
@@ -26,16 +26,18 @@ import com.softwaremill.diffx.Diff
 import com.softwaremill.diffx.scalatest.DiffShouldMatcher
 import eu.timepit.refined.auto._
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model
 import io.renku.graph.model.Schemas.{prov, renku, schema}
+import io.renku.graph.model._
 import io.renku.graph.model.projects.DateCreated
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
-import io.renku.graph.model.{GraphClass, GraphModelGenerators, entities, projects}
 import io.renku.jsonld.syntax._
 import io.renku.testtools.IOSpec
 import io.renku.tinytypes.syntax.all._
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
 import io.renku.triplesstore.client.model.Quad
+import io.renku.triplesstore.client.syntax._
 import monocle.Lens
 import org.scalacheck.Gen
 import org.scalatest.matchers.should
@@ -156,7 +158,10 @@ class UpdatesCreatorSpec
         .runAll(on = projectsDataset)
         .unsafeRunSync()
 
-      findProjects shouldMatchTo Set(CurrentProjectState.from(project))
+      project.images.foreach { im =>
+        findImage(im.resourceId) shouldBe im.some
+      }
+      findProjects.flatMap(_.images) should contain theSameElementsAs project.images.map(_.resourceId.show)
     }
 
     "generate queries which delete the project images when changed" in {
@@ -165,14 +170,16 @@ class UpdatesCreatorSpec
 
       upload(to = projectsDataset, project)
 
-      prepareUpdates(
-        project,
-        toProjectMutableData(project).copy(images = projectImageResourceIds(project.resourceId).generateOne)
-      )
+      findProjects.flatMap(_.images) should contain theSameElementsAs project.images.map(_.resourceId.show)
+
+      prepareUpdates(project, toProjectMutableData(project).copy(images = Nil))
         .runAll(on = projectsDataset)
         .unsafeRunSync()
 
-      findProjects.flatMap(_.images) shouldMatchTo Set.empty
+      findProjects.flatMap(_.images) shouldBe Set.empty
+      project.images.foreach { im =>
+        findImage(im.resourceId) shouldBe None
+      }
     }
 
     "generate queries which delete the project name when changed" in {
@@ -440,6 +447,31 @@ class UpdatesCreatorSpec
       )
     )
     .toSet
+
+  private def findImage(id: model.images.ImageResourceId): Option[model.images.Image] = runSelect(
+    on = projectsDataset,
+    SparqlQuery.of(
+      "fetch image",
+      Prefixes of schema -> "schema",
+      s"""|SELECT ?imageId ?uri ?position
+          |WHERE {
+          |  GRAPH ?id {
+          |    BIND (${id.asEntityId.asSparql.sparql} AS ?imageId)
+          |    ?imageId schema:contentUrl ?uri;
+          |             schema:position ?position.
+          |  }
+          |}
+          |""".stripMargin
+    )
+  ).unsafeRunSync()
+    .map(row =>
+      model.images.Image(
+        row.get("imageId").map(model.images.ImageResourceId.apply).getOrElse(fail("No image id")),
+        row.get("uri").map(model.images.ImageUri.apply).getOrElse(fail("No image uri")),
+        row.get("position").map(p => model.images.ImagePosition(p.toInt)).getOrElse(fail("No image position"))
+      )
+    )
+    .headOption
 
   def projectCreatedLens: Lens[entities.Project, DateCreated] =
     Lens[entities.Project, DateCreated](_.dateCreated) { created =>

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreatorSpec.scala
@@ -409,7 +409,7 @@ class UpdatesCreatorSpec
           |  (GROUP_CONCAT(?keyword; separator=',') AS ?keywords) ?maybeAgent ?maybeCreatorId
           |  (GROUP_CONCAT(?imageId; separator=',') AS ?images)
           |WHERE {
-          |  GRAPH ?g {
+          |  GRAPH ?id {
           |    ?id a schema:Project
           |    OPTIONAL { ?id schema:name ?name } 
           |    OPTIONAL { ?id schema:dateCreated ?dateCreated } 


### PR DESCRIPTION
This PR improves the algorithm that finds the results for the User's Projects API. The new version finds the creators' names only for the page of results that is returned to the caller.

closes #1316 
/deploy #persist 