### PR TITLE
refactor: MEMBER_SYNC & COMMIT_SYNC consumers to notify on ready

### DIFF
--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/commitsync/SubscriptionFactory.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/consumers/commitsync/SubscriptionFactory.scala
@@ -39,6 +39,6 @@ object SubscriptionFactory {
         categoryName,
         defaultSubscriptionPayloadComposerFactory(Microservice.ServicePort, Microservice.Identifier)
       )
-    handler <- EventHandler[F]
+    handler <- EventHandler[F](subscriptionMechanism)
   } yield handler -> subscriptionMechanism
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/SubscriptionFactory.scala
@@ -40,6 +40,6 @@ object SubscriptionFactory {
         defaultSubscriptionPayloadComposerFactory(Microservice.ServicePort, Microservice.Identifier)
       )
     _       <- ReProvisioningStatus[F].registerForNotification(subscriptionMechanism)
-    handler <- EventHandler[F]
+    handler <- EventHandler[F](subscriptionMechanism)
   } yield handler -> subscriptionMechanism
 }


### PR DESCRIPTION
This PR aligns consumers of the `MEMBER_SYNC` and `COMMIT_SYNC` events to notify the sender when they are able to take new events.