### PR TITLE
chore: Refactor decoding tests to use cli models

### DIFF
--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/DatasetsCollectorSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/DatasetsCollectorSpec.scala
@@ -87,7 +87,7 @@ class DatasetsCollectorSpec extends AnyWordSpec with should.Matchers with TableD
         .withDatasets(datasetEntities(provenanceNonModified))
         .modify { p =>
           val modifications = p.datasets.map(_.createModification()(p.dateCreated).generateOne)
-          val invalidations = modifications.map(_.invalidateNow)
+          val invalidations = modifications.map(_.invalidateNow(personEntities))
           p.addDatasets(modifications ::: invalidations: _*)
         }
         .generateOne

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
@@ -335,7 +335,7 @@ class DatasetsFinderSpec
 
           val (dataset, project -> fork) =
             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).forkOnce().generateOne
-          val forkUpdated = fork.addDatasets(dataset.invalidateNow)
+          val forkUpdated = fork.addDatasets(dataset.invalidateNow(personEntities))
 
           upload(to = projectsDataset, project, forkUpdated)
 
@@ -351,7 +351,7 @@ class DatasetsFinderSpec
 
           val (dataset, project -> fork) =
             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).forkOnce().generateOne
-          val afterForkingUpdated = project.addDatasets(dataset.invalidateNow)
+          val afterForkingUpdated = project.addDatasets(dataset.invalidateNow(personEntities))
 
           upload(to = projectsDataset, afterForkingUpdated, fork)
 
@@ -367,7 +367,7 @@ class DatasetsFinderSpec
 
           val (_ -> datasetModified, project) =
             publicProjectEntities.addDatasetAndModification(datasetEntities(provenanceInternal)).generateOne
-          val projectUpdated = project.addDatasets(datasetModified.invalidateNow)
+          val projectUpdated = project.addDatasets(datasetModified.invalidateNow(personEntities))
 
           upload(to = projectsDataset, projectUpdated)
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/DatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/DatasetFinderSpec.scala
@@ -190,7 +190,7 @@ class DatasetFinderSpec
         )
         .generateOne
       val partToInvalidate           = Random.shuffle(dataset.parts).head
-      val datasetWithInvalidatedPart = dataset.invalidatePartNow(partToInvalidate)
+      val datasetWithInvalidatedPart = dataset.invalidatePartNow(partToInvalidate, personEntities)
       val projectBothDatasets        = project.addDatasets(datasetWithInvalidatedPart)
 
       upload(to = projectsDataset, projectBothDatasets)
@@ -426,7 +426,7 @@ class DatasetFinderSpec
       "- case when a dataset on a fork is deleted" in new TestCase {
         forAll(anyRenkuProjectEntities(visibilityPublic).addDataset(datasetEntities(provenanceInternal)).forkOnce()) {
           case (original, project -> fork) =>
-            val invalidation         = original.invalidateNow
+            val invalidation         = original.invalidateNow(personEntities)
             val forkWithInvalidation = fork.addDatasets(invalidation)
 
             upload(to = projectsDataset, project, forkWithInvalidation)
@@ -453,7 +453,7 @@ class DatasetFinderSpec
             .addDataset(datasetEntities(provenanceInternal))
             .forkOnce()
             .generateOne
-        val invalidation            = original.invalidateNow
+        val invalidation            = original.invalidateNow(personEntities)
         val projectWithInvalidation = project.addDatasets(invalidation)
 
         upload(to = projectsDataset, projectWithInvalidation, fork)
@@ -579,7 +579,7 @@ class DatasetFinderSpec
         val (dataset1, project1) =
           anyRenkuProjectEntities(visibilityPublic).addDataset(datasetEntities(provenanceInternal)).generateOne
         val (dataset2, project2) = anyRenkuProjectEntities(visibilityPublic).importDataset(dataset1).generateOne
-        val dataset2Invalidation = dataset2.invalidateNow
+        val dataset2Invalidation = dataset2.invalidateNow(personEntities)
         val project2Updated      = project2.addDatasets(dataset2Invalidation)
 
         upload(to = projectsDataset, project1, project2Updated)
@@ -604,7 +604,7 @@ class DatasetFinderSpec
         val (dataset1, project1) =
           anyRenkuProjectEntities(visibilityPublic).addDataset(datasetEntities(provenanceInternal)).generateOne
         val (dataset2, project2) = anyRenkuProjectEntities(visibilityPublic).importDataset(dataset1).generateOne
-        val dataset1Invalidation = dataset1.invalidateNow
+        val dataset1Invalidation = dataset1.invalidateNow(personEntities)
         val project1Updated      = project1.addDatasets(dataset1Invalidation)
 
         upload(to = projectsDataset, project1Updated, project2)
@@ -627,7 +627,7 @@ class DatasetFinderSpec
         val (dataset -> datasetModified, project) = anyRenkuProjectEntities(visibilityPublic)
           .addDatasetAndModification(datasetEntities(provenanceInternal))
           .generateOne
-        val datasetInvalidation = datasetModified.invalidateNow
+        val datasetInvalidation = datasetModified.invalidateNow(personEntities)
         val projectUpdated      = project.addDatasets(datasetInvalidation)
 
         upload(to = projectsDataset, projectUpdated)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetsFinderSpec.scala
@@ -149,7 +149,7 @@ class ProjectDatasetsFinderSpec
       val (_ -> modification, project) =
         renkuProjectEntities(anyVisibility).addDatasetAndModification(datasetEntities(provenanceInternal)).generateOne
 
-      upload(to = projectsDataset, project.addDatasets(modification.invalidateNow))
+      upload(to = projectsDataset, project.addDatasets(modification.invalidateNow(personEntities)))
 
       datasetsFinder.findProjectDatasets(project.path).unsafeRunSync() shouldBe Nil
     }

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliActivity.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliActivity.scala
@@ -39,7 +39,7 @@ final case class CliActivity(
 
 object CliActivity {
 
-  private val entityTypes: EntityTypes = EntityTypes.of(Prov.Activity)
+  private[model] val entityTypes: EntityTypes = EntityTypes.of(Prov.Activity)
 
   implicit def jsonLDDecoder: JsonLDDecoder[CliActivity] =
     JsonLDDecoder.entity(entityTypes) { cursor =>

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliDataset.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliDataset.scala
@@ -158,4 +158,13 @@ object CliDataset {
       ).flatten.toMap
     )
   }
+
+  /** Encodes into a flat array, including publication events. */
+  def flatJsonLDEncoder(implicit
+      fileEncoder:   JsonLDEncoder[CliDatasetFile],
+      personEncoder: JsonLDEncoder[CliPerson]
+  ): JsonLDEncoder[CliDataset] = JsonLDEncoder.instance { dataset =>
+    val data = dataset.asNestedJsonLD :: dataset.publicationEvents.map(_.asNestedJsonLD)
+    JsonLD.arr(data: _*).flatten.fold(throw _, identity)
+  }
 }

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliModel.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliModel.scala
@@ -59,7 +59,18 @@ object CliModel {
     }
 
   final implicit class HListCliModelOps[A <: CliModel, L <: HList](hl: A :: L) {
+    def asNestedJsonLD(implicit enc: JsonLDEncoder[A :: L]): JsonLD =
+      enc.apply(hl)
+
     def asFlattenedJsonLD(implicit enc: JsonLDEncoder[A :: L]): JsonLD =
       enc.apply(hl).flatten.fold(throw _, identity)
+  }
+
+  final implicit class ListCliModelOps[A <: CliModel](list: List[A]) {
+    def asNestedJsonLD(implicit enc: JsonLDEncoder[List[A]]): JsonLD =
+      enc.apply(list)
+
+    def asFlattenedJsonLD(implicit enc: JsonLDEncoder[List[A]]): JsonLD =
+      enc.apply(list).flatten.fold(throw _, identity)
   }
 }

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
@@ -34,7 +34,7 @@ final case class CliPerson(
 
 object CliPerson {
 
-  private val entityTypes: EntityTypes = EntityTypes.of(Schema.Person, Prov.Person)
+  private[model] val entityTypes: EntityTypes = EntityTypes.of(Schema.Person, Prov.Person)
 
   private[model] def matchingEntityTypes(entityTypes: EntityTypes): Boolean =
     entityTypes == this.entityTypes

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliProject.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliProject.scala
@@ -192,4 +192,11 @@ object CliProject {
         Renku.hasActivity    -> project.activities.asJsonLD
       )
     }
+
+  /** Encodes into a flat array, including publication events. */
+  def flatJsonLDEncoder: JsonLDEncoder[CliProject] =
+    JsonLDEncoder.instance { project =>
+      val data = project.asNestedJsonLD :: project.datasets.flatMap(_.publicationEvents).map(_.asNestedJsonLD)
+      JsonLD.arr(data: _*).flatten.fold(throw _, identity)
+    }
 }

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/CliPersonSpec.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/CliPersonSpec.scala
@@ -18,10 +18,14 @@
 
 package io.renku.cli.model
 
