### PR TITLE
fix: TS migration updating renku version pair in the TS

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -41,6 +41,7 @@ private[tsmigrationrequest] object Migrations {
     fixMultipleProjectCreatedDates <- FixMultipleProjectCreatedDates[F]
     addRenkuPlanWhereMissing       <- AddRenkuPlanWhereMissing[F]
     migrationToV10                 <- v10migration.MigrationToV10[F]
+    v10VersionSetter               <- V10VersionUpdater[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -49,7 +50,8 @@ private[tsmigrationrequest] object Migrations {
                     compositePlan,
                     fixMultipleProjectCreatedDates,
                     addRenkuPlanWhereMissing,
-                    migrationToV10
+                    migrationToV10,
+                    v10VersionSetter
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/V10VersionUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/V10VersionUpdater.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.data.EitherT
+import cats.effect.Async
+import cats.syntax.all._
+import cats.MonadThrow
+import com.typesafe.config.ConfigFactory
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
+import io.renku.graph.model.versions.RenkuVersionPair
+import io.renku.triplesgenerator.config.VersionCompatibilityConfig
+import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
+import io.renku.triplesstore.{MigrationsConnectionConfig, SparqlQueryTimeRecorder}
+import org.typelevel.log4cats.Logger
+import reprovisioning.RenkuVersionPairUpdater
+import tooling.{MigrationExecutionRegister, RecoverableErrorsRecovery, RegisteredMigration}
+
+private class V10VersionUpdater[F[_]: MonadThrow: Logger](
+    versionPair:             RenkuVersionPair,
+    renkuVersionPairUpdater: RenkuVersionPairUpdater[F],
+    executionRegister:       MigrationExecutionRegister[F],
+    recoveryStrategy:        RecoverableErrorsRecovery = RecoverableErrorsRecovery
+) extends RegisteredMigration[F](V10VersionUpdater.name, executionRegister, recoveryStrategy) {
+
+  import recoveryStrategy._
+
+  protected[migrations] override def migrate(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
+    renkuVersionPairUpdater
+      .update(versionPair)
+      .map(_.asRight[ProcessingRecoverableError])
+      .recoverWith(maybeRecoverableError[F, Unit])
+  }
+}
+
+private[migrations] object V10VersionUpdater {
+
+  val name: Migration.Name = Migration.Name("V10 version Updater")
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[Migration[F]] = for {
+    implicit0(ru: RenkuUrl)    <- RenkuUrlLoader[F]()
+    compatibility              <- VersionCompatibilityConfig.fromConfigF[F](ConfigFactory.load())
+    migrationsConnectionConfig <- MigrationsConnectionConfig[F]()
+    executionRegister          <- MigrationExecutionRegister[F]
+  } yield new V10VersionUpdater(compatibility.asVersionPair,
+                                RenkuVersionPairUpdater(migrationsConnectionConfig),
+                                executionRegister
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisioning.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisioning.scala
@@ -25,8 +25,8 @@ import cats.effect.{Async, Temporal}
 import cats.syntax.all._
 import com.typesafe.config.{Config, ConfigFactory}
 import io.circe.literal._
-import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent}
+import io.renku.events.producers.EventSender
 import io.renku.graph.config.{EventLogUrl, RenkuUrlLoader}
 import io.renku.logging.ExecutionTimeRecorder
 import io.renku.logging.ExecutionTimeRecorder.ElapsedTime
@@ -138,7 +138,7 @@ private[migrations] object ReProvisioning {
       judge,
       triplesRemover,
       eventSender,
-      new RenkuVersionPairUpdaterImpl(migrationsConnectionConfig),
+      RenkuVersionPairUpdater(migrationsConnectionConfig),
       microserviceUrlFinder,
       ReProvisioningStatus[F],
       executionTimeRecorder,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/RenkuVersionPairUpdater.scala
@@ -21,16 +21,23 @@ package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
 import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
-import io.renku.graph.model.Schemas._
 import io.renku.graph.model.RenkuUrl
+import io.renku.graph.model.Schemas._
 import io.renku.graph.model.versions.RenkuVersionPair
 import io.renku.jsonld.syntax._
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
+import io.renku.triplesstore.SparqlQuery.Prefixes
 import org.typelevel.log4cats.Logger
 
-trait RenkuVersionPairUpdater[F[_]] {
+private[migrations] trait RenkuVersionPairUpdater[F[_]] {
   def update(versionPair: RenkuVersionPair): F[Unit]
+}
+
+private[migrations] object RenkuVersionPairUpdater {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      migrationsDSConfig: MigrationsConnectionConfig
+  )(implicit renkuUrl: RenkuUrl): RenkuVersionPairUpdater[F] =
+    new RenkuVersionPairUpdaterImpl[F](migrationsDSConfig)
 }
 
 private class RenkuVersionPairUpdaterImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/V10VersionUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/V10VersionUpdaterSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.MonadThrow
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.generators.ErrorGenerators.processingRecoverableErrors
+import io.renku.triplesgenerator.generators.VersionGenerators.renkuVersionPairs
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{EitherValues, TryValues}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import reprovisioning.RenkuVersionPairUpdater
+import tooling.{MigrationExecutionRegister, RecoverableErrorsRecovery}
+
+import scala.util.Try
+
+class V10VersionUpdaterSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with MockFactory
+    with TryValues
+    with EitherValues {
+
+  "migrate" should {
+
+    "replace the current schema with v10 and cli version 2.3.0" in new TestCase {
+
+      (renkuVersionPairUpdater.update _)
+        .expects(renkuVersionPair)
+        .returning(().pure[Try])
+
+      setter.migrate().value.success.value.value shouldBe ()
+    }
+  }
+
+  private trait TestCase {
+
+    private implicit val logger: TestLogger[Try] = TestLogger()
+    val renkuVersionPair          = renkuVersionPairs.generateOne
+    val renkuVersionPairUpdater   = mock[RenkuVersionPairUpdater[Try]]
+    private val executionRegister = mock[MigrationExecutionRegister[Try]]
+    private val recoverableError  = processingRecoverableErrors.generateOne
+    private val recoveryStrategy = new RecoverableErrorsRecovery {
+      override def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = { _ =>
+        recoverableError.asLeft[OUT].pure[F]
+      }
+    }
+    val setter =
+      new V10VersionUpdater[Try](renkuVersionPair, renkuVersionPairUpdater, executionRegister, recoveryStrategy)
+  }
+}


### PR DESCRIPTION
This TS migration updates, the so-called, _renku version pair_ in the `migrations` DS in the TS. It was overlooked during the work introducing the V10 migration