### PR TITLE
fix: optional model String TTs to be decoded to None when blank

### DIFF
--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/ProjectJsonLDEncoderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/ProjectJsonLDEncoderSpec.scala
@@ -49,14 +49,14 @@ class ProjectJsonLDEncoderSpec extends AnyWordSpec with should.Matchers with Sca
         resourceId   <- cursor.downEntityId.as[projects.ResourceId]
         identifier   <- cursor.downField(schema / "identifier").as[projects.GitLabId]
         path         <- cursor.downField(renku / "projectPath").as[projects.Path]
-        name         <- cursor.downField(schema / "name").as[projects.Name]
+        name         <- cursor.downField(schema / "name").as[Option[projects.Name]].flatMap(projects.Name.failIfNone)
         maybeDesc    <- cursor.downField(schema / "description").as[Option[projects.Description]]
         visibility   <- cursor.downField(renku / "projectVisibility").as[projects.Visibility]
         dateCreated  <- cursor.downField(schema / "dateCreated").as[projects.DateCreated]
         maybeCreator <- cursor.downField(schema / "creator").as[Option[Creator]]
         dateUpdated  <- cursor.downField(schema / "dateModified").as[DateUpdated]
         maybeParent  <- cursor.downField(prov / "wasDerivedFrom").as[Option[ParentProject]]
