### PR TITLE
fix: CliProject not to decode resourceId

### DIFF
--- a/renku-cli-model/src/main/scala/io/renku/cli/model/CliProject.scala
+++ b/renku-cli-model/src/main/scala/io/renku/cli/model/CliProject.scala
@@ -30,7 +30,6 @@ import io.renku.jsonld._
 import io.renku.jsonld.syntax._
 
 final case class CliProject(
-    id:            ResourceId,
     name:          Option[Name],
     description:   Option[Description],
     dateCreated:   DateCreated,
@@ -142,7 +141,6 @@ object CliProject {
   implicit val jsonLDDecoder: JsonLDEntityDecoder[CliProject] =
     JsonLDDecoder.cacheableEntity(entityTypes) { cursor =>
       for {
-        id            <- cursor.downEntityId.as[ResourceId]
         name          <- cursor.downField(Schema.name).as[Option[Name]]
         description   <- cursor.downField(Schema.description).as[Option[Description]]
         dateCreated   <- cursor.downField(Schema.dateCreated).as[DateCreated]
@@ -155,7 +153,6 @@ object CliProject {
         agentVersion  <- cursor.downField(Schema.agent).as[Option[CliVersion]]
         schemaVersion <- cursor.downField(Schema.schemaVersion).as[Option[SchemaVersion]]
       } yield CliProject(
-        id,
         name,
         description,
         dateCreated,
@@ -187,7 +184,7 @@ object CliProject {
   implicit def jsonLDEncoder: JsonLDEncoder[CliProject] =
     JsonLDEncoder.instance { project =>
       JsonLD.entity(
-        project.id.asEntityId,
+        EntityId.blank,
         entityTypes,
         Schema.agent         -> project.agentVersion.asJsonLD,
         Schema.creator       -> project.creator.asJsonLD,

--- a/renku-cli-model/src/test/scala/io/renku/cli/model/generators/ProjectGenerators.scala
+++ b/renku-cli-model/src/test/scala/io/renku/cli/model/generators/ProjectGenerators.scala
@@ -50,7 +50,6 @@ trait ProjectGenerators {
     agentVersion  <- RenkuTinyTypeGenerators.cliVersions.toGeneratorOfOptions
     schemaVersion <- RenkuTinyTypeGenerators.projectSchemaVersions.toGeneratorOfOptions
   } yield CliProject(
-    id,
     name,
     description,
     dateCreated,

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
@@ -56,7 +56,6 @@ private[entities] object CliProjectConverter {
     all.andThen { case (creator, persons, datasets, activities, plans) =>
       newProject(
         gitLabInfo,
-        cliProject.id,
         dateCreated,
         descr,
         cliProject.agentVersion,
@@ -77,7 +76,6 @@ private[entities] object CliProjectConverter {
   }
 
   private def newProject(gitLabInfo:       GitLabProjectInfo,
-                         resourceId:       ResourceId,
                          dateCreated:      DateCreated,
                          maybeDescription: Option[Description],
                          maybeAgent:       Option[CliVersion],
@@ -93,7 +91,7 @@ private[entities] object CliProjectConverter {
       case (Some(agent), Some(version), Some(parentPath)) =>
         RenkuProject.WithParent
           .from(
-            resourceId,
+            ResourceId(gitLabInfo.path),
             gitLabInfo.path,
             gitLabInfo.name,
             maybeDescription,
@@ -114,7 +112,7 @@ private[entities] object CliProjectConverter {
       case (Some(agent), Some(version), None) =>
         RenkuProject.WithoutParent
           .from(
-            resourceId,
+            ResourceId(gitLabInfo.path),
             gitLabInfo.path,
             gitLabInfo.name,
             maybeDescription,
@@ -134,7 +132,7 @@ private[entities] object CliProjectConverter {
       case (None, None, Some(parentPath)) =>
         NonRenkuProject
           .WithParent(
-            resourceId,
+            ResourceId(gitLabInfo.path),
             gitLabInfo.path,
             gitLabInfo.name,
             maybeDescription,
@@ -151,7 +149,7 @@ private[entities] object CliProjectConverter {
       case (None, None, None) =>
         NonRenkuProject
           .WithoutParent(
-            resourceId,
+            ResourceId(gitLabInfo.path),
             gitLabInfo.path,
             gitLabInfo.name,
             maybeDescription,

--- a/renku-model/src/test/scala/io/renku/graph/model/cli/CliProjectConverters.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/cli/CliProjectConverters.scala
@@ -20,8 +20,8 @@ package io.renku.graph.model.cli
 
 import cats.syntax.all._
 import io.renku.cli.model.CliProject
+import io.renku.graph.model.{testentities, RenkuUrl}
 import io.renku.graph.model.testentities.ModelOps
-import io.renku.graph.model.{RenkuUrl, projects, testentities}
 import io.renku.jsonld.syntax._
 
 trait CliProjectConverters extends CliActivityConverters with CliDatasetConverters {
@@ -31,7 +31,6 @@ trait CliProjectConverters extends CliActivityConverters with CliDatasetConverte
 
   private def renkuProject(p: testentities.RenkuProject)(implicit renkuUrl: RenkuUrl): CliProject =
     CliProject(
-      projects.ResourceId(p.asEntityId),
       p.name.some,
       p.maybeDescription,
       p.dateCreated,
@@ -47,7 +46,6 @@ trait CliProjectConverters extends CliActivityConverters with CliDatasetConverte
 
   def nonRenkuProject(p: testentities.NonRenkuProject)(implicit renkuUrl: RenkuUrl): CliProject =
     CliProject(
-      projects.ResourceId(p.asEntityId),
       p.name.some,
       p.maybeDescription,
       p.dateCreated,


### PR DESCRIPTION
Apparently, the Project resourceIds coming from the CLI payload are not trustworthy. We have to create them on our side