### PR TITLE
fix: SearchInfoFeatcher to work with ',' in names

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/commands/SearchInfoFetcher.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/commands/SearchInfoFetcher.scala
@@ -106,7 +106,7 @@ private class SearchInfoFetcherImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder
         |""".stripMargin
   )
 
-  private lazy val rowsSeparator = "##"
+  private lazy val rowsSeparator = '\u0000'
 
   private implicit lazy val recordsDecoder: Decoder[List[SearchInfo]] = ResultsDecoder[List, SearchInfo] {
     implicit cur =>

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/commands/SearchInfoFetcherSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/commands/SearchInfoFetcherSpec.scala
@@ -50,13 +50,7 @@ class SearchInfoFetcherSpec
       // other project DS
       insert(projectsDataset, searchInfoObjectsGen.generateOne.asQuads)
 
-      fetcher.fetchTSSearchInfos(projectId).unsafeRunSync() shouldBe infos.sortBy(_.name).map { info =>
-        info.copy(creators = info.creators.sortBy(_.name),
-                  keywords = info.keywords.sorted,
-                  images = info.images.sortBy(_.position),
-                  links = info.links.sortBy(_.projectId)
-        )
-      }
+      fetcher.fetchTSSearchInfos(projectId).unsafeRunSync() shouldBe infos.sortBy(_.name).map(orderValues)
     }
 
     "work if there are ',' in names" in new TestCase {
@@ -67,7 +61,7 @@ class SearchInfoFetcherSpec
 
       insert(projectsDataset, infos.map(_.asQuads).toSet.flatten)
 
-      fetcher.fetchTSSearchInfos(projectId).unsafeRunSync() shouldBe infos.sortBy(_.name)
+      fetcher.fetchTSSearchInfos(projectId).unsafeRunSync() shouldBe infos.sortBy(_.name).map(orderValues)
     }
 
     "return nothing if no Datasets for the Project" in new TestCase {
@@ -86,4 +80,10 @@ class SearchInfoFetcherSpec
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
     val fetcher = new SearchInfoFetcherImpl[IO](projectsDSConnectionInfo)
   }
+
+  private def orderValues(info: SearchInfo) = info.copy(creators = info.creators.sortBy(_.name),
+                                                        keywords = info.keywords.sorted,
+                                                        images = info.images.sortBy(_.position),
+                                                        links = info.links.sortBy(_.projectId)
+  )
 }


### PR DESCRIPTION
Apparently, there are `,`s appearing names of Person entities. Unfortunately, the `SearchInfoFeatcher` was using that char to separate rows in the results set.
This PR fixes that.