-        keywords     <- cursor.downField(schema / "keywords").as[List[projects.Keyword]]
+        keywords     <- cursor.downField(schema / "keywords").as[List[Option[projects.Keyword]]].map(_.flatten)
         maybeVersion <- cursor.downField(schema / "schemaVersion").as[Option[SchemaVersion]]
         images       <- cursor.downField(schema / "image").as[List[ImageUri]]
       } yield Project(
@@ -83,7 +83,7 @@ class ProjectJsonLDEncoderSpec extends AnyWordSpec with should.Matchers with Sca
     JsonLDDecoder.entity(entities.Person.entityTypes) { cursor =>
       for {
         resourceId       <- cursor.downEntityId.as[persons.ResourceId]
-        name             <- cursor.downField(schema / "name").as[persons.Name]
+        name             <- cursor.downField(schema / "name").as[Option[persons.Name]].flatMap(persons.Name.failIfNone)
         maybeEmail       <- cursor.downField(schema / "email").as[Option[persons.Email]]
         maybeAffiliation <- cursor.downField(schema / "affiliation").as[Option[persons.Affiliation]]
       } yield Creator(resourceId, name, maybeEmail, maybeAffiliation)
@@ -94,7 +94,7 @@ class ProjectJsonLDEncoderSpec extends AnyWordSpec with should.Matchers with Sca
       for {
         resourceId   <- cursor.downEntityId.as[projects.ResourceId]
         path         <- cursor.downField(renku / "projectPath").as[projects.Path]
-        name         <- cursor.downField(schema / "name").as[projects.Name]
+        name         <- cursor.downField(schema / "name").as[Option[projects.Name]].flatMap(projects.Name.failIfNone)
         dateCreated  <- cursor.downField(schema / "dateCreated").as[projects.DateCreated]
         maybeCreator <- cursor.downField(schema / "creator").as[Option[Creator]]
       } yield ParentProject(resourceId, path, name, Creation(dateCreated, maybeCreator))

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
@@ -42,10 +42,11 @@ object CliPerson {
   implicit val jsonLDDecoder: JsonLDDecoder[CliPerson] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       for {
-        resourceId       <- cursor.downEntityId.as[CliPersonResourceId]
-        names            <- cursor.downField(Schema.name).as[List[Name]]
-        maybeEmail       <- cursor.downField(Schema.email).as[Option[Email]]
-        maybeAffiliation <- cursor.downField(Schema.affiliation).as[List[Affiliation]].map(_.reverse.headOption)
+        resourceId <- cursor.downEntityId.as[CliPersonResourceId]
+        names      <- cursor.downField(Schema.name).as[List[Option[Name]]].map(_.flatten)
+        maybeEmail <- cursor.downField(Schema.email).as[Option[Email]]
+        maybeAffiliation <-
+          cursor.downField(Schema.affiliation).as[List[Option[Affiliation]]].map(_.flatten.reverse.headOption)
         name <- if (names.isEmpty) DecodingFailure(s"No name on Person $resourceId", Nil).asLeft
                 else names.reverse.head.asRight
       } yield CliPerson(resourceId, name, maybeEmail, maybeAffiliation)
@@ -54,10 +55,11 @@ object CliPerson {
   private[model] val jsonLDCliModelDecoder: JsonLDEntityDecoder[CliModel] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       for {
-        resourceId       <- cursor.downEntityId.as[CliPersonResourceId]
-        names            <- cursor.downField(Schema.name).as[List[Name]]
-        maybeEmail       <- cursor.downField(Schema.email).as[Option[Email]]
-        maybeAffiliation <- cursor.downField(Schema.affiliation).as[List[Affiliation]].map(_.reverse.headOption)
+        resourceId <- cursor.downEntityId.as[CliPersonResourceId]
+        names      <- cursor.downField(Schema.name).as[List[Option[Name]]].map(_.flatten)
+        maybeEmail <- cursor.downField(Schema.email).as[Option[Email]]
+        maybeAffiliation <-
+          cursor.downField(Schema.affiliation).as[List[Option[Affiliation]]].map(_.flatten.reverse.headOption)
         name <- if (names.isEmpty) DecodingFailure(s"No name on Person $resourceId", Nil).asLeft
                 else names.reverse.head.asRight
       } yield CliPerson(resourceId, name, maybeEmail, maybeAffiliation)

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliProject.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliProject.scala
@@ -142,17 +142,13 @@ object CliProject {
   implicit def jsonLDDecoder: JsonLDDecoder[CliProject] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       for {
-        id          <- cursor.downEntityId.as[ResourceId]
-        name        <- cursor.downField(Schema.name).as[Option[Name]]
-        description <- cursor.downField(Schema.description).as[Option[Description]]
-        dateCreated <- cursor.downField(Schema.dateCreated).as[DateCreated]
-        creator     <- cursor.downField(Schema.creator).as[Option[CliPerson]]
-        keywords    <- cursor.downField(Schema.keywords).as[Set[Keyword]]
-        images <-
-          cursor
-            .downField(Schema.image)
-            .as[List[Image]]
-            .map(_.sortBy(_.position))
+        id            <- cursor.downEntityId.as[ResourceId]
+        name          <- cursor.downField(Schema.name).as[Option[Name]]
+        description   <- cursor.downField(Schema.description).as[Option[Description]]
+        dateCreated   <- cursor.downField(Schema.dateCreated).as[DateCreated]
+        creator       <- cursor.downField(Schema.creator).as[Option[CliPerson]]
+        keywords      <- cursor.downField(Schema.keywords).as[Set[Option[Keyword]]].map(_.flatten)
+        images        <- cursor.downField(Schema.image).as[List[Image]].map(_.sortBy(_.position))
         plans         <- cursor.downField(Renku.hasPlan).as[List[ProjectPlan]]
         datasets      <- cursor.downField(Renku.hasDataset).as[List[CliDataset]]
         activities    <- cursor.downField(Renku.hasActivity).as[List[CliActivity]]

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/commandParameters.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/commandParameters.scala
@@ -25,7 +25,7 @@ import eu.timepit.refined.collection.NonEmpty
 import io.circe.DecodingFailure
 import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model.entityModel.{Location, LocationLike}
-import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, NonBlankTTJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.jsonld._
 import io.renku.jsonld.ontology.{Class, DataProperty, DataPropertyRange, Type}
 import io.renku.jsonld.syntax._
@@ -57,19 +57,19 @@ object commandParameters {
   implicit object Description
       extends TinyTypeFactory[Description](new Description(_))
       with NonBlank[Description]
-      with TinyTypeJsonLDOps[Description]
+      with NonBlankTTJsonLDOps[Description]
 
   final class EncodingFormat private (val value: String) extends AnyVal with StringTinyType
   implicit object EncodingFormat
       extends TinyTypeFactory[EncodingFormat](new EncodingFormat(_))
       with NonBlank[EncodingFormat]
-      with TinyTypeJsonLDOps[EncodingFormat]
+      with NonBlankTTJsonLDOps[EncodingFormat]
 
   final class Prefix private (val value: String) extends AnyVal with StringTinyType
   implicit object Prefix
       extends TinyTypeFactory[Prefix](new Prefix(_))
       with NonBlank[Prefix]
-      with TinyTypeJsonLDOps[Prefix]
+      with NonBlankTTJsonLDOps[Prefix]
 
   final case class InputDefaultValue(value: LocationLike) extends TinyType { type V = LocationLike }
   object InputDefaultValue {

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
@@ -31,7 +31,7 @@ import io.renku.jsonld.JsonLDEncoder._
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 import io.renku.tinytypes._
-import io.renku.tinytypes.constraints.{InstantNotInTheFuture, LocalDateNotInTheFuture, NonBlank, UUID, Url => UrlConstraint, UrlOps}
+import io.renku.tinytypes.constraints.{InstantNotInTheFuture, LocalDateNotInTheFuture, NonBlank, UUID, UrlOps, Url => UrlConstraint}
 
 import java.time.{Instant, LocalDate, ZoneOffset}
 
@@ -62,7 +62,7 @@ object datasets {
   implicit object OriginalIdentifier
       extends TinyTypeFactory[OriginalIdentifier](new OriginalIdentifier(_))
       with DatasetIdentifierFactory[OriginalIdentifier]
-      with TinyTypeJsonLDOps[OriginalIdentifier]
+      with NonBlankTTJsonLDOps[OriginalIdentifier]
       with NonBlank[OriginalIdentifier]
 
   final class Title private (val value: String) extends AnyVal with StringTinyType
@@ -75,25 +75,25 @@ object datasets {
   implicit object Description
       extends TinyTypeFactory[Description](new Description(_))
       with NonBlank[Description]
-      with TinyTypeJsonLDOps[Description]
+      with NonBlankTTJsonLDOps[Description]
 
   final class License private (val value: String) extends AnyVal with StringTinyType
   implicit object License
       extends TinyTypeFactory[License](new License(_))
       with NonBlank[License]
-      with TinyTypeJsonLDOps[License]
+      with NonBlankTTJsonLDOps[License]
 
   final class Version private (val value: String) extends AnyVal with StringTinyType
   implicit object Version
       extends TinyTypeFactory[Version](new Version(_))
       with NonBlank[Version]
-      with TinyTypeJsonLDOps[Version]
+      with NonBlankTTJsonLDOps[Version]
 
   final class Keyword private (val value: String) extends AnyVal with StringTinyType
   implicit object Keyword
       extends TinyTypeFactory[Keyword](new Keyword(_))
       with NonBlank[Keyword]
-      with TinyTypeJsonLDOps[Keyword]
+      with NonBlankTTJsonLDOps[Keyword]
 
   final class PartLocation private (val value: String) extends AnyVal with StringTinyType
   implicit object PartLocation

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
@@ -31,7 +31,7 @@ import io.renku.jsonld.JsonLDEncoder._
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 import io.renku.tinytypes._
-import io.renku.tinytypes.constraints.{InstantNotInTheFuture, LocalDateNotInTheFuture, NonBlank, UUID, UrlOps, Url => UrlConstraint}
+import io.renku.tinytypes.constraints.{InstantNotInTheFuture, LocalDateNotInTheFuture, NonBlank, UUID, Url => UrlConstraint, UrlOps}
 
 import java.time.{Instant, LocalDate, ZoneOffset}
 

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/persons.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/persons.scala
@@ -20,7 +20,7 @@ package io.renku.graph.model
 
 import cats.syntax.all._
 import io.circe.DecodingFailure
-import io.renku.graph.model.views.{EntityIdJsonLDOps, RdfResource, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, NonBlankTTJsonLDOps, RdfResource, TinyTypeJsonLDOps}
 import io.renku.jsonld.{EntityId, EntityIdEncoder, JsonLDDecoder}
 import io.renku.tinytypes.constraints.{NonBlank, NonNegativeInt}
 import io.renku.triplesstore.client.sparql.SparqlEncoder
@@ -192,7 +192,7 @@ object persons {
   implicit object Email
       extends TinyTypeFactory[Email](new Email(_))
       with NonBlank[Email]
-      with TinyTypeJsonLDOps[Email] {
+      with NonBlankTTJsonLDOps[Email] {
 
     addConstraint(
       check = _.split('@').toList match {
@@ -208,7 +208,7 @@ object persons {
   }
 
   final class Name private (val value: String) extends AnyVal with StringTinyType
-  implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank[Name] with TinyTypeJsonLDOps[Name]
+  implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank[Name] with NonBlankTTJsonLDOps[Name]
 
   final class Username private (val value: String) extends AnyVal with StringTinyType
   implicit object Username extends TinyTypeFactory[Username](new Username(_)) with NonBlank[Username]
@@ -217,5 +217,5 @@ object persons {
   implicit object Affiliation
       extends TinyTypeFactory[Affiliation](new Affiliation(_))
       with NonBlank[Affiliation]
-      with TinyTypeJsonLDOps[Affiliation]
+      with NonBlankTTJsonLDOps[Affiliation]
 }

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/plans.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/plans.scala
@@ -19,7 +19,7 @@
 package io.renku.graph.model
 
 import cats.syntax.all._
-import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLDOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{AnyResourceRenderer, EntityIdJsonLDOps, NonBlankTTJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.jsonld.{EntityId, EntityIdEncoder}
 import io.renku.jsonld.syntax._
 import io.renku.tinytypes.constraints.{InstantNotInTheFuture, NonBlank, NonNegativeInt, Url}
@@ -59,19 +59,19 @@ object plans {
   implicit object Description
       extends TinyTypeFactory[Description](new Description(_))
       with NonBlank[Description]
-      with TinyTypeJsonLDOps[Description]
+      with NonBlankTTJsonLDOps[Description]
 
   final class Command private (val value: String) extends AnyVal with StringTinyType
   implicit object Command
       extends TinyTypeFactory[Command](new Command(_))
       with NonBlank[Command]
-      with TinyTypeJsonLDOps[Command]
+      with NonBlankTTJsonLDOps[Command]
 
   final class Keyword private (val value: String) extends AnyVal with StringTinyType
   implicit object Keyword
       extends TinyTypeFactory[Keyword](new Keyword(_))
       with NonBlank[Keyword]
-      with TinyTypeJsonLDOps[Keyword]
+      with NonBlankTTJsonLDOps[Keyword]
 
   final class ProgrammingLanguage private (val value: String) extends AnyVal with StringTinyType
 

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
@@ -21,7 +21,7 @@ package io.renku.graph.model
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps, UrlResourceRenderer}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, NonBlankTTJsonLDOps, TinyTypeJsonLDOps, UrlResourceRenderer}
 import io.renku.jsonld.{EntityId, JsonLDDecoder, JsonLDEncoder}
 import io.renku.tinytypes.constraints._
 import io.renku.tinytypes._
@@ -90,7 +90,7 @@ object projects {
   }
 
   final class Name private (val value: String) extends AnyVal with StringTinyType
-  implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank[Name] with TinyTypeJsonLDOps[Name]
+  implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank[Name] with NonBlankTTJsonLDOps[Name]
 
   final class DateCreated private (val value: Instant) extends AnyVal with InstantTinyType
   implicit object DateCreated
@@ -109,7 +109,7 @@ object projects {
   implicit object Description
       extends TinyTypeFactory[Description](new Description(_))
       with NonBlank[Description]
-      with TinyTypeJsonLDOps[Description]
+      with NonBlankTTJsonLDOps[Description]
 
   sealed trait Visibility extends StringTinyType with Product with Serializable {
     def compareTo(other: Visibility): Int =
@@ -186,5 +186,5 @@ object projects {
   implicit object Keyword
       extends TinyTypeFactory[Keyword](new Keyword(_))
       with NonBlank[Keyword]
-      with TinyTypeJsonLDOps[Keyword]
+      with NonBlankTTJsonLDOps[Keyword]
 }

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/publicationEvents.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/publicationEvents.scala
@@ -18,7 +18,7 @@
 
 package io.renku.graph.model
 
-import io.renku.graph.model.views.{EntityIdJsonLDOps, TinyTypeJsonLDOps}
+import io.renku.graph.model.views.{EntityIdJsonLDOps, NonBlankTTJsonLDOps, TinyTypeJsonLDOps}
 import io.renku.tinytypes.constraints.{InstantNotInTheFuture, NonBlank, Url}
 import io.renku.tinytypes.{InstantTinyType, StringTinyType, TinyTypeFactory}
 
@@ -39,7 +39,7 @@ object publicationEvents {
   implicit object Description
       extends TinyTypeFactory[Description](new Description(_))
       with NonBlank[Description]
-      with TinyTypeJsonLDOps[Description]
+      with NonBlankTTJsonLDOps[Description]
 
   final class Name private (val value: String) extends AnyVal with StringTinyType
   implicit object Name extends TinyTypeFactory[Name](new Name(_)) with NonBlank[Name] with TinyTypeJsonLDOps[Name]

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/versions.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/versions.scala
@@ -21,7 +21,7 @@ package io.renku.graph.model
 import cats.Show
 import cats.syntax.show._
 import io.circe.Decoder
-import io.renku.graph.model.views.TinyTypeJsonLDOps
+import io.renku.graph.model.views.NonBlankTTJsonLDOps
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints.NonBlank
 import io.renku.tinytypes.json.TinyTypeDecoders
@@ -29,7 +29,10 @@ import io.renku.tinytypes.json.TinyTypeDecoders
 object versions {
 
   final class CliVersion private (val value: String) extends AnyVal with StringTinyType
-  object CliVersion extends TinyTypeFactory[CliVersion](new CliVersion(_)) with TinyTypeJsonLDOps[CliVersion] {
+  object CliVersion
+      extends TinyTypeFactory[CliVersion](new CliVersion(_))
+      with NonBlankTTJsonLDOps[CliVersion]
+      with NonBlank[CliVersion] {
 
     private val validationRegex: String = raw"\d+\.\d+\.\d+.*"
 
@@ -75,7 +78,7 @@ object versions {
   object SchemaVersion
       extends TinyTypeFactory[SchemaVersion](new SchemaVersion(_))
       with NonBlank[SchemaVersion]
-      with TinyTypeJsonLDOps[SchemaVersion] {
+      with NonBlankTTJsonLDOps[SchemaVersion] {
     implicit val jsonDecoder: Decoder[SchemaVersion] = TinyTypeDecoders.stringDecoder(SchemaVersion)
   }
 }

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/views/NonBlankTTJsonLDOps.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/views/NonBlankTTJsonLDOps.scala
@@ -28,8 +28,13 @@ import io.renku.tinytypes.{From, StringTinyType, TinyTypeFactory}
 trait NonBlankTTJsonLDOps[TT <: StringTinyType] extends JsonLDTinyTypeEncoder[TT] with StringTinyTypeJsonLDDecoders {
   self: TinyTypeFactory[TT] with NonBlank[TT] =>
 
-  implicit lazy val decoder: JsonLDDecoder[Option[TT]] =
+  implicit lazy val optionalTTDecoder: JsonLDDecoder[Option[TT]] =
     decodeBlankStringToNone[TT](self)
+
+  val failIfNone: Option[TT] => JsonLDDecoder.Result[TT] = {
+    case Some(v) => v.asRight
+    case None    => DecodingFailure(s"A value of '$typeName' expected but got any", Nil).asLeft
+  }
 }
 
 object StringTinyTypeJsonLDDecoders extends StringTinyTypeJsonLDDecoders

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/views/NonBlankTTJsonLDOps.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/views/NonBlankTTJsonLDOps.scala
@@ -33,7 +33,7 @@ trait NonBlankTTJsonLDOps[TT <: StringTinyType] extends JsonLDTinyTypeEncoder[TT
 
   val failIfNone: Option[TT] => JsonLDDecoder.Result[TT] = {
     case Some(v) => v.asRight
-    case None    => DecodingFailure(s"A value of '$typeName' expected but got any", Nil).asLeft
+    case None    => DecodingFailure(s"A value of '$typeName' expected but got none", Nil).asLeft
   }
 }
 

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/views/NonBlankTTJsonLDOps.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/views/NonBlankTTJsonLDOps.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.views
+
+import cats.syntax.all._
+import io.circe.DecodingFailure
+import io.renku.jsonld.JsonLDDecoder
+import io.renku.jsonld.JsonLDDecoder.{decodeOption, decodeString}
+import io.renku.tinytypes.constraints.NonBlank
+import io.renku.tinytypes.{From, StringTinyType, TinyTypeFactory}
+
+trait NonBlankTTJsonLDOps[TT <: StringTinyType] extends JsonLDTinyTypeEncoder[TT] with StringTinyTypeJsonLDDecoders {
+  self: TinyTypeFactory[TT] with NonBlank[TT] =>
+
+  implicit lazy val decoder: JsonLDDecoder[Option[TT]] =
+    decodeBlankStringToNone[TT](self)
+}
+
+object StringTinyTypeJsonLDDecoders extends StringTinyTypeJsonLDDecoders
+
+trait StringTinyTypeJsonLDDecoders {
+
+  implicit def decodeBlankStringToNone[TT <: StringTinyType](implicit ttFactory: From[TT]): JsonLDDecoder[Option[TT]] =
+    decodeOption(decodeString).emap((blankToNone andThen toOption)(_).leftMap(_.getMessage()))
+
+  private lazy val blankToNone: Option[String] => Option[String] = _.map(_.trim) >>= {
+    case ""       => None
+    case nonBlank => Some(nonBlank)
+  }
+
+  private def toOption[TT <: StringTinyType](implicit
+      ttFactory: From[TT]
+  ): Option[String] => Either[DecodingFailure, Option[TT]] = {
+    case Some(nonBlank) =>
+      ttFactory.from(nonBlank).map(Option.apply).leftMap(exception => DecodingFailure(exception.getMessage, Nil))
+    case None => Right(None)
+  }
+}

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/ModelTinyTypesDiffInstances.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/ModelTinyTypesDiffInstances.scala
@@ -28,6 +28,8 @@ trait ModelTinyTypesDiffInstances extends TinyTypeDiffInstances {
 
   implicit val datasetsCreatedOrPublishedDiff: Diff[datasets.CreatedOrPublished] =
     Diff.derived[datasets.CreatedOrPublished]
+  implicit val datasetsDateModified: Diff[datasets.DateModified] =
+    Diff.derived[datasets.DateModified]
 
   implicit val datasetsSameAsDiff: Diff[datasets.SameAs] = Diff.diffForString.contramap {
     case sa: datasets.InternalSameAs => sa.value

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/views/NonBlankTTJsonLDOpsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/views/NonBlankTTJsonLDOpsSpec.scala
@@ -22,6 +22,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{blankStrings, nonEmptyStrings}
 import io.renku.jsonld.JsonLD
 import io.renku.jsonld.syntax._
+import cats.syntax.all._
 import io.renku.tinytypes.constraints.NonBlank
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
 import org.scalatest.EitherValues
@@ -52,6 +53,21 @@ class NonBlankTTJsonLDOpsSpec extends AnyWordSpec with should.Matchers with Eith
     "produce a Json String" in {
       val tt = nonEmptyStrings().generateAs(TestStringTinyType)
       tt.asJsonLD shouldBe JsonLD.fromString(tt.value)
+    }
+  }
+
+  "failIfNone" should {
+
+    "return the value for Some" in {
+      val tinyType = nonEmptyStrings().generateAs(TestStringTinyType)
+
+      TestStringTinyType.failIfNone(tinyType.some) shouldBe tinyType.asRight
+    }
+
+    "fail for None" in {
+      val result = TestStringTinyType.failIfNone(None)
+
+      result.left.value.getMessage() shouldBe s"A value of '${TestStringTinyType.typeName}' expected but got any"
     }
   }
 }

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/views/NonBlankTTJsonLDOpsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/views/NonBlankTTJsonLDOpsSpec.scala
@@ -67,7 +67,7 @@ class NonBlankTTJsonLDOpsSpec extends AnyWordSpec with should.Matchers with Eith
     "fail for None" in {
       val result = TestStringTinyType.failIfNone(None)
 
-      result.left.value.getMessage() shouldBe s"A value of '${TestStringTinyType.typeName}' expected but got any"
+      result.left.value.getMessage() shouldBe s"A value of '${TestStringTinyType.typeName}' expected but got none"
     }
   }
 }

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/views/NonBlankTTJsonLDOpsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/views/NonBlankTTJsonLDOpsSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.views
+
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{blankStrings, nonEmptyStrings}
+import io.renku.jsonld.JsonLD
+import io.renku.jsonld.syntax._
+import io.renku.tinytypes.constraints.NonBlank
+import io.renku.tinytypes.{StringTinyType, TinyTypeFactory}
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class NonBlankTTJsonLDOpsSpec extends AnyWordSpec with should.Matchers with EitherValues {
+
+  "decode" should {
+
+    "turn a valid string value from Json to the relevant type" in {
+      val value = nonEmptyStrings().generateOne
+      JsonLD.fromString(value).cursor.as[Option[TestStringTinyType]].value shouldBe Some(TestStringTinyType(value))
+    }
+
+    "return a None for a blank value in Json" in {
+      val value = blankStrings().generateOne
+      JsonLD.fromString(value).cursor.as[Option[TestStringTinyType]].value shouldBe None
+    }
+
+    "return a None for a Null Json" in {
+      JsonLD.Null.cursor.as[Option[TestStringTinyType]].value shouldBe None
+    }
+  }
+
+  "encode" should {
+
+    "produce a Json String" in {
+      val tt = nonEmptyStrings().generateAs(TestStringTinyType)
+      tt.asJsonLD shouldBe JsonLD.fromString(tt.value)
+    }
+  }
+}
+
+private final class TestStringTinyType private (val value: String) extends AnyVal with StringTinyType
+private object TestStringTinyType
+    extends TinyTypeFactory[TestStringTinyType](new TestStringTinyType(_))
+    with NonBlank[TestStringTinyType]
+    with NonBlankTTJsonLDOps[TestStringTinyType]

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Person.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Person.scala
@@ -220,13 +220,14 @@ object Person {
         }
 
       for {
-        maybeOrcidAsId   <- cursor.downEntityId.as[OrcidId].map(_.some).leftFlatMap(_ => None.asRight)
-        resourceId       <- maybeOrcidAsId.map(ResourceId(_).asRight).getOrElse(cursor.downEntityId.as[ResourceId])
-        names            <- cursor.downField(schema / "name").as[List[Name]]
-        maybeEmail       <- cursor.downField(schema / "email").as[Option[Email]]
-        maybeAffiliation <- cursor.downField(schema / "affiliation").as[List[Affiliation]].map(_.reverse.headOption)
-        maybeGitLabId    <- decodeSameAs(use = gitLabIdDecoder, onMultiple = "multiple GitLabId sameAs")
-        maybeOrcidId     <- decodeSameAs(use = orcidIdDecoder, onMultiple = "multiple OrcidId sameAs")
+        maybeOrcidAsId <- cursor.downEntityId.as[OrcidId].map(_.some).leftFlatMap(_ => None.asRight)
+        resourceId     <- maybeOrcidAsId.map(ResourceId(_).asRight).getOrElse(cursor.downEntityId.as[ResourceId])
+        names          <- cursor.downField(schema / "name").as[List[Option[Name]]].map(_.flatten)
+        maybeEmail     <- cursor.downField(schema / "email").as[Option[Email]]
+        maybeAffiliation <-
+          cursor.downField(schema / "affiliation").as[List[Option[Affiliation]]].map(_.flatten.reverse.headOption)
+        maybeGitLabId <- decodeSameAs(use = gitLabIdDecoder, onMultiple = "multiple GitLabId sameAs")
+        maybeOrcidId  <- decodeSameAs(use = orcidIdDecoder, onMultiple = "multiple OrcidId sameAs")
         name <- if (names.isEmpty) DecodingFailure(s"No name on Person $resourceId", Nil).asLeft
                 else names.reverse.head.asRight
         person <-


### PR DESCRIPTION
This PR fixes the model String TTs so that they get decoded to None in case of a blank value instead of failing.