### PR TITLE
chore: Move dependencies into a single source

### DIFF
--- a/commit-event-service/build.sbt
+++ b/commit-event-service/build.sbt
@@ -18,4 +18,4 @@
 
 name := "commit-event-service"
 
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.5"
+libraryDependencies ++= Dependencies.logbackClassic

--- a/event-log/build.sbt
+++ b/event-log/build.sbt
@@ -20,4 +20,4 @@ name := "event-log"
 
 Test / fork := true
 
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.5"
+libraryDependencies ++= Dependencies.logbackClassic

--- a/generators/build.sbt
+++ b/generators/build.sbt
@@ -19,8 +19,9 @@
 organization := "io.renku"
 name := "generators"
 
-libraryDependencies += "eu.timepit"     %% "refined"    % "0.10.1"
-libraryDependencies += "io.circe"       %% "circe-core" % "0.14.4"
-libraryDependencies += "io.renku"       %% "jsonld4s"   % "0.9.0"
-libraryDependencies += "org.typelevel"  %% "cats-core"  % "2.9.0"
-libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.17.0"
+libraryDependencies ++=
+  Dependencies.refined ++
+    Dependencies.circeCore ++
+    Dependencies.jsonld4s ++
+    Dependencies.catsCore ++
+    Dependencies.scalacheck

--- a/graph-commons/build.sbt
+++ b/graph-commons/build.sbt
@@ -20,32 +20,22 @@ name := "graph-commons"
 
 Test / fork := true
 
-val pureConfigVersion = "0.17.2"
-libraryDependencies += "com.github.pureconfig" %% "pureconfig"      % pureConfigVersion
-libraryDependencies += "com.github.pureconfig" %% "pureconfig-cats" % pureConfigVersion
-
-libraryDependencies += "eu.timepit"       %% "refined-pureconfig" % "0.10.1"
-libraryDependencies += "io.sentry"         % "sentry-logback"     % "6.14.0"
-libraryDependencies += "org.apache.lucene" % "lucene-queryparser" % "9.5.0"
-
-val http4sVersion           = "0.23.18"
-val http4sBlazeVersion      = "0.23.13"
-val http4sPrometheusVersion = "0.24.3"
-libraryDependencies += "org.http4s" %% "http4s-blaze-client"       % http4sBlazeVersion
-libraryDependencies += "org.http4s" %% "http4s-blaze-server"       % http4sBlazeVersion
-libraryDependencies += "org.http4s" %% "http4s-circe"              % http4sVersion
-libraryDependencies += "org.http4s" %% "http4s-dsl"                % http4sVersion
-libraryDependencies += "org.http4s" %% "http4s-prometheus-metrics" % http4sPrometheusVersion
-libraryDependencies += "org.http4s" %% "http4s-server"             % http4sVersion
-
-libraryDependencies += "org.tpolecat"  %% "skunk-core"    % "0.5.1"
-libraryDependencies += "org.typelevel" %% "cats-effect"   % "3.4.8"
-libraryDependencies += "org.typelevel" %% "log4cats-core" % "2.5.0"
+libraryDependencies ++=
+  Dependencies.pureconfig ++
+    Dependencies.refinedPureconfig ++
+    Dependencies.sentryLogback ++
+    Dependencies.luceneQueryParser ++
+    Dependencies.http4sClient ++
+    Dependencies.http4sServer ++
+    Dependencies.http4sCirce ++
+    Dependencies.http4sDsl ++
+    Dependencies.http4sPrometheus ++
+    Dependencies.skunk ++
+    Dependencies.catsEffect ++
+    Dependencies.log4Cats
 
 // Test dependencies
-val testContainersScalaVersion = "0.40.12"
-libraryDependencies += "com.dimafeng"          %% "testcontainers-scala-scalatest"  % testContainersScalaVersion % Test
-libraryDependencies += "com.dimafeng"          %% "testcontainers-scala-postgresql" % testContainersScalaVersion % Test
-libraryDependencies += "com.github.tomakehurst" % "wiremock-jre8"                   % "2.35.0"                   % Test
-
-libraryDependencies += "org.scalamock" %% "scalamock" % "5.2.0" % Test
+libraryDependencies ++=
+  (Dependencies.testContainersPostgres ++
+    Dependencies.wiremock ++
+    Dependencies.scalamock).map(_ % Test)