+import cats.syntax.all._
+import io.circe.DecodingFailure
 import io.renku.cli.model.diffx.CliDiffInstances
 import io.renku.cli.model.generators.PersonGenerators
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.{RenkuTinyTypeGenerators, RenkuUrl}
+import io.renku.jsonld.JsonLD
+import io.renku.jsonld.syntax._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -46,6 +50,20 @@ class CliPersonSpec
     "work on multiple items" in {
       forAll(personGen, personGen) { (cliPerson1, cliPerson2) =>
         assertCompatibleCodec(cliPerson1, cliPerson2)
+      }
+    }
+
+    "fail when there is no name" in {
+      forAll(personGen) { person =>
+        val jsonLDPerson = JsonLD.entity(
+          person.resourceId.asEntityId,
+          CliPerson.entityTypes,
+          Ontologies.Schema.email -> person.email.asJsonLD
+        )
+
+        val Left(failure) = jsonLDPerson.cursor.as[CliPerson]
+        failure         shouldBe a[DecodingFailure]
+        failure.message shouldBe show"No name on Person ${person.resourceId}"
       }
     }
   }

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/CliPersonSpec.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/CliPersonSpec.scala
@@ -66,5 +66,35 @@ class CliPersonSpec
         failure.message shouldBe show"No name on Person ${person.resourceId}"
       }
     }
+
+    "support multiple names, picking any" in {
+      val resourceId = RenkuTinyTypeGenerators.personNameResourceId.generateOne
+      val firstName  = RenkuTinyTypeGenerators.personNames.generateOne
+      val secondName = RenkuTinyTypeGenerators.personNames.generateOne
+      val jsonLDPerson = JsonLD.entity(
+        resourceId.asEntityId,
+        CliPerson.entityTypes,
+        Ontologies.Schema.name -> JsonLD.arr(firstName.asJsonLD, secondName.asJsonLD)
+      )
+
+      val Right(person) = jsonLDPerson.cursor.as[CliPerson]
+
+      person.name should (be(firstName) or be(secondName))
+    }
+
+    "support multiple affiliations, picking last" in {
+      val resourceId   = RenkuTinyTypeGenerators.personNameResourceId.generateOne
+      val name         = RenkuTinyTypeGenerators.personNames.generateOne
+      val affiliation1 = RenkuTinyTypeGenerators.personAffiliations.generateOne
+      val affiliation2 = RenkuTinyTypeGenerators.personAffiliations.generateOne
+      val jsonLDPerson = JsonLD.entity(
+        resourceId.asEntityId,
+        CliPerson.entityTypes,
+        Ontologies.Schema.name        -> name.asJsonLD,
+        Ontologies.Schema.affiliation -> List(affiliation1, affiliation2).asJsonLD
+      )
+
+      jsonLDPerson.cursor.as[CliPerson].map(_.affiliation) shouldBe affiliation2.some.asRight
+    }
   }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/cli/CliActivityConverters.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/cli/CliActivityConverters.scala
@@ -110,11 +110,17 @@ trait CliActivityConverters extends CliPlanConverters {
     val id = parameterValues.ResourceId(paramValue.asEntityId.show)
     paramValue match {
       case p: testentities.ParameterValue.LocationParameterValue.CommandOutputValue =>
-        CliParameterValue(id, commandParameters.ResourceId(p.asEntityId.show), ValueOverride(p.value.value))
+        CliParameterValue(id,
+                          commandParameters.ResourceId(p.valueReference.asEntityId.show),
+                          ValueOverride(p.value.value)
+        )
       case p: testentities.ParameterValue.LocationParameterValue.CommandInputValue =>
-        CliParameterValue(id, commandParameters.ResourceId(p.asEntityId.show), ValueOverride(p.value.value))
+        CliParameterValue(id,
+                          commandParameters.ResourceId(p.valueReference.asEntityId.show),
+                          ValueOverride(p.value.value)
+        )
       case p: testentities.ParameterValue.CommandParameterValue =>
-        CliParameterValue(id, commandParameters.ResourceId(p.asEntityId.show), p.value)
+        CliParameterValue(id, commandParameters.ResourceId(p.valueReference.asEntityId.show), p.value)
     }
   }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AgentSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AgentSpec.scala
@@ -19,10 +19,10 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliSoftwareAgent
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.entities
 import io.renku.graph.model.testentities._
-import io.renku.jsonld.syntax._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -33,7 +33,9 @@ class AgentSpec extends AnyWordSpec with should.Matchers with ScalaCheckProperty
 
     "turn JsonLD Agent entity into the Agent object" in {
       forAll { agent: Agent =>
-        agent.asJsonLD.cursor.as[entities.Agent] shouldBe agent.to[entities.Agent].asRight
+        agent.to[CliSoftwareAgent].asFlattenedJsonLD.cursor.as[List[entities.Agent]] shouldBe List(
+          agent.to[entities.Agent]
+        ).asRight
       }
     }
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliAssociation
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators.{graphClasses, projectCreatedDates}
 import io.renku.graph.model.testentities._
@@ -32,16 +33,18 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
   "decode" should {
-    implicit val graph: GraphClass = GraphClass.Default
 
     "turn JsonLD Association entity with Renku agent into the Association object" in {
-      forAll(activityEntities(stepPlanEntities())(projectCreatedDates().generateOne).map(_.association)) {
-        association =>
-          implicit val decoder: JsonLDDecoder[entities.Association] =
-            createDecoder(association.plan.to[entities.StepPlan])
+      forAll(
+        activityEntities(stepPlanEntities(planCommands, cliShapedPersons), cliShapedPersons)(
+          projectCreatedDates().generateOne
+        ).map(_.association)
+      ) { association =>
+        implicit val decoder: JsonLDDecoder[entities.Association] =
+          createDecoder(association.plan.to[entities.StepPlan])
 
-          association.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.Association]] shouldBe
-            List(association.to[entities.Association]).asRight
+        association.to[CliAssociation].asFlattenedJsonLD.cursor.as[List[entities.Association]] shouldBe
+          List(association.to[entities.Association]).asRight
       }
     }
 
@@ -49,25 +52,29 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
       val (association, _, plan) = generateAssociationWithPersonAgent
 
-      implicit val decoder: JsonLDDecoder[entities.Association] = createDecoder(plan)
+      implicit val decoder: JsonLDDecoder[entities.Association] = createDecoder(plan.to[entities.StepPlan])
 
-      association.asJsonLD.flatten
-        .fold(throw _, identity)
+      association
+        .to[CliAssociation]
+        .asFlattenedJsonLD
         .cursor
-        .as[List[entities.Association]] shouldBe List(association).asRight
+        .as[List[entities.Association]] shouldBe List(association.to[entities.Association]).asRight
     }
 
     "fail decoding if there's no Plan with the Id the Association points to" in {
 
-      val association =
-        activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)
+      val testAssociation =
+        activityEntities(stepPlanEntities(planCommands, cliShapedPersons), cliShapedPersons)(
+          projectCreatedDates().generateOne
+        )
           .map(_.association)
           .generateOne
-          .to[entities.Association]
+
+      val association = testAssociation.to[entities.Association]
 
       implicit val dl: DependencyLinks = (_: plans.ResourceId) => Option.empty[entities.StepPlan]
 
