### PR TITLE
chore: Move from http4s blaze backend to ember

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
@@ -40,7 +40,7 @@ import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.UserAccessToken
 import org.http4s._
-import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.client.Client
 import org.http4s.dsl.Http4sDsl
@@ -185,11 +185,12 @@ final class GitLabApiStub[F[_]: Async: Logger](private val stateRef: Ref[F, Stat
 
   def resource(bindAddress: Host, port: Port): Resource[F, Server] =
     Resource.eval(logger.trace(s"Starting GitLab stub on $bindAddress:$port")) *>
-      BlazeServerBuilder[F]
-        .bindHttp(port.value, bindAddress.show)
-        .withoutBanner
+      EmberServerBuilder
+        .default[F]
+        .withHost(bindAddress)
+        .withPort(port)
         .withHttpApp(enableLogging[F](allRoutes.orNotFound))
-        .resource
+        .build
 
   def resource(bindAddress: String, port: Int): Resource[F, Server] =
     (Host.fromString(bindAddress), Port.fromInt(port))

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/MicroserviceRunnerSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/MicroserviceRunnerSpec.scala
@@ -19,33 +19,21 @@
 package io.renku.commiteventservice
 
 import cats.effect._
-import cats.syntax.all._
-import fs2.concurrent.SignallingRef
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
-import io.renku.events.EventRequestContent
 import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.http.server.HttpServer
 import io.renku.interpreters.TestLogger
-import io.renku.microservices.ServiceReadinessChecker
-import io.renku.testtools.{IOSpec, MockedRunnableCollaborators}
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import io.renku.microservices.{AbstractMicroserviceRunnerTest, CallCounter, ServiceReadinessChecker, ServiceRunCounter}
+import io.renku.testtools.IOSpec
+
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-
 import scala.concurrent.duration._
 
-class MicroserviceRunnerSpec
-    extends AnyWordSpec
-    with IOSpec
-    with MockedRunnableCollaborators
-    with MockFactory
-    with Eventually
-    with IntegrationPatience
-    with should.Matchers {
+class MicroserviceRunnerSpec extends AnyWordSpec with IOSpec with should.Matchers {
 
   "run" should {
 
@@ -53,22 +41,14 @@ class MicroserviceRunnerSpec
       "if certificate loader, sentry, events consumer and metrics initialisation are fine " +
       "and http server starts up" in new TestCase {
 
-        given(certificateLoader).succeeds(returning = ())
-        given(sentryInitializer).succeeds(returning = ())
-        (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
-        given(httpServer).succeeds()
-
-        startRunnerFor(2.second).unsafeRunSync() shouldBe ExitCode.Success
-
-        eventually {
-          eventConsumersRegistry.counter.get.unsafeRunSync() should be > 1
-        }
+        startFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
+        assertCalledAll.unsafeRunSync()
       }
 
     "fail if certificate loading fails" in new TestCase {
 
       val exception = exceptions.generateOne
-      given(certificateLoader).fails(becauseOf = exception)
+      certificateLoader.failWith(exception).unsafeRunSync()
 
       intercept[Exception] {
         startRunnerForever.unsafeRunSync()
@@ -77,9 +57,8 @@ class MicroserviceRunnerSpec
 
     "fail if sentry initialisation fails" in new TestCase {
 
-      given(certificateLoader).succeeds(returning = ())
       val exception = exceptions.generateOne
-      given(sentryInitializer).fails(becauseOf = exception)
+      sentryInitializer.failWith(exception).unsafeRunSync()
 
       intercept[Exception] {
         startRunnerForever.unsafeRunSync()
@@ -88,35 +67,32 @@ class MicroserviceRunnerSpec
 
     "fail if starting the http server fails" in new TestCase {
 
-      given(certificateLoader).succeeds(returning = ())
-      given(sentryInitializer).succeeds(returning = ())
-      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
       val exception = exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      httpServer.failWith(exception).unsafeRunSync()
 
       intercept[Exception](startRunnerForever.unsafeRunSync()) shouldBe exception
     }
 
     "return Success ExitCode even if Event Consumers Registry initialisation fails" in new TestCase {
 
-      override val eventConsumersRegistry = new EventsConsumersRegistryStub(exceptions.generateSome)
+      eventConsumersRegistry.failWith(exceptions.generateOne).unsafeRunSync()
 
-      given(certificateLoader).succeeds(returning = ())
-      given(sentryInitializer).succeeds(returning = ())
-      (() => serviceReadinessChecker.waitIfNotUp).expects().returning(().pure[IO])
-      given(httpServer).succeeds()
-
-      startRunnerFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
+      startAndStopRunner.unsafeRunSync() shouldBe ExitCode.Success
+      assertCalledAllBut(eventConsumersRegistry).unsafeRunSync()
     }
   }
 
-  private trait TestCase {
+  private trait TestCase extends AbstractMicroserviceRunnerTest {
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
-    val serviceReadinessChecker = mock[ServiceReadinessChecker[IO]]
-    val certificateLoader       = mock[CertificateLoader[IO]]
-    val sentryInitializer       = mock[SentryInitializer[IO]]
-    val eventConsumersRegistry  = new EventsConsumersRegistryStub()
-    val httpServer              = mock[HttpServer[IO]]
+    val serviceReadinessChecker: ServiceReadinessChecker[IO] with CallCounter = new ServiceRunCounter(
+      "ServiceReadinessChecker"
+    )
+    val certificateLoader: CertificateLoader[IO] with CallCounter = new ServiceRunCounter("CertificateLoader")
+    val sentryInitializer: SentryInitializer[IO] with CallCounter = new ServiceRunCounter("SentryInitializer")
+    val eventConsumersRegistry: EventConsumersRegistry[IO] with CallCounter = new ServiceRunCounter(
+      "EventConsumerRegistry"
+    )
+    val httpServer: HttpServer[IO] with CallCounter = new ServiceRunCounter("HttpServer")
     val runner = new MicroserviceRunner(serviceReadinessChecker,
                                         certificateLoader,
                                         sentryInitializer,
@@ -124,28 +100,12 @@ class MicroserviceRunnerSpec
                                         httpServer
     )
 
-    def startRunnerFor(duration: FiniteDuration): IO[ExitCode] =
-      for {
-        term <- SignallingRef.of[IO, Boolean](false)
-        _    <- (IO.sleep(duration) *> term.set(true)).start
-        exit <- runner.run(term)
-      } yield exit
-
-    def startRunnerForever: IO[ExitCode] =
-      for {
-        term <- SignallingRef.of[IO, Boolean](false)
-        exit <- runner.run(term)
-      } yield exit
-  }
-
-  private class EventsConsumersRegistryStub(maybeFail: Option[Exception] = None) extends EventConsumersRegistry[IO] {
-    val counter = Ref.unsafe[IO, Int](0)
-
-    override def run: IO[Unit] = maybeFail.map(_.raiseError[IO, Unit]).getOrElse(keepGoing.foreverM)
-
-    private def keepGoing = Temporal[IO].delayBy(counter.update(_ + 1), 500 millis)
-
-    override def handle(requestContent: EventRequestContent) = fail("Shouldn't be called")
-    override def renewAllSubscriptions() = fail("Shouldn't be called")
+    val all: List[CallCounter] = List(
+      serviceReadinessChecker,
+      certificateLoader,
+      sentryInitializer,
+      eventConsumersRegistry,
+      httpServer
+    )
   }
 }

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/MicroserviceRunnerSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/MicroserviceRunnerSpec.scala
@@ -77,8 +77,8 @@ class MicroserviceRunnerSpec extends AnyWordSpec with IOSpec with should.Matcher
 
       eventConsumersRegistry.failWith(exceptions.generateOne).unsafeRunSync()
 
-      startAndStopRunner.unsafeRunSync() shouldBe ExitCode.Success
-      assertCalledAllBut(eventConsumersRegistry).unsafeRunSync()
+      startFor(500.millis).unsafeRunSync() shouldBe ExitCode.Success
+      assertCalledAllBut(eventConsumersRegistry, httpServer).unsafeRunSync()
     }
   }
 

--- a/event-log/src/main/scala/io/renku/eventlog/Microservice.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/Microservice.scala
@@ -22,7 +22,7 @@ import cats.effect._
 import cats.effect.kernel.Ref
 import cats.syntax.all._
 import com.comcast.ip4s._
-import fs2.concurrent.SignallingRef
+import fs2.concurrent.{Signal, SignallingRef}
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
 import io.renku.db.{SessionPoolResource, SessionResource}
@@ -127,7 +127,7 @@ private class MicroserviceRunner[F[_]: Spawn: Concurrent: Logger](
     httpServer:              HttpServer[F]
 ) {
 
-  def run(signal: SignallingRef[F, Boolean]): F[ExitCode] =
+  def run(signal: Signal[F, Boolean]): F[ExitCode] =
     Ref.of(ExitCode.Success).flatMap(rc => ResourceUse(createServer).useUntil(signal, rc))
 
   def createServer: Resource[F, Server] =

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueue.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueue.scala
@@ -47,7 +47,7 @@ trait StatusChangeEventsQueue[F[_]] {
       show:      Show[E]
   ): Kleisli[F, Session[F], Unit]
 
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 object StatusChangeEventsQueue {
@@ -104,7 +104,7 @@ private class StatusChangeEventsQueueImpl[F[_]: Async: Logger: SessionResource: 
     case other                => Logger[F].error(s"$categoryName offering ${event.show} failed with $other")
   }
 
-  override def run(): F[Unit] = dequeueAll().foreverM
+  override def run: F[Unit] = dequeueAll().foreverM
 
   private def dequeueAll(): F[Unit] = Temporal[F].andWait(
     (handlers.get >>= (_.map(h => dequeueType(h)).sequence.void)) recoverWith loggingStatement,

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/EventProducersRegistry.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/EventProducersRegistry.scala
@@ -30,7 +30,7 @@ import io.renku.metrics.MetricsRegistry
 import org.typelevel.log4cats.Logger
 
 trait EventProducersRegistry[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
   def register(subscriptionRequest: Json): F[SubscriptionResult]
   def getStatus: F[Set[EventProducerStatus]]
 }
@@ -39,7 +39,7 @@ private[producers] class EventProducersRegistryImpl[F[_]: Parallel: Applicative]
     categories: Set[SubscriptionCategory[F]]
 ) extends EventProducersRegistry[F] {
 
-  override def run(): F[Unit] = categories.toList.map(_.run()).parSequence.void
+  override def run: F[Unit] = categories.toList.map(_.run()).parSequence.void
 
   override def register(subscriptionRequest: Json): F[SubscriptionResult] =
     if (categories.isEmpty) {

--- a/event-log/src/main/scala/io/renku/eventlog/init/BatchDateAdder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/BatchDateAdder.scala
@@ -38,7 +38,7 @@ private class BatchDateAdderImpl[F[_]: MonadCancelThrow: Logger: SessionResource
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("event")(
       Kleisli.liftF(Logger[F] info "'batch_date' column adding skipped"),
       otherwise = checkColumnExists("event_log", "batch_date") >>= {

--- a/event-log/src/main/scala/io/renku/eventlog/init/CleanUpEventsTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/CleanUpEventsTableCreator.scala
@@ -38,7 +38,7 @@ private class CleanUpEventsTableCreatorImpl[F[_]: MonadCancelThrow: Logger: Sess
   import skunk._
   import skunk.implicits._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists("clean_up_events_queue") >>= {
       case true  => Kleisli.liftF(Logger[F] info "'clean_up_events_queue' table exists")
       case false => createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/DbInitializer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/DbInitializer.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.control.NonFatal
 
 trait DbInitializer[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 class DbInitializerImpl[F[_]: Temporal: Logger](migrators: List[DbMigrator[F]],
@@ -37,12 +37,12 @@ class DbInitializerImpl[F[_]: Temporal: Logger](migrators: List[DbMigrator[F]],
                                                 retrySleepDuration: FiniteDuration = 20.seconds
 ) extends DbInitializer[F] {
 
-  override def run(): F[Unit] = runMigrations()
+  override def run: F[Unit] = runMigrations()
 
   private def runMigrations(retryCount: Int = 0): F[Unit] = {
     for {
       _ <- isMigrating.update(_ => true)
-      _ <- migrators.map(_.run()).sequence
+      _ <- migrators.map(_.run).sequence
       _ <- Logger[F].info("Event Log database initialization success")
       _ <- isMigrating.update(_ => false)
     } yield ()

--- a/event-log/src/main/scala/io/renku/eventlog/init/DbMigrator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/DbMigrator.scala
@@ -19,5 +19,5 @@
 package io.renku.eventlog.init
 
 trait DbMigrator[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }

--- a/event-log/src/main/scala/io/renku/eventlog/init/EventDeliveryEventTypeAdder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/EventDeliveryEventTypeAdder.scala
@@ -38,7 +38,7 @@ private class EventDeliveryEventTypeAdderImpl[F[_]: MonadCancelThrow: Logger: Se
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkColumnExists("event_delivery", "event_type_id") >>= {
       case true  => Kleisli.liftF(Logger[F] info "'event_type_id' column adding skipped")
       case false => addEventTypeColumn()

--- a/event-log/src/main/scala/io/renku/eventlog/init/EventDeliveryTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/EventDeliveryTableCreator.scala
@@ -34,7 +34,7 @@ private class EventDeliveryTableCreatorImpl[F[_]: MonadCancelThrow: Logger: Sess
   import MigratorTools._
   import cats.syntax.all._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists >>= {
       case true  => Kleisli.liftF(Logger[F] info "'event_delivery' table exists")
       case false => createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/EventLogTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/EventLogTableCreator.scala
@@ -42,7 +42,7 @@ private class EventLogTableCreatorImpl[F[_]: MonadCancelThrow: Logger: SessionRe
   import MigratorTools._
   import cats.syntax.all._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("event")(
       Kleisli.liftF(Logger[F] info "'event_log' table creation skipped"),
       otherwise = checkTableExists flatMap {

--- a/event-log/src/main/scala/io/renku/eventlog/init/EventLogTableRenamer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/EventLogTableRenamer.scala
@@ -38,7 +38,7 @@ private class EventLogTableRenamerImpl[F[_]: MonadCancelThrow: Logger: SessionRe
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkOldTableExists >>= {
       case false => Kleisli.liftF(Logger[F] info "'event' table already exists")
       case true =>

--- a/event-log/src/main/scala/io/renku/eventlog/init/EventPayloadTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/EventPayloadTableCreator.scala
@@ -39,7 +39,7 @@ private class EventPayloadTableCreatorImpl[F[_]: MonadCancelThrow: Logger: Sessi
   import MigratorTools._
   import cats.syntax.all._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("event")(
       checkTableExists >>= {
         case true  => Kleisli.liftF(Logger[F] info "'event_payload' table exists")

--- a/event-log/src/main/scala/io/renku/eventlog/init/EventStatusRenamer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/EventStatusRenamer.scala
@@ -33,7 +33,7 @@ private trait EventStatusRenamer[F[_]] extends DbMigrator[F]
 
 private class EventStatusRenamerImpl[F[_]: MonadCancelThrow: Logger: SessionResource]() extends EventStatusRenamer[F] {
 
-  override def run(): F[Unit] = {
+  override def run: F[Unit] = {
     for {
       _ <- renameAllStatuses(from = "PROCESSING", to = "GENERATING_TRIPLES")
       _ <- Logger[F].info(s"'PROCESSING' event status renamed to 'GENERATING_TRIPLES'")

--- a/event-log/src/main/scala/io/renku/eventlog/init/FailedEventsRestorer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/FailedEventsRestorer.scala
@@ -47,7 +47,7 @@ private class FailedEventsRestorerImpl[F[_]: MonadCancelThrow: Logger: SessionRe
     discardingStatuses: List[EventStatus]
 ) extends FailedEventsRestorer[F] {
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     Kleisli[F, Session[F], Completion](_ execute updateQuery) flatMapF {
       case Completion.Update(count) => Logger[F].info(s"$count events restored for processing from '$failure'")
       case completion => Logger[F].info(s"Events restoration for processing from '$failure' did not work: $completion")

--- a/event-log/src/main/scala/io/renku/eventlog/init/PayloadTypeChanger.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/PayloadTypeChanger.scala
@@ -37,7 +37,7 @@ private class PayloadTypeChangerImpl[F[_]: MonadCancelThrow: Logger: SessionReso
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkIfAlreadyMigrated >>= {
       case true =>
         Kleisli.liftF(Logger[F].info("event_payload.payload already in bytea type"))

--- a/event-log/src/main/scala/io/renku/eventlog/init/ProjectIdOnCleanUpTable.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/ProjectIdOnCleanUpTable.scala
@@ -38,7 +38,7 @@ private class ProjectIdOnCleanUpTableImpl[F[_]: MonadCancelThrow: Logger: Sessio
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkColumnExists("clean_up_events_queue", "project_id") >>= {
       case true  => Kleisli.liftF(Logger[F] info "'clean_up_events_queue.project_id' column exists")
       case false => addColumn()

--- a/event-log/src/main/scala/io/renku/eventlog/init/ProjectPathAdder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/ProjectPathAdder.scala
@@ -47,7 +47,7 @@ private class ProjectPathAdderImpl[F[_]: MonadCancelThrow: Logger: SessionResour
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("event")(
       Kleisli.liftF(Logger[F] info "'project_path' column adding skipped"),
       otherwise = checkColumnExists("event_log", "project_path") >>= {

--- a/event-log/src/main/scala/io/renku/eventlog/init/ProjectPathRemover.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/ProjectPathRemover.scala
@@ -36,7 +36,7 @@ private object ProjectPathRemover {
 private class ProjectPathRemoverImpl[F[_]: MonadCancelThrow: Logger: SessionResource] extends ProjectPathRemover[F] {
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("event")(
       Kleisli.liftF(Logger[F] info "'project_path' column dropping skipped"),
       otherwise = checkColumnExists >>= {

--- a/event-log/src/main/scala/io/renku/eventlog/init/ProjectTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/ProjectTableCreator.scala
@@ -35,7 +35,7 @@ private class ProjectTableCreatorImpl[F[_]: MonadCancelThrow: Logger: SessionRes
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("event")(
       Kleisli.liftF(Logger[F] info "'project' table creation skipped"),
       otherwise = whenTableExists("project")(

--- a/event-log/src/main/scala/io/renku/eventlog/init/StatusChangeEventsTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/StatusChangeEventsTableCreator.scala
@@ -39,7 +39,7 @@ private class StatusChangeEventsTableCreatorImpl[F[_]: MonadCancelThrow: Logger:
   import skunk.codec.all._
   import skunk.implicits._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists flatMap {
       case true  => Kleisli.liftF(Logger[F] info "'status_change_events_queue' table exists")
       case false => createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/StatusesProcessingTimeTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/StatusesProcessingTimeTableCreator.scala
@@ -39,7 +39,7 @@ private class StatusesProcessingTimeTableCreatorImpl[F[_]: MonadCancelThrow: Log
   import MigratorTools._
   import cats.syntax.all._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists >>= {
       case true  => Kleisli.liftF(Logger[F] info "'status_processing_time' table exists")
       case false => createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/SubscriberTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/SubscriberTableCreator.scala
@@ -32,7 +32,7 @@ private class SubscriberTableCreatorImpl[F[_]: MonadCancelThrow: Logger: Session
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     whenTableExists("subscriber")(
       Kleisli.liftF(Logger[F] info "'subscriber' table exists"),
       otherwise = createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/SubscriptionCategorySyncTimeTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/SubscriptionCategorySyncTimeTableCreator.scala
@@ -39,7 +39,7 @@ private class SubscriptionCategorySyncTimeTableCreatorImpl[F[_]: MonadCancelThro
   import MigratorTools._
   import cats.syntax.all._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists >>= {
       case true  => Kleisli.liftF(Logger[F] info "'subscription_category_sync_time' table exists")
       case false => createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/TSMigrationTableCreator.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/TSMigrationTableCreator.scala
@@ -39,7 +39,7 @@ private class TSMigrationTableCreatorImpl[F[_]: MonadCancelThrow: Logger: Sessio
   import skunk.codec.all._
   import skunk.implicits._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists >>= {
       case true  => Kleisli.liftF(Logger[F] info "'ts_migration' table exists")
       case false => createTable()

--- a/event-log/src/main/scala/io/renku/eventlog/init/TimestampZoneAdder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/TimestampZoneAdder.scala
@@ -40,7 +40,7 @@ private class TimestampZoneAdderImpl[F[_]: MonadCancelThrow: Logger: SessionReso
 
   import MigratorTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     columnsToMigrate.map { case (table, column) => migrateIfNeeded(table, column) }.sequence.void
   }
 

--- a/event-log/src/main/scala/io/renku/eventlog/metrics/EventLogMetrics.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/metrics/EventLogMetrics.scala
@@ -32,7 +32,7 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 trait EventLogMetrics[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 class EventLogMetricsImpl[F[_]: Temporal: Logger](
@@ -43,7 +43,7 @@ class EventLogMetricsImpl[F[_]: Temporal: Logger](
     interval:                FiniteDuration = EventLogMetrics.interval
 ) extends EventLogMetrics[F] {
 
-  override def run(): F[Unit] = updateStatuses().foreverM[Unit]
+  override def run: F[Unit] = updateStatuses().foreverM[Unit]
 
   private def updateStatuses(): F[Unit] = for {
     _ <- Temporal[F] sleep interval

--- a/event-log/src/test/scala/io/renku/eventlog/InMemoryEventLogDbSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/InMemoryEventLogDbSpec.scala
@@ -37,7 +37,7 @@ trait InMemoryEventLogDbSpec
 
   self: TestSuite with IOSpec =>
 
-  protected def initDb(): Unit = allMigrations.map(_.run()).sequence.void.unsafeRunSync()
+  protected def initDb(): Unit = allMigrations.map(_.run).sequence.void.unsafeRunSync()
 
   private def findAllTables(): List[String] = execute {
     Kleisli { session =>

--- a/event-log/src/test/scala/io/renku/eventlog/MicroserviceRunnerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/MicroserviceRunnerSpec.scala
@@ -66,7 +66,7 @@ class MicroserviceRunnerSpec
         given(eventProducersRegistry).succeeds(returning = ())
         given(eventConsumersRegistry).succeeds(returning = ())
         given(eventsQueue).succeeds(returning = ())
-        given(httpServer).succeeds(returning = ExitCode.Success)
+        given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
         runner.run().unsafeRunAndForget()
 
@@ -99,7 +99,7 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).succeeds(returning = ())
       val exception = exceptions.generateOne
       given(dbInitializer).fails(becauseOf = exception)
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunSync() shouldBe ExitCode.Success
     }
@@ -116,7 +116,7 @@ class MicroserviceRunnerSpec
       given(eventConsumersRegistry).succeeds(returning = ())
       given(eventsQueue).succeeds(returning = ())
       val exception = exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      given(Runnable(httpServer.run)).fails(becauseOf = exception)
 
       intercept[Exception](runner.run().unsafeRunSync()) shouldBe exception
 
@@ -138,7 +138,7 @@ class MicroserviceRunnerSpec
       given(eventProducersRegistry).fails(becauseOf = exceptions.generateOne)
       given(eventConsumersRegistry).succeeds(returning = ())
       given(eventsQueue).succeeds(returning = ())
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunSync() shouldBe ExitCode.Success
 
@@ -160,7 +160,7 @@ class MicroserviceRunnerSpec
       given(eventProducersRegistry).succeeds(returning = ())
       given(eventConsumersRegistry).fails(becauseOf = exceptions.generateOne)
       given(eventsQueue).succeeds(returning = ())
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunSync() shouldBe ExitCode.Success
 
@@ -182,7 +182,7 @@ class MicroserviceRunnerSpec
       given(eventProducersRegistry).succeeds(returning = ())
       given(eventConsumersRegistry).succeeds(returning = ())
       given(eventsQueue).succeeds(returning = ())
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunAndForget() shouldBe ()
 
@@ -203,7 +203,7 @@ class MicroserviceRunnerSpec
       given(eventProducersRegistry).succeeds(returning = ())
       given(eventConsumersRegistry).succeeds(returning = ())
       given(eventsQueue).fails(becauseOf = exceptions.generateOne)
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunAndForget() shouldBe ()
 
@@ -224,7 +224,7 @@ class MicroserviceRunnerSpec
       given(eventConsumersRegistry).succeeds(returning = ())
       given(eventsQueue).succeeds(returning = ())
       given(gaugeScheduler).fails(becauseOf = exceptions.generateOne)
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunAndForget()
 
@@ -263,7 +263,7 @@ class MicroserviceRunnerSpec
   private class Metrics extends EventLogMetrics[IO] {
     val counter = Ref.unsafe[IO, Int](0)
 
-    override def run(): IO[Unit] = keepGoing.foreverM
+    override def run: IO[Unit] = keepGoing.foreverM
 
     private def keepGoing =
       Temporal[IO].delayBy(counter.update(_ + 1), 1000 millis)
@@ -272,7 +272,7 @@ class MicroserviceRunnerSpec
   private class Gauge extends GaugeResetScheduler[IO] {
     val counter = Ref.unsafe[IO, Int](0)
 
-    override def run(): IO[Unit] = keepGoing.foreverM
+    override def run: IO[Unit] = keepGoing.foreverM
 
     private def keepGoing =
       Temporal[IO].delayBy(counter.update(_ + 1), 1000 millis)

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueueSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueueSpec.scala
@@ -52,7 +52,7 @@ class StatusChangeEventsQueueSpec
 
       sessionResource.useK(queue offer event).unsafeRunSync()
 
-      queue.run().unsafeRunAndForget()
+      queue.run.unsafeRunAndForget()
 
       queue.register(eventHandler).unsafeRunSync()
 
@@ -77,7 +77,7 @@ class StatusChangeEventsQueueSpec
 
       queue.register(eventHandler).unsafeRunSync()
 
-      queue.run().unsafeRunAndForget()
+      queue.run.unsafeRunAndForget()
 
       eventually {
         dequeuedEvents.get.unsafeRunSync() shouldBe List(event, nextEvent)
@@ -98,7 +98,7 @@ class StatusChangeEventsQueueSpec
 
       queue.register(failingHandler).unsafeRunSync()
 
-      queue.run().unsafeRunAndForget()
+      queue.run.unsafeRunAndForget()
 
       eventually {
         logger.loggedOnly(
@@ -130,7 +130,7 @@ class StatusChangeEventsQueueSpec
       val handler: ProjectEventsToNew => IO[Unit] = _ => ().pure[IO]
       queue.register(handler).unsafeRunSync()
 
-      queue.run().unsafeRunAndForget()
+      queue.run.unsafeRunAndForget()
 
       eventually {
         logger

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/EventProducersRegistrySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/EventProducersRegistrySpec.scala
@@ -40,7 +40,7 @@ private class EventProducersRegistrySpec extends AnyWordSpec with IOSpec with Mo
     "return unit when all of the categories return Unit" in new TestCase {
       val categories = Set[SubscriptionCategory[IO]](SubscriptionCategoryWithoutRegistration)
       val registry   = new EventProducersRegistryImpl[IO](categories)
-      registry.run().unsafeRunSync() shouldBe ()
+      registry.run.unsafeRunSync() shouldBe ()
     }
 
     "throw an error when one of the categories throws an error" in new TestCase {
@@ -52,7 +52,7 @@ private class EventProducersRegistrySpec extends AnyWordSpec with IOSpec with Mo
       val registry   = new EventProducersRegistryImpl[IO](categories)
 
       intercept[Exception] {
-        registry.run().unsafeRunSync()
+        registry.run.unsafeRunSync()
       } shouldBe exception
     }
   }

--- a/event-log/src/test/scala/io/renku/eventlog/init/BatchDateAdderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/BatchDateAdderSpec.scala
@@ -54,7 +54,7 @@ class BatchDateAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       createEventTable()
 
-      batchDateAdder.run().unsafeRunSync() shouldBe ()
+      batchDateAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'batch_date' column adding skipped"))
     }
@@ -63,7 +63,7 @@ class BatchDateAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       checkColumnExists shouldBe false
 
-      batchDateAdder.run().unsafeRunSync() shouldBe ()
+      batchDateAdder.run.unsafeRunSync() shouldBe ()
 
       checkColumnExists shouldBe true
 
@@ -71,7 +71,7 @@ class BatchDateAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       logger.reset()
 
-      batchDateAdder.run().unsafeRunSync() shouldBe ()
+      batchDateAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'batch_date' column exists"))
     }
@@ -87,7 +87,7 @@ class BatchDateAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
       val event2CreatedDate = createdDates.generateOne
       storeEvent(event2, event2CreatedDate)
 
-      batchDateAdder.run().unsafeRunSync() shouldBe ()
+      batchDateAdder.run.unsafeRunSync() shouldBe ()
 
       findBatchDates shouldBe Set(BatchDate(event1CreatedDate.value), BatchDate(event2CreatedDate.value))
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/CleanUpEventsTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/CleanUpEventsTableCreatorSpec.scala
@@ -36,18 +36,18 @@ class CleanUpEventsTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitS
 
     "create the 'clean_up_events_queue' table if does not exist" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'clean_up_events_queue' table created"))
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'clean_up_events_queue' table created"), Info("'clean_up_events_queue' table exists"))
     }
 
     "create indices for the date column" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       verifyIndexExists("clean_up_events_queue", "idx_date")
       verifyIndexExists("clean_up_events_queue", "idx_project_path")

--- a/event-log/src/test/scala/io/renku/eventlog/init/DbInitSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/DbInitSpec.scala
@@ -37,7 +37,7 @@ trait DbInitSpec extends InMemoryEventLogDb with EventLogDbMigrations with Befor
 
   before {
     findAllTables() foreach dropTable
-    migrationsToRun.map(_.run()).sequence.unsafeRunSync()
+    migrationsToRun.map(_.run).sequence.unsafeRunSync()
   }
 
   private def findAllTables(): List[String] = execute {
@@ -52,7 +52,7 @@ trait DbInitSpec extends InMemoryEventLogDb with EventLogDbMigrations with Befor
 
   protected def createEventTable(): Unit =
     List(EventLogTableCreator[IO], BatchDateAdder[IO], EventLogTableRenamer[IO])
-      .map(_.run())
+      .map(_.run)
       .sequence
       .void
       .unsafeRunSync()

--- a/event-log/src/test/scala/io/renku/eventlog/init/DbInitializerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/DbInitializerSpec.scala
@@ -52,7 +52,7 @@ class DbInitializerSpec
           .expects(where((f: Boolean => Boolean) => !f(true) && !f(false)))
           .returning(IO.unit)
 
-        dbInitializer.run().unsafeRunSync() shouldBe ((): Unit)
+        dbInitializer.run.unsafeRunSync() shouldBe ((): Unit)
 
         logger.loggedOnly(Info("Event Log database initialization success"))
       }
@@ -79,7 +79,7 @@ class DbInitializerSpec
           .returning(IO.unit)
 
       }
-      dbInitializer.run().unsafeRunSync()
+      dbInitializer.run.unsafeRunSync()
 
       logger.loggedOnly(Error("Event Log database initialization failed: retrying 1 time(s)", exception),
                         Info("Event Log database initialization success")

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventDeliveryEventTypeAdderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventDeliveryEventTypeAdderSpec.scala
@@ -43,13 +43,13 @@ class EventDeliveryEventTypeAdderSpec
 
     "do nothing if the 'event_type_id' collumn already exists" in new TestCase {
 
-      eventTypeAdder.run().unsafeRunSync() shouldBe ()
+      eventTypeAdder.run.unsafeRunSync() shouldBe ()
 
       verifyColumnExists("event_delivery", "event_type_id") shouldBe true
 
       logger.reset()
 
-      eventTypeAdder.run().unsafeRunSync() shouldBe ()
+      eventTypeAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'event_type_id' column adding skipped"))
     }
@@ -58,7 +58,7 @@ class EventDeliveryEventTypeAdderSpec
 
       verifyColumnExists("event_delivery", "event_type_id") shouldBe false
 
-      eventTypeAdder.run().unsafeRunSync() shouldBe ()
+      eventTypeAdder.run.unsafeRunSync() shouldBe ()
 
       verifyColumnExists("event_delivery", "event_type_id") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventDeliveryTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventDeliveryTableCreatorSpec.scala
@@ -39,7 +39,7 @@ class EventDeliveryTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitS
 
       tableExists("event_delivery") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_delivery") shouldBe true
 
@@ -47,14 +47,14 @@ class EventDeliveryTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitS
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'event_delivery' table exists"))
     }
 
     "create indices for all the columns" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_delivery") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventLogTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventLogTableCreatorSpec.scala
@@ -38,7 +38,7 @@ class EventLogTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec w
       tableExists("event")     shouldBe true
       tableExists("event_log") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       tableExists("event_log") shouldBe false
 
@@ -49,7 +49,7 @@ class EventLogTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       tableExists("event_log") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       tableExists("event_log") shouldBe true
 
@@ -60,7 +60,7 @@ class EventLogTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       tableExists("event_log") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       tableExists("event_log") shouldBe true
 
@@ -68,14 +68,14 @@ class EventLogTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'event_log' table exists"))
     }
 
     "create indices for certain columns" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       tableExists("event_log") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventLogTableRenamerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventLogTableRenamerSpec.scala
@@ -41,7 +41,7 @@ class EventLogTableRenamerSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       tableExists("event_log") shouldBe true
 
-      tableRenamer.run().unsafeRunSync() shouldBe ((): Unit)
+      tableRenamer.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_log") shouldBe false
       tableExists("event")     shouldBe true
@@ -53,7 +53,7 @@ class EventLogTableRenamerSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       tableExists("event_log") shouldBe true
 
-      tableRenamer.run().unsafeRunSync() shouldBe ((): Unit)
+      tableRenamer.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_log") shouldBe false
       tableExists("event")     shouldBe true
@@ -62,7 +62,7 @@ class EventLogTableRenamerSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       logger.reset()
 
-      tableRenamer.run().unsafeRunSync() shouldBe ((): Unit)
+      tableRenamer.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'event' table already exists"))
     }
@@ -71,7 +71,7 @@ class EventLogTableRenamerSpec extends AnyWordSpec with IOSpec with DbInitSpec w
 
       tableExists("event_log") shouldBe true
 
-      tableRenamer.run().unsafeRunSync() shouldBe ((): Unit)
+      tableRenamer.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_log") shouldBe false
       tableExists("event")     shouldBe true
@@ -85,7 +85,7 @@ class EventLogTableRenamerSpec extends AnyWordSpec with IOSpec with DbInitSpec w
       tableExists("event_log") shouldBe true
       tableExists("event")     shouldBe true
 
-      tableRenamer.run().unsafeRunSync() shouldBe ((): Unit)
+      tableRenamer.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_log") shouldBe false
       tableExists("event")     shouldBe true

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventPayloadTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventPayloadTableCreatorSpec.scala
@@ -41,7 +41,7 @@ class EventPayloadTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSp
 
       intercept[Exception] {
 
-        tableCreator.run().unsafeRunSync()
+        tableCreator.run.unsafeRunSync()
       }.getMessage shouldBe "Event table missing; creation of event_payload is not possible"
     }
 
@@ -49,7 +49,7 @@ class EventPayloadTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSp
 
       tableExists("event_payload") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_payload") shouldBe true
 
@@ -60,7 +60,7 @@ class EventPayloadTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSp
 
       tableExists("event_payload") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_payload") shouldBe true
 
@@ -68,7 +68,7 @@ class EventPayloadTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSp
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'event_payload' table exists"))
     }
@@ -77,7 +77,7 @@ class EventPayloadTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSp
 
       tableExists("event_payload") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("event_payload") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventStatusRenamerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventStatusRenamerSpec.scala
@@ -68,7 +68,7 @@ class EventStatusRenamerSpec
         val otherEvents = events.generateNonEmptyList()
         otherEvents.map(event => store(event, withStatus = event.status.toString))
 
-        eventStatusRenamer.run().unsafeRunSync() shouldBe ()
+        eventStatusRenamer.run.unsafeRunSync() shouldBe ()
 
         findEventsCompoundId(status = GeneratingTriples).toSet shouldBe
           (processingEvents.toList ++ otherEvents.filter(_.status == GeneratingTriples))
@@ -96,7 +96,7 @@ class EventStatusRenamerSpec
       val otherEvents = events.generateNonEmptyList()
       otherEvents.map(event => store(event, withStatus = event.status.show))
 
-      eventStatusRenamer.run().unsafeRunSync() shouldBe ()
+      eventStatusRenamer.run.unsafeRunSync() shouldBe ()
 
       findEventsCompoundId(status = GeneratingTriples).toSet shouldBe otherEvents
         .filter(_.status == GeneratingTriples)

--- a/event-log/src/test/scala/io/renku/eventlog/init/FailedEventsRestorerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/FailedEventsRestorerSpec.scala
@@ -81,7 +81,7 @@ class FailedEventsRestorerSpec
           projectPath
         )._1
 
-        restorer.run().unsafeRunSync() shouldBe ()
+        restorer.run.unsafeRunSync() shouldBe ()
 
         findEvent(compoundId(eventToChange)).map(_._2)         shouldBe New.some
         findEvent(compoundId(olderMatchingEvent)).map(_._2)    shouldBe New.some
@@ -114,7 +114,7 @@ class FailedEventsRestorerSpec
           projectPath
         )._1
 
-        restorer.run().unsafeRunSync() shouldBe ()
+        restorer.run.unsafeRunSync() shouldBe ()
 
         findEvent(compoundId(matchingEvent)).map(_._2)                shouldBe GenerationNonRecoverableFailure.some
         findEvent(compoundId(olderMatchingEvent)).map(_._2)           shouldBe GenerationNonRecoverableFailure.some

--- a/event-log/src/test/scala/io/renku/eventlog/init/PayloadTypeChangerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/PayloadTypeChangerSpec.scala
@@ -41,12 +41,12 @@ class PayloadTypeChangerSpec extends AnyWordSpec with IOSpec with DbInitSpec wit
       verify("event_payload", "payload", "text")
       verify("event_payload", "schema_version", "text")
 
-      tableRefactor.run().unsafeRunSync() shouldBe ()
+      tableRefactor.run.unsafeRunSync() shouldBe ()
 
       verify("event_payload", "payload", "bytea")
       verifyColumnExists("event_payload", "schema_version") shouldBe false
 
-      tableRefactor.run().unsafeRunSync() shouldBe ()
+      tableRefactor.run.unsafeRunSync() shouldBe ()
 
       verify("event_payload", "payload", "bytea")
       verifyColumnExists("event_payload", "schema_version") shouldBe false

--- a/event-log/src/test/scala/io/renku/eventlog/init/ProjectIdOnCleanUpTableSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/ProjectIdOnCleanUpTableSpec.scala
@@ -51,7 +51,7 @@ class ProjectIdOnCleanUpTableSpec
 
       verifyColumnExists("clean_up_events_queue", "project_id") shouldBe false
 
-      migrator.run().unsafeRunSync() shouldBe ()
+      migrator.run.unsafeRunSync() shouldBe ()
 
       verifyColumnExists("clean_up_events_queue", "project_id") shouldBe true
 
@@ -59,7 +59,7 @@ class ProjectIdOnCleanUpTableSpec
 
       logger.reset()
 
-      migrator.run().unsafeRunSync() shouldBe ()
+      migrator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'clean_up_events_queue.project_id' column exists"))
     }
@@ -75,7 +75,7 @@ class ProjectIdOnCleanUpTableSpec
         val projectPath2 = projectPaths.generateOne
         insertToQueue(projectPath2)
 
-        migrator.run().unsafeRunSync() shouldBe ()
+        migrator.run.unsafeRunSync() shouldBe ()
 
         findQueueRows shouldBe List(projectPath1 -> projectId1)
       }

--- a/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathAdderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathAdderSpec.scala
@@ -58,7 +58,7 @@ class ProjectPathAdderSpec
 
       createEventTable()
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ()
+      projectPathAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'project_path' column adding skipped"))
     }
@@ -67,7 +67,7 @@ class ProjectPathAdderSpec
 
       verifyColumnExists("event_log", "project_path") shouldBe false
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ()
+      projectPathAdder.run.unsafeRunSync() shouldBe ()
 
       verifyColumnExists("event_log", "project_path") shouldBe true
 
@@ -75,7 +75,7 @@ class ProjectPathAdderSpec
 
       logger.reset()
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ()
+      projectPathAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'project_path' column exists"))
     }
@@ -89,7 +89,7 @@ class ProjectPathAdderSpec
       val event2 = events.generateOne
       storeEvent(event2)
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ()
+      projectPathAdder.run.unsafeRunSync() shouldBe ()
 
       findProjectPaths shouldBe Set(event1.project.path, event2.project.path)
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathRemoverSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathRemoverSpec.scala
@@ -49,7 +49,7 @@ class ProjectPathRemoverSpec
 
       createEventTable()
 
-      projectPathRemover.run().unsafeRunSync() shouldBe ((): Unit)
+      projectPathRemover.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'project_path' column dropping skipped"))
     }
@@ -58,7 +58,7 @@ class ProjectPathRemoverSpec
 
       checkColumnExists shouldBe true
 
-      projectPathRemover.run().unsafeRunSync() shouldBe ((): Unit)
+      projectPathRemover.run.unsafeRunSync() shouldBe ((): Unit)
 
       checkColumnExists shouldBe false
 
@@ -66,7 +66,7 @@ class ProjectPathRemoverSpec
 
       logger.reset()
 
-      projectPathRemover.run().unsafeRunSync() shouldBe ((): Unit)
+      projectPathRemover.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'project_path' column already removed"))
     }

--- a/event-log/src/test/scala/io/renku/eventlog/init/ProjectTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/ProjectTableCreatorSpec.scala
@@ -50,7 +50,7 @@ class ProjectTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec wi
 
       createEventTable()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'project' table creation skipped"))
     }
@@ -72,7 +72,7 @@ class ProjectTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec wi
 
         tableExists("project") shouldBe false
 
-        tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+        tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
         tableExists("project") shouldBe true
 
@@ -90,7 +90,7 @@ class ProjectTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec wi
 
     "create indices for all the columns" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("project") shouldBe true
 
@@ -105,7 +105,7 @@ class ProjectTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec wi
 
       createEvent()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       fetchProjectData should have size 1
 
@@ -113,7 +113,7 @@ class ProjectTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec wi
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       fetchProjectData should have size 1
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/StatusChangeEventsTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/StatusChangeEventsTableCreatorSpec.scala
@@ -37,11 +37,11 @@ class StatusChangeEventsTableCreatorSpec extends AnyWordSpec with IOSpec with Db
 
     "create the 'status_change_events_queue' table if does not exist" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'status_change_events_queue' table created"))
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'status_change_events_queue' table created"),
                         Info("'status_change_events_queue' table exists")
@@ -50,7 +50,7 @@ class StatusChangeEventsTableCreatorSpec extends AnyWordSpec with IOSpec with Db
 
     "create indices for the date and event_type columns" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       verifyTrue(sql"DROP INDEX idx_date;".command)
       verifyTrue(sql"DROP INDEX idx_event_type;".command)

--- a/event-log/src/test/scala/io/renku/eventlog/init/StatusesProcessingTimeTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/StatusesProcessingTimeTableCreatorSpec.scala
@@ -39,7 +39,7 @@ class StatusesProcessingTimeTableCreatorSpec extends AnyWordSpec with IOSpec wit
 
       tableExists("status_processing_time") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("status_processing_time") shouldBe true
 
@@ -47,7 +47,7 @@ class StatusesProcessingTimeTableCreatorSpec extends AnyWordSpec with IOSpec wit
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'status_processing_time' table exists"))
 
@@ -57,7 +57,7 @@ class StatusesProcessingTimeTableCreatorSpec extends AnyWordSpec with IOSpec wit
 
       tableExists("status_processing_time") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("status_processing_time") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/SubscriberTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/SubscriberTableCreatorSpec.scala
@@ -39,7 +39,7 @@ class SubscriberTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec
 
       tableExists("subscriber") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("subscriber") shouldBe true
 
@@ -47,14 +47,14 @@ class SubscriberTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpec
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'subscriber' table exists"))
     }
 
     "create indices for all the columns" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("subscriber") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/SubscriptionCategorySyncTimeTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/SubscriptionCategorySyncTimeTableCreatorSpec.scala
@@ -43,7 +43,7 @@ class SubscriptionCategorySyncTimeTableCreatorSpec
 
       tableExists("subscription_category_sync_time") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("subscription_category_sync_time") shouldBe true
 
@@ -51,7 +51,7 @@ class SubscriptionCategorySyncTimeTableCreatorSpec
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       logger.loggedOnly(Info("'subscription_category_sync_time' table exists"))
 
@@ -61,7 +61,7 @@ class SubscriptionCategorySyncTimeTableCreatorSpec
 
       tableExists("subscription_category_sync_time") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ((): Unit)
+      tableCreator.run.unsafeRunSync() shouldBe ((): Unit)
 
       tableExists("subscription_category_sync_time") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/TSMigrationTableCreatorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/TSMigrationTableCreatorSpec.scala
@@ -38,7 +38,7 @@ class TSMigrationTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpe
 
       tableExists("ts_migration") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       tableExists("ts_migration") shouldBe true
 
@@ -46,14 +46,14 @@ class TSMigrationTableCreatorSpec extends AnyWordSpec with IOSpec with DbInitSpe
 
       logger.reset()
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'ts_migration' table exists"))
     }
 
     "create relevant indices and constraints" in new TestCase {
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       tableExists("ts_migration") shouldBe true
 

--- a/event-log/src/test/scala/io/renku/eventlog/init/TimestampZoneAdderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/TimestampZoneAdderSpec.scala
@@ -42,7 +42,7 @@ class TimestampZoneAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec wit
         verify(table, column, timestampType)
       }
 
-      tableRefactor.run().unsafeRunSync() shouldBe ((): Unit)
+      tableRefactor.run.unsafeRunSync() shouldBe ((): Unit)
 
       columnsToMigrate foreach { case (table, column) =>
         verify(table, column, timestamptzType)
@@ -58,13 +58,13 @@ class TimestampZoneAdderSpec extends AnyWordSpec with IOSpec with DbInitSpec wit
 
       tableExists("event") shouldBe true
 
-      tableRefactor.run().unsafeRunSync() shouldBe ()
+      tableRefactor.run.unsafeRunSync() shouldBe ()
 
       columnsToMigrate foreach { case (table, column) =>
         verify(table, column, timestamptzType)
       }
 
-      tableRefactor.run().unsafeRunSync() shouldBe ()
+      tableRefactor.run.unsafeRunSync() shouldBe ()
 
       columnsToMigrate foreach { case (table, column) =>
         verify(table, column, timestamptzType)

--- a/event-log/src/test/scala/io/renku/eventlog/metrics/EventLogMetricsSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/metrics/EventLogMetricsSpec.scala
@@ -62,7 +62,7 @@ class EventLogMetricsSpec
       val statusCount = statusCounts.generateOne
       givenStatusesMethodToReturn add statusCount.pure[IO]
 
-      metrics.run().unsafeRunAndForget()
+      metrics.run.unsafeRunAndForget()
 
       eventually {
         categoryNameEventsGauge.categoryNameValues.asScala shouldBe categoryNameCount
@@ -85,7 +85,7 @@ class EventLogMetricsSpec
       val statuses = statusCounts.generateOne
       givenStatusesMethodToReturn add statuses.pure[IO]
 
-      metrics.run().unsafeRunAndForget()
+      metrics.run.unsafeRunAndForget()
 
       eventually {
         categoryNameEventsGauge.categoryNameValues.asScala shouldBe categoryNameCount
@@ -105,7 +105,7 @@ class EventLogMetricsSpec
       val categoryNameCount2 = categoryNameCounts.generateOne
       givenCountEventsByCategoryNameMethodToReturn add categoryNameCount2.pure[IO]
 
-      metrics.run().unsafeRunAndForget()
+      metrics.run.unsafeRunAndForget()
 
       eventually {
         categoryNameEventsGauge.categoryNameValues.asScala shouldBe categoryNameCount2

--- a/generators/build.sbt
+++ b/generators/build.sbt
@@ -24,4 +24,5 @@ libraryDependencies ++=
     Dependencies.circeCore ++
     Dependencies.jsonld4s ++
     Dependencies.catsCore ++
-    Dependencies.scalacheck).map(_ % Test)
+    Dependencies.scalacheck).map(_ % Test) ++
+    Dependencies.ip4s

--- a/generators/src/test/scala/io/renku/generators/Generators.scala
+++ b/generators/src/test/scala/io/renku/generators/Generators.scala
@@ -21,6 +21,7 @@ package io.renku.generators
 import cats.data.NonEmptyList
 import cats.syntax.all._
 import cats.{Functor, Monad, Semigroupal}
+import com.comcast.ip4s.Port
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection.NonEmpty
@@ -187,7 +188,7 @@ object Generators {
     } yield parts.mkString("/")
   }
 
-  val httpPorts: Gen[Int] = choose(2000, 10000)
+  val httpPorts: Gen[Port] = choose(2000, 10000).map(Port.fromInt).map(_.getOrElse(sys.error("Invalid generated port")))
 
   def httpUrls(hostGenerator: Gen[String] = nonEmptyStrings(),
                pathGenerator: Gen[String] = relativePaths(minSegments = 0, maxSegments = 2)

--- a/graph-commons/src/main/scala/io/renku/config/certificates/CertificateLoader.scala
+++ b/graph-commons/src/main/scala/io/renku/config/certificates/CertificateLoader.scala
@@ -22,7 +22,7 @@ import cats.MonadThrow
 import org.typelevel.log4cats.Logger
 
 trait CertificateLoader[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 object CertificateLoader {
@@ -50,7 +50,7 @@ class CertificateLoaderImpl[F[_]: MonadThrow: Logger] private[certificates] (
 
   import scala.util.control.NonFatal
 
-  override def run(): F[Unit] = {
+  override def run: F[Unit] = {
     for {
       maybeCertificate <- findCertificate()
       _                <- maybeCertificate map addCertificate getOrElse Logger[F].info("No client certificate found")

--- a/graph-commons/src/main/scala/io/renku/config/sentry/SentryInitializer.scala
+++ b/graph-commons/src/main/scala/io/renku/config/sentry/SentryInitializer.scala
@@ -23,7 +23,7 @@ import cats.syntax.all._
 import io.sentry.SentryOptions
 
 trait SentryInitializer[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 class SentryInitializerImpl[F[_]: MonadThrow](
@@ -31,7 +31,7 @@ class SentryInitializerImpl[F[_]: MonadThrow](
     initSentry:        SentryOptions => Unit
 ) extends SentryInitializer[F] {
 
-  override def run(): F[Unit] = maybeSentryConfig.map(toSentryOptions) match {
+  override def run: F[Unit] = maybeSentryConfig.map(toSentryOptions) match {
     case Some(options) => MonadThrow[F].catchNonFatal(initSentry(options))
     case _             => MonadThrow[F].unit
   }

--- a/graph-commons/src/main/scala/io/renku/events/consumers/EventConsumersRegistry.scala
+++ b/graph-commons/src/main/scala/io/renku/events/consumers/EventConsumersRegistry.scala
@@ -27,7 +27,7 @@ import io.renku.events.{CategoryName, EventRequestContent}
 trait EventConsumersRegistry[F[_]] {
   def handle(requestContent: EventRequestContent): F[EventSchedulingResult]
   def renewAllSubscriptions(): F[Unit]
-  def run():                   F[Unit]
+  def run:                     F[Unit]
 }
 
 class EventConsumersRegistryImpl[F[_]: MonadThrow: Parallel](
@@ -58,7 +58,7 @@ class EventConsumersRegistryImpl[F[_]: MonadThrow: Parallel](
           .raiseError[F, SubscriptionMechanism[F]]
       )
 
-  def run(): F[Unit] = subscriptionsMechanisms.map(_.run()).parSequence.void
+  def run: F[Unit] = subscriptionsMechanisms.map(_.run()).parSequence.void
 
   def renewAllSubscriptions(): F[Unit] =
     subscriptionsMechanisms.map(_.renewSubscription()).parSequence.void

--- a/graph-commons/src/main/scala/io/renku/events/consumers/subscriptions/SubscriptionPayloadComposer.scala
+++ b/graph-commons/src/main/scala/io/renku/events/consumers/subscriptions/SubscriptionPayloadComposer.scala
@@ -21,9 +21,8 @@ package io.renku.events.consumers.subscriptions
 import cats.MonadThrow
 import cats.data.Kleisli
 import cats.syntax.all._
-import eu.timepit.refined.api.Refined
+import com.comcast.ip4s._
 import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric.Positive
 import io.renku.events.{CategoryName, DefaultSubscription, Subscription}
 import io.renku.events.DefaultSubscription.DefaultSubscriber
 import io.renku.events.Subscription._
@@ -60,7 +59,7 @@ class DefaultSubscriptionPayloadComposer[F[_]: MonadThrow](
 object SubscriptionPayloadComposer {
 
   def defaultSubscriptionPayloadComposerFactory[F[_]: MonadThrow](
-      microservicePort:       Int Refined Positive,
+      microservicePort:       Port,
       microserviceIdentifier: MicroserviceIdentifier
   ): Kleisli[F, CategoryName, SubscriptionPayloadComposer[F, DefaultSubscription]] =
     Kleisli[F, CategoryName, SubscriptionPayloadComposer[F, DefaultSubscription]] { categoryName =>
@@ -70,7 +69,7 @@ object SubscriptionPayloadComposer {
     }
 
   def defaultSubscriptionPayloadComposerFactory[F[_]: MonadThrow](
-      microservicePort:       Int Refined Positive,
+      microservicePort:       Port,
       microserviceIdentifier: MicroserviceIdentifier,
       capacity:               SubscriberCapacity
   ): Kleisli[F, CategoryName, SubscriptionPayloadComposer[F, DefaultSubscription]] =

--- a/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
@@ -46,7 +46,7 @@ import org.typelevel.ci._
 import org.typelevel.log4cats.Logger
 
 import java.io.IOException
-import java.net.{ConnectException, SocketException}
+import java.net.{ConnectException, SocketException, UnknownHostException}
 import java.nio.channels.ClosedChannelException
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.control.NonFatal
@@ -197,8 +197,10 @@ abstract class RestClient[F[_]: Async: Logger, ThrottlingTarget](
   object ConnectionError {
     def unapply(ex: Throwable): Option[Throwable] =
       ex match {
-        case NonFatal(_: ConnectionFailure | _: ConnectException | _: SocketException | _: ConnectException) => Some(ex)
-        case NonFatal(_: IOException)
+        case _: ConnectionFailure | _: ConnectException | _: SocketException | _: ConnectException |
+            _: UnknownHostException =>
+          Some(ex)
+        case _: IOException
             if ex.getMessage.toLowerCase
               .contains("connection reset") || ex.getMessage.toLowerCase.contains("broken pipe") =>
           Some(ex)

--- a/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
@@ -37,8 +37,7 @@ import org.http4s.AuthScheme.Bearer
 import org.http4s.Credentials.Token
 import org.http4s.Status.BadRequest
 import org.http4s._
-import org.http4s.blaze.client.BlazeClientBuilder
-import org.http4s.blaze.pipeline.Command
+import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.client.{Client, ConnectionFailure}
 import org.http4s.headers.{Authorization, `Content-Disposition`, `Content-Type`}
 import org.http4s.multipart.{Multiparts, Part}
@@ -106,7 +105,7 @@ abstract class RestClient[F[_]: Async: Logger, ThrottlingTarget](
   protected def send[ResultType](
       request: HttpRequest[F]
   )(mapResponse: ResponseMapping[ResultType]): F[ResultType] =
-    httpClientBuilder.resource.use { httpClient =>
+    httpClientBuilder.build.use { httpClient =>
       for {
         _          <- throttler.acquire()
         callResult <- measureExecutionTime(callRemote(httpClient, request, mapResponse, attempt = 1), request)
@@ -114,10 +113,10 @@ abstract class RestClient[F[_]: Async: Logger, ThrottlingTarget](
       } yield callResult
     }
 
-  private def httpClientBuilder: BlazeClientBuilder[F] = {
-    val clientBuilder      = BlazeClientBuilder[F]
-    val updatedIdleTimeout = idleTimeoutOverride map clientBuilder.withIdleTimeout getOrElse clientBuilder
-    requestTimeoutOverride map updatedIdleTimeout.withRequestTimeout getOrElse updatedIdleTimeout
+  private def httpClientBuilder: EmberClientBuilder[F] = {
+    val clientBuilder      = EmberClientBuilder.default[F]
+    val updatedIdleTimeout = idleTimeoutOverride map clientBuilder.withIdleConnectionTime getOrElse clientBuilder
+    requestTimeoutOverride map updatedIdleTimeout.withTimeout getOrElse updatedIdleTimeout
   }
 
   private def measureExecutionTime[ResultType](block: => F[ResultType], request: HttpRequest[F]): F[ResultType] =
@@ -180,14 +179,14 @@ abstract class RestClient[F[_]: Async: Logger, ThrottlingTarget](
                                  attempt:     Int
   ): PartialFunction[Throwable, F[T]] = {
     case error: RestClientError => throttler.release() >> error.raiseError[F, T]
-    case NonFatal(exception @ (_: ConnectionFailure | _: ConnectException | _: Command.EOF.type | _: SocketException))
+    case NonFatal(exception @ (_: ConnectionFailure | _: ConnectException | _: SocketException))
         if attempt <= maxRetries.value =>
       for {
         _      <- Logger[F].warn(LogMessage(request.request, s"timed out -> retrying attempt $attempt", exception))
         _      <- Temporal[F] sleep retryInterval
         result <- callRemote(httpClient, request, mapResponse, attempt + 1)
       } yield result
-    case NonFatal(exception @ (_: ConnectionFailure | _: ConnectException | _: Command.EOF.type | _: SocketException))
+    case NonFatal(exception @ (_: ConnectionFailure | _: ConnectException | _: SocketException))
         if attempt > maxRetries.value =>
       throttler.release() >> ConnectivityException(LogMessage(request.request, exception), exception).raiseError[F, T]
     case NonFatal(exception) =>

--- a/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
@@ -197,8 +197,7 @@ abstract class RestClient[F[_]: Async: Logger, ThrottlingTarget](
   object ConnectionError {
     def unapply(ex: Throwable): Option[Throwable] =
       ex match {
-        case _: ConnectionFailure | _: ConnectException | _: SocketException | _: ConnectException |
-            _: UnknownHostException =>
+        case _: ConnectionFailure | _: ConnectException | _: SocketException | _: UnknownHostException =>
           Some(ex)
         case _: IOException
             if ex.getMessage.toLowerCase

--- a/graph-commons/src/main/scala/io/renku/http/server/HttpServer.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/HttpServer.scala
@@ -28,8 +28,6 @@ import org.http4s.server.Server
 trait HttpServer[F[_]] {
   val httpApp: HttpApp[F]
   def createServer: Resource[F, Server]
-
-  final def run(implicit F: Spawn[F]): F[ExitCode] = createServer.use(_ => Spawn[F].never[ExitCode])
 }
 
 object HttpServer {

--- a/graph-commons/src/main/scala/io/renku/metrics/GaugeResetScheduler.scala
+++ b/graph-commons/src/main/scala/io/renku/metrics/GaugeResetScheduler.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 trait GaugeResetScheduler[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 class GaugeResetSchedulerImpl[F[_]: MonadThrow: Temporal: Logger, LabelValue](
@@ -36,7 +36,7 @@ class GaugeResetSchedulerImpl[F[_]: MonadThrow: Temporal: Logger, LabelValue](
     metricsSchedulerConfig: MetricsConfigProvider[F]
 ) extends GaugeResetScheduler[F] {
 
-  override def run(): F[Unit] = for {
+  override def run: F[Unit] = for {
     interval <- metricsSchedulerConfig.getInterval()
     _        <- resetGauges
     _        <- resetGaugesEvery(interval).foreverM[Unit]

--- a/graph-commons/src/main/scala/io/renku/microservices/MicroserviceUrlFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/microservices/MicroserviceUrlFinder.scala
@@ -19,8 +19,7 @@
 package io.renku.microservices
 
 import cats.MonadThrow
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
+import com.comcast.ip4s._
 import io.circe.Decoder
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.tinytypes.constraints.{Url, UrlOps}
@@ -31,8 +30,7 @@ trait MicroserviceUrlFinder[F[_]] {
   def findBaseUrl(): F[MicroserviceBaseUrl]
 }
 
-class MicroserviceUrlFinderImpl[F[_]: MonadThrow](microservicePort: Int Refined Positive)
-    extends MicroserviceUrlFinder[F] {
+class MicroserviceUrlFinderImpl[F[_]: MonadThrow](microservicePort: Port) extends MicroserviceUrlFinder[F] {
 
   import cats.syntax.all._
 
@@ -58,7 +56,7 @@ class MicroserviceUrlFinderImpl[F[_]: MonadThrow](microservicePort: Int Refined 
 
 object MicroserviceUrlFinder {
 
-  def apply[F[_]: MonadThrow](microservicePort: Int Refined Positive): F[MicroserviceUrlFinder[F]] =
+  def apply[F[_]: MonadThrow](microservicePort: Port): F[MicroserviceUrlFinder[F]] =
     MonadThrow[F].catchNonFatal {
       new MicroserviceUrlFinderImpl[F](microservicePort)
     }

--- a/graph-commons/src/main/scala/io/renku/microservices/ResourceUse.scala
+++ b/graph-commons/src/main/scala/io/renku/microservices/ResourceUse.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.microservices
+
+import cats.effect._
+import cats.syntax.all._
+import fs2._
+import fs2.concurrent.{Signal, SignallingRef}
+
+object ResourceUse {
+
+  def apply[F[_]: Spawn: Concurrent, A](resource: Resource[F, A]): UseSyntax[F, A] = new UseSyntax(resource)
+
+  final class UseSyntax[F[_]: Spawn: Concurrent, A](resource: Resource[F, A]) {
+
+    /** Evaluates `resource` endlessly or until the signal turns `true`. */
+    def useUntil(signal: Signal[F, Boolean], returnValue: Ref[F, ExitCode]): F[ExitCode] = {
+      val server         = Stream.resource(resource)
+      val blockUntilTrue = signal.discrete.takeWhile(_ == false).drain
+      val exit           = fs2.Stream.eval(returnValue.get)
+      (server *> (blockUntilTrue ++ exit)).compile.lastOrError
+    }
+
+    def useForever(implicit ev: Async[F]): F[ExitCode] = for {
+      termSignal <- SignallingRef.of[F, Boolean](false)
+      exitValue  <- Ref.of(ExitCode.Success)
+      rc         <- useUntil(termSignal, exitValue)
+    } yield rc
+  }
+}

--- a/graph-commons/src/main/scala/io/renku/microservices/ServiceReadinessChecker.scala
+++ b/graph-commons/src/main/scala/io/renku/microservices/ServiceReadinessChecker.scala
@@ -20,8 +20,7 @@ package io.renku.microservices
 
 import cats.effect.{Async, Temporal}
 import cats.syntax.all._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.numeric.Positive
+import com.comcast.ip4s._
 import io.renku.http.client.ServiceHealthChecker
 import org.typelevel.log4cats.Logger
 
@@ -32,7 +31,7 @@ trait ServiceReadinessChecker[F[_]] {
 }
 
 object ServiceReadinessChecker {
-  def apply[F[_]: Async: Logger](microservicePort: Int Refined Positive): F[ServiceReadinessChecker[F]] = for {
+  def apply[F[_]: Async: Logger](microservicePort: Port): F[ServiceReadinessChecker[F]] = for {
     urlFinder     <- MicroserviceUrlFinder[F](microservicePort)
     healthChecker <- ServiceHealthChecker[F]
   } yield new ServiceReadinessCheckerImpl(urlFinder, healthChecker)

--- a/graph-commons/src/test/scala/io/renku/config/certificates/CertificateLoaderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/config/certificates/CertificateLoaderSpec.scala
@@ -53,7 +53,7 @@ class CertificateLoaderSpec extends AnyWordSpec with MockFactory with should.Mat
 
         makeSslContextDefault.expects(sslContext, *).returning(().pure[Try])
 
-        certificateLoader.run() shouldBe ().pure[Try]
+        certificateLoader.run shouldBe ().pure[Try]
 
         logger.loggedOnly(Info("Client certificate added"))
       }
@@ -62,7 +62,7 @@ class CertificateLoaderSpec extends AnyWordSpec with MockFactory with should.Mat
 
       findCertificate.expects().returning(None.pure[Try])
 
-      certificateLoader.run() shouldBe ().pure[Try]
+      certificateLoader.run shouldBe ().pure[Try]
 
       logger.loggedOnly(Info("No client certificate found"))
     }
@@ -72,7 +72,7 @@ class CertificateLoaderSpec extends AnyWordSpec with MockFactory with should.Mat
       val exception = exceptions.generateOne
       findCertificate.expects().returning(exception.raiseError[Try, Option[Certificate]])
 
-      certificateLoader.run() shouldBe Failure(exception)
+      certificateLoader.run shouldBe Failure(exception)
 
       logger.loggedOnly(Error("Loading client certificate failed", exception))
     }
@@ -85,7 +85,7 @@ class CertificateLoaderSpec extends AnyWordSpec with MockFactory with should.Mat
       val exception = exceptions.generateOne
       (keystore.load(_: Certificate)).expects(certificate).returning(exception.raiseError[Try, Unit])
 
-      certificateLoader.run() shouldBe Failure(exception)
+      certificateLoader.run shouldBe Failure(exception)
 
       logger.loggedOnly(Error("Loading client certificate failed", exception))
     }
@@ -100,7 +100,7 @@ class CertificateLoaderSpec extends AnyWordSpec with MockFactory with should.Mat
       val exception = exceptions.generateOne
       createSslContext.expects(keystore).returning(exception.raiseError[Try, SslContext])
 
-      certificateLoader.run() shouldBe Failure(exception)
+      certificateLoader.run shouldBe Failure(exception)
 
       logger.loggedOnly(Error("Loading client certificate failed", exception))
     }
@@ -118,7 +118,7 @@ class CertificateLoaderSpec extends AnyWordSpec with MockFactory with should.Mat
       val exception = exceptions.generateOne
       makeSslContextDefault.expects(sslContext, *).returning(exception.raiseError[Try, Unit])
 
-      certificateLoader.run() shouldBe Failure(exception)
+      certificateLoader.run shouldBe Failure(exception)
 
       logger.loggedOnly(Error("Loading client certificate failed", exception))
     }

--- a/graph-commons/src/test/scala/io/renku/config/sentry/SentryInitializerSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/config/sentry/SentryInitializerSpec.scala
@@ -42,7 +42,7 @@ class SentryInitializerSpec extends AnyWordSpec with MockFactory with should.Mat
 
       val sentryConfig = sentryConfigs.generateOne
 
-      sentryInitializer(sentryConfig.some).run() shouldBe ().pure[Try]
+      sentryInitializer(sentryConfig.some).run shouldBe ().pure[Try]
 
       val options = optionsCapture.value
       options.getDsn         shouldBe sentryConfig.baseUrl.value
@@ -53,7 +53,7 @@ class SentryInitializerSpec extends AnyWordSpec with MockFactory with should.Mat
 
     "do nothing if no config given" in new TestCase {
       val maybeConfig = None
-      sentryInitializer(maybeConfig).run() shouldBe MonadThrow[Try].unit
+      sentryInitializer(maybeConfig).run shouldBe MonadThrow[Try].unit
     }
 
     "fail if Sentry initialisation fails" in new TestCase {
@@ -62,7 +62,7 @@ class SentryInitializerSpec extends AnyWordSpec with MockFactory with should.Mat
       val exception = exceptions.generateOne
       initSentry.expects(*).throwing(exception)
 
-      sentryInitializer(sentryConfig.some).run() shouldBe exception.raiseError[Try, Unit]
+      sentryInitializer(sentryConfig.some).run shouldBe exception.raiseError[Try, Unit]
     }
   }
 

--- a/graph-commons/src/test/scala/io/renku/events/consumers/EventConsumersRegistrySpec.scala
+++ b/graph-commons/src/test/scala/io/renku/events/consumers/EventConsumersRegistrySpec.scala
@@ -45,7 +45,7 @@ class EventConsumersRegistrySpec extends AnyWordSpec with IOSpec with should.Mat
         .expects()
         .returning(IO.unit)
 
-      registry.run().unsafeRunSync() shouldBe ()
+      registry.run.unsafeRunSync() shouldBe ()
     }
 
     "fail if one of the subscriptionMechanisms fails to start" in new TestCase {
@@ -59,7 +59,7 @@ class EventConsumersRegistrySpec extends AnyWordSpec with IOSpec with should.Mat
         .returning(IO.unit)
 
       intercept[Exception] {
-        registry.run().unsafeRunSync()
+        registry.run.unsafeRunSync()
       } shouldBe exception
     }
   }

--- a/graph-commons/src/test/scala/io/renku/http/client/RestClientSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/client/RestClientSpec.scala
@@ -275,9 +275,7 @@ class RestClientSpec
           client.callRemote(mapResponseToInt).unsafeRunSync()
         }
 
-//        exception.getCause shouldBe a[IOException]
         val causeMessage = exception.getCause.getMessage
-//        exception.getMessage shouldBe s"GET $hostUrl/resource error: Connection reset"
 
         logger.loggedOnly(
           Warn(s"GET $hostUrl/resource timed out -> retrying attempt 1 error: $causeMessage"),

--- a/graph-commons/src/test/scala/io/renku/metrics/GaugeResetSchedulerSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/GaugeResetSchedulerSpec.scala
@@ -58,7 +58,7 @@ class GaugeResetSchedulerSpec
         gauge1.givenResetMethodToReturn add IO.unit
         gauge2.givenResetMethodToReturn add IO.unit
 
-        gaugeScheduler.run().start.unsafeRunAndForget()
+        gaugeScheduler.run.start.unsafeRunAndForget()
 
         sleep(2 * interval.toMillis + 1000)
 
@@ -78,7 +78,7 @@ class GaugeResetSchedulerSpec
       val exception2 = exceptions.generateOne
       gauge2.givenResetMethodToReturn add IO.raiseError(exception2)
 
-      gaugeScheduler.run().start.unsafeRunAndForget()
+      gaugeScheduler.run.start.unsafeRunAndForget()
 
       sleep(3 * interval.toMillis + 1000)
 

--- a/graph-commons/src/test/scala/io/renku/microservices/AbstractMicroserviceRunnerTest.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/AbstractMicroserviceRunnerTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.microservices
+
+import cats.effect.{ExitCode, IO}
+import fs2.concurrent.{Signal, SignallingRef}
+import scala.language.reflectiveCalls
+import scala.concurrent.duration._
+
+trait AbstractMicroserviceRunnerTest {
+
+  type Microservice = { def run(signal: Signal[IO, Boolean]): IO[ExitCode] }
+
+  def all: List[CallCounter]
+
+  def runner: Microservice
+
+  def startFor(duration: FiniteDuration) =
+    for {
+      term <- SignallingRef.of[IO, Boolean](true)
+      _ <-  (IO.sleep(duration) *> term.set(true)).start
+      exit <- runner.run(term)
+    } yield exit
+
+  def startAndStopRunner: IO[ExitCode] =
+    for {
+      term <- SignallingRef.of[IO, Boolean](true)
+      exit <- runner.run(term)
+    } yield exit
+
+  def startRunnerForever: IO[ExitCode] =
+    for {
+      term <- SignallingRef.of[IO, Boolean](false)
+      exit <- runner.run(term)
+    } yield exit
+
+  def assertCalledAll = CallCounter.assertCalled(all)
+
+  def assertCalledAllBut(exclude: CallCounter, excludes: CallCounter*) =
+    CallCounter.assertCalled(all.diff(exclude :: excludes.toList)) >>
+      CallCounter.assertNotCalled(excludes.toList)
+}

--- a/graph-commons/src/test/scala/io/renku/microservices/AbstractMicroserviceRunnerTest.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/AbstractMicroserviceRunnerTest.scala
@@ -33,8 +33,8 @@ trait AbstractMicroserviceRunnerTest {
 
   def startFor(duration: FiniteDuration) =
     for {
-      term <- SignallingRef.of[IO, Boolean](true)
-      _ <-  (IO.sleep(duration) *> term.set(true)).start
+      term <- SignallingRef.of[IO, Boolean](false)
+      _    <- (IO.sleep(duration) *> term.set(true)).start
       exit <- runner.run(term)
     } yield exit
 
@@ -53,6 +53,8 @@ trait AbstractMicroserviceRunnerTest {
   def assertCalledAll = CallCounter.assertCalled(all)
 
   def assertCalledAllBut(exclude: CallCounter, excludes: CallCounter*) =
-    CallCounter.assertCalled(all.diff(exclude :: excludes.toList)) >>
-      CallCounter.assertNotCalled(excludes.toList)
+    CallCounter.assertCalled(all.diff(exclude :: excludes.toList))
+
+  def assertNotCalled(counter: CallCounter, more: CallCounter*) =
+    CallCounter.assertNotCalled(counter :: more.toList)
 }

--- a/graph-commons/src/test/scala/io/renku/microservices/CallCounter.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/CallCounter.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.microservices
+
+import cats.data.{Validated, ValidatedNel}
+import cats.effect._
+import cats.syntax.all._
+import org.scalatest.Assertions
+
+trait CallCounter {
+
+  def name: String
+
+  val counter = Ref.unsafe[IO, Either[Throwable, Int]](Right(0))
+
+  def getCount: IO[Either[Throwable, Int]] = counter.get
+
+  def failWith(ex: Throwable): IO[Unit] =
+    counter.set(Left(ex))
+}
+
+object CallCounter extends Assertions {
+  def assertNotCalled(counters: List[CallCounter]) =
+    verify(counters,
+           (c, n) =>
+             if (n == 0) Validated.validNel(n)
+             else Validated.invalidNel(s"${c.name} was called $n times")
+    )
+
+  def assertCalled(counters: List[CallCounter]) =
+    verify(counters,
+           (c, n) =>
+             if (n >= 1) Validated.validNel(n)
+             else Validated.invalidNel(s"${c.name} not called")
+    )
+
+  private def verify(counters: List[CallCounter], check: (CallCounter, Int) => ValidatedNel[String, Int]) =
+    counters
+      .traverse(c =>
+        c.getCount.map {
+          case Left(ex) =>
+            Validated.invalidNel(s"${c.name} failed with: ${ex.getClass}: ${ex.getMessage}")
+          case Right(n) =>
+            check(c, n)
+        }
+      )
+      .map(_.combineAll)
+      .map(_.toEither.leftMap(err => new Exception(err.toList.mkString("; "))))
+      .rethrow
+
+}

--- a/graph-commons/src/test/scala/io/renku/microservices/MicroserviceUrlFinderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/MicroserviceUrlFinderSpec.scala
@@ -20,7 +20,7 @@ package io.renku.microservices
 
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.positiveInts
+import io.renku.generators.Generators.httpPorts
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -40,7 +40,7 @@ class MicroserviceUrlFinderSpec extends AnyWordSpec with should.Matchers {
   }
 
   private trait TestCase {
-    val microservicePort = positiveInts().generateOne
+    val microservicePort = httpPorts.generateOne
     val finder           = new MicroserviceUrlFinderImpl[Try](microservicePort)
   }
 

--- a/graph-commons/src/test/scala/io/renku/microservices/ServiceRunCounter.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/ServiceRunCounter.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.microservices
+
+import cats.data.Kleisli
+import cats.effect._
+import io.renku.config.certificates.CertificateLoader
+import io.renku.config.sentry.SentryInitializer
+import io.renku.events.EventRequestContent
+import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
+import io.renku.http.server.HttpServer
+import io.renku.metrics.GaugeResetScheduler
+import org.http4s.{HttpApp, Response}
+import org.http4s.server.Server
+
+import java.net.InetSocketAddress
+
+class ServiceRunCounter(val name: String)
+    extends ServiceReadinessChecker[IO]
+    with CertificateLoader[IO]
+    with SentryInitializer[IO]
+    with EventConsumersRegistry[IO]
+    with GaugeResetScheduler[IO]
+    with HttpServer[IO]
+    with CallCounter {
+
+  def run: IO[Unit] = counter.updateAndGet(_.map(_ + 1)).rethrow.as(())
+
+  override def waitIfNotUp: IO[Unit] = run
+
+  override val httpApp: HttpApp[IO] = Kleisli(req => Response.notFoundFor(req))
+
+  override def handle(requestContent: EventRequestContent): IO[EventSchedulingResult] = ???
+
+  override def createServer: Resource[IO, Server] =
+    Resource
+      .eval(run)
+      .map(_ =>
+        new Server {
+          override def address:  InetSocketAddress = InetSocketAddress.createUnresolved("localhost", 8080)
+          override def isSecure: Boolean           = false
+        }
+      )
+
+  override def renewAllSubscriptions(): IO[Unit] = ???
+}

--- a/graph-commons/src/test/scala/io/renku/testtools/MockedRunnableCollaborators.scala
+++ b/graph-commons/src/test/scala/io/renku/testtools/MockedRunnableCollaborators.scala
@@ -18,10 +18,8 @@
 
 package io.renku.testtools
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.syntax.all._
-import io.renku.http.server.HttpServer
-import org.http4s.server.Server
 import org.scalamock.handlers.CallHandler0
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Suite
@@ -34,22 +32,6 @@ trait MockedRunnableCollaborators {
   type Runnable[R] = { def run: IO[R] }
 
   def `given`[R](runnable: Runnable[R]) = new RunnableOps[R](runnable)
-
-  def `given`(server: HttpServer[IO]) = new HttpServerOps(server)
-
-  class HttpServerOps(value: HttpServer[IO]) {
-    @annotation.nowarn
-    def succeeds() =
-      (value.createServer _)
-        .expects()
-        .returning(Resource.pure(mock[Server]))
-
-    @annotation.nowarn
-    def fails(becauseOf: Exception) =
-      (value.createServer _)
-        .expects()
-        .returning(becauseOf.raiseError[Resource[IO, *], Server])
-  }
 
   class RunnableOps[R](runnable: Runnable[R]) {
     @annotation.nowarn

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/metrics/KGMetrics.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/metrics/KGMetrics.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
 trait KGMetrics[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 class KGMetricsImpl[F[_]: Temporal: Logger](
@@ -39,7 +39,7 @@ class KGMetricsImpl[F[_]: Temporal: Logger](
     countsInterval: FiniteDuration = KGMetrics.countsInterval
 ) extends KGMetrics[F] {
 
-  def run(): F[Unit] = Temporal[F].delayBy(updateCounts().foreverM[Unit], initialDelay)
+  def run: F[Unit] = Temporal[F].delayBy(updateCounts().foreverM[Unit], initialDelay)
 
   private def updateCounts(): F[Unit] = {
     for {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRunnerSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRunnerSpec.scala
@@ -45,9 +45,9 @@ class MicroserviceRunnerSpec
       given(certificateLoader).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
       given(kgMetrics).succeeds(returning = ())
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
-      runner.run().unsafeRunSync() shouldBe ExitCode.Success
+      runner.run.unsafeRunSync() shouldBe ExitCode.Success
     }
 
     "fail if Certificate loading fails" in new TestCase {
@@ -56,7 +56,7 @@ class MicroserviceRunnerSpec
       given(certificateLoader).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
     }
 
@@ -64,12 +64,12 @@ class MicroserviceRunnerSpec
 
       given(certificateLoader).succeeds(returning = ())
       val exception = exceptions.generateOne
-      (sentryInitializer.run _)
+      (() => sentryInitializer.run)
         .expects()
         .returning(context.raiseError(exception))
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
     }
 
@@ -79,10 +79,10 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).succeeds(returning = ())
       given(kgMetrics).succeeds(returning = ())
       val exception = exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      given(Runnable(httpServer.run)).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
     }
 
@@ -92,9 +92,9 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).succeeds(returning = ())
       val exception = exceptions.generateOne
       given(kgMetrics).fails(becauseOf = exception)
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
-      runner.run().unsafeRunSync() shouldBe ExitCode.Success
+      runner.run.unsafeRunSync() shouldBe ExitCode.Success
     }
   }
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/KGMetricsSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/metrics/KGMetricsSpec.scala
@@ -63,7 +63,7 @@ class KGMetricsSpec
 
       sleep(500)
 
-      metrics.run().unsafeRunAndForget()
+      metrics.run.unsafeRunAndForget()
 
       sleep(1000)
 
@@ -91,7 +91,7 @@ class KGMetricsSpec
 
       sleep(500)
 
-      metrics.run().start.unsafeRunAndForget()
+      metrics.run.start.unsafeRunAndForget()
 
       sleep(1000)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,8 +12,9 @@ object Dependencies {
     val circeOptics            = "0.14.1"
     val diffx                  = "0.8.2"
     val http4s                 = "0.23.18"
-    val http4sBlaze            = "0.23.13"
+    val http4sBlaze            = "0.23.18"
     val http4sPrometheus       = "0.24.3"
+    val ip4s                   = "3.2.0"
     val jsonld4s               = "0.10.0"
     val log4cats               = "2.5.0"
     val log4jCore              = "2.20.0"
@@ -36,6 +37,10 @@ object Dependencies {
     val widoco                 = "1.4.17"
     val wiremock               = "2.35.0"
   }
+
+  val ip4s = Seq(
+    "com.comcast" %% "ip4s-core" % V.ip4s
+  )
 
   val scalatestScalaCheck = Seq(
     "org.scalatestplus" %% "scalacheck-1-14" % V.scalatestScalacheck
@@ -93,10 +98,10 @@ object Dependencies {
   )
 
   val http4sClient = Seq(
-    "org.http4s" %% "http4s-blaze-client" % V.http4sBlaze
+    "org.http4s" %% "http4s-ember-client" % V.http4sBlaze
   )
   val http4sServer = Seq(
-    "org.http4s" %% "http4s-blaze-server" % V.http4sBlaze,
+    "org.http4s" %% "http4s-ember-server" % V.http4sBlaze,
     "org.http4s" %% "http4s-server"       % V.http4s
   )
   val http4sCirce = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val circeOptics            = "0.14.1"
     val diffx                  = "0.8.2"
     val http4s                 = "0.23.18"
-    val http4sBlaze            = "0.23.18"
+    val http4sEmber            = "0.23.18"
     val http4sPrometheus       = "0.24.3"
     val ip4s                   = "3.2.0"
     val jsonld4s               = "0.10.0"
@@ -98,10 +98,10 @@ object Dependencies {
   )
 
   val http4sClient = Seq(
-    "org.http4s" %% "http4s-ember-client" % V.http4sBlaze
+    "org.http4s" %% "http4s-ember-client" % V.http4sEmber
   )
   val http4sServer = Seq(
-    "org.http4s" %% "http4s-ember-server" % V.http4sBlaze,
+    "org.http4s" %% "http4s-ember-server" % V.http4sEmber,
     "org.http4s" %% "http4s-server"       % V.http4s
   )
   val http4sCirce = Seq(

--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliPlan.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliPlan.scala
@@ -21,12 +21,14 @@ package io.renku.cli.model
 import Ontologies.{Prov, Schema}
 import cats.syntax.all._
 import io.circe.DecodingFailure
-import io.renku.graph.model.commandParameters
+import io.renku.graph.model.{commandParameters, plans}
 import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 
 sealed trait CliPlan extends CliModel {
   def fold[A](fa: CliStepPlan => A, fb: CliCompositePlan => A): A
+
+  def id: plans.ResourceId = fold(_.id, _.id)
 }
 
 object CliPlan {

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/CliStepPlanSpec.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/CliStepPlanSpec.scala
@@ -62,16 +62,19 @@ class CliStepPlanSpec
 
     "work with additional types" in {
       val planDecoder = JsonLDDecoder.decodeList(CliPlan.jsonLDDecoderLenientTyped)
-      val plan        = PlanGenerators.compositePlanChildPlanGen(Instant.EPOCH).generateOne
-      val newJson =
-        JsonLDTools
-          .view(plan)
-          .selectByTypes(CliPlan.entityTypes)
-          .addType(Schemas.renku / "SomeOtherType")
-          .value
+      forAll(PlanGenerators.compositePlanChildPlanGen(Instant.EPOCH)) { plan =>
+        val newJson =
+          JsonLDTools
+            .view(plan)
+            .selectByTypes(CliPlan.entityTypes)
+            .addType(Schemas.renku / "SomeOtherType")
+            .value
 
-      val result = newJson.cursor.as[List[CliPlan]](planDecoder)
-      result.value shouldMatchTo List(plan)
+        val result = newJson.cursor
+          .as[List[CliPlan]](planDecoder)
+          .map(_.filter(_.id == plan.id))
+        result.value shouldMatchTo List(plan)
+      }
     }
   }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DBMigration.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DBMigration.scala
@@ -19,5 +19,5 @@
 package io.renku.tokenrepository.repository.init
 
 trait DBMigration[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DbInitializer.scala
@@ -29,16 +29,16 @@ import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.control.NonFatal
 
 trait DbInitializer[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 class DbInitializerImpl[F[_]: Async: Logger](migrators: List[DBMigration[F]],
                                              retrySleepDuration: FiniteDuration = 20 seconds
 ) extends DbInitializer[F] {
 
-  override def run(): F[Unit] = {
+  override def run: F[Unit] = {
     for {
-      _ <- migrators.map(_.run()).sequence
+      _ <- migrators.map(_.run).sequence
       _ <- Logger[F].info("Projects Tokens database initialization success")
     } yield ()
   } recoverWith logAndRetry
@@ -47,7 +47,7 @@ class DbInitializerImpl[F[_]: Async: Logger](migrators: List[DBMigration[F]],
     for {
       _ <- Temporal[F] sleep retrySleepDuration
       _ <- Logger[F].error(exception)(s"Projects Tokens database initialization failed")
-      _ <- run()
+      _ <- run
     } yield ()
   }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemover.scala
@@ -33,7 +33,7 @@ private object DuplicateProjectsRemover {
 
 private class DuplicateProjectsRemover[F[_]: MonadCancelThrow: Logger: SessionResource] extends DBMigration[F] {
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     for {
       _ <- deduplicateProjects()
       _ <- Kleisli.liftF(Logger[F] info "Projects de-duplicated")

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdder.scala
@@ -35,7 +35,7 @@ private class ExpiryAndCreatedDatesAdder[F[_]: Spawn: Logger: SessionResource] e
   import skunk._
   import skunk.implicits._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     addIfNotExists(column = "expiry_date", "DATE") >> addIfNotExists(column = "created_at", "TIMESTAMPTZ")
   }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNull.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNull.scala
@@ -32,7 +32,7 @@ private class ExpiryAndCreatedDatesNotNull[F[_]: MonadCancelThrow: Logger: Sessi
 
   import MigrationTools._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     ensureNotNullable("expiry_date") >> ensureNotNullable("created_at")
   }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
@@ -39,7 +39,7 @@ private class ProjectPathAdder[F[_]: Spawn: Logger: SessionResource]
 
   import MigrationTools._
 
-  def run(): F[Unit] = SessionResource[F].useK {
+  def run: F[Unit] = SessionResource[F].useK {
     checkColumnExists("projects_tokens", "project_path") >>= {
       case true  => Kleisli.liftF(Logger[F].info("'project_path' column existed"))
       case false => addColumn()

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreator.scala
@@ -34,7 +34,7 @@ private class ProjectsTokensTableCreator[F[_]: MonadCancelThrow: Logger: Session
   import skunk._
   import skunk.implicits._
 
-  override def run(): F[Unit] = SessionResource[F].useK {
+  override def run: F[Unit] = SessionResource[F].useK {
     checkTableExists >>= {
       case false => createTable.flatMapF(_ => Logger[F].info("'projects_tokens' table created"))
       case true  => Kleisli.liftF(Logger[F].info("'projects_tokens' table existed"))

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
@@ -66,7 +66,7 @@ private class TokensMigrator[F[_]: Async: SessionResource: Logger: QueriesExecut
   import tokenValidator._
   import tokensCreator._
 
-  override def run(): F[Unit] =
+  override def run: F[Unit] =
     Stream
       .repeatEval(findTokenWithoutDates)
       .unNoneTerminate

--- a/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRunnerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRunnerSpec.scala
@@ -51,7 +51,7 @@ class MicroserviceRunnerSpec
       given(certificateLoader).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
       given(dbInitializer).succeeds(returning = ())
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunSync() shouldBe ExitCode.Success
 
@@ -87,7 +87,7 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).succeeds(returning = ())
       val exception = exceptions.generateOne
       given(dbInitializer).fails(becauseOf = exception)
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
       runner.run().unsafeRunSync() shouldBe ExitCode.Success
 
@@ -104,7 +104,7 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).succeeds(returning = ())
       given(dbInitializer).succeeds(returning = ())
       val exception = exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      given(Runnable(httpServer.run)).fails(becauseOf = exception)
 
       intercept[Exception] {
         runner.run().unsafeRunSync()

--- a/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRunnerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRunnerSpec.scala
@@ -75,6 +75,7 @@ class MicroserviceRunnerSpec extends AnyWordSpec with should.Matchers {
 
       startFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
       assertCalledAllBut(dbInitializer, microserviceRoutes).unsafeRunSync()
+      assertNotCalled(microserviceRoutes).unsafeRunSync()
 
       logger.logged(Error("DB initialization failed", exception), Info("Service started"))
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
@@ -42,7 +42,7 @@ trait InMemoryProjectsTokensDbSpec extends DbSpec with InMemoryProjectsTokensDb 
   self: Suite with IOSpec with MockFactory =>
 
   protected def initDb(): Unit =
-    allMigrations.map(_.run()).sequence.void.unsafeRunSync()
+    allMigrations.map(_.run).sequence.void.unsafeRunSync()
 
   protected def prepareDbForTest(): Unit = execute {
     Kleisli[IO, Session[IO], Unit] { session =>

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitSpec.scala
@@ -41,7 +41,7 @@ trait DbInitSpec extends InMemoryProjectsTokensDb with DbMigrations with BeforeA
 
   before {
     findAllTables() foreach dropTable
-    migrationsToRun.map(_.run()).sequence.unsafeRunSync()
+    migrationsToRun.map(_.run).sequence.unsafeRunSync()
   }
 
   private def findAllTables(): List[String] = execute {

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitializerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitializerSpec.scala
@@ -43,7 +43,7 @@ class DbInitializerSpec
       given(migrator1).succeeds(returning = ())
       given(migrator2).succeeds(returning = ())
 
-      initializer.run().unsafeRunSync() shouldBe ()
+      initializer.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("Projects Tokens database initialization success"))
     }
@@ -58,7 +58,7 @@ class DbInitializerSpec
         given(migrator2).succeeds(returning = ())
       }
 
-      initializer.run().unsafeRunSync() shouldBe ()
+      initializer.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Error("Projects Tokens database initialization failed", exception),
                         Info("Projects Tokens database initialization success")

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DuplicateProjectsRemoverSpec.scala
@@ -66,7 +66,7 @@ class DuplicateProjectsRemoverSpec
       findToken(projectId1) shouldBe Some(encryptedToken1.value)
       findToken(projectId2) shouldBe Some(encryptedToken2.value)
 
-      deduplicator.run().unsafeRunSync() shouldBe ((): Unit)
+      deduplicator.run.unsafeRunSync() shouldBe ((): Unit)
 
       findToken(projectId1)   shouldBe None
       findToken(projectId2)   shouldBe Some(encryptedToken2.value)

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesAdderSpec.scala
@@ -45,7 +45,7 @@ class ExpiryAndCreatedDatesAdderSpec
       verifyColumnExists("projects_tokens", "expiry_date") shouldBe false
       verifyColumnExists("projects_tokens", "created_at")  shouldBe false
 
-      datesAdder.run().unsafeRunSync() shouldBe ()
+      datesAdder.run.unsafeRunSync() shouldBe ()
 
       verifyColumnExists("projects_tokens", "expiry_date")    shouldBe true
       verifyColumnExists("projects_tokens", "created_at")     shouldBe true
@@ -55,7 +55,7 @@ class ExpiryAndCreatedDatesAdderSpec
       logger.loggedOnly(Info("'expiry_date' column added"), Info("'created_at' column added"))
       logger.reset()
 
-      datesAdder.run().unsafeRunSync() shouldBe ()
+      datesAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'expiry_date' column existed"), Info("'created_at' column existed"))
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNullSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ExpiryAndCreatedDatesNotNullSpec.scala
@@ -44,7 +44,7 @@ class ExpiryAndCreatedDatesNotNullSpec
       verifyColumnNullable("projects_tokens", "expiry_date") shouldBe true
       verifyColumnNullable("projects_tokens", "created_at")  shouldBe true
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       verifyColumnNullable("projects_tokens", "expiry_date") shouldBe false
       verifyColumnNullable("projects_tokens", "created_at")  shouldBe false
@@ -53,7 +53,7 @@ class ExpiryAndCreatedDatesNotNullSpec
 
       logger.reset()
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'expiry_date' column already NOT NULL"), Info("'created_at' column already NOT NULL"))
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
@@ -46,12 +46,12 @@ class ProjectPathAdderSpec
 
       verifyColumnExists("projects_tokens", "project_path") shouldBe false
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ()
+      projectPathAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'project_path' column added"))
       logger.reset()
 
-      projectPathAdder.run().unsafeRunSync() shouldBe ()
+      projectPathAdder.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'project_path' column existed"))
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectsTokensTableCreatorSpec.scala
@@ -39,13 +39,13 @@ class ProjectsTokensTableCreatorSpec
     "create the projects_tokens table if id does not exist" in new TestCase {
       tableExists("projects_tokens") shouldBe false
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'projects_tokens' table created"))
 
       tableExists("projects_tokens") shouldBe true
 
-      tableCreator.run().unsafeRunSync() shouldBe ()
+      tableCreator.run.unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(Info("'projects_tokens' table created"), Info("'projects_tokens' table existed"))
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
@@ -65,7 +65,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
         val (projectTokenEncrypted, creationInfo) =
           givenSuccessfulTokenReplacement(oldTokenProject, oldTokenEncrypted)
 
-        migration.run().unsafeRunSync() shouldBe ()
+        migration.run.unsafeRunSync() shouldBe ()
 
         findToken(validTokenProject.id)    shouldBe validTokenEncrypted.value.some
         findToken(oldTokenProject.id)      shouldBe projectTokenEncrypted.value.some
@@ -88,7 +88,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
       val (projectTokenEncrypted1, creationInfo1) =
         givenSuccessfulTokenReplacement(oldTokenProject1, oldTokenEncrypted1)
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       findToken(validTokenProject.id)     shouldBe validTokenEncrypted.value.some
       findToken(oldTokenProject.id)       shouldBe projectTokenEncrypted.value.some
@@ -112,7 +112,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       givenTokenValidation(oldToken, returning = false.pure[IO])
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       findToken(validTokenProject.id) shouldBe validTokenEncrypted.value.some
       findToken(oldTokenProject.id)   shouldBe None
@@ -131,7 +131,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       givenProjectTokenCreator(oldTokenProject.id, oldToken, returning = OptionT.none)
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       findToken(validTokenProject.id) shouldBe validTokenEncrypted.value.some
       findToken(oldTokenProject.id)   shouldBe None
@@ -144,7 +144,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
       val exception = exceptions.generateOne
       givenDecryption(oldTokenEncrypted, returning = exception.raiseError[IO, AccessToken])
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       findToken(oldTokenProject.id) shouldBe None
     }
@@ -171,7 +171,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
       val projectTokenEncrypted = encryptedAccessTokens.generateOne
       givenEncryption(projectToken, returning = projectTokenEncrypted.pure[IO])
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       findToken(oldTokenProject.id) shouldBe projectTokenEncrypted.value.some
 
@@ -206,7 +206,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
       val projectTokenEncrypted = encryptedAccessTokens.generateOne
       givenEncryption(projectToken, returning = projectTokenEncrypted.pure[IO])
 
-      migration.run().unsafeRunSync() shouldBe ()
+      migration.run.unsafeRunSync() shouldBe ()
 
       findToken(oldTokenProject.id) shouldBe projectTokenEncrypted.value.some
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/config/certificates/GitCertificateInstaller.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/config/certificates/GitCertificateInstaller.scala
@@ -25,7 +25,7 @@ import org.typelevel.log4cats.Logger
 import scala.util.control.NonFatal
 
 trait GitCertificateInstaller[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 object GitCertificateInstaller {
@@ -46,7 +46,7 @@ class GitCertificateInstallerImpl[F[_]: MonadThrow: Logger](
 
   import cats.syntax.all._
 
-  def run(): F[Unit] = findCertificate() flatMap {
+  def run: F[Unit] = findCertificate() flatMap {
     case None => ().pure[F]
     case Some(certificate) =>
       for {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/init/CliVersionCompatibilityVerifier.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/init/CliVersionCompatibilityVerifier.scala
@@ -28,14 +28,14 @@ import io.renku.triplesgenerator.config.TriplesGeneration.{RemoteTriplesGenerati
 import org.typelevel.log4cats.Logger
 
 trait CliVersionCompatibilityVerifier[F[_]] {
-  def run(): F[Unit]
+  def run: F[Unit]
 }
 
 private class CliVersionCompatibilityVerifierImpl[F[_]: MonadThrow](
     cliVersion:    CliVersion,
     compatibility: VersionCompatibilityConfig
 ) extends CliVersionCompatibilityVerifier[F] {
-  override def run(): F[Unit] =
+  override def run: F[Unit] =
     if (cliVersion != compatibility.cliVersion)
       MonadThrow[F].raiseError(
         new IllegalStateException(

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/MicroserviceRunnerSpec.scala
@@ -57,9 +57,9 @@ class MicroserviceRunnerSpec
         given(sentryInitializer).succeeds(returning = ())
         given(cliVersionCompatChecker).succeeds(returning = ())
         given(eventConsumersRegistry).succeeds(returning = ())
-        given(httpServer).succeeds(returning = ExitCode.Success)
+        given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
-        Temporal[IO].andWait(runner.run(), 1 second).unsafeRunSync() shouldBe ExitCode.Success
+        Temporal[IO].andWait(runner.run, 1 second).unsafeRunSync() shouldBe ExitCode.Success
       }
 
     "fail if Certificate loading fails" in new TestCase {
@@ -68,7 +68,7 @@ class MicroserviceRunnerSpec
       given(certificateLoader).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
 
       logger.loggedOnly(
@@ -83,7 +83,7 @@ class MicroserviceRunnerSpec
       given(gitCertificateInstaller).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
 
       logger.loggedOnly(
@@ -99,7 +99,7 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
 
       logger.loggedOnly(
@@ -115,7 +115,7 @@ class MicroserviceRunnerSpec
       given(cliVersionCompatChecker) fails (becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
 
       logger.loggedOnly(
@@ -132,10 +132,10 @@ class MicroserviceRunnerSpec
       given(cliVersionCompatChecker).succeeds(returning = ())
       given(eventConsumersRegistry).succeeds(returning = ())
       val exception = exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      given(Runnable(httpServer.run)).fails(becauseOf = exception)
 
       intercept[Exception] {
-        Temporal[IO].andWait(runner.run(), 1 second).unsafeRunSync()
+        Temporal[IO].andWait(runner.run, 1 second).unsafeRunSync()
       } shouldBe exception
 
       logger.loggedOnly(
@@ -151,9 +151,9 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).succeeds(returning = ())
       given(cliVersionCompatChecker).succeeds(returning = ())
       given(eventConsumersRegistry).fails(becauseOf = exceptions.generateOne)
-      given(httpServer).succeeds(returning = ExitCode.Success)
+      given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
-      Temporal[IO].andWait(runner.run(), 1 second).unsafeRunSync() shouldBe ExitCode.Success
+      Temporal[IO].andWait(runner.run, 1 second).unsafeRunSync() shouldBe ExitCode.Success
     }
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/config/certificates/GitCertificateInstallerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/config/certificates/GitCertificateInstallerSpec.scala
@@ -53,7 +53,7 @@ class GitCertificateInstallerSpec extends AnyWordSpec with should.Matchers with 
         .expects(path)
         .returning(Applicative[Try].unit)
 
-      certInstaller.run() shouldBe Applicative[Try].unit
+      certInstaller.run shouldBe Applicative[Try].unit
 
       logger.loggedOnly(Info("Certificate installed for Git"))
     }
@@ -62,7 +62,7 @@ class GitCertificateInstallerSpec extends AnyWordSpec with should.Matchers with 
 
       findCertificate.expects().returning(None.pure[Try])
 
-      certInstaller.run() shouldBe Applicative[Try].unit
+      certInstaller.run shouldBe Applicative[Try].unit
     }
 
     "fail if finding the certificate fails" in new TestCase {
@@ -70,7 +70,7 @@ class GitCertificateInstallerSpec extends AnyWordSpec with should.Matchers with 
       val exception = exceptions.generateOne
       findCertificate.expects().returning(exception.raiseError[Try, Option[Certificate]])
 
-      certInstaller.run() shouldBe exception.raiseError[Try, Unit]
+      certInstaller.run shouldBe exception.raiseError[Try, Unit]
 
       logger.loggedOnly(Error("Certificate installation for Git failed", exception))
     }
@@ -86,7 +86,7 @@ class GitCertificateInstallerSpec extends AnyWordSpec with should.Matchers with 
         .expects(certificate)
         .returning(exception.raiseError[Try, Path])
 
-      certInstaller.run() shouldBe exception.raiseError[Try, Unit]
+      certInstaller.run shouldBe exception.raiseError[Try, Unit]
 
       logger.loggedOnly(Error("Certificate installation for Git failed", exception))
     }
@@ -108,7 +108,7 @@ class GitCertificateInstallerSpec extends AnyWordSpec with should.Matchers with 
         .expects(path)
         .returning(exception.raiseError[Try, Unit])
 
-      certInstaller.run() shouldBe exception.raiseError[Try, Unit]
+      certInstaller.run shouldBe exception.raiseError[Try, Unit]
 
       logger.loggedOnly(Error("Certificate installation for Git failed", exception))
     }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/init/CliVersionCompatibilityVerifierImplSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/init/CliVersionCompatibilityVerifierImplSpec.scala
@@ -35,14 +35,14 @@ class CliVersionCompatibilityVerifierImplSpec extends AnyWordSpec with MockFacto
       val compatConfig = compatibilityGen.generateOne.copy(configuredCliVersion = cliVersion, renkuDevVersion = None)
       val checker      = new CliVersionCompatibilityVerifierImpl[Try](cliVersion, compatConfig)
 
-      checker.run() shouldBe Success(())
+      checker.run shouldBe Success(())
     }
 
     "fail if the cli version does not match the cli version from the compatibility config" in {
       val cliVersion         = cliVersions.generateOne
       val compatConfig       = compatibilityGen.suchThat(c => c.cliVersion != cliVersion).generateOne
       val checker            = new CliVersionCompatibilityVerifierImpl[Try](cliVersion, compatConfig)
-      val Failure(exception) = checker.run()
+      val Failure(exception) = checker.run
       exception shouldBe a[IllegalStateException]
       exception.getMessage shouldBe s"Incompatible versions. cliVersion: $cliVersion, configured version: ${compatConfig.cliVersion}"
     }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/MicroserviceRunnerSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/MicroserviceRunnerSpec.scala
@@ -45,9 +45,9 @@ class MicroserviceRunnerSpec
 
         given(certificateLoader).succeeds(returning = ())
         given(sentryInitializer).succeeds(returning = ())
-        given(httpServer).succeeds(returning = ExitCode.Success)
+        given(Runnable(httpServer.run)).succeeds(returning = ExitCode.Success)
 
-        runner.run().unsafeRunSync() shouldBe ExitCode.Success
+        runner.run.unsafeRunSync() shouldBe ExitCode.Success
       }
 
     "fail if Certificate loading fails" in new TestCase {
@@ -56,7 +56,7 @@ class MicroserviceRunnerSpec
       given(certificateLoader).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
     }
 
@@ -67,7 +67,7 @@ class MicroserviceRunnerSpec
       given(sentryInitializer).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
     }
 
@@ -76,10 +76,10 @@ class MicroserviceRunnerSpec
       given(certificateLoader).succeeds(returning = ())
       given(sentryInitializer).succeeds(returning = ())
       val exception = Generators.exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      given(Runnable(httpServer.run)).fails(becauseOf = exception)
 
       intercept[Exception] {
-        runner.run().unsafeRunSync()
+        runner.run.unsafeRunSync()
       } shouldBe exception
     }
   }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/MicroserviceRunnerSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/MicroserviceRunnerSpec.scala
@@ -19,26 +19,19 @@
 package io.renku.webhookservice
 
 import cats.effect._
-import fs2.concurrent.SignallingRef
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
 import io.renku.generators.Generators
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
 import io.renku.http.server.HttpServer
-import io.renku.testtools.{IOSpec, MockedRunnableCollaborators}
-import org.scalamock.scalatest.MockFactory
+import io.renku.microservices.{AbstractMicroserviceRunnerTest, CallCounter, ServiceRunCounter}
+import io.renku.testtools.IOSpec
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-
 import scala.concurrent.duration._
 
-class MicroserviceRunnerSpec
-    extends AnyWordSpec
-    with MockedRunnableCollaborators
-    with MockFactory
-    with should.Matchers
-    with IOSpec {
+class MicroserviceRunnerSpec extends AnyWordSpec with should.Matchers with IOSpec {
 
   "run" should {
 
@@ -46,17 +39,14 @@ class MicroserviceRunnerSpec
       "Sentry initialisation is fine and " +
       "Http Server start up" in new TestCase {
 
-        given(certificateLoader).succeeds(returning = ())
-        given(sentryInitializer).succeeds(returning = ())
-        given(httpServer).succeeds()
-
-        startRunnerFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
+        startFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
+        assertCalledAll.unsafeRunSync()
       }
 
     "fail if Certificate loading fails" in new TestCase {
 
       val exception = exceptions.generateOne
-      given(certificateLoader).fails(becauseOf = exception)
+      certificateLoader.failWith(exception).unsafeRunSync()
 
       intercept[Exception] {
         startRunnerForever.unsafeRunSync()
@@ -65,45 +55,34 @@ class MicroserviceRunnerSpec
 
     "fail if Sentry initialization fails" in new TestCase {
 
-      given(certificateLoader).succeeds(returning = ())
       val exception = Generators.exceptions.generateOne
-      given(sentryInitializer).fails(becauseOf = exception)
+      sentryInitializer.failWith(exception).unsafeRunSync()
 
       intercept[Exception] {
         startRunnerForever.unsafeRunSync()
       } shouldBe exception
+
+      assertCalledAllBut(sentryInitializer, httpServer).unsafeRunSync()
     }
 
     "fail if starting Http Server fails" in new TestCase {
 
-      given(certificateLoader).succeeds(returning = ())
-      given(sentryInitializer).succeeds(returning = ())
       val exception = Generators.exceptions.generateOne
-      given(httpServer).fails(becauseOf = exception)
+      httpServer.failWith(exception).unsafeRunSync()
 
       intercept[Exception] {
         startRunnerForever.unsafeRunSync()
       } shouldBe exception
+      assertCalledAllBut(httpServer).unsafeRunSync()
     }
   }
 
-  private trait TestCase {
-    val certificateLoader = mock[CertificateLoader[IO]]
-    val sentryInitializer = mock[SentryInitializer[IO]]
-    val httpServer        = mock[HttpServer[IO]]
-    val runner            = new MicroserviceRunner(certificateLoader, sentryInitializer, httpServer)
+  private trait TestCase extends AbstractMicroserviceRunnerTest {
+    val certificateLoader: CertificateLoader[IO] with CallCounter = new ServiceRunCounter("CertificateLoader")
+    val sentryInitializer: SentryInitializer[IO] with CallCounter = new ServiceRunCounter("SentryInitializer")
+    val httpServer:        HttpServer[IO] with CallCounter        = new ServiceRunCounter("HttpServer")
+    val runner = new MicroserviceRunner(certificateLoader, sentryInitializer, httpServer)
 
-    def startRunnerFor(duration: FiniteDuration): IO[ExitCode] =
-      for {
-        term <- SignallingRef.of[IO, Boolean](false)
-        _    <- (IO.sleep(duration) *> term.set(true)).start
-        exit <- runner.run(term)
-      } yield exit
-
-    def startRunnerForever: IO[ExitCode] =
-      for {
-        term <- SignallingRef.of[IO, Boolean](false)
-        exit <- runner.run(term)
-      } yield exit
+    lazy val all: List[CallCounter] = List(certificateLoader, sentryInitializer, httpServer)
   }
 }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/MicroserviceRunnerSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/MicroserviceRunnerSpec.scala
@@ -63,6 +63,7 @@ class MicroserviceRunnerSpec extends AnyWordSpec with should.Matchers with IOSpe
       } shouldBe exception
 
       assertCalledAllBut(sentryInitializer, httpServer).unsafeRunSync()
+      assertNotCalled(httpServer).unsafeRunSync()
     }
 
     "fail if starting Http Server fails" in new TestCase {


### PR DESCRIPTION
This PR changes the http4s backend from blaze to ember, which is the newer and better maintained http4s backend recommended to use by http4s.

It also contains a tiny refactoring removing parens `()` from a non-sideeffect method that carries a bit of adaptions 😅.

Closes: #1329 