### PR TITLE
feat: Decoders to use cli model

### DIFF
--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliDataset.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliDataset.scala
@@ -106,6 +106,8 @@ object CliDataset {
       maybeLicense     <- cursor.downField(Schema.license).as[Option[License]]
       maybeVersion     <- cursor.downField(Schema.version).as[Option[Version]]
       parts            <- cursor.downField(Schema.hasPart).as[List[CliDatasetFile]]
+      publicationEvents <-
+        cursor.focusTop.as(JsonLDDecoder.decodeList(CliPublicationEvent.decoder(identifier, resourceId)))
     } yield CliDataset(
       resourceId,
       identifier,
@@ -124,7 +126,7 @@ object CliDataset {
       maybeDerivedFrom,
       maybeOriginalIdentifier,
       maybeInvalidationTime,
-      publicationEvents = Nil
+      publicationEvents
     )
   }
 

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliEntity.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliEntity.scala
@@ -22,8 +22,9 @@ import cats.syntax.all._
 import io.circe.DecodingFailure
 import io.renku.cli.model.Ontologies.Prov
 import io.renku.graph.model.{entityModel, generations}
+import io.renku.jsonld.JsonLDDecoder.Result
 import io.renku.jsonld.syntax._
-import io.renku.jsonld.{EntityTypes, JsonLDDecoder, JsonLDEncoder}
+import io.renku.jsonld.{Cursor, EntityTypes, JsonLDDecoder, JsonLDEncoder}
 
 sealed trait CliEntity extends CliModel {
   def resourceId:    entityModel.ResourceId
@@ -63,10 +64,16 @@ object CliEntity {
   private def selectCandidates(ets: EntityTypes): Boolean =
     CliSingleEntity.matchingEntityTypes(ets) || CliCollectionEntity.matchingEntityTypes(ets)
 
-  implicit def jsonLDDecoder: JsonLDDecoder[CliEntity] = {
+  implicit def jsonLDDecoder: JsonLDDecoder[CliEntity] =
+    jsonLDDecoderFor(_ => Right(true))
+
+  def jsonLDDecoderForGeneration(generationId: generations.ResourceId): JsonLDDecoder[CliEntity] =
+    jsonLDDecoderFor(withSpecificGeneration(generationId))
+
+  private def jsonLDDecoderFor(filter: Cursor => Result[Boolean]): JsonLDDecoder[CliEntity] = {
     val da = CliSingleEntity.jsonLDDecoder.emap(e => Right(CliEntity(e)))
     val db = CliCollectionEntity.jsonLdDecoder.emap(e => Right(CliEntity(e)))
-    JsonLDDecoder.entity(entityTypes, _.getEntityTypes.map(selectCandidates)) { cursor =>
+    JsonLDDecoder.entity(entityTypes, c => (c.getEntityTypes.map(selectCandidates), filter(c)).mapN(_ && _)) { cursor =>
       val currentTypes = cursor.getEntityTypes
       (currentTypes.map(CliSingleEntity.matchingEntityTypes), currentTypes.map(CliCollectionEntity.matchingEntityTypes))
         .flatMapN {
@@ -79,6 +86,11 @@ object CliEntity {
         }
     }
   }
+
+  private def withSpecificGeneration(generationId: generations.ResourceId): Cursor => Result[Boolean] =
+    _.downField(Prov.qualifiedGeneration)
+      .as[List[generations.ResourceId]]
+      .map(_.contains(generationId))
 
   implicit def jsonLDEncoder: JsonLDEncoder[CliEntity] = JsonLDEncoder.instance(_.fold(_.asJsonLD, _.asJsonLD))
 }

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliGeneration.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliGeneration.scala
@@ -18,10 +18,12 @@
 
 package io.renku.cli.model
 
+import cats.syntax.all._
 import io.circe.DecodingFailure
 import io.renku.cli.model.Ontologies.Prov
 import io.renku.graph.model.activities
 import io.renku.graph.model.generations._
+import io.renku.jsonld.JsonLDDecoder.Result
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 
@@ -46,14 +48,27 @@ object CliGeneration {
     }
 
   implicit val jsonLDDecoder: JsonLDDecoder[CliGeneration] =
-    JsonLDDecoder.entity(entityTypes) { cursor =>
+    jsonLDDecoderFor(_ => Right(true))
+
+  def decoderForActivity(activityId: activities.ResourceId): JsonLDDecoder[CliGeneration] =
+    jsonLDDecoderFor(withActivity(activityId))
+
+  private def jsonLDDecoderFor(filter: Cursor => Result[Boolean]): JsonLDDecoder[CliGeneration] =
+    JsonLDDecoder.entity(entityTypes, filter) { cursor =>
       for {
-        resourceId  <- cursor.downEntityId.as[ResourceId]
-        activityId  <- cursor.downField(Prov.activity).downEntityId.as[activities.ResourceId]
-        allEntities <- cursor.focusTop.as[List[CliEntity]]
-        entity <- allEntities
-                    .find(_.generationIds.contains(resourceId))
-                    .toRight(DecodingFailure(s"No related entity found for generation '$resourceId'", Nil))
+        resourceId <- cursor.downEntityId.as[ResourceId]
+        activityId <- cursor.downField(Prov.activity).downEntityId.as[activities.ResourceId]
+        entity <-
+          cursor.focusTop
+            .as[List[CliEntity]](JsonLDDecoder.decodeList(CliEntity.jsonLDDecoderForGeneration(resourceId)))
+            .flatMap {
+              case entity :: Nil => entity.asRight
+              case _ =>
+                DecodingFailure(s"Generation $resourceId without or with multiple entities ", Nil).asLeft
+            }
       } yield CliGeneration(resourceId, entity, activityId)
     }
+
+  private def withActivity(activityId: activities.ResourceId): Cursor => JsonLDDecoder.Result[Boolean] =
+    _.downField(Prov.activity).downEntityId.as[activities.ResourceId].map(_ == activityId)
 }

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
@@ -39,7 +39,11 @@ object CliPerson {
   private[model] def matchingEntityTypes(entityTypes: EntityTypes): Boolean =
     entityTypes == this.entityTypes
 
+<<<<<<< HEAD
   implicit val jsonLDDecoder: JsonLDDecoder[CliPerson] =
+=======
+  implicit val jsonLDDecoder: JsonLDEntityDecoder[CliPerson] =
+>>>>>>> 381d96775 (WIP: base model decoders on cli code)
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       for {
         resourceId <- cursor.downEntityId.as[CliPersonResourceId]

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPerson.scala
@@ -39,11 +39,7 @@ object CliPerson {
   private[model] def matchingEntityTypes(entityTypes: EntityTypes): Boolean =
     entityTypes == this.entityTypes
 
-<<<<<<< HEAD
-  implicit val jsonLDDecoder: JsonLDDecoder[CliPerson] =
-=======
   implicit val jsonLDDecoder: JsonLDEntityDecoder[CliPerson] =
->>>>>>> 381d96775 (WIP: base model decoders on cli code)
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       for {
         resourceId <- cursor.downEntityId.as[CliPersonResourceId]

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPlan.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPlan.scala
@@ -52,11 +52,11 @@ object CliPlan {
   private val entityTypes: EntityTypes =
     EntityTypes.of(Prov.Plan, Schema.Action, Schema.CreativeWork)
 
-  implicit val jsonLDDecoder: JsonLDEntityDecoder[CliPlan] =
+  implicit def jsonLDDecoder: JsonLDEntityDecoder[CliPlan] =
     jsonLDDecoderWith(CliStepPlan.jsonLDDecoder, CliCompositePlan.jsonLDDecoder)
 
   /** Decodes also "subtypes" of step plans, i.e. the WorkflowFilePlan, viewing them as a step/composite plan. */
-  val jsonLDDecoderLenientTyped: JsonLDEntityDecoder[CliPlan] =
+  def jsonLDDecoderLenientTyped: JsonLDEntityDecoder[CliPlan] =
     jsonLDDecoderWith(CliStepPlan.jsonLDDecoderLenientTyped, CliCompositePlan.jsonLDDecoderLenientTyped)
 
   private def jsonLDDecoderWith(
@@ -70,9 +70,7 @@ object CliPlan {
 
     JsonLDDecoder.cacheableEntity(entityTypes, predicate) { cursor =>
       val currentEntityTypes = cursor.getEntityTypes
-      (currentEntityTypes.map(CliStepPlan.matchingEntityTypes),
-       currentEntityTypes.map(CliCompositePlan.matchingEntityTypes)
-      ).flatMapN {
+      (stepPlanDecoder.predicate(cursor), compPlanDecoder.predicate(cursor)).flatMapN {
         case (true, _) => step(cursor)
         case (_, true) => comp(cursor)
         case _ =>

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPlan.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPlan.scala
@@ -52,9 +52,6 @@ object CliPlan {
   private val entityTypes: EntityTypes =
     EntityTypes.of(Prov.Plan, Schema.Action, Schema.CreativeWork)
 
-  private def selectCandidates(ets: EntityTypes): Boolean =
-    CliStepPlan.matchingEntityTypes(ets) || CliCompositePlan.matchingEntityTypes(ets)
-
   implicit val jsonLDDecoder: JsonLDEntityDecoder[CliPlan] =
     jsonLDDecoderWith(CliStepPlan.jsonLDDecoder, CliCompositePlan.jsonLDDecoder)
 

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPublicationEvent.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPublicationEvent.scala
@@ -63,14 +63,20 @@ object CliPublicationEvent {
     _.downField(Schema.about).as[EntityId].map(_.show endsWith datasetId.show)
 
   def decoder(dataset: CliDataset): JsonLDDecoder[CliPublicationEvent] =
-    JsonLDDecoder.entity(entityTypes, forDataset(dataset.identifier)) { cursor =>
+    decoder(dataset.identifier, dataset.resourceId)
+
+  def decoder(
+      datasetIdentifier: datasets.Identifier,
+      datasetId:         datasets.ResourceId
+  ): JsonLDDecoder[CliPublicationEvent] =
+    JsonLDDecoder.entity(entityTypes, forDataset(datasetIdentifier)) { cursor =>
       for {
         resourceId       <- cursor.downEntityId.as[ResourceId]
-        about            <- cursor.downField(Schema.about).as(datasetEdgeDecoder(dataset.resourceId))
+        about            <- cursor.downField(Schema.about).as(datasetEdgeDecoder(datasetId))
         maybeDescription <- cursor.downField(Schema.description).as[Option[Description]]
         name             <- cursor.downField(Schema.name).as[Name]
         startDate        <- cursor.downField(Schema.startDate).as[StartDate]
-      } yield CliPublicationEvent(resourceId, about, dataset.resourceId, maybeDescription, name, startDate)
+      } yield CliPublicationEvent(resourceId, about, datasetId, maybeDescription, name, startDate)
     }
 
   private def datasetEdgeDecoder(datasetId: datasets.ResourceId): JsonLDDecoder[About] =

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliUsage.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliUsage.scala
@@ -29,7 +29,7 @@ object CliUsage {
 
   private val entityTypes: EntityTypes = EntityTypes.of(Prov.Usage)
 
-  implicit lazy val decoder: JsonLDDecoder[CliUsage] =
+  implicit lazy val jsonLDDecoder: JsonLDDecoder[CliUsage] =
     JsonLDDecoder.entity(entityTypes) { cursor =>
       for {
         resourceId <- cursor.downEntityId.as[ResourceId]

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliWorkflowFileStepPlan.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliWorkflowFileStepPlan.scala
@@ -31,7 +31,7 @@ final case class CliWorkflowFileStepPlan(
     description:      Option[Description],
     creators:         List[CliPerson],
     dateCreated:      DateCreated,
-    dateModified:     Option[DateModified],
+    dateModified:     DateModified,
     keywords:         List[Keyword],
     command:          Option[Command],
     parameters:       List[CliCommandParameter],
@@ -40,17 +40,35 @@ final case class CliWorkflowFileStepPlan(
     successCodes:     List[SuccessCode],
     derivedFrom:      Option[DerivedFrom],
     invalidationTime: Option[InvalidationTime]
-) extends CliModel
+) extends CliModel {
+  def asCliStepPlan: CliStepPlan =
+    CliStepPlan(
+      id,
+      name,
+      description,
+      creators,
+      dateCreated,
+      dateModified,
+      keywords,
+      command,
+      parameters,
+      inputs,
+      outputs,
+      successCodes,
+      derivedFrom,
+      invalidationTime
+    )
+}
 
 object CliWorkflowFileStepPlan {
 
   private val entityTypes: EntityTypes =
-    EntityTypes.of(Renku.WorkflowFilePlan, Prov.Plan, Schema.Action, Schema.CreativeWork)
+    EntityTypes.of(Renku.WorkflowFilePlan, Renku.Plan, Prov.Plan, Schema.Action, Schema.CreativeWork)
 
   private[model] def matchingEntityTypes(entityTypes: EntityTypes): Boolean =
     entityTypes == this.entityTypes
 
-  implicit val jsonLDDecoder: JsonLDDecoder[CliWorkflowFileStepPlan] =
+  implicit val jsonLDDecoder: JsonLDEntityDecoder[CliWorkflowFileStepPlan] =
     JsonLDDecoder.cacheableEntity(entityTypes, _.getEntityTypes.map(matchingEntityTypes)) { cursor =>
       for {
         resourceId   <- cursor.downEntityId.as[ResourceId]
@@ -59,7 +77,7 @@ object CliWorkflowFileStepPlan {
         command      <- cursor.downField(Renku.command).as[Option[Command]]
         creators     <- cursor.downField(Schema.creator).as[List[CliPerson]]
         dateCreated  <- cursor.downField(Schema.dateCreated).as[DateCreated]
-        dateModified <- cursor.downField(Schema.dateModified).as[Option[DateModified]]
+        dateModified <- cursor.downField(Schema.dateModified).as[DateModified]
         keywords     <- cursor.downField(Schema.keywords).as[List[Option[Keyword]]].map(_.flatten)
         parameters   <- cursor.downField(Renku.hasArguments).as[List[CliCommandParameter]]
         inputs       <- cursor.downField(Renku.hasInputs).as[List[CliCommandInput]]

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/CliActivitySpec.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/CliActivitySpec.scala
@@ -79,6 +79,7 @@ class CliActivitySpec
       error       shouldBe a[DecodingFailure]
       error.message should endWith(s"Cannot decode SoftwareAgent on activity ${activity.resourceId}")
     }
+
     "fail if there is no Author entity" in {
       import io.renku.jsonld.syntax._
       val encoder = JsonLDEncoder.instance[CliActivity] { entity =>

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/generators/PlanGenerators.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/generators/PlanGenerators.scala
@@ -104,7 +104,7 @@ trait PlanGenerators {
       descr            <- planDescriptions.toGeneratorOfOptions
       creators         <- PersonGenerators.cliPersonGen.toGeneratorOfList(max = 3)
       dateCreated      <- planCreatedDates(plans.DateCreated(minCreated))
-      dateModified     <- planModifiedDates(after = dateCreated).toGeneratorOfOptions
+      dateModified     <- planModifiedDates(after = dateCreated)
       keywords         <- planKeywords.toGeneratorOfList(max = 3)
       command          <- planCommands.toGeneratorOfOptions
       parameters       <- CommandParameterGenerators.commandParameterGen.toGeneratorOfList(max = 3)
@@ -139,6 +139,7 @@ trait PlanGenerators {
       description      <- planDescriptions.toGeneratorOfOptions
       creators         <- PersonGenerators.cliPersonGen.toGeneratorOfList(max = 3)
       dateCreated      <- planCreatedDates(plans.DateCreated(minCreated))
+      dateModified     <- planModifiedDates(after = dateCreated)
       keywords         <- planKeywords.toGeneratorOfList(max = 3)
       derivedFrom      <- planDerivedFroms.toGeneratorOfOptions
       invalidationTime <- invalidationTimes(minCreated.minusMillis(1000)).toGeneratorOfOptions
@@ -152,6 +153,7 @@ trait PlanGenerators {
       description,
       creators,
       dateCreated,
+      dateModified,
       keywords,
       derivedFrom,
       invalidationTime,

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/generators/ProjectGenerators.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/generators/ProjectGenerators.scala
@@ -45,7 +45,7 @@ trait ProjectGenerators {
     keywords    <- RenkuTinyTypeGenerators.projectKeywords.toGeneratorOfList(max = 3)
     images     <- RenkuTinyTypeGenerators.imageUris.toGeneratorOfList(max = 3).map(uris => Image.projectImage(id, uris))
     plans      <- projectPlanGen(minCreated).toGeneratorOfList(max = 3)
-    activities <- ActivityGenerators.activityGen(minCreated).toGeneratorOfList(max = 1)
+    activities <- ActivityGenerators.activityGen(minCreated).toGeneratorOfList(max = 3).map(_.sortBy(_.startTime))
     datasets   <- DatasetGenerators.datasetGen.toGeneratorOfList(max = 3)
     agentVersion  <- RenkuTinyTypeGenerators.cliVersions.toGeneratorOfOptions
     schemaVersion <- RenkuTinyTypeGenerators.projectSchemaVersions.toGeneratorOfOptions

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Entity.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Entity.scala
@@ -94,18 +94,7 @@ object Entity {
   }
 
   implicit lazy val decoder: JsonLDDecoder[Entity] =
-    JsonLDDecoder.cacheableEntity(fileEntityTypes, withStrictEntityTypes) { cursor =>
-      for {
-        resourceId         <- cursor.downEntityId.as[ResourceId]
-        entityTypes        <- cursor.getEntityTypes
-        location           <- cursor.downField(prov / "atLocation").as[Location](locationDecoder(entityTypes))
-        checksum           <- cursor.downField(renku / "checksum").as[Checksum]
-        maybeGenerationIds <- cursor.downField(prov / "qualifiedGeneration").as[List[generations.ResourceId]]
-      } yield maybeGenerationIds match {
-        case Nil           => InputEntity(resourceId, location, checksum)
-        case generationIds => OutputEntity(resourceId, location, checksum, generationIds)
-      }
-    }
+    CliEntity.jsonLDDecoder.map(fromCli)
 
   def outputEntityDecoder(generationId: generations.ResourceId): JsonLDDecoder[OutputEntity] =
     JsonLDDecoder.entity(

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Entity.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Entity.scala
@@ -18,14 +18,12 @@
 
 package io.renku.graph.model.entities
 
-import cats.syntax.all._
 import io.renku.cli.model.{CliCollectionEntity, CliEntity, CliSingleEntity}
 import io.renku.graph.model.Schemas.{prov, renku}
 import io.renku.graph.model.entityModel._
 import io.renku.graph.model.generations
-import io.renku.jsonld.JsonLDDecoder.Result
 import io.renku.jsonld.ontology._
-import io.renku.jsonld.{Cursor, EntityTypes, JsonLDDecoder}
+import io.renku.jsonld.{EntityTypes, JsonLDDecoder}
 
 sealed trait Entity {
   val resourceId: ResourceId
@@ -97,34 +95,9 @@ object Entity {
     CliEntity.jsonLDDecoder.map(fromCli)
 
   def outputEntityDecoder(generationId: generations.ResourceId): JsonLDDecoder[OutputEntity] =
-    JsonLDDecoder.entity(
-      fileEntityTypes,
-      (withStrictEntityTypes &&& withSpecific(generationId)).fmap(_.mapN(_ && _))
-    ) { cursor =>
-      for {
-        resourceId   <- cursor.downEntityId.as[ResourceId]
-        entityTypes  <- cursor.getEntityTypes
-        location     <- cursor.downField(prov / "atLocation").as[Location](locationDecoder(entityTypes))
-        checksum     <- cursor.downField(renku / "checksum").as[Checksum]
-        generationId <- cursor.downField(prov / "qualifiedGeneration").as[List[generations.ResourceId]]
-      } yield OutputEntity(resourceId, location, checksum, generationId)
-    }
-
-  private lazy val withStrictEntityTypes: Cursor => Result[Boolean] =
-    _.getEntityTypes.map(types => types == fileEntityTypes || types == folderEntityTypes)
-
-  private def withSpecific(generationId: generations.ResourceId): Cursor => Result[Boolean] =
-    _.downField(prov / "qualifiedGeneration")
-      .as[List[generations.ResourceId]]
-      .map(_.contains(generationId))
-
-  private def locationDecoder(entityTypes: EntityTypes): JsonLDDecoder[Location] =
-    JsonLDDecoder.decodeString.emap { value =>
-      entityTypes match {
-        case types if types contains folderEntityTypes => Location.Folder.from(value).leftMap(_.getMessage)
-        case types if types contains fileEntityTypes   => Location.File.from(value).leftMap(_.getMessage)
-        case types                                     => s"Entity with unknown $types types".asLeft
-      }
+    CliEntity.jsonLDDecoderForGeneration(generationId).map(fromCli).emap {
+      case oe: OutputEntity => Right(oe)
+      case e => Left(s"Invalid entity type! Expected output entity, but got: $e")
     }
 
   lazy val ontology: Type = Type.Def(

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Generation.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Generation.scala
@@ -18,13 +18,14 @@
 
 package io.renku.graph.model.entities
 
+import cats.data.{Validated, ValidatedNel}
 import cats.syntax.all._
 import io.circe.DecodingFailure
+import io.renku.cli.model.CliGeneration
 import io.renku.graph.model.Schemas.prov
 import io.renku.graph.model.entities.Entity.OutputEntity
 import io.renku.graph.model.generations.ResourceId
 import io.renku.graph.model.{activities, generations}
-import io.renku.jsonld.JsonLDDecoder.decodeList
 import io.renku.jsonld._
 import io.renku.jsonld.ontology._
 import io.renku.jsonld.syntax.JsonEncoderOps
@@ -45,6 +46,21 @@ object Generation {
       )
     }
 
+  def fromCli(cliGen: CliGeneration): ValidatedNel[String, Generation] = {
+    val entity =
+      Entity.fromCli(cliGen.entity) match {
+        case e: Entity.OutputEntity => e.validNel
+        case e => Validated.invalidNel(s"Expected output entity for a Generation, but got: $e")
+      }
+    entity.map { e =>
+      Generation(
+        cliGen.resourceId,
+        cliGen.activityResourceId,
+        e
+      )
+    }
+  }
+
   private def withActivity(activityId: activities.ResourceId): Cursor => JsonLDDecoder.Result[Boolean] =
     _.downField(prov / "activity").downEntityId.as[activities.ResourceId].map(_ == activityId)
 
@@ -54,7 +70,7 @@ object Generation {
         resourceId         <- cursor.downEntityId.as[generations.ResourceId]
         activityResourceId <- cursor.downField(prov / "activity").downEntityId.as[activities.ResourceId]
         entity <- cursor.focusTop
-                    .as[List[OutputEntity]](decodeList(Entity.outputEntityDecoder(resourceId))) >>= {
+                    .as[List[OutputEntity]](JsonLDDecoder.decodeList(Entity.outputEntityDecoder(resourceId))) >>= {
                     case entity :: Nil => entity.asRight
                     case _ => DecodingFailure(s"Generation $resourceId without or with multiple entities ", Nil).asLeft
                   }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
@@ -23,14 +23,12 @@ import Schemas.{prov, renku, schema}
 import StepPlanCommandParameter.{CommandInput, CommandOutput, CommandParameter}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.syntax.all._
-import io.circe.DecodingFailure
-import io.renku.cli.model.CliCompositePlan
+import io.renku.cli.model.{CliCompositePlan, CliPlan, CliStepPlan}
 import io.renku.graph.model.entities.Plan.Derivation
-import io.renku.jsonld.JsonLDDecoder.{decodeList, decodeOption}
 import io.renku.jsonld._
 import io.renku.jsonld.ontology._
 import io.renku.jsonld.syntax._
-import plans.{Command, DateCreated, DateModified, DerivedFrom, Description, Keyword, Name, ProgrammingLanguage, ResourceId, SuccessCode}
+import plans.{Command, DateCreated, DerivedFrom, Description, Keyword, Name, ProgrammingLanguage, ResourceId, SuccessCode}
 
 import scala.math.Ordering.Implicits._
 
@@ -55,8 +53,8 @@ object Plan {
 
   final case class Derivation(derivedFrom: DerivedFrom, originalResourceId: ResourceId)
 
-//  def fromCli(cliPlan: CliPlan): ValidatedNel[String, Plan] =
-//    cliPlan.fold(StepPlan.fromCli, CompositePlan.fromCli)
+  def fromCli(cliPlan: CliPlan)(implicit renkuUrl: RenkuUrl): ValidatedNel[String, Plan] =
+    cliPlan.fold(StepPlan.fromCli, CompositePlan.fromCli)
 
   implicit def entityFunctions(implicit gitLabApiUrl: GitLabApiUrl): EntityFunctions[Plan] =
     new EntityFunctions[Plan] {
@@ -71,19 +69,8 @@ object Plan {
     }
 
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[Plan] =
-    JsonLDDecoder.entity(EntityTypes of prov / "Plan") { cursor =>
-      lazy val noMatchFailure: Either[DecodingFailure, Plan] = cursor.getEntityTypes.flatMap { ets =>
-        DecodingFailure(
-          DecodingFailure.Reason.CustomReason(show"Cannot decode entity as Plan: $ets"),
-          cursor.jsonLD.toJson.hcursor
-        ).asLeft
-      }
-
-      cursor.getEntityTypes.flatMap { ets =>
-        if (ets.contains(StepPlan.entityTypes)) StepPlan.decoder.apply(cursor)
-        else if (ets.contains(CompositePlan.Ontology.entityTypes)) CompositePlan.decoder.apply(cursor)
-        else noMatchFailure
-      }
+    CliPlan.jsonLDDecoderLenientTyped.emap { cliPlan =>
+      fromCli(cliPlan).toEither.leftMap(_.intercalate("; "))
     }
 
   lazy val ontology: Type =
@@ -241,26 +228,51 @@ object StepPlan {
     )
   }
 
-//  def fromCli(cliPlan: CliStepPlan): ValidatedNel[String, StepPlan] =
-//    cliPlan.derivedFrom match {
-//      case Some(derived) =>
-//        ???
-//      case None =>
-//        from(
-//          cliPlan.id,
-//          cliPlan.name,
-//          cliPlan.description,
-//          cliPlan.command,
-//          cliPlan.creators,
-//          cliPlan.dateCreated,
-//          None,
-//          cliPlan.keywords,
-//          cliPlan.parameters,
-//          cliPlan.inputs,
-//          cliPlan.outputs,
-//          cliPlan.successCodes
-//        )
-//    }
+  def fromCli(cliPlan: CliStepPlan)(implicit renkuUrl: RenkuUrl): ValidatedNel[String, StepPlan] = {
+    val creatorsV = cliPlan.creators.traverse(Person.fromCli)
+    val inputsV   = cliPlan.inputs.traverse(StepPlanCommandParameter.CommandInput.fromCli)
+    val outputsV  = cliPlan.outputs.traverse(StepPlanCommandParameter.CommandOutput.fromCli)
+    val paramsV   = cliPlan.parameters.traverse(StepPlanCommandParameter.CommandParameter.fromCli)
+    val all       = (creatorsV, inputsV, outputsV, paramsV).mapN(Tuple4.apply)
+    all.andThen { case (creators, inputs, outputs, params) =>
+      (cliPlan.derivedFrom, cliPlan.invalidationTime) match {
+        case (Some(derivedFrom), _) =>
+          from(
+            cliPlan.id,
+            cliPlan.name,
+            cliPlan.description,
+            cliPlan.command,
+            creators,
+            cliPlan.dateCreated,
+            None,
+            cliPlan.keywords,
+            params,
+            inputs,
+            outputs,
+            cliPlan.successCodes,
+            Derivation(derivedFrom, ResourceId(derivedFrom.value)),
+            cliPlan.invalidationTime
+          )
+        case (None, None) =>
+          from(
+            cliPlan.id,
+            cliPlan.name,
+            cliPlan.description,
+            cliPlan.command,
+            creators,
+            cliPlan.dateCreated,
+            None,
+            cliPlan.keywords,
+            params,
+            inputs,
+            outputs,
+            cliPlan.successCodes
+          )
+        case (None, Some(_)) =>
+          show"Plan ${cliPlan.id} has no parent but invalidation time".invalidNel
+      }
+    }
+  }
 
   val entityTypes: EntityTypes =
     EntityTypes of (renku / "Plan", prov / "Plan", schema / "Action", schema / "CreativeWork")
@@ -306,81 +318,8 @@ object StepPlan {
     }
 
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[StepPlan] =
-    JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
-      for {
-        resourceId            <- cursor.downEntityId.as[ResourceId]
-        name                  <- cursor.downField(schema / "name").as[Name]
-        maybeDescription      <- cursor.downField(schema / "description").as[Option[Description]]
-        maybeCommand          <- cursor.downField(renku / "command").as[Option[Command]]
-        creators              <- cursor.downField(schema / "creator").as[List[Person]]
-        dateCreated           <- cursor.downField(schema / "dateCreated").as[DateCreated]
-        dateModified          <- cursor.downField(schema / "dateModified").as[DateModified]
-        maybeProgrammingLang  <- cursor.downField(schema / "programmingLanguage").as[Option[ProgrammingLanguage]]
-        keywords              <- cursor.downField(schema / "keywords").as[List[Option[Keyword]]].map(_.flatten)
-        parameters            <- cursor.downField(renku / "hasArguments").as[List[CommandParameter]]
-        inputs                <- cursor.downField(renku / "hasInputs").as[List[CommandInput]]
-        outputs               <- cursor.downField(renku / "hasOutputs").as[List[CommandOutput]]
-        successCodes          <- cursor.downField(renku / "successCodes").as[List[SuccessCode]]
-        maybeDerivedFrom      <- cursor.downField(prov / "wasDerivedFrom").as(decodeOption(DerivedFrom.ttDecoder))
-        maybeInvalidationTime <- cursor.downField(prov / "invalidatedAtTime").as[Option[InvalidationTime]]
-        plan <- {
-                  (maybeDerivedFrom, maybeInvalidationTime) match {
-                    case (None, None) =>
-                      StepPlan
-                        .from(
-                          resourceId,
-                          name,
-                          maybeDescription,
-                          maybeCommand,
-                          creators,
-                          dateCreated,
-                          maybeProgrammingLang,
-                          keywords,
-                          parameters,
-                          inputs,
-                          outputs,
-                          successCodes
-                        )
-                    case (Some(derivedFrom), None) =>
-                      StepPlan
-                        .from(
-                          resourceId,
-                          name,
-                          maybeDescription,
-                          maybeCommand,
-                          creators,
-                          DateCreated(dateModified.value),
-                          maybeProgrammingLang,
-                          keywords,
-                          parameters,
-                          inputs,
-                          outputs,
-                          successCodes,
-                          Derivation(derivedFrom, ResourceId(derivedFrom.value)),
-                          maybeInvalidationTime = None
-                        )
-                    case (Some(derivedFrom), Some(invalidationTime)) =>
-                      StepPlan.from(
-                        resourceId,
-                        name,
-                        maybeDescription,
-                        maybeCommand,
-                        creators,
-                        DateCreated(dateModified.value),
-                        maybeProgrammingLang,
-                        keywords,
-                        parameters,
-                        inputs,
-                        outputs,
-                        successCodes,
-                        Derivation(derivedFrom, ResourceId(derivedFrom.value)),
-                        invalidationTime.some
-                      )
-                    case (None, Some(_)) =>
-                      show"Plan $resourceId has no parent but invalidation time".invalidNel
-                  }
-                }.toEither.leftMap(errors => DecodingFailure(errors.intercalate("; "), Nil))
-      } yield plan
+    CliStepPlan.jsonLDDecoderLenientTyped.emap { cliPlan =>
+      fromCli(cliPlan).toEither.leftMap(_.intercalate("; "))
     }
 
   lazy val ontology: Type = {
@@ -455,8 +394,49 @@ object CompositePlan {
     ): P = cpm(this)
   }
 
-  def fromCli(cliPlan: CliCompositePlan): ValidatedNel[String, CompositePlan] =
-    ???
+  def fromCli(cliPlan: CliCompositePlan)(implicit renkuUrl: RenkuUrl): ValidatedNel[String, CompositePlan] = {
+    val creatorsV   = cliPlan.creators.traverse(Person.fromCli)
+    val childPlansV = cliPlan.plans.traverse(Plan.fromCli)
+    val linksV      = cliPlan.links.traverse(ParameterLink.fromCli)
+    val mappingsV   = cliPlan.mappings.traverse(ParameterMapping.fromCli)
+    val all         = (creatorsV, childPlansV, linksV, mappingsV).mapN(Tuple4.apply)
+    all.andThen { case (creators, childPlans, links, mappings) =>
+      (cliPlan.derivedFrom, cliPlan.invalidationTime) match {
+        case (None, None) =>
+          validate(
+            CompositePlan.NonModified(
+              cliPlan.id,
+              cliPlan.name,
+              cliPlan.description,
+              creators,
+              cliPlan.dateCreated,
+              cliPlan.keywords,
+              childPlans.map(_.resourceId),
+              mappings,
+              links
+            )
+          )
+        case (Some(derivedFrom), mit) =>
+          validate(
+            CompositePlan.Modified(
+              cliPlan.id,
+              cliPlan.name,
+              cliPlan.description,
+              creators,
+              cliPlan.dateCreated,
+              cliPlan.keywords,
+              childPlans.map(_.resourceId),
+              mappings,
+              links,
+              mit,
+              Derivation(derivedFrom, ResourceId(derivedFrom.value))
+            )
+          )
+        case (None, Some(_)) =>
+          show"Plan ${cliPlan.id} has no parent but invalidation time".invalidNel
+      }
+    }
+  }
 
   // noinspection TypeAnnotation
   object Ontology {
@@ -526,57 +506,8 @@ object CompositePlan {
     }
 
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDEntityDecoder[CompositePlan] =
-    JsonLDDecoder.entity(Ontology.entityTypes) { cursor =>
-      import io.renku.graph.model.views.StringTinyTypeJsonLDDecoders._
-      for {
-        resourceId            <- cursor.downEntityId.as[ResourceId]
-        name                  <- cursor.downField(Ontology.name).as[Name]
-        maybeDescription      <- cursor.downField(Ontology.description).as[Option[Description]]
-        creators              <- cursor.downField(Ontology.creators).as[List[Person]]
-        dateCreated           <- cursor.downField(Ontology.dateCreated).as[DateCreated]
-        keywords              <- cursor.downField(Ontology.keywords).as[List[Option[Keyword]]].map(_.flatten)
-        maybeDerivedFrom      <- cursor.downField(Ontology.wasDerivedFrom).as(decodeOption(DerivedFrom.ttDecoder))
-        maybeInvalidationTime <- cursor.downField(Ontology.invalidatedAtTime).as[Option[InvalidationTime]]
-        links                 <- cursor.downField(Ontology.workflowLinks).as[List[ParameterLink]]
-        mappings              <- cursor.downField(Ontology.hasMappings).as[List[ParameterMapping]]
-        plans                 <- cursor.downField(Ontology.hasSubprocess).as[NonEmptyList[ResourceId]]
-        plan <- {
-                  (maybeDerivedFrom, maybeInvalidationTime) match {
-                    case (None, None) =>
-                      validate(
-                        CompositePlan.NonModified(
-                          resourceId,
-                          name,
-                          maybeDescription,
-                          creators,
-                          dateCreated,
-                          keywords,
-                          plans,
-                          mappings,
-                          links
-                        )
-                      )
-                    case (Some(derivedFrom), mit) =>
-                      validate(
-                        CompositePlan.Modified(
-                          resourceId,
-                          name,
-                          maybeDescription,
-                          creators,
-                          dateCreated,
-                          keywords,
-                          plans,
-                          mappings,
-                          links,
-                          mit,
-                          Derivation(derivedFrom, ResourceId(derivedFrom.value))
-                        )
-                      )
-                    case (None, Some(_)) =>
-                      show"Plan $resourceId has no parent but invalidation time".invalidNel
-                  }
-                }.toEither.leftMap(errors => DecodingFailure(errors.intercalate("; "), Nil))
-      } yield plan
+    CliCompositePlan.jsonLDDecoderLenientTyped.emap { cliPlan =>
+      fromCli(cliPlan).toEither.leftMap(_.intercalate("; "))
     }
 
   def validate(plan: CompositePlan): ValidatedNel[String, CompositePlan] = {

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Plan.scala
@@ -24,6 +24,7 @@ import StepPlanCommandParameter.{CommandInput, CommandOutput, CommandParameter}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.syntax.all._
 import io.circe.DecodingFailure
+import io.renku.cli.model.CliCompositePlan
 import io.renku.graph.model.entities.Plan.Derivation
 import io.renku.jsonld.JsonLDDecoder.{decodeList, decodeOption}
 import io.renku.jsonld._
@@ -53,6 +54,9 @@ sealed trait Plan extends Product with Serializable {
 object Plan {
 
   final case class Derivation(derivedFrom: DerivedFrom, originalResourceId: ResourceId)
+
+//  def fromCli(cliPlan: CliPlan): ValidatedNel[String, Plan] =
+//    cliPlan.fold(StepPlan.fromCli, CompositePlan.fromCli)
 
   implicit def entityFunctions(implicit gitLabApiUrl: GitLabApiUrl): EntityFunctions[Plan] =
     new EntityFunctions[Plan] {
@@ -237,6 +241,27 @@ object StepPlan {
     )
   }
 
+//  def fromCli(cliPlan: CliStepPlan): ValidatedNel[String, StepPlan] =
+//    cliPlan.derivedFrom match {
+//      case Some(derived) =>
+//        ???
+//      case None =>
+//        from(
+//          cliPlan.id,
+//          cliPlan.name,
+//          cliPlan.description,
+//          cliPlan.command,
+//          cliPlan.creators,
+//          cliPlan.dateCreated,
+//          None,
+//          cliPlan.keywords,
+//          cliPlan.parameters,
+//          cliPlan.inputs,
+//          cliPlan.outputs,
+//          cliPlan.successCodes
+//        )
+//    }
+
   val entityTypes: EntityTypes =
     EntityTypes of (renku / "Plan", prov / "Plan", schema / "Action", schema / "CreativeWork")
 
@@ -282,7 +307,6 @@ object StepPlan {
 
   implicit def decoder(implicit renkuUrl: RenkuUrl): JsonLDDecoder[StepPlan] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
-      import io.renku.graph.model.views.StringTinyTypeJsonLDDecoders._
       for {
         resourceId            <- cursor.downEntityId.as[ResourceId]
         name                  <- cursor.downField(schema / "name").as[Name]
@@ -430,6 +454,9 @@ object CompositePlan {
                          cpm:  CompositePlan.Modified => P
     ): P = cpm(this)
   }
+
+  def fromCli(cliPlan: CliCompositePlan): ValidatedNel[String, CompositePlan] =
+    ???
 
   // noinspection TypeAnnotation
   object Ontology {

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ProjectJsonLDDecoder.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ProjectJsonLDDecoder.scala
@@ -54,7 +54,7 @@ object ProjectJsonLDDecoder {
     }
     val dateCreated = (gitLabInfo.dateCreated :: cliProject.dateCreated :: Nil).min
     val all         = (creatorV, allPersonV, datasetV, activityV, planV).mapN(Tuple5.apply)
-    all.andThen { case (creator, _, datasets, activities, plans) =>
+    all.andThen { case (creator, persons, datasets, activities, plans) =>
       newProject(
         gitLabInfo,
         cliProject.id,
@@ -63,7 +63,7 @@ object ProjectJsonLDDecoder {
         cliProject.agentVersion,
         keywords,
         cliProject.schemaVersion,
-        creator.toSet,
+        persons.toSet ++ creator.toSet,
         activities,
         datasets,
         plans,

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -227,9 +227,16 @@ class PlanSpec
           .addType(renku / "WorkflowCompositePlan")
           .value
 
-      newJson.cursor
-        .as[List[entities.CompositePlan]]
-        .map(_.filter(_.resourceId == plan.resourceId)) shouldMatchToRight List(plan)
+      // only decode the one plan and its children (not also include composite plans that
+      // are children of the generated one)
+      implicit val planListDecoder: JsonLDDecoder[List[entities.CompositePlan]] =
+        JsonLDDecoder
+          .decodeList(entities.CompositePlan.decoder)
+          .map(_.filter(_.resourceId == plan.resourceId))
+
+      val decoded = newJson.cursor.as[List[entities.CompositePlan]]
+      println(s"decoded plans: ${decoded.map(_.map(_.plans.size))}")
+      newJson should decodeAndEqualTo(List(plan))
     }
 
     "fail decode if a parameter maps to itself" in {

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/PlanSpec.scala
@@ -91,7 +91,7 @@ class PlanSpec
         JsonLDTools
           .view(cliPlan)
           .selectByTypes(entities.StepPlan.entityTypes)
-          .addType(renku / "WorkflowPlan")
+          .addType(renku / "WorkflowFilePlan")
           .value
 
       newJson.cursor.as[List[entities.StepPlan]] shouldBe List(plan).asRight

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -432,7 +432,7 @@ class ProjectSpec
 
       results.left.value shouldBe a[DecodingFailure]
       results.left.value.getMessage() should include(
-        s"Finding Person entities for project ${projectInfo.path} failed: "
+        s"Finding Person entities for project ${projectInfo.name.some.asRight} failed: "
       )
     }
 


### PR DESCRIPTION
The decoders for the model entities are now going through the cli data model and don't define their own decoders anymore.

On the model entities a new method `fromCli` is added to the companion objects. It accepts the corresponding cli data (and potentially some more supporting data) and creates a `ValidatedNel[String, A]` as e result. For consistency it always returns a `ValidatedNel` even when sometimes it wouldn't be necessary.

Issue: #1168 