-      val Left(failure) = association.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.Association]]
+      val Left(failure) = testAssociation.to[CliAssociation].asFlattenedJsonLD.cursor.as[List[entities.Association]]
 
       failure.message should include(
         show"Association ${association.resourceId} points to a non-existing Plan ${association.planId}"
@@ -80,7 +87,7 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "produce JsonLD with all the relevant properties" in {
 
-      val (association, agent, _) = generateAssociationWithPersonAgent
+      val (association, agent) = generateEntitiesAssociationWithPersonAgent
 
       association.asJsonLD shouldBe JsonLD.entity(
         association.resourceId.asEntityId,
@@ -96,12 +103,12 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "produce JsonLD with all the relevant properties and only links to Person entities" in {
 
-      val (association, agent, _) = generateAssociationWithPersonAgent
+      val (association, agent) = generateEntitiesAssociationWithPersonAgent
 
       association.asJsonLD shouldBe JsonLD.entity(
         association.resourceId.asEntityId,
         entities.Association.entityTypes,
-        prov / "agent"   -> agent.asEntityId.asJsonLD,
+        prov / "agent"   -> agent.resourceId.asEntityId.asJsonLD,
         prov / "hadPlan" -> association.planId.asEntityId.asJsonLD
       )
     }
@@ -111,9 +118,9 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "return Association's agent if of type Person" in {
 
-      val (association, agent, _) = generateAssociationWithPersonAgent
+      val (association, agent) = generateEntitiesAssociationWithPersonAgent
 
-      EntityFunctions[entities.Association].findAllPersons(association) shouldBe Set(agent.to[entities.Person])
+      EntityFunctions[entities.Association].findAllPersons(association) shouldBe Set(agent)
     }
   }
 
@@ -121,7 +128,7 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
     "return encoder that honors the given GraphClass" in {
 
-      val (association, _, _) = generateAssociationWithPersonAgent
+      val (association, _) = generateEntitiesAssociationWithPersonAgent
 
       implicit val graph: GraphClass = graphClasses.generateOne
       val functionsEncoder = EntityFunctions[entities.Association].encoder(graph)
@@ -130,18 +137,25 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
     }
   }
 
-  private def generateAssociationWithPersonAgent: (entities.Association, Person, entities.StepPlan) = {
+  private def generateEntitiesAssociationWithPersonAgent: (entities.Association, entities.Person) = {
+    val (association, agent, _) = generateAssociationWithPersonAgent
+    (association.to[entities.Association], agent.to[entities.Person])
+  }
+
+  private def generateAssociationWithPersonAgent: (Association, Person, StepPlan) = {
     val associationWithRenkuAgent =
-      activityEntities(stepPlanEntities())(projectCreatedDates().generateOne)
+      activityEntities(stepPlanEntities(planCommands, cliShapedPersons), cliShapedPersons)(
+        projectCreatedDates().generateOne
+      )
         .map(_.association)
         .generateOne
 
-    val agent = personEntities.generateOne
-    val plan  = associationWithRenkuAgent.plan.to[entities.StepPlan]
-    val association = entities.Association.WithPersonAgent(
-      associationWithRenkuAgent.to[entities.Association].resourceId,
-      agent.to[entities.Person],
-      plan.resourceId
+    val agent = cliShapedPersons.generateOne
+    val plan  = associationWithRenkuAgent.plan
+    val association = Association.WithPersonAgent(
+      associationWithRenkuAgent.activity,
+      agent,
+      associationWithRenkuAgent.plan
     )
 
     (association, agent, plan)

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/AssociationSpec.scala
@@ -26,11 +26,12 @@ import io.renku.graph.model.testentities._
 import io.renku.graph.model.{GraphClass, entities, plans}
 import io.renku.jsonld.syntax._
 import io.renku.jsonld.{JsonLD, JsonLDDecoder}
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
+class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks with EitherValues {
 
   "decode" should {
 
@@ -74,9 +75,9 @@ class AssociationSpec extends AnyWordSpec with should.Matchers with ScalaCheckPr
 
       implicit val dl: DependencyLinks = (_: plans.ResourceId) => Option.empty[entities.StepPlan]
 
-      val Left(failure) = testAssociation.to[CliAssociation].asFlattenedJsonLD.cursor.as[List[entities.Association]]
+      val result = testAssociation.to[CliAssociation].asFlattenedJsonLD.cursor.as[List[entities.Association]]
 
-      failure.message should include(
+      result.left.value.message should include(
         show"Association ${association.resourceId} points to a non-existing Plan ${association.planId}"
       )
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/DatasetPartSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/DatasetPartSpec.scala
@@ -26,6 +26,7 @@ import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
 import io.renku.graph.model.testentities._
 import io.renku.graph.model.tools.AdditionalMatchers
 import io.renku.graph.model.{InvalidationTime, entities}
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -33,6 +34,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class DatasetPartSpec
     extends AnyWordSpec
     with should.Matchers
+    with EitherValues
     with ScalaCheckPropertyChecks
     with AdditionalMatchers
     with DiffInstances {
@@ -70,14 +72,14 @@ class DatasetPartSpec
       val datasetPart      = datasetPartEntities(timestampsNotInTheFuture.generateOne).generateOne.to[CliDatasetFile]
       val invalidationTime = timestamps(max = datasetPart.dateCreated.value).generateAs(InvalidationTime)
 
-      val Left(error) = datasetPart
+      val result = datasetPart
         .copy(invalidationTime = invalidationTime.some)
         .asFlattenedJsonLD
         .cursor
         .as[List[entities.DatasetPart]]
 
-      error          shouldBe a[DecodingFailure]
-      error.getMessage should include
+      result.left.value          shouldBe a[DecodingFailure]
+      result.left.value.getMessage should include
       s"invalidationTime $invalidationTime is older than DatasetPart ${datasetPart.dateCreated.value}"
     }
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
@@ -19,9 +19,12 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
+import io.renku.cli.model
+import io.renku.cli.model.{CliActivity, CliDatasetFile, CliEntity}
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators.{datasetCreatedDates, projectCreatedDates}
 import io.renku.graph.model.entities.Generators._
+import io.renku.graph.model.testentities.StepPlan.CommandParameters.CommandParameterFactory
 import io.renku.graph.model.testentities._
 import io.renku.graph.model.{GraphClass, entities, generations}
 import io.renku.jsonld.JsonLD
@@ -33,13 +36,19 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
+  def activityGenerator(paramFactory: CommandParameterFactory) =
+    projectCreatedDates().flatMap(date =>
+      activityEntities(stepPlanEntities(planCommands, cliShapedPersons, paramFactory), cliShapedPersons)(date)
+    )
+
   "decode" should {
     implicit val graph: GraphClass = GraphClass.Default
 
     "turn JsonLD InputEntity entity into the Entity object " in {
       forAll(inputEntities) { entity =>
-        entity.asJsonLD.flatten
-          .fold(throw _, identity)
+        entity
+          .to[CliEntity]
+          .asFlattenedJsonLD
           .cursor
           .as[List[entities.Entity]] shouldBe List(entity.to[entities.Entity.InputEntity]).asRight
       }
@@ -47,10 +56,11 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
 
     "turn JsonLD Output entity into the Entity object " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
+        val activity    = activityGenerator(commandOutput).generateOne
+        val datasetPart = datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne
 
         val Right(decodedEntities) = JsonLD
-          .arr(activity.asJsonLD, datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne.asJsonLD)
+          .arr(activity.to[CliActivity].asJsonLD, datasetPart.to[CliDatasetFile].asJsonLD)
           .flatten
           .fold(throw _, identity)
           .cursor
@@ -64,19 +74,20 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
 
     "turn JsonLD Output entity into the OutputEntity object for the given generation Id " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
-          .to[entities.Activity]
+        val activity     = activityGenerator(commandOutput).generateOne
+        val prodActivity = activity.to[entities.Activity]
+        val datasetPart  = datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne
 
         val Right(decodedEntities) = JsonLD
-          .arr(activity.asJsonLD, datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne.asJsonLD)
+          .arr(activity.to[model.CliActivity].asJsonLD, datasetPart.to[model.CliDatasetFile].asJsonLD)
           .flatten
           .fold(throw _, identity)
           .cursor
           .as[List[entities.Entity.OutputEntity]](
-            decodeList(entities.Entity.outputEntityDecoder(activity.generations.head.resourceId))
+            decodeList(entities.Entity.outputEntityDecoder(prodActivity.generations.head.resourceId))
           )
 
-        decodedEntities should contain allElementsOf activity.generations.map(_.entity)
+        decodedEntities should contain allElementsOf prodActivity.generations.map(_.entity)
       }
     }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/EntitySpec.scala
@@ -19,31 +19,30 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
-import io.renku.cli.model
 import io.renku.cli.model.{CliActivity, CliDatasetFile, CliEntity}
+import io.renku.cli.model.CliModel._
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators.{datasetCreatedDates, projectCreatedDates}
 import io.renku.graph.model.entities.Generators._
+import io.renku.graph.model.testentities.Entity.OutputEntity
 import io.renku.graph.model.testentities.StepPlan.CommandParameters.CommandParameterFactory
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.{GraphClass, entities, generations}
-import io.renku.jsonld.JsonLD
+import io.renku.graph.model.entities
 import io.renku.jsonld.JsonLDDecoder._
-import io.renku.jsonld.syntax._
+import org.scalacheck.Gen
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import shapeless.HList
 
 class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
-  def activityGenerator(paramFactory: CommandParameterFactory) =
+  def activityGenerator(paramFactory: CommandParameterFactory): Gen[Activity] =
     projectCreatedDates().flatMap(date =>
       activityEntities(stepPlanEntities(planCommands, cliShapedPersons, paramFactory), cliShapedPersons)(date)
     )
 
   "decode" should {
-    implicit val graph: GraphClass = GraphClass.Default
-
     "turn JsonLD InputEntity entity into the Entity object " in {
       forAll(inputEntities) { entity =>
         entity
@@ -59,12 +58,9 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
         val activity    = activityGenerator(commandOutput).generateOne
         val datasetPart = datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne
 
-        val Right(decodedEntities) = JsonLD
-          .arr(activity.to[CliActivity].asJsonLD, datasetPart.to[CliDatasetFile].asJsonLD)
-          .flatten
-          .fold(throw _, identity)
-          .cursor
-          .as[List[entities.Entity]]
+        val Right(decodedEntities) =
+          HList(activity.to[CliActivity], datasetPart.to[CliDatasetFile]).asFlattenedJsonLD.cursor
+            .as[List[entities.Entity]]
 
         decodedEntities should contain allElementsOf activity.generations.map(
           _.entity.to[entities.Entity.OutputEntity]
@@ -78,14 +74,11 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
         val prodActivity = activity.to[entities.Activity]
         val datasetPart  = datasetPartEntities(datasetCreatedDates().generateOne.value).generateOne
 
-        val Right(decodedEntities) = JsonLD
-          .arr(activity.to[model.CliActivity].asJsonLD, datasetPart.to[model.CliDatasetFile].asJsonLD)
-          .flatten
-          .fold(throw _, identity)
-          .cursor
-          .as[List[entities.Entity.OutputEntity]](
-            decodeList(entities.Entity.outputEntityDecoder(prodActivity.generations.head.resourceId))
-          )
+        val Right(decodedEntities) =
+          HList(activity.to[CliActivity], datasetPart.to[CliDatasetFile]).asFlattenedJsonLD.cursor
+            .as[List[entities.Entity.OutputEntity]](
+              decodeList(entities.Entity.outputEntityDecoder(prodActivity.generations.head.resourceId))
+            )
 
         decodedEntities should contain allElementsOf prodActivity.generations.map(_.entity)
       }
@@ -93,27 +86,24 @@ class EntitySpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
 
     "turn JsonLD Output entity with multiple Generations into the Entity object " in {
       forAll(locationCommandOutputObjects) { commandOutput =>
-        val activity = activityEntities(stepPlanEntities(commandOutput))(projectCreatedDates().generateOne).generateOne
-          .to[entities.Activity]
-
-        val updateGenerations = activity.generations.map { generation =>
-          val updatedEntity = generation.entity.copy(generationResourceIds =
-            generation.entity.generationResourceIds ::: generations.ResourceId(
-              (renkuUrl / Generation.Id.generate).show
-            ) :: Nil
+        val testActivity = activityGenerator(commandOutput).generateOne
+        val updatedActivity = testActivity.copy(generationFactories =
+          testActivity.generationFactories :+ (act =>
+            Generation(Generation.Id.generate,
+                       act,
+                       gen => OutputEntity(entityLocations.generateOne, entityChecksums.generateOne, gen)
+            )
           )
-          generation.copy(entity = updatedEntity)
-        }
-        val updatedActivity = activity.copy(generations = updateGenerations)
+        )
 
-        val Right(decodedEntities) = JsonLD
-          .arr(updatedActivity.asJsonLD)
-          .flatten
-          .fold(throw _, identity)
-          .cursor
+        val cliActivity = updatedActivity.to[CliActivity]
+
+        val Right(decodedEntities) = cliActivity.asFlattenedJsonLD.cursor
           .as[List[entities.Entity]]
 
-        decodedEntities should contain allElementsOf updatedActivity.generations.map(_.entity)
+        decodedEntities should contain allElementsOf updatedActivity.generations.map(g =>
+          Entity.toEntity.apply(g.entity)
+        )
       }
     }
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ParameterValueSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ParameterValueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Swiss Data Science Center (ßSDSC)
+ * Copyright 2023 Swiss Data Science Center (SDSC)
  * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
  * Eidgenössische Technische Hochschule Zürich (ETHZ).
  *
@@ -19,7 +19,6 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
-import io.circe.DecodingFailure
 import io.renku.cli.model.CliActivity
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
@@ -32,6 +31,7 @@ import io.renku.graph.model.{entities, plans}
 import io.renku.jsonld.JsonLDDecoder._
 import monocle.Lens
 import org.scalacheck.Gen
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -39,6 +39,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class ParameterValueSpec
     extends AnyWordSpec
     with should.Matchers
+    with EitherValues
     with ScalaCheckPropertyChecks
     with AdditionalMatchers
     with DiffInstances {
@@ -122,14 +123,13 @@ class ParameterValueSpec
       implicit val dl: DependencyLinks =
         createDependencyLinks(planParametersLens.modify(_ => Nil)(activity.plan.to[entities.StepPlan]))
 
-      val Left(failure) = activity
+      val results = activity
         .to[CliActivity]
         .asFlattenedJsonLD
         .cursor
         .as(decodeList(entities.ParameterValue.decoder(entitiesActivity.association)))
 
-      failure shouldBe a[DecodingFailure]
-      failure.message should endWith(
+      results.left.value.message should endWith(
         s"ParameterValue points to a non-existing command parameter ${entitiesActivity.parameters.head.valueReference.resourceId}"
       )
     }
@@ -144,14 +144,13 @@ class ParameterValueSpec
       implicit val dl: DependencyLinks =
         createDependencyLinks(planInputsLens.modify(_ => Nil)(activity.plan.to[entities.StepPlan]))
 
-      val Left(failure) = activity
+      val results = activity
         .to[CliActivity]
         .asFlattenedJsonLD
         .cursor
         .as(decodeList(entities.ParameterValue.decoder(entitiesActivity.association)))
 
-      failure shouldBe a[DecodingFailure]
-      failure.message should endWith(
+      results.left.value.message should endWith(
         s"ParameterValue points to a non-existing command parameter ${activity.plan.to[entities.StepPlan].inputs.map(_.resourceId).head}"
       )
     }
@@ -164,14 +163,13 @@ class ParameterValueSpec
       implicit val dl: DependencyLinks =
         createDependencyLinks(planOutputsLens.modify(_ => Nil)(activity.plan.to[entities.StepPlan]))
 
-      val Left(failure) = activity
+      val results = activity
         .to[CliActivity]
         .asFlattenedJsonLD
         .cursor
         .as(decodeList(entities.ParameterValue.decoder(entitiesActivity.association)))
 
-      failure shouldBe a[DecodingFailure]
-      failure.message should endWith(
+      results.left.value.message should endWith(
         s"ParameterValue points to a non-existing command parameter ${activity.plan.to[entities.StepPlan].outputs.map(_.resourceId).head}"
       )
     }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PersonSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PersonSpec.scala
@@ -23,7 +23,7 @@ import io.circe.DecodingFailure
 import io.renku.cli.model.CliPerson
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.Schemas.schema
-import io.renku.graph.model.entities.Person.{entityTypes, gitLabIdEncoder, orcidIdEncoder}
+import io.renku.graph.model.entities.Person.entityTypes
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
 import io.renku.graph.model.testentities.Person
 import io.renku.graph.model.{GraphClass, GraphModelGenerators, entities, persons}
@@ -35,31 +35,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class PersonSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks with EntitiesGenerators {
-
-  (GraphClass.Default :: GraphClass.Persons :: Nil) foreach { implicit graph =>
-    show"encode as an Entity for the $graph Graph" should {
-
-      "use the Person resourceId if there's no GitLabId" in {
-        val person = personEntities(withoutGitLabId).generateOne.to[entities.Person]
-        person.asJsonLD.cursor.downEntityId.as[persons.ResourceId] shouldBe person.resourceId.asRight
-      }
-
-      "use the resourceId based on person's GitLabId if it exists" in {
-        val gitLabId = personGitLabIds.generateOne
-        forAll(personEntities().map(_.copy(maybeGitLabId = gitLabId.some))) { person =>
-          person.asJsonLD.cursor.downEntityId.as[persons.ResourceId] shouldBe persons.ResourceId(gitLabId).asRight
-        }
-      }
-
-      "use the resourceId based on person's GitLabId if it exists even if there's an orcidId" in {
-        val gitLabId = personGitLabIds.generateOne
-        val person = personEntities()
-          .map(_.copy(maybeGitLabId = gitLabId.some, maybeOrcidId = personOrcidIds.generateSome))
-          .generateOne
-        person.asJsonLD.cursor.downEntityId.as[persons.ResourceId] shouldBe persons.ResourceId(gitLabId).asRight
-      }
-    }
-  }
 
   "encode as entityId only for the Project Graph" should {
     implicit val graph: GraphClass = GraphClass.Project
@@ -75,78 +50,6 @@ class PersonSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropert
     "turn JsonLD Person entity into the Person object" in {
       forAll(cliShapedPersons) { person: Person =>
         person.to[CliPerson].asFlattenedJsonLD.cursor.as[entities.Person] shouldBe person.to[entities.Person].asRight
-      }
-    }
-
-    "turn JsonLD Person entity with multiple names" in {
-      val resourceId = personNameResourceId.generateOne
-      val firstName  = personNames.generateOne
-      val secondName = personNames.generateOne
-      val jsonLDPerson = JsonLD.entity(
-        resourceId.asEntityId,
-        entityTypes,
-        schema / "name" -> JsonLD.arr(firstName.asJsonLD, secondName.asJsonLD)
-      )
-
-      val Right(person) = jsonLDPerson.cursor.as[entities.Person]
-
-      person.name should (be(firstName) or be(secondName))
-    }
-
-    "take the last Affiliation in case of multiple for a Person" in {
-      val resourceId   = personNameResourceId.generateOne
-      val name         = personNames.generateOne
-      val affiliation1 = personAffiliations.generateOne
-      val affiliation2 = personAffiliations.generateOne
-      val jsonLDPerson = JsonLD.entity(
-        resourceId.asEntityId,
-        entityTypes,
-        schema / "name"        -> name.asJsonLD,
-        schema / "affiliation" -> JsonLD.arr(affiliation1.asJsonLD, affiliation2.asJsonLD)
-      )
-
-      jsonLDPerson.cursor.as[entities.Person].map(_.maybeAffiliation) shouldBe affiliation2.some.asRight
-    }
-
-    "fail if person's ResourceId does not match the GitLabId based ResourceId if GitLabId given" in {
-      forAll(Gen.oneOf(personEmailResourceId, personNameResourceId).widen[persons.ResourceId],
-             personGitLabIds,
-             personEmails.toGeneratorOfOptions,
-             personNames
-      ) { (invalidResourceId, gitLabId, maybeEmail, name) =>
-        val jsonLDPerson = JsonLD.entity(
-          invalidResourceId.asEntityId,
-          entityTypes,
-          schema / "name"   -> name.asJsonLD,
-          schema / "email"  -> maybeEmail.asJsonLD,
-          schema / "sameAs" -> gitLabId.asJsonLD(gitLabIdEncoder)
-        )
-
-        val Left(failure) = jsonLDPerson.cursor.as[entities.Person]
-
-        failure shouldBe a[DecodingFailure]
-        failure.message shouldBe
-          show"Invalid Person: ${invalidResourceId.asEntityId}, name = $name, gitLabId = ${gitLabId.some}, " +
-          show"orcidId = ${Option.empty[persons.OrcidId]}, email = $maybeEmail, affiliation = None"
-      }
-    }
-
-    "fail if person's ResourceId does not match the OrcidId based ResourceId if OrcidId given" in {
-      forAll(personOrcidResourceId.widen[persons.ResourceId], personOrcidIds, personNames) {
-        (invalidResourceId, orcidId, name) =>
-          val jsonLDPerson = JsonLD.entity(
-            invalidResourceId.asEntityId,
-            entityTypes,
-            schema / "name"   -> name.asJsonLD,
-            schema / "sameAs" -> orcidId.asJsonLD(orcidIdEncoder)
-          )
-
-          val Left(failure) = jsonLDPerson.cursor.as[entities.Person]
-
-          failure shouldBe a[DecodingFailure]
-          failure.message shouldBe
-            show"Invalid Person: ${invalidResourceId.asEntityId}, name = $name, gitLabId = ${Option.empty[persons.GitLabId]}, " +
-            show"orcidId = ${orcidId.some}, email = ${Option.empty[persons.Email]}, affiliation = None"
       }
     }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -20,16 +20,16 @@ package io.renku.graph.model.entities
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import io.renku.cli.model.{CliCompositePlan, CliStepPlan}
+import io.renku.cli.model.CliModel._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
 import io.renku.graph.model.GraphModelGenerators.{graphClasses, projectCreatedDates}
 import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model._
-import io.renku.graph.model.cli.CliPlanConverters
 import io.renku.graph.model.entities.Generators._
 import io.renku.graph.model.testentities._
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.ProjectBasedGenFactoryOps
-import io.renku.graph.model.tools.JsonLDTools._
 import io.renku.graph.model.tools.{AdditionalMatchers, JsonLDTools}
 import io.renku.jsonld.JsonLDEncoder.encodeEntityId
 import io.renku.jsonld._
@@ -39,6 +39,7 @@ import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import shapeless.HList
 
 class PlanSpec
     extends AnyWordSpec
@@ -53,8 +54,8 @@ class PlanSpec
     "turn JsonLD of a non-modified Plan entity into the StepPlan object" in {
       forAll(stepPlans) { plan =>
         val prodPlan = plan.to[entities.StepPlan]
-        CliPlanConverters
-          .from(prodPlan)
+        plan
+          .to[CliStepPlan]
           .asFlattenedJsonLD
           .cursor
           .as[List[entities.StepPlan]] shouldMatchToRight List(prodPlan)
@@ -62,8 +63,8 @@ class PlanSpec
     }
 
     "turn JsonLD of a modified Plan entity into the StepPlan object" in {
-      forAll(stepPlans.map(_.createModification())) { plan =>
-        val cliPlan = CliPlanConverters.from(plan.to[entities.Plan], Nil)
+      forAll(stepPlans.map(_.createModification())) { (plan: StepPlan) =>
+        val cliPlan = plan.to[CliStepPlan]
         cliPlan.asFlattenedJsonLD.cursor
           .as[List[entities.StepPlan]] shouldMatchToRight List(plan.to[entities.StepPlan])
       }
@@ -71,21 +72,20 @@ class PlanSpec
 
     "decode if invalidation after the creation date" in {
 
-      val plan = stepPlans
+      val plan: StepPlan = stepPlans
         .map(_.invalidate())
         .generateOne
-        .to[entities.StepPlan]
 
-      val cliPlan = CliPlanConverters.from(plan)
+      val cliPlan = plan.to[CliStepPlan]
 
-      cliPlan.asFlattenedJsonLD.cursor.as[List[entities.StepPlan]] shouldMatchToRight List(plan)
+      cliPlan.asFlattenedJsonLD.cursor.as[List[entities.StepPlan]] shouldMatchToRight List(plan.to[entities.StepPlan])
     }
 
     "decode a Step Plan that has additional types" in {
 
       val testPlan = stepPlans.generateOne
       val plan     = testPlan.to[entities.StepPlan]
-      val cliPlan  = CliPlanConverters.from(plan)
+      val cliPlan  = testPlan.to[CliStepPlan]
 
       val newJson =
         JsonLDTools
@@ -99,39 +99,40 @@ class PlanSpec
 
     "fail if invalidatedAtTime present on non-modified Plan" in {
 
-      val plan = stepPlans
+      val plan: StepPlan = stepPlans
         .map(_.invalidate())
         .generateOne
-        .to[entities.StepPlan]
 
       val cliPlan =
-        CliPlanConverters
-          .from(plan)
+        plan
+          .to[CliStepPlan]
           .copy(derivedFrom = None)
 
       val result = cliPlan.asFlattenedJsonLD.cursor.as[List[entities.StepPlan]].leftMap(_.message)
 
-      result.left.value should include(show"Plan ${plan.resourceId} has no parent but invalidation time")
+      result.left.value should include(
+        show"Plan ${plan.to[entities.StepPlan].resourceId} has no parent but invalidation time"
+      )
     }
 
     "fail if invalidation done before the creation date" in {
 
-      val plan = stepPlans
+      val plan: StepPlan = stepPlans
         .map(_.invalidate())
         .generateOne
-        .to[entities.StepPlan]
+      val modelPlan = plan.to[entities.StepPlan]
 
       val wrongInvalidationTime = timestamps(max = plan.dateCreated.value.minusSeconds(1)).generateAs(InvalidationTime)
 
       val cliPlan =
-        CliPlanConverters
-          .from(plan)
+        plan
+          .to[CliStepPlan]
           .copy(invalidationTime = wrongInvalidationTime.some)
 
       val result = cliPlan.asFlattenedJsonLD.cursor.as[List[entities.StepPlan]].leftMap(_.message)
 
       result.left.value should include {
-        show"Invalidation time $wrongInvalidationTime on StepPlan ${plan.resourceId} is older than dateCreated ${plan.dateCreated}"
+        show"Invalidation time $wrongInvalidationTime on StepPlan ${modelPlan.resourceId} is older than dateCreated ${modelPlan.dateCreated}"
       }
     }
   }
@@ -141,9 +142,8 @@ class PlanSpec
     "return json for a non-modified composite plan" in {
       forAll(compositePlanGen(cliShapedPersons)) { plan =>
         val expected = plan.to[entities.CompositePlan]
-        val allPlans = plan.recursivePlans
-        CliPlanConverters
-          .from(expected, allPlans.map(_.to[entities.Plan]))
+        plan
+          .to[CliCompositePlan]
           .asFlattenedJsonLD
           .cursor
           .as[List[entities.CompositePlan]]
@@ -155,8 +155,8 @@ class PlanSpec
     "return json for a modified composite plan" in {
       forAll(compositePlanGen(cliShapedPersons).map(_.createModification())) { plan =>
         val expected = plan.to[entities.CompositePlan]
-        CliPlanConverters
-          .from(expected, plan.recursivePlans.map(_.to[entities.Plan]))
+        plan
+          .to[CliCompositePlan]
           .asFlattenedJsonLD
           .cursor
           .as[List[entities.CompositePlan]]
@@ -168,12 +168,7 @@ class PlanSpec
     "decode if invalidation after the creation date" in {
       forAll(compositePlanGen(cliShapedPersons).map(_.createModification().invalidate())) { plan =>
         val expected = List(plan.to[entities.CompositePlan])
-        val json = CliPlanConverters
-          .from(
-            plan.to[entities.CompositePlan],
-            plan.recursivePlans.map(_.to[entities.Plan])
-          )
-          .asFlattenedJsonLD
+        val json     = plan.to[CliCompositePlan].asFlattenedJsonLD
         json.cursor
           .as[List[entities.CompositePlan]]
           .fold(fail(_), _.filter(_.resourceId == expected.head.resourceId))
@@ -187,12 +182,7 @@ class PlanSpec
       val cp     = testCp.to[entities.CompositePlan]
       val sp     = testSp.to[entities.StepPlan]
 
-      val jsonLD = flattenedJsonLDFrom(
-        CliPlanConverters
-          .from(cp, testCp.recursivePlans.map(_.to[entities.Plan]))
-          .asNestedJsonLD,
-        CliPlanConverters.from(sp).asNestedJsonLD
-      )
+      val jsonLD = HList(testCp.to[CliCompositePlan], testSp.to[CliStepPlan]).asFlattenedJsonLD
 
       val decoded = jsonLD.cursor
         .as[List[entities.Plan]]
@@ -204,9 +194,9 @@ class PlanSpec
 
     "decode a Composite Plan without default value on its Parameter Mapping" in {
 
-      val testPlan  = compositePlanNonEmptyMappings(cliShapedPersons).generateOne
-      val modelPlan = testPlan.to[entities.CompositePlan]
-      val cliPlan   = CliPlanConverters.from(modelPlan, testPlan.recursivePlans.map(_.to[entities.Plan]))
+      val testPlan                         = compositePlanNonEmptyMappings(cliShapedPersons).generateOne
+      val modelPlan                        = testPlan.to[entities.CompositePlan]
+      val cliPlan                          = testPlan.to[CliCompositePlan]
       val cliFirstMapping :: otherMappings = cliPlan.mappings
 
       val result = cliPlan
@@ -228,7 +218,7 @@ class PlanSpec
     "decode a Composite Plan that has additional types" in {
       val testPlan = compositePlanGen(cliShapedPersons).generateOne
       val plan     = testPlan.to[entities.CompositePlan]
-      val cliPlan  = CliPlanConverters.from(plan, testPlan.recursivePlans.map(_.to[entities.Plan]))
+      val cliPlan  = testPlan.to[CliCompositePlan]
 
       val newJson =
         JsonLDTools
@@ -247,13 +237,14 @@ class PlanSpec
       val pm_  = plan.mappings.head
       val pm   = pm_.copy(mappedParam = NonEmptyList.one(pm_))
 
-      val ex = intercept[Throwable] {
-        plan
-          .addParamMapping(pm)
-          .to[entities.CompositePlan]
-      }
+      val jsonld = plan
+        .addParamMapping(pm)
+        .to[CliCompositePlan]
+        .asNestedJsonLD
 
-      ex.getMessage should include(
+      val Left(error) = jsonld.cursor.as[List[entities.CompositePlan]]
+
+      error.getMessage should include(
         show"Parameter ${pm.to(ParameterMapping.toEntitiesParameterMapping).resourceId} maps to itself"
       )
     }
@@ -263,8 +254,8 @@ class PlanSpec
         .map(_.createModification().invalidate())
         .generateOne
       val plan = testPlan.to[entities.CompositePlan]
-      val cliPlan = CliPlanConverters
-        .from(plan, testPlan.recursivePlans.map(_.to[entities.Plan]))
+      val cliPlan = testPlan
+        .to[CliCompositePlan]
         .copy(derivedFrom = None)
 
       val jsonLD = cliPlan.asFlattenedJsonLD
@@ -280,8 +271,8 @@ class PlanSpec
       val plan = testPlan.to[entities.CompositePlan]
 
       val invalidationTime = timestamps(max = plan.dateCreated.value.minusSeconds(1)).generateAs(InvalidationTime)
-      val cliPlan = CliPlanConverters
-        .from(plan, testPlan.recursivePlans.map(_.to[entities.Plan]))
+      val cliPlan = testPlan
+        .to[CliCompositePlan]
         .copy(invalidationTime = invalidationTime.some)
 
       val jsonLD = cliPlan.asNestedJsonLD

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -20,7 +20,7 @@ package io.renku.graph.model.entities
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
-import io.renku.cli.model.{CliCompositePlan, CliStepPlan}
+import io.renku.cli.model.{CliCompositePlan, CliPlan, CliStepPlan}
 import io.renku.cli.model.CliModel._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
@@ -55,7 +55,7 @@ class PlanSpec
       forAll(stepPlans) { plan =>
         val prodPlan = plan.to[entities.StepPlan]
         plan
-          .to[CliStepPlan]
+          .to[CliPlan]
           .asFlattenedJsonLD
           .cursor
           .as[List[entities.StepPlan]] shouldMatchToRight List(prodPlan)
@@ -64,7 +64,7 @@ class PlanSpec
 
     "turn JsonLD of a modified Plan entity into the StepPlan object" in {
       forAll(stepPlans.map(_.createModification())) { (plan: StepPlan) =>
-        val cliPlan = plan.to[CliStepPlan]
+        val cliPlan = plan.to[CliPlan]
         cliPlan.asFlattenedJsonLD.cursor
           .as[List[entities.StepPlan]] shouldMatchToRight List(plan.to[entities.StepPlan])
       }
@@ -76,7 +76,7 @@ class PlanSpec
         .map(_.invalidate())
         .generateOne
 
-      val cliPlan = plan.to[CliStepPlan]
+      val cliPlan = plan.to[CliPlan]
 
       cliPlan.asFlattenedJsonLD.cursor.as[List[entities.StepPlan]] shouldMatchToRight List(plan.to[entities.StepPlan])
     }
@@ -85,7 +85,7 @@ class PlanSpec
 
       val testPlan = stepPlans.generateOne
       val plan     = testPlan.to[entities.StepPlan]
-      val cliPlan  = testPlan.to[CliStepPlan]
+      val cliPlan  = testPlan.to[CliPlan]
 
       val newJson =
         JsonLDTools

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PublicationEventSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PublicationEventSpec.scala
@@ -19,12 +19,12 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
+import io.renku.cli.model.CliPublicationEvent
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestampsNotInTheFuture
 import io.renku.graph.model.entities
 import io.renku.graph.model.testentities._
 import io.renku.jsonld.JsonLDDecoder
-import io.renku.jsonld.syntax._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -43,7 +43,7 @@ class PublicationEventSpec extends AnyWordSpec with should.Matchers with ScalaCh
           dataset.to[entities.Dataset[entities.Dataset.Provenance]].identification
         )
 
-        event.asJsonLD.flatten.fold(throw _, identity).cursor.as[List[entities.PublicationEvent]] shouldBe List(
+        event.to[CliPublicationEvent].asFlattenedJsonLD.cursor.as[List[entities.PublicationEvent]] shouldBe List(
           event.to[entities.PublicationEvent]
         ).asRight
       }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/StepPlanCommandParameterSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/StepPlanCommandParameterSpec.scala
@@ -19,129 +19,142 @@
 package io.renku.graph.model.entities
 
 import cats.syntax.all._
+import io.renku.cli.model
+import io.renku.cli.model.CliStepPlan
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators.projectCreatedDates
 import io.renku.graph.model.entities.Generators._
+import io.renku.graph.model.testentities.StepPlan.CommandParameters.CommandParameterFactory
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.{GraphClass, entities}
-import io.renku.jsonld.syntax._
+import io.renku.graph.model.entities
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class StepPlanCommandParameterSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
-  (GraphClass.Default :: GraphClass.Project :: Nil) foreach { implicit graphClass =>
-    show"StepPlanCommandParameter.decode graphClass=$graphClass" should {
+  def planGenerator(parameterFactory: CommandParameterFactory) =
+    projectCreatedDates().flatMap { date =>
+      stepPlanEntities(planCommands, cliShapedPersons, parameterFactory)(date)
+    }
 
-      "turn JsonLD of ExplicitCommandParameter entity into the ExplicitCommandParameter object" in {
-        forAll(explicitCommandParameterObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.parameters.head
+  show"StepPlanCommandParameter.decode" should {
 
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandParameter]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandParameter]).asRight
-        }
-      }
+    "turn JsonLD of ExplicitCommandParameter entity into the ExplicitCommandParameter object" in {
+      forAll(explicitCommandParameterObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.parameters.head
 
-      "turn JsonLD of ImplicitCommandParameter entity into the ExplicitCommandParameter object" in {
-        forAll(implicitCommandParameterObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.parameters.head
-
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandParameter]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandParameter]).asRight
-        }
+        plan
+          .to[CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandParameter]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandParameter]).asRight
       }
     }
 
-    show"CommandInput.decode graphClass=$graphClass" should {
+    "turn JsonLD of ImplicitCommandParameter entity into the ExplicitCommandParameter object" in {
+      forAll(implicitCommandParameterObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.parameters.head
 
-      "turn JsonLD of LocationCommandInput entity into the LocationCommandInput object" in {
-        forAll(locationCommandInputObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.inputs.head
-
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandInput]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandInput]).asRight
-        }
+        plan
+          .to[CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandParameter]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandParameter]).asRight
       }
+    }
+  }
 
-      "turn JsonLD of MappedCommandInput entity into the MappedCommandInput object" in {
-        forAll(mappedCommandInputObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.inputs.head
+  show"CommandInput.decode" should {
 
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandInput]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandInput]).asRight
-        }
-      }
+    "turn JsonLD of LocationCommandInput entity into the LocationCommandInput object" in {
+      forAll(locationCommandInputObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.inputs.head
 
-      "turn JsonLD of ImplicitCommandInput entity into the ImplicitCommandInput object" in {
-        forAll(implicitCommandInputObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.inputs.head
-
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandInput]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandInput]).asRight
-        }
+        plan
+          .to[model.CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandInput]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandInput]).asRight
       }
     }
 
-    show"CommandOutput.decode graphClass=$graphClass" should {
+    "turn JsonLD of MappedCommandInput entity into the MappedCommandInput object" in {
+      forAll(mappedCommandInputObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.inputs.head
 
-      "turn JsonLD of LocationCommandOutput entity into the LocationCommandOutput object" in {
-        forAll(locationCommandOutputObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.outputs.head
-
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandOutput]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandOutput]).asRight
-        }
+        plan
+          .to[CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandInput]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandInput]).asRight
       }
+    }
 
-      "turn JsonLD of MappedCommandOutput entity into the MappedCommandOutput object" in {
-        forAll(mappedCommandOutputObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.outputs.head
+    "turn JsonLD of ImplicitCommandInput entity into the ImplicitCommandInput object" in {
+      forAll(implicitCommandInputObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.inputs.head
 
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandOutput]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandOutput]).asRight
-        }
+        plan
+          .to[model.CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandInput]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandInput]).asRight
       }
+    }
+  }
 
-      "turn JsonLD of ImplicitCommandOutput entity into the ImplicitCommandOutput object" in {
-        forAll(implicitCommandOutputObjects) { parameterFactory =>
-          val plan = stepPlanEntities(parameterFactory)(planCommands)(projectCreatedDates().generateOne).generateOne
-          val parameter = plan.outputs.head
+  show"CommandOutput.decode" should {
 
-          plan.asJsonLD.flatten
-            .fold(throw _, identity)
-            .cursor
-            .as[List[entities.StepPlanCommandParameter.CommandOutput]] shouldBe
-            List(parameter.to[entities.StepPlanCommandParameter.CommandOutput]).asRight
-        }
+    "turn JsonLD of LocationCommandOutput entity into the LocationCommandOutput object" in {
+      forAll(locationCommandOutputObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.outputs.head
+
+        plan
+          .to[model.CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandOutput]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandOutput]).asRight
+      }
+    }
+
+    "turn JsonLD of MappedCommandOutput entity into the MappedCommandOutput object" in {
+      forAll(mappedCommandOutputObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.outputs.head
+
+        plan
+          .to[model.CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandOutput]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandOutput]).asRight
+      }
+    }
+
+    "turn JsonLD of ImplicitCommandOutput entity into the ImplicitCommandOutput object" in {
+      forAll(implicitCommandOutputObjects) { parameterFactory =>
+        val plan      = planGenerator(parameterFactory).generateOne
+        val parameter = plan.outputs.head
+
+        plan
+          .to[model.CliStepPlan]
+          .asFlattenedJsonLD
+          .cursor
+          .as[List[entities.StepPlanCommandParameter.CommandOutput]] shouldBe
+          List(parameter.to[entities.StepPlanCommandParameter.CommandOutput]).asRight
       }
     }
   }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/StepPlanCommandParameterSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/StepPlanCommandParameterSpec.scala
