### PR TITLE
feat: Allow any type for a command parameter value

### DIFF
--- a/generators/build.sbt
+++ b/generators/build.sbt
@@ -21,6 +21,6 @@ name := "generators"
 
 libraryDependencies += "eu.timepit"     %% "refined"    % "0.10.1"
 libraryDependencies += "io.circe"       %% "circe-core" % "0.14.4"
-libraryDependencies += "io.renku"       %% "jsonld4s"   % "0.8.0"
+libraryDependencies += "io.renku"       %% "jsonld4s"   % "0.9.0"
 libraryDependencies += "org.typelevel"  %% "cats-core"  % "2.9.0"
 libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.17.0"

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/diffx/CliDiffInstances.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/diffx/CliDiffInstances.scala
@@ -42,6 +42,9 @@ trait CliDiffInstances extends ModelTinyTypesDiffInstances {
 
   implicit lazy val cliSoftwareAgentDiff: Diff[CliSoftwareAgent] = Diff.derived[CliSoftwareAgent]
 
+  implicit lazy val cliParameterValueValueDiff: Diff[CliParameterValue.Value] =
+    Diff.derived[CliParameterValue.Value]
+
   implicit lazy val cliParameterValueDiff: Diff[CliParameterValue] = Diff.derived[CliParameterValue]
 
   implicit lazy val cliCommandParameterDiff: Diff[CliCommandParameter] = Diff.derived[CliCommandParameter]

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/TinyTypeDiffInstances.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/TinyTypeDiffInstances.scala
@@ -20,6 +20,8 @@ package io.renku.graph.model.diffx
 
 import cats.data.NonEmptyList
 import com.softwaremill.diffx.Diff
+import io.circe.Json
+import io.renku.jsonld.JsonLD
 import io.renku.tinytypes._
 
 trait TinyTypeDiffInstances {
@@ -59,6 +61,12 @@ trait TinyTypeDiffInstances {
 
   implicit def relativePathTinyType[A <: RelativePathTinyType]: Diff[A] =
     Diff.diffForString.contramap(_.value)
+
+  implicit def jsonDiff: Diff[Json] =
+    Diff.diffForString.contramap(_.spaces2)
+
+  implicit def jsonLDDiff: Diff[JsonLD] =
+    jsonDiff.contramap(_.toJson)
 }
 
 object TinyTypeDiffInstances extends TinyTypeDiffInstances

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/ParameterValue.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/ParameterValue.scala
@@ -96,17 +96,17 @@ object ParameterValue {
     def maybeCommandParameter(resourceId: ResourceId, valueReferenceId: commandParameters.ResourceId) =
       forPlan
         .findParameter(valueReferenceId)
-        .map(parameter => CommandParameterValue(resourceId, cliParam.value, parameter))
+        .map(parameter => CommandParameterValue(resourceId, cliParam.value.asString, parameter))
 
     def maybeCommandInput(resourceId: ResourceId, valueReferenceId: commandParameters.ResourceId) =
       forPlan
         .findInput(valueReferenceId)
-        .map(input => CommandInputValue(resourceId, Location.FileOrFolder(cliParam.value.value), input))
+        .map(input => CommandInputValue(resourceId, Location.FileOrFolder(cliParam.value.asString), input))
 
     def maybeCommandOutput(resourceId: ResourceId, valueReferenceId: commandParameters.ResourceId) =
       forPlan
         .findOutput(valueReferenceId)
-        .map(output => CommandOutputValue(resourceId, Location.FileOrFolder(cliParam.value.value), output))
+        .map(output => CommandOutputValue(resourceId, Location.FileOrFolder(cliParam.value.asString), output))
 
     List(maybeCommandParameter _, maybeCommandInput _, maybeCommandOutput _)
       .flatMap(_.apply(cliParam.id, cliParam.parameter)) match {

--- a/renku-model/src/test/scala/io/renku/graph/model/cli/CliActivityConverters.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/cli/CliActivityConverters.scala
@@ -22,7 +22,6 @@ import cats.syntax.show._
 import CliConversionFunctions._
 import io.renku.cli.model._
 import io.renku.graph.model.{RenkuUrl, activities, agents, associations, commandParameters, entities, generations, parameterValues, testentities, usages}
-import io.renku.graph.model.parameterValues.ValueOverride
 import io.renku.jsonld.syntax._
 
 trait CliActivityConverters extends CliPlanConverters {
@@ -101,9 +100,9 @@ trait CliActivityConverters extends CliPlanConverters {
 
   def from(paramValue: entities.ParameterValue): CliParameterValue = paramValue match {
     case v: entities.ParameterValue.LocationParameterValue =>
-      CliParameterValue(v.resourceId, v.valueReference.resourceId, ValueOverride(v.value.value))
+      CliParameterValue(v.resourceId, v.valueReference.resourceId, CliParameterValue.Value(v.value.value))
     case v: entities.ParameterValue.CommandParameterValue =>
-      CliParameterValue(v.resourceId, v.valueReference.resourceId, v.value)
+      CliParameterValue(v.resourceId, v.valueReference.resourceId, CliParameterValue.Value(v.value.value))
   }
 
   def from(paramValue: testentities.ParameterValue)(implicit renkuUrl: RenkuUrl): CliParameterValue = {
@@ -112,15 +111,18 @@ trait CliActivityConverters extends CliPlanConverters {
       case p: testentities.ParameterValue.LocationParameterValue.CommandOutputValue =>
         CliParameterValue(id,
                           commandParameters.ResourceId(p.valueReference.asEntityId.show),
-                          ValueOverride(p.value.value)
+                          CliParameterValue.Value(p.value.value)
         )
       case p: testentities.ParameterValue.LocationParameterValue.CommandInputValue =>
         CliParameterValue(id,
                           commandParameters.ResourceId(p.valueReference.asEntityId.show),
-                          ValueOverride(p.value.value)
+                          CliParameterValue.Value(p.value.value)
         )
       case p: testentities.ParameterValue.CommandParameterValue =>
-        CliParameterValue(id, commandParameters.ResourceId(p.valueReference.asEntityId.show), p.value)
+        CliParameterValue(id,
+                          commandParameters.ResourceId(p.valueReference.asEntityId.show),
+                          CliParameterValue.Value(p.value.value)
+        )
     }
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilderSpec.scala
@@ -81,13 +81,13 @@ class EntityBuilderSpec
         .returning(rightT[Try, ProcessingRecoverableError](glProject.some))
 
       val modelProject = testProject.to[entities.Project]
-      val cliProject   = modelProject.toCliEntity
+      val cliProject   = testProject.to[CliProject]
 
       val results = entityBuilder
         .buildEntity(
           triplesGeneratedEvents.generateOne.copy(
             project = consumers.Project(projectIds.generateOne, testProject.path),
-            payload = payloadJsonLD(cliProject)
+            payload = cliProject.asJsonLD(CliProject.flatJsonLDEncoder)
           )
         )
         .value

--- a/triples-store-client/build.sbt
+++ b/triples-store-client/build.sbt
@@ -19,7 +19,7 @@
 organization := "io.renku"
 name := "triples-store-client"
 
-libraryDependencies += "io.renku" %% "jsonld4s" % "0.8.0"
+libraryDependencies += "io.renku" %% "jsonld4s" % "0.9.0"
 
 libraryDependencies += "org.eclipse.rdf4j" % "rdf4j-queryparser-sparql" % "4.2.3"
 


### PR DESCRIPTION
A command parameter value sometimes is given as an json number instead of a string. It can be potentially all primitives, so now the "raw" json value is taken.

Closes: #1335