--- a/knowledge-graph/build.sbt
+++ b/knowledge-graph/build.sbt
@@ -20,17 +20,9 @@ name := "knowledge-graph"
 
 Test / fork := true
 
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.5"
-
-libraryDependencies += "com.github.dgarijo" % "widoco" % "1.4.17"
-
-libraryDependencies += "io.swagger.parser.v3" % "swagger-parser" % "2.1.12"
-
-// needed by widoco only - explicitly bumped up to work with rdf4j-queryparser-sparql (triples-store-client)
-// from 5.1.18 that widoco comes with
-libraryDependencies += "net.sourceforge.owlapi" % "owlapi-distribution" % "5.5.0"
-
-// needed by widoco only
-libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.20.0"
+libraryDependencies ++=
+  Dependencies.logbackClassic ++
+    Dependencies.widoco ++
+    Dependencies.swaggerParser
 
 resolvers += "jitpack" at "https://jitpack.io"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,177 @@
+import sbt._
+
+//noinspection TypeAnnotation
+object Dependencies {
+
+  object V {
+    val rdf4jQueryParserSparql = "4.2.3"
+    val ammonite               = "2.4.1"
+    val diffx                  = "0.8.2"
+    val http4s                 = "0.23.18"
+    val http4sBlaze            = "0.23.13"
+    val http4sPrometheus       = "0.24.3"
+    val logback                = "1.4.5"
+    val log4cats               = "2.5.0"
+    val log4jCore              = "2.20.0"
+    val luceneQueryParser      = "9.5.0"
+    val refined                = "0.10.1"
+    val refinedPureconfig      = "0.10.1"
+    val circeCore              = "0.14.4"
+    val circeOptics            = "0.14.1"
+    val jsonld4s               = "0.9.0"
+    val catsCore               = "2.9.0"
+    val catsEffect             = "3.4.8"
+    val monocle                = "2.1.0"
+    val scalacheck             = "1.17.0"
+    val scalatest              = "3.2.15"
+    val scalatestScalacheck    = "3.2.2.0"
+    val scalamock              = "5.2.0"
+    val sentryLogback          = "6.14.0"
+    val owlapi                 = "5.5.0"
+    val pureconfig             = "0.17.2"
+    val skunk                  = "0.5.1"
+    val swaggerParser          = "2.1.12"
+    val testContainersScala    = "0.40.12"
+    val wiremock               = "2.35.0"
+    val widoco                 = "1.4.17"
+  }
+
+  val scalatestScalaCheck = Seq(
+    "org.scalatestplus" %% "scalacheck-1-14" % V.scalatestScalacheck
+  )
+
+  val scalatest = Seq(
+    "org.scalatest" %% "scalatest" % V.scalatest
+  )
+
+  val ammoniteOps = Seq(
+    "com.lihaoyi" %% "ammonite-ops" % V.ammonite
+  )
+
+  val rdf4jQueryParserSparql = Seq(
+    "org.eclipse.rdf4j" % "rdf4j-queryparser-sparql" % V.rdf4jQueryParserSparql
+  )
+
+  val monocle = Seq(
+    // libraryDependencies += "dev.optics" %% "monocle-core" % 3.x.x // to be used when circe-optics starts to use is
+    "com.github.julien-truffaut" %% "monocle-core" % V.monocle
+  )
+
+  val diffx = Seq(
+    "com.softwaremill.diffx" %% "diffx-scalatest-should" % V.diffx
+  )
+
+  val swaggerParser = Seq(
+    "io.swagger.parser.v3" % "swagger-parser" % V.swaggerParser
+  )
+
+  val widoco = Seq(
+    "com.github.dgarijo" % "widoco" % V.widoco,
+    // needed by widoco only - explicitly bumped up to work with rdf4j-queryparser-sparql (triples-store-client)
+    // from 5.1.18 that widoco comes with
+    "net.sourceforge.owlapi" % "owlapi-distribution" % V.owlapi,
+    // needed by widoco only
+    "org.apache.logging.log4j" % "log4j-core" % V.log4jCore
+  )
+
+  val pureconfig = Seq(
+    "com.github.pureconfig" %% "pureconfig"      % V.pureconfig,
+    "com.github.pureconfig" %% "pureconfig-cats" % V.pureconfig
+  )
+
+  val refinedPureconfig = Seq(
+    "eu.timepit" %% "refined-pureconfig" % V.refinedPureconfig
+  )
+
+  val sentryLogback = Seq(
+    "io.sentry" % "sentry-logback" % V.sentryLogback
+  )
+
+  val luceneQueryParser = Seq(
+    "org.apache.lucene" % "lucene-queryparser" % V.luceneQueryParser
+  )
+
+  val http4sClient = Seq(
+    "org.http4s" %% "http4s-blaze-client" % V.http4sBlaze
+  )
+  val http4sServer = Seq(
+    "org.http4s" %% "http4s-blaze-server" % V.http4sBlaze,
+    "org.http4s" %% "http4s-server"       % V.http4s
+  )
+  val http4sCirce = Seq(
+    "org.http4s" %% "http4s-circe" % V.http4s
+  )
+  val http4sDsl = Seq(
+    "org.http4s" %% "http4s-dsl" % V.http4s
+  )
+  val http4sPrometheus = Seq(
+    "org.http4s" %% "http4s-prometheus-metrics" % V.http4sPrometheus
+  )
+
+  val skunk = Seq(
+    "org.tpolecat" %% "skunk-core" % V.skunk
+  )
+
+  val catsEffect = Seq(
+    "org.typelevel" %% "cats-effect" % V.catsEffect
+  )
+
+  val log4Cats = Seq(
+    "org.typelevel" %% "log4cats-core" % V.log4cats
+  )
+
+  val testContainersPostgres = Seq(
+    "com.dimafeng" %% "testcontainers-scala-scalatest"  % V.testContainersScala,
+    "com.dimafeng" %% "testcontainers-scala-postgresql" % V.testContainersScala
+  )
+
+  val wiremock = Seq(
+    "com.github.tomakehurst" % "wiremock-jre8" % V.wiremock
+  )
+
+  val scalamock = Seq(
+    "org.scalamock" %% "scalamock" % V.scalamock
+  )
+
+  val logbackClassic = Seq(
+    "ch.qos.logback" % "logback-classic" % V.logback
+  )
+
+  val refined = Seq(
+    "eu.timepit" %% "refined" % V.refined
+  )
+
+  val circeCore = Seq(
+    "io.circe" %% "circe-core" % V.circeCore
+  )
+  val circeLiteral = Seq(
+    "io.circe" %% "circe-literal" % V.circeCore
+  )
+  val circeGeneric = Seq(
+    "io.circe" %% "circe-generic" % V.circeCore
+  )
+  val circeParser = Seq(
+    "io.circe" %% "circe-parser" % V.circeCore
+  )
+
+  val circeOptics = Seq(
+    "io.circe" %% "circe-optics" % V.circeOptics
+  )
+
+  val jsonld4s = Seq(
+    "io.renku" %% "jsonld4s" % V.jsonld4s
+  )
+
+  val catsCore = Seq(
+    "org.typelevel" %% "cats-core" % V.catsCore
+  )
+
+  val catsFree = Seq(
+    "org.typelevel" %% "cats-free" % V.catsCore
+  )
+
+  val scalacheck = Seq(
+    "org.scalacheck" %% "scalacheck" % V.scalacheck
+  )
+
+}

