### PR TITLE
feat: EventSender to take service url on instantiation

### DIFF
--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/commitsync/eventgeneration/CommitsSynchronizer.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/commitsync/eventgeneration/CommitsSynchronizer.scala
@@ -24,12 +24,13 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.circe.literal._
 import io.renku.commiteventservice.events.consumers.commitsync._
+import io.renku.commiteventservice.events.consumers.common._
 import io.renku.commiteventservice.events.consumers.common.SynchronizationSummary._
 import io.renku.commiteventservice.events.consumers.common.UpdateResult._
-import io.renku.commiteventservice.events.consumers.common._
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.Project
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.{BatchDate, CommitId}
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.{AccessToken, GitLabClient}
@@ -228,7 +229,7 @@ private[commitsync] object CommitsSynchronizer {
     commitInfoFinder    <- CommitInfoFinder[F]
     commitToEventLog    <- CommitToEventLog[F]
     commitEventsRemover <- CommitEventsRemover[F]
-    eventSender         <- EventSender[F]
+    eventSender         <- EventSender[F](EventLogUrl)
   } yield new CommitsSynchronizerImpl[F](latestCommitFinder,
                                          eventDetailsFinder,
                                          commitInfoFinder,

--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/common/CommitEventsRemover.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/common/CommitEventsRemover.scala
@@ -24,9 +24,10 @@ import cats.syntax.all._
 import io.circe.literal._
 import io.renku.commiteventservice.events.consumers.commitsync.categoryName
 import io.renku.commiteventservice.events.consumers.common.UpdateResult._
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.Project
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.events.EventStatus.AwaitingDeletion
 import io.renku.metrics.MetricsRegistry
@@ -66,5 +67,5 @@ private class CommitEventsRemoverImpl[F[_]: MonadThrow](eventSender: EventSender
 
 private[consumers] object CommitEventsRemover {
   def apply[F[_]: Async: Temporal: Logger: MetricsRegistry]: F[CommitEventsRemover[F]] =
-    EventSender[F].map(new CommitEventsRemoverImpl[F](_))
+    EventSender[F](EventLogUrl).map(new CommitEventsRemoverImpl[F](_))
 }

--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/common/CommitToEventLog.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/common/CommitToEventLog.scala
@@ -24,9 +24,10 @@ import cats.syntax.all._
 import io.renku.commiteventservice.events.consumers.commitsync.categoryName
 import io.renku.commiteventservice.events.consumers.common.CommitEvent.{NewCommitEvent, SkippedCommitEvent}
 import io.renku.commiteventservice.events.consumers.common.UpdateResult.{Created, Failed}
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.Project
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.{BatchDate, CommitId, EventBody}
 import io.renku.metrics.MetricsRegistry
 import org.typelevel.log4cats.Logger
@@ -125,5 +126,5 @@ private[consumers] class CommitToEventLogImpl[F[_]: MonadThrow](
 
 private[consumers] object CommitToEventLog {
   def apply[F[_]: Async: Logger: MetricsRegistry]: F[CommitToEventLog[F]] =
-    EventSender[F].map(new CommitToEventLogImpl[F](_, CommitEventSerializer))
+    EventSender[F](EventLogUrl).map(new CommitToEventLogImpl[F](_, CommitEventSerializer))
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/projectsync/ProjectInfoSynchronizer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/projectsync/ProjectInfoSynchronizer.scala
@@ -26,6 +26,7 @@ import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.EventRequestContent
 import io.renku.events.producers.EventSender
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.projects
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
@@ -95,6 +96,6 @@ private object ProjectInfoSynchronizer {
       : F[ProjectInfoSynchronizer[F]] = for {
     gitLabProjectFetcher <- GitLabProjectFetcher[F]
     projectRemover       <- ProjectRemover[F]
-    eventSender          <- EventSender[F]
+    eventSender          <- EventSender[F](EventLogUrl)
   } yield new ProjectInfoSynchronizerImpl(gitLabProjectFetcher, projectRemover, eventSender)
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/AllEventsToNewUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/AllEventsToNewUpdater.scala
@@ -29,9 +29,10 @@ import io.circe.syntax._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers
 import io.renku.eventlog.metrics.QueriesExecutionTimes
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.Project
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.EventStatus
 import io.renku.graph.model.projects
 import io.renku.metrics.MetricsRegistry
@@ -101,5 +102,5 @@ private class AllEventsToNewUpdater[F[_]: Async: QueriesExecutionTimes](
 
 private object AllEventsToNewUpdater {
   def apply[F[_]: Async: Logger: MetricsRegistry: QueriesExecutionTimes]: F[AllEventsToNewUpdater[F]] =
-    EventSender[F] map (new AllEventsToNewUpdater(_))
+    EventSender[F](EventLogUrl) map (new AllEventsToNewUpdater(_))
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/awaitinggeneration/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/awaitinggeneration/DispatchRecovery.scala
@@ -25,9 +25,10 @@ import io.circe.literal._
 import io.renku.eventlog.events.producers
 import io.renku.eventlog.events.producers.DispatchRecovery
 import io.renku.eventlog.events.producers.EventsSender.SendingResult
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.subscriptions.SubscriberUrl
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.EventMessage
 import io.renku.graph.model.events.EventStatus.{GenerationNonRecoverableFailure, New}
 import io.renku.metrics.MetricsRegistry
@@ -81,7 +82,6 @@ private class DispatchRecoveryImpl[F[_]: MonadThrow: Logger](
 }
 
 private object DispatchRecovery {
-  def apply[F[_]: Async: Logger: MetricsRegistry]: F[DispatchRecovery[F, AwaitingGenerationEvent]] = for {
-    eventSender <- EventSender[F]
-  } yield new DispatchRecoveryImpl[F](eventSender)
+  def apply[F[_]: Async: Logger: MetricsRegistry]: F[DispatchRecovery[F, AwaitingGenerationEvent]] =
+    EventSender[F](EventLogUrl).map(new DispatchRecoveryImpl[F](_))
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/cleanup/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/cleanup/DispatchRecovery.scala
@@ -24,9 +24,10 @@ import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
 import io.circe.literal._
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.subscriptions.SubscriberUrl
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.EventStatus
 import io.renku.graph.model.events.EventStatus._
 import io.renku.metrics.MetricsRegistry
@@ -71,7 +72,6 @@ private class DispatchRecoveryImpl[F[_]: MonadThrow: Logger](eventSender: EventS
 }
 
 private object DispatchRecovery {
-  def apply[F[_]: Async: Logger: MetricsRegistry]: F[DispatchRecovery[F, CleanUpEvent]] = for {
-    eventSender <- EventSender[F]
-  } yield new DispatchRecoveryImpl[F](eventSender)
+  def apply[F[_]: Async: Logger: MetricsRegistry]: F[DispatchRecovery[F, CleanUpEvent]] =
+    EventSender[F](EventLogUrl).map(new DispatchRecoveryImpl[F](_))
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/triplesgenerated/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/triplesgenerated/DispatchRecovery.scala
@@ -26,9 +26,10 @@ import io.circe.literal._
 import io.renku.eventlog.events.producers
 import io.renku.eventlog.events.producers.DispatchRecovery
 import io.renku.eventlog.events.producers.EventsSender.SendingResult
+import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.events.consumers.subscriptions.SubscriberUrl
 import io.renku.events.producers.EventSender
-import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.events.EventMessage
 import io.renku.graph.model.events.EventStatus.{TransformationNonRecoverableFailure, TriplesGenerated}
 import io.renku.metrics.MetricsRegistry
@@ -84,5 +85,5 @@ private class DispatchRecoveryImpl[F[_]: MonadThrow: Logger](
 private object DispatchRecovery {
 
   def apply[F[_]: Async: Logger: MetricsRegistry]: F[DispatchRecovery[F, TriplesGeneratedEvent]] =
-    EventSender[F].map(new DispatchRecoveryImpl[F](_))
+    EventSender[F](EventLogUrl).map(new DispatchRecoveryImpl[F](_))
 }

--- a/graph-commons/src/main/scala/io/renku/events/producers/EventSender.scala
+++ b/graph-commons/src/main/scala/io/renku/events/producers/EventSender.scala
@@ -18,23 +18,24 @@
 
 package io.renku.events.producers
 
+import cats.{Applicative, Eval}
 import cats.effect.{Async, Temporal}
 import cats.syntax.all._
-import cats.{Applicative, Eval}
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.NonNegative
 import io.renku.control.Throttler
-import io.renku.events.producers.EventSender.EventContext
 import io.renku.events.{CategoryName, EventRequestContent}
-import io.renku.graph.config.EventLogUrl
+import io.renku.events.producers.EventSender.EventContext
+import io.renku.graph.config.EventConsumerUrl
 import io.renku.graph.metrics.SentEventsGauge
 import io.renku.http.client.RestClient
 import io.renku.http.client.RestClient.{MaxRetriesAfterConnectionTimeout, SleepAfterConnectionIssue}
 import io.renku.http.client.RestClientError.{ClientException, ConnectivityException, UnexpectedResponseException}
 import io.renku.metrics.MetricsRegistry
+import io.renku.tinytypes.UrlTinyType
+import org.http4s._
 import org.http4s.Method.POST
 import org.http4s.Status.{Accepted, BadGateway, GatewayTimeout, NotFound, ServiceUnavailable}
-import org.http4s._
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
@@ -48,8 +49,19 @@ trait EventSender[F[_]] {
   ): F[Unit]
 }
 
+object EventSender {
+  def apply[F[_]: Async: Logger: MetricsRegistry](
+      consumerUrl: EventConsumerUrl
+  ): F[EventSender[F]] = for {
+    serviceUrl      <- consumerUrl()
+    sentEventsGauge <- SentEventsGauge[F]
+  } yield new EventSenderImpl(serviceUrl, sentEventsGauge, onErrorSleep = 15 seconds)
+
+  final case class EventContext(categoryName: CategoryName, errorMessage: String)
+}
+
 class EventSenderImpl[F[_]: Async: Logger](
-    eventLogUrl:            EventLogUrl,
+    serviceUrl:             UrlTinyType,
     sentEventsGauge:        SentEventsGauge[F],
     onErrorSleep:           FiniteDuration,
     retryInterval:          FiniteDuration = SleepAfterConnectionIssue,
@@ -66,7 +78,7 @@ class EventSenderImpl[F[_]: Async: Logger](
   import applicative.whenA
 
   override def sendEvent(eventContent: EventRequestContent.NoPayload, context: EventContext): F[Unit] = for {
-    uri            <- validateUri(s"$eventLogUrl/events")
+    uri            <- validateUri(s"$serviceUrl/events")
     request        <- createRequest(uri, eventContent)
     responseStatus <- sendWithRetry(request, context)
     _              <- whenA(responseStatus == Accepted)(sentEventsGauge.increment(context.categoryName))
@@ -75,7 +87,7 @@ class EventSenderImpl[F[_]: Async: Logger](
   override def sendEvent[PayloadType](eventContent: EventRequestContent.WithPayload[PayloadType],
                                       context:      EventContext
   )(implicit partEncoder: RestClient.PartEncoder[PayloadType]): F[Unit] = for {
-    uri            <- validateUri(s"$eventLogUrl/events")
+    uri            <- validateUri(s"$serviceUrl/events")
     request        <- createRequest(uri, eventContent)
     responseStatus <- sendWithRetry(request, context)
     _              <- whenA(responseStatus == Accepted)(sentEventsGauge.increment(context.categoryName))
@@ -114,13 +126,4 @@ class EventSenderImpl[F[_]: Async: Logger](
     case (Accepted, _, _) => Accepted.pure[F]
     case (NotFound, _, _) => NotFound.pure[F]
   }
-}
-
-object EventSender {
-  def apply[F[_]: Async: Logger: MetricsRegistry]: F[EventSender[F]] = for {
-    eventLogUrl     <- EventLogUrl[F]()
-    sentEventsGauge <- SentEventsGauge[F]
-  } yield new EventSenderImpl(eventLogUrl, sentEventsGauge, onErrorSleep = 15 seconds)
-
-  final case class EventContext(categoryName: CategoryName, errorMessage: String)
 }

--- a/graph-commons/src/main/scala/io/renku/graph/config/EventConsumerUrl.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/config/EventConsumerUrl.scala
@@ -20,24 +20,11 @@ package io.renku.graph.config
 
 import cats.MonadThrow
 import com.typesafe.config.{Config, ConfigFactory}
-import io.renku.config.ConfigLoader.{find, urlTinyTypeReader}
-import io.renku.tinytypes.{TinyTypeFactory, UrlTinyType}
-import io.renku.tinytypes.constraints.{Url, UrlOps}
-import pureconfig.ConfigReader
+import io.renku.tinytypes.UrlTinyType
 
-final class EventLogUrl private (val value: String) extends AnyVal with UrlTinyType
-object EventLogUrl
-    extends TinyTypeFactory[EventLogUrl](new EventLogUrl(_))
-    with Url[EventLogUrl]
-    with UrlOps[EventLogUrl]
-    with EventConsumerUrl {
+trait EventConsumerUrl {
 
-  type T = EventLogUrl
+  type T <: UrlTinyType
 
-  implicit val eventLogUrlOps: EventLogUrl.type = this
-
-  private implicit val urlReader: ConfigReader[EventLogUrl] = urlTinyTypeReader(EventLogUrl)
-
-  override def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[EventLogUrl] =
-    find[F, EventLogUrl]("services.event-log.url", config)
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[T]
 }

--- a/graph-commons/src/main/scala/io/renku/graph/config/EventConsumerUrlFactory.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/config/EventConsumerUrlFactory.scala
@@ -22,9 +22,9 @@ import cats.MonadThrow
 import com.typesafe.config.{Config, ConfigFactory}
 import io.renku.tinytypes.UrlTinyType
 
-trait EventConsumerUrl {
-
-  type T <: UrlTinyType
-
+trait EventConsumerUrlFactory {
+  type T <: EventConsumerUrl
   def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[T]
 }
+
+trait EventConsumerUrl extends Any with UrlTinyType

--- a/graph-commons/src/main/scala/io/renku/graph/config/EventLogUrl.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/config/EventLogUrl.scala
@@ -21,16 +21,16 @@ package io.renku.graph.config
 import cats.MonadThrow
 import com.typesafe.config.{Config, ConfigFactory}
 import io.renku.config.ConfigLoader.{find, urlTinyTypeReader}
-import io.renku.tinytypes.{TinyTypeFactory, UrlTinyType}
+import io.renku.tinytypes.TinyTypeFactory
 import io.renku.tinytypes.constraints.{Url, UrlOps}
 import pureconfig.ConfigReader
 
-final class EventLogUrl private (val value: String) extends AnyVal with UrlTinyType
+final class EventLogUrl private (val value: String) extends AnyVal with EventConsumerUrl
 object EventLogUrl
     extends TinyTypeFactory[EventLogUrl](new EventLogUrl(_))
     with Url[EventLogUrl]
     with UrlOps[EventLogUrl]
-    with EventConsumerUrl {
+    with EventConsumerUrlFactory {
 
   type T = EventLogUrl
 

--- a/graph-commons/src/main/scala/io/renku/graph/config/TriplesGeneratorUrl.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/config/TriplesGeneratorUrl.scala
@@ -21,16 +21,16 @@ package io.renku.graph.config
 import cats.MonadThrow
 import com.typesafe.config.{Config, ConfigFactory}
 import io.renku.config.ConfigLoader.{find, urlTinyTypeReader}
-import io.renku.tinytypes.{TinyTypeFactory, UrlTinyType}
+import io.renku.tinytypes.TinyTypeFactory
 import io.renku.tinytypes.constraints.{Url, UrlOps}
 import pureconfig.ConfigReader
 
-final class TriplesGeneratorUrl private (val value: String) extends AnyVal with UrlTinyType
+final class TriplesGeneratorUrl private (val value: String) extends AnyVal with EventConsumerUrl
 object TriplesGeneratorUrl
     extends TinyTypeFactory[TriplesGeneratorUrl](new TriplesGeneratorUrl(_))
     with Url[TriplesGeneratorUrl]
     with UrlOps[TriplesGeneratorUrl]
-    with EventConsumerUrl {
+    with EventConsumerUrlFactory {
 
   type T = TriplesGeneratorUrl
 

--- a/graph-commons/src/main/scala/io/renku/graph/config/TriplesGeneratorUrl.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/config/TriplesGeneratorUrl.scala
@@ -25,19 +25,19 @@ import io.renku.tinytypes.{TinyTypeFactory, UrlTinyType}
 import io.renku.tinytypes.constraints.{Url, UrlOps}
 import pureconfig.ConfigReader
 
-final class EventLogUrl private (val value: String) extends AnyVal with UrlTinyType
-object EventLogUrl
-    extends TinyTypeFactory[EventLogUrl](new EventLogUrl(_))
-    with Url[EventLogUrl]
-    with UrlOps[EventLogUrl]
+final class TriplesGeneratorUrl private (val value: String) extends AnyVal with UrlTinyType
+object TriplesGeneratorUrl
+    extends TinyTypeFactory[TriplesGeneratorUrl](new TriplesGeneratorUrl(_))
+    with Url[TriplesGeneratorUrl]
+    with UrlOps[TriplesGeneratorUrl]
     with EventConsumerUrl {
 
-  type T = EventLogUrl
+  type T = TriplesGeneratorUrl
 
-  implicit val eventLogUrlOps: EventLogUrl.type = this
+  implicit val eventLogUrlOps: TriplesGeneratorUrl.type = this
 
-  private implicit val urlReader: ConfigReader[EventLogUrl] = urlTinyTypeReader(EventLogUrl)
+  private implicit val urlReader: ConfigReader[TriplesGeneratorUrl] = urlTinyTypeReader(TriplesGeneratorUrl)
 
-  override def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[EventLogUrl] =
-    find[F, EventLogUrl]("services.event-log.url", config)
+  override def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[TriplesGeneratorUrl] =
+    find[F, TriplesGeneratorUrl]("services.triples-generator.url", config)
 }

--- a/graph-commons/src/test/scala/io/renku/events/producers/EventSenderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/events/producers/EventSenderSpec.scala
@@ -29,11 +29,11 @@ import io.renku.events.CategoryName
 import io.renku.events.Generators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
-import io.renku.graph.config.EventLogUrl
 import io.renku.graph.metrics.SentEventsGauge
 import io.renku.interpreters.TestLogger
 import io.renku.stubbing.ExternalServiceStubbing
 import io.renku.testtools.IOSpec
+import io.renku.tinytypes.UrlTinyType
 import org.http4s.Status.{Accepted, BadGateway, GatewayTimeout, NotFound, ServiceUnavailable}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
@@ -161,11 +161,12 @@ class EventSenderSpec
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val sentEventsGauge = mock[SentEventsGauge[IO]]
-    val eventLogUrl:  EventLogUrl    = EventLogUrl(externalServiceBaseUrl)
-    val onErrorSleep: FiniteDuration = 500 millis
-    val eventSender = new EventSenderImpl[IO](eventLogUrl,
+    private val serviceUrl: UrlTinyType = new UrlTinyType {
+      override val value: String = externalServiceBaseUrl
+    }
+    val eventSender = new EventSenderImpl[IO](serviceUrl,
                                               sentEventsGauge,
-                                              onErrorSleep,
+                                              onErrorSleep = 500 millis,
                                               retryInterval = 100 millis,
                                               maxRetries = 2,
                                               requestTimeoutOverride = Some(requestTimeout)

--- a/graph-commons/src/test/scala/io/renku/events/producers/EventSenderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/events/producers/EventSenderSpec.scala
@@ -29,11 +29,11 @@ import io.renku.events.CategoryName
 import io.renku.events.Generators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
+import io.renku.graph.config.EventConsumerUrl
 import io.renku.graph.metrics.SentEventsGauge
 import io.renku.interpreters.TestLogger
 import io.renku.stubbing.ExternalServiceStubbing
 import io.renku.testtools.IOSpec
-import io.renku.tinytypes.UrlTinyType
 import org.http4s.Status.{Accepted, BadGateway, GatewayTimeout, NotFound, ServiceUnavailable}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
@@ -161,10 +161,10 @@ class EventSenderSpec
 
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val sentEventsGauge = mock[SentEventsGauge[IO]]
-    private val serviceUrl: UrlTinyType = new UrlTinyType {
+    private val eventConsumerUrl = new EventConsumerUrl {
       override val value: String = externalServiceBaseUrl
     }
-    val eventSender = new EventSenderImpl[IO](serviceUrl,
+    val eventSender = new EventSenderImpl[IO](eventConsumerUrl,
                                               sentEventsGauge,
                                               onErrorSleep = 500 millis,
                                               retryInterval = 100 millis,

--- a/graph-commons/src/test/scala/io/renku/graph/config/TriplesGeneratorUrlSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/config/TriplesGeneratorUrlSpec.scala
@@ -29,27 +29,27 @@ import org.scalatest.TryValues
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-class EventLogUrlSpec extends AnyWordSpec with should.Matchers with TryValues {
+class TriplesGeneratorUrlSpec extends AnyWordSpec with should.Matchers with TryValues {
 
   "apply" should {
 
-    "read 'services.event-log.url' from the config" in {
+    "read 'services.triples-generator.url' from the config" in {
       val url = httpUrls().generateOne
       val config = ConfigFactory.parseMap(
         Map(
           "services" -> Map(
-            "event-log" -> Map(
+            "triples-generator" -> Map(
               "url" -> url
             ).asJava
           ).asJava
         ).asJava
       )
 
-      EventLogUrl[Try](config).success.value shouldBe EventLogUrl(url)
+      TriplesGeneratorUrl[Try](config).success.value shouldBe TriplesGeneratorUrl(url)
     }
 
-    "fail if there's no 'services.event-log.url' entry" in {
-      EventLogUrl[Try](ConfigFactory.empty()).failure.exception shouldBe an[ConfigLoadingException]
+    "fail if there's no 'services.triples-generator.url' entry" in {
+      TriplesGeneratorUrl[Try](ConfigFactory.empty()).failure.exception shouldBe an[ConfigLoadingException]
     }
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandler.scala
@@ -33,6 +33,7 @@ import io.renku.events.consumers.subscriptions.{SubscriberUrl, SubscriptionMecha
 import io.renku.events.consumers.{ConcurrentProcessesLimiter, EventHandlingProcess, EventSchedulingResult}
 import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent, consumers}
+import io.renku.graph.config.EventLogUrl
 import io.renku.metrics.MetricsRegistry
 import io.renku.microservices.MicroserviceIdentifier
 import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
@@ -159,7 +160,7 @@ private[events] object EventHandler {
   ): F[EventHandler[F]] = for {
     tsStateChecker           <- TSStateChecker[F]
     migrationsRunner         <- MigrationsRunner[F](config)
-    eventSender              <- EventSender[F]
+    eventSender              <- EventSender[F](EventLogUrl)
     concurrentProcessLimiter <- ConcurrentProcessesLimiter(1)
   } yield new EventHandler[F](subscriberUrl,
                               serviceId,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/CompositePlanProvision.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/CompositePlanProvision.scala
@@ -38,7 +38,7 @@ import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.CompositePlanProvision.{Context, Result}
-import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling.{AllProjects, MigrationExecutionRegister, RecoverableErrorsRecovery, RegisteredMigration}
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling._
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
 
@@ -105,10 +105,9 @@ private[migrations] class CompositePlanProvision[F[_]: Sync: Logger](
 object CompositePlanProvision {
   def create[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[CompositePlanProvision[F]] =
     for {
-      allProjects <- AllProjects.create[F]
-      eventSender <- EventSender[F]
-      eventLogUrl <- EventLogUrl()
-      elClient = EventLogClient(eventLogUrl)
+      allProjects       <- AllProjects.create[F]
+      eventSender       <- EventSender[F](EventLogUrl)
+      elClient          <- EventLogClient[F]
       executionRegister <- MigrationExecutionRegister[F]
       name = Migration.Name("CompositePlanProvision")
     } yield new CompositePlanProvision[F](name, allProjects, eventSender, elClient, executionRegister)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToV10.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/MigrationToV10.scala
@@ -28,6 +28,7 @@ import io.circe.Decoder
 import io.circe.literal._
 import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.{Schemas, projects}
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesstore.SparqlQuery.Prefixes
@@ -79,7 +80,7 @@ private object MigrationToV10 {
 
   def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder] = for {
     projectsFinder    <- PagedProjectsFinder[F]
-    eventsSender      <- EventSender[F]
+    eventsSender      <- EventSender[F](EventLogUrl)
     executionRegister <- MigrationExecutionRegister[F]
   } yield new MigrationToV10(projectsFinder, eventsSender, executionRegister)
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisioning.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisioning.scala
@@ -27,7 +27,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.literal._
 import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent}
-import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.config.{EventLogUrl, RenkuUrlLoader}
 import io.renku.logging.ExecutionTimeRecorder
 import io.renku.logging.ExecutionTimeRecorder.ElapsedTime
 import io.renku.metrics.MetricsRegistry
@@ -126,7 +126,7 @@ private[migrations] object ReProvisioning {
     for {
       retryDelay                 <- find[F, FiniteDuration]("re-provisioning-retry-delay", config)
       migrationsConnectionConfig <- MigrationsConnectionConfig[F](config)
-      eventSender                <- EventSender[F]
+      eventSender                <- EventSender[F](EventLogUrl)
       microserviceUrlFinder      <- MicroserviceUrlFinder[F](Microservice.ServicePort)
       compatibility              <- VersionCompatibilityConfig.fromConfigF[F](config)
       executionTimeRecorder      <- ExecutionTimeRecorder[F]()

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigration.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigration.scala
@@ -24,8 +24,9 @@ import cats.MonadThrow
 import cats.data.EitherT
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.events.producers.EventSender
+import io.renku.graph.config.EventLogUrl
 import io.renku.graph.model.projects
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
@@ -70,7 +71,7 @@ private[migrations] object QueryBasedMigration {
       eventProducer: projects.Path => EventData
   ): F[QueryBasedMigration[F]] = for {
     projectsFinder    <- ProjectsFinder[F](query)
-    eventSender       <- EventSender[F]
+    eventSender       <- EventSender[F](EventLogUrl)
     executionRegister <- MigrationExecutionRegister[F]
   } yield new QueryBasedMigration[F](name, projectsFinder, eventProducer, eventSender, executionRegister)
 }

--- a/webhook-service/src/main/scala/io/renku/webhookservice/CommitSyncRequestSender.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/CommitSyncRequestSender.scala
@@ -21,8 +21,9 @@ package io.renku.webhookservice
 import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.events.producers.EventSender
+import io.renku.graph.config.EventLogUrl
 import io.renku.metrics.MetricsRegistry
 import io.renku.webhookservice.model.CommitSyncRequest
 import org.typelevel.log4cats.Logger
@@ -64,5 +65,5 @@ private class CommitSyncRequestSenderImpl[F[_]: MonadThrow: Logger](eventSender:
 
 private object CommitSyncRequestSender {
   def apply[F[_]: Async: Logger: MetricsRegistry]: F[CommitSyncRequestSender[F]] =
-    EventSender[F].map(new CommitSyncRequestSenderImpl(_))
+    EventSender[F](EventLogUrl).map(new CommitSyncRequestSenderImpl(_))
 }


### PR DESCRIPTION
This PR makes the `EventSender` take service URL factory instead of using hardcoded `EventLogUrl`