@@ -38,7 +38,7 @@ class StepPlanCommandParameterSpec extends AnyWordSpec with should.Matchers with
       stepPlanEntities(planCommands, cliShapedPersons, parameterFactory)(date)
     }
 
-  show"StepPlanCommandParameter.decode" should {
+  "StepPlanCommandParameter.decode" should {
 
     "turn JsonLD of ExplicitCommandParameter entity into the ExplicitCommandParameter object" in {
       forAll(explicitCommandParameterObjects) { parameterFactory =>
@@ -69,7 +69,7 @@ class StepPlanCommandParameterSpec extends AnyWordSpec with should.Matchers with
     }
   }
 
-  show"CommandInput.decode" should {
+  "CommandInput.decode" should {
 
     "turn JsonLD of LocationCommandInput entity into the LocationCommandInput object" in {
       forAll(locationCommandInputObjects) { parameterFactory =>

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Activity.scala
@@ -28,6 +28,7 @@ import io.renku.graph.model.testentities.Activity._
 import io.renku.graph.model.testentities.Entity.OutputEntity
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints.UUID
+import monocle.Lens
 
 final case class Activity(id:                  Id,
                           startTime:           StartTime,
@@ -116,4 +117,18 @@ object Activity {
 
   implicit def entityIdEncoder(implicit renkuUrl: RenkuUrl): EntityIdEncoder[Activity] =
     EntityIdEncoder.instance(entity => EntityId of renkuUrl / "activities" / entity.id)
+
+  object Lenses {
+    val association: Lens[Activity, Association] =
+      Lens[Activity, Association](_.association)(assoc => a => a.copy(associationFactory = _ => assoc))
+
+    val plan: Lens[Activity, StepPlan] =
+      association.composeLens(Association.Lenses.plan)
+
+    val planCreators: Lens[Activity, List[Person]] =
+      plan.composeLens(StepPlan.Lenses.creators)
+
+    val associationAgent: Lens[Activity, Either[Agent, Person]] =
+      association.composeLens(Association.Lenses.agent)
+  }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Plan.scala
@@ -27,6 +27,7 @@ import io.renku.graph.model._
 import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.commandParameters.Position
 import io.renku.graph.model.plans._
+import monocle.Lens
 
 trait Plan extends PlanAlg {
   val id:               Identifier
@@ -121,4 +122,12 @@ object Plan {
 
   implicit def entityIdEncoder[R <: Plan](implicit renkuUrl: RenkuUrl): EntityIdEncoder[R] =
     EntityIdEncoder.instance(plan => plan.id.asEntityId)
+
+  object Lenses {
+    val creators: Lens[Plan, List[Person]] =
+      Lens[Plan, List[Person]](_.creators)(persons => {
+        case sp: StepPlan      => StepPlan.Lenses.creators.set(persons)(sp)
+        case cp: CompositePlan => CompositePlan.Lenses.creators.set(persons)(cp)
+      })
+  }
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -216,11 +216,12 @@ trait RenkuProjectEntitiesGenerators {
     }
 
     def addDatasetAndInvalidation[P <: Dataset.Provenance](
-        factory: DatasetGenFactory[P]
+        factory:    DatasetGenFactory[P],
+        creatorGen: Gen[Person] = personEntities
     ): Gen[((Dataset[P], Dataset[Dataset.Provenance.Modified]), RenkuProject)] = for {
       project    <- projectGen
       originalDs <- factory(project.dateCreated)
-      invalidated = originalDs.invalidateNow
+      invalidated = originalDs.invalidateNow(creatorGen)
     } yield (originalDs -> invalidated) -> project.addDatasets(originalDs, invalidated)
 
     def importDataset[PIN <: Dataset.Provenance, POUT <: Dataset.Provenance](
@@ -264,11 +265,12 @@ trait RenkuProjectEntitiesGenerators {
     } yield ((entities -> originalDs) -> modifiedDs) -> project.addDatasets(originalDs, modifiedDs)
 
     def addDatasetAndInvalidation[P <: Dataset.Provenance](
-        factory: DatasetGenFactory[P]
+        factory:    DatasetGenFactory[P],
+        creatorGen: Gen[Person] = personEntities
     ): Gen[(((T, Dataset[P]), Dataset[Dataset.Provenance.Modified]), RenkuProject)] = for {
       (entities, project) <- tupleGen
       originalDs          <- factory(project.dateCreated)
-      invalidated = originalDs.invalidateNow
+      invalidated = originalDs.invalidateNow(creatorGen)
     } yield ((entities -> originalDs) -> invalidated) -> project.addDatasets(originalDs, invalidated)
 
     def importDataset[PIN <: Dataset.Provenance, POUT <: Dataset.Provenance](

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/ProjectFunctionsSpec.scala
@@ -188,7 +188,9 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
         val originalImportedInternal =
           datasetEntities(provenanceImportedInternalAncestorInternal())(renkuUrl)(project.dateCreated).generateOne
         val projectWithAllDatasets =
-          project.addDatasets(originalImportedInternal, originalImportedInternal.invalidateNow).to[entities.Project]
+          project
+            .addDatasets(originalImportedInternal, originalImportedInternal.invalidateNow(personEntities))
+            .to[entities.Project]
 
         findInternallyImportedDatasets(projectWithAllDatasets) should contain theSameElementsAs List(
           importedInternalAncestorInternal,
@@ -209,7 +211,7 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
 
       val (original, modifiedBeforeInvalidation, modifiedInvalidated) =
         datasetAndModificationEntities(provenanceInternal, projectDateCreated = project.dateCreated).map {
-          case (orig, modified) => (orig, modified, modified.invalidateNow)
+          case (orig, modified) => (orig, modified, modified.invalidateNow(personEntities))
         }.generateOne
       val projectWithAllDatasets =
         project.addDatasets(original, modifiedBeforeInvalidation, modifiedInvalidated).to[entities.Project]
@@ -232,7 +234,7 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
           .generateOne
       val (beforeModification, modified, modificationInvalidated) =
         datasetAndModificationEntities(provenanceInternal, projectDateCreated = project.dateCreated).map {
-          case internal ::~ modified => (internal, modified, modified.invalidateNow)
+          case internal ::~ modified => (internal, modified, modified.invalidateNow(personEntities))
         }.generateOne
       val (beforeNotInvalidatedModification, notInvalidatedModification) =
         datasetAndModificationEntities(provenanceInternal, projectDateCreated = project.dateCreated).generateOne

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/HierarchyOnInvalidationUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/HierarchyOnInvalidationUpdaterSpec.scala
@@ -48,7 +48,7 @@ class HierarchyOnInvalidationUpdaterSpec extends AnyWordSpec with MockFactory wi
 
       val (beforeModification, modification, modificationInvalidated) =
         datasetAndModificationEntities(provenanceInternal, projectDateCreated = project.dateCreated).map {
-          case internal ::~ modified => (internal, modified, modified.invalidateNow)
+          case internal ::~ modified => (internal, modified, modified.invalidateNow(personEntities))
         }.generateOne
 
       val entitiesProject = project
@@ -121,7 +121,7 @@ class HierarchyOnInvalidationUpdaterSpec extends AnyWordSpec with MockFactory wi
 
       val (beforeModification, modification, modificationInvalidated) =
         datasetAndModificationEntities(provenanceInternal, projectDateCreated = project.dateCreated).map {
-          case internal ::~ modified => (internal, modified, modified.invalidateNow)
+          case internal ::~ modified => (internal, modified, modified.invalidateNow(personEntities))
         }.generateOne
 
       val entitiesProject = project

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/KGDatasetInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/KGDatasetInfoFinderSpec.scala
@@ -324,7 +324,7 @@ class KGDatasetInfoFinderSpec
           .forkOnce()
           .generateOne
 
-      val forkWithInvalidatedDS = fork1.addDatasets(ds.invalidateNow)
+      val forkWithInvalidatedDS = fork1.addDatasets(ds.invalidateNow(personEntities))
 
       val (_, (_, forkWithModification)) = project.forkOnce().bimap(identity, _.addDataset(ds.createModification()))
 


### PR DESCRIPTION
This PR refactors renku model tests that test decoding cli payload by using the new cli model classes to generated the expected cli output.