--- a/renku-cli-model/build.sbt
+++ b/renku-cli-model/build.sbt
@@ -19,4 +19,4 @@
 organization := "io.renku"
 name := "renku-cli-model"
 
-libraryDependencies += "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.8.2" % Test
+libraryDependencies ++= Dependencies.diffx.map(_ % Test)

--- a/renku-model-tiny-types/build.sbt
+++ b/renku-model-tiny-types/build.sbt
@@ -19,4 +19,4 @@
 organization := "io.renku"
 name := "renku-model-tiny-types"
 
-libraryDependencies += "com.softwaremill.diffx" %% "diffx-scalatest-should" % "0.8.2" % Test
+libraryDependencies ++= Dependencies.diffx.map(_ % Test)

--- a/renku-model/build.sbt
+++ b/renku-model/build.sbt
@@ -19,6 +19,8 @@
 organization := "io.renku"
 name := "renku-model"
 
-//libraryDependencies += "dev.optics" %% "monocle-core" % 3.x.x // to be used when circe-optics starts to use is
-libraryDependencies += "com.github.julien-truffaut" %% "monocle-core"           % "2.1.0"
-libraryDependencies += "com.softwaremill.diffx"     %% "diffx-scalatest-should" % "0.8.2" % Test
+libraryDependencies ++=
+  Dependencies.monocle
+
+libraryDependencies ++=
+  Dependencies.diffx.map(_ % Test)

