### PR TITLE
feat: re-provisioning process skip removing ProjectViewedTimes graph

### DIFF
--- a/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
@@ -31,8 +31,8 @@ import io.renku.graph.model.entities.{EntityFunctions, Person}
 import io.renku.graph.triplesstore.DatasetTTLs._
 import io.renku.http.client._
 import io.renku.interpreters.TestLogger
-import io.renku.jsonld.JsonLD.{JsonLDArray, JsonLDEntityLike}
 import io.renku.jsonld._
+import io.renku.jsonld.JsonLD.{JsonLDArray, JsonLDEntityLike}
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.triplesstore.client.model.{Quad, Triple}
 import io.renku.triplesstore.client.syntax._
@@ -133,6 +133,17 @@ trait InMemoryJena {
       .flatMap(
         _.runQuery(
           SparqlQuery.of("triples count", "SELECT (COUNT(?s) AS ?count) WHERE { GRAPH ?g { ?s ?p ?o } }")
+        ).map(_.headOption.map(_.apply("count")).flatMap(_.toLongOption).getOrElse(0L))
+      )
+      .unsafeRunSync()
+
+  def triplesCount(on: DatasetName, graphId: EntityId)(implicit ioRuntime: IORuntime): Long =
+    queryRunnerFor(on)
+      .flatMap(
+        _.runQuery(
+          SparqlQuery.of("triples count on graph",
+                         s"SELECT (COUNT(?s) AS ?count) WHERE { GRAPH ${graphId.sparql} { ?s ?p ?o } }"
+          )
         ).map(_.headOption.map(_.apply("count")).flatMap(_.toLongOption).getOrElse(0L))
       )
       .unsafeRunSync()

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/TriplesRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/TriplesRemover.scala
@@ -44,7 +44,9 @@ private class TriplesRemoverImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
 
   import eu.timepit.refined.auto._
   import io.circe.Decoder
+  import io.renku.graph.model.GraphClass
   import io.renku.graph.model.Schemas._
+  import io.renku.triplesstore.client.syntax._
 
   override def removeAllTriples(): F[Unit] =
     queryExpecting[Option[EntityId]](findGraph) >>= {
@@ -56,7 +58,10 @@ private class TriplesRemoverImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     name = "triples remove - count",
     Prefixes of renku -> "renku",
     s"""|SELECT DISTINCT ?graph
-        |WHERE { GRAPH ?graph { ?s ?p ?o } }
+        |WHERE {
+        |  GRAPH ?graph { ?s ?p ?o }
+        |  FILTER (?graph != ${GraphClass.ProjectViewedTimes.id.sparql})
+        |}
         |LIMIT 1
         |""".stripMargin
   )
@@ -64,7 +69,7 @@ private class TriplesRemoverImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
   private def remove(graphId: EntityId) = SparqlQuery.of(
     name = "triples remove - delete",
     Prefixes of renku -> "renku",
-    s"DROP GRAPH <$graphId>"
+    s"DROP GRAPH ${graphId.sparql}"
   )
 
   private implicit val graphIdDecoder: Decoder[Option[EntityId]] = ResultsDecoder[List, EntityId] { implicit cur =>


### PR DESCRIPTION
This PR changes the re-provisioning process in a way that it does remove the `renku:ProjectViewedTime` graph.