### PR TITLE
chore: bump ca certificates chart to 0.0.4

### DIFF
--- a/helm-chart/renku-graph/requirements.yaml
+++ b/helm-chart/renku-graph/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: certificates
-  version: "0.0.3"
+  version: "0.0.4"
   repository: "https://swissdatasciencecenter.github.io/helm-charts/"
 - name: renku-jena
   version: "0.0.19"


### PR DESCRIPTION
This allows the certificate injection to work properly with the (relatively new) updates to the base scala/java images across the board.

Already has been tested by the BIT. 