--- a/tiny-types/build.sbt
+++ b/tiny-types/build.sbt
@@ -19,16 +19,12 @@
 organization := "io.renku"
 name := "tiny-types"
 
-libraryDependencies += "eu.timepit" %% "refined" % "0.10.1"
-
-val circeVersion       = "0.14.4"
-val circeOpticsVersion = "0.14.1"
-libraryDependencies += "io.circe" %% "circe-core"    % circeVersion
-libraryDependencies += "io.circe" %% "circe-literal" % circeVersion
-libraryDependencies += "io.circe" %% "circe-generic" % circeVersion
-libraryDependencies += "io.circe" %% "circe-optics"  % circeOpticsVersion
-libraryDependencies += "io.circe" %% "circe-parser"  % circeVersion
-
-val catsVersion = "2.9.0"
-libraryDependencies += "org.typelevel" %% "cats-core" % catsVersion
-libraryDependencies += "org.typelevel" %% "cats-free" % catsVersion
+libraryDependencies ++=
+  Dependencies.refined ++
+    Dependencies.circeCore ++
+    Dependencies.circeLiteral ++
+    Dependencies.circeGeneric ++
+    Dependencies.circeOptics ++
+    Dependencies.circeParser ++
+    Dependencies.catsCore ++
+    Dependencies.catsFree

--- a/triples-generator/build.sbt
+++ b/triples-generator/build.sbt
@@ -20,5 +20,6 @@ name := "triples-generator"
 
 Test / fork := true
 
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.5"
-libraryDependencies += "com.lihaoyi"   %% "ammonite-ops"    % "2.4.1"
+libraryDependencies ++=
+  Dependencies.logbackClassic ++
+    Dependencies.ammoniteOps

--- a/triples-store-client/build.sbt
+++ b/triples-store-client/build.sbt
@@ -19,10 +19,11 @@
 organization := "io.renku"
 name := "triples-store-client"
 
-libraryDependencies += "io.renku" %% "jsonld4s" % "0.9.0"
+libraryDependencies ++=
+  Dependencies.jsonld4s ++
+    Dependencies.rdf4jQueryParserSparql
 
-libraryDependencies += "org.eclipse.rdf4j" % "rdf4j-queryparser-sparql" % "4.2.3"
-
-libraryDependencies += "org.scalacheck"    %% "scalacheck"      % "1.17.0"  % Test
-libraryDependencies += "org.scalatest"     %% "scalatest"       % "3.2.15"  % Test
-libraryDependencies += "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test
+libraryDependencies ++=
+  (Dependencies.scalacheck ++
+    Dependencies.scalatest ++
+    Dependencies.scalatestScalaCheck).map(_ % Test)

--- a/webhook-service/build.sbt
+++ b/webhook-service/build.sbt
@@ -18,4 +18,4 @@
 
 name := "webhook-service"
 
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.5"
+libraryDependencies ++= Dependencies.logbackClassic


### PR DESCRIPTION
This PR only re-organizes our dependencies into a single file and uses this "single source" to reference dependencies in our build files.