### PR TITLE
feat: MIN_PROJECT_INFO consumer to send PROJECT_VIEWED event on success

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/Endpoint.scala
@@ -85,7 +85,7 @@ class EndpointImpl[F[_]: MonadThrow: Logger](
     case Some(proj) =>
       tgClient
         .send(ProjectViewedEvent.forProject(proj.path, now))
-        .handleErrorWith(err => Logger[F].error(err)(show"Sending ${ProjectViewedEvent.categoryName} event failed"))
+        .handleErrorWith(err => Logger[F].error(err)(show"sending ${ProjectViewedEvent.categoryName} event failed"))
   }
 
   private def toHttpResult(path: projects.Path)(implicit request: Request[F]): Option[Project] => F[Response[F]] = {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/EndpointSpec.scala
@@ -159,7 +159,7 @@ class EndpointSpec
 
       endpoint.`GET /projects/:path`(project.path, maybeAuthUser)(Request[IO]()).unsafeRunSync().status shouldBe Ok
 
-      logger.logged(Error(show"Sending ${ProjectViewedEvent.categoryName} event failed", exception))
+      logger.logged(Error(show"sending ${ProjectViewedEvent.categoryName} event failed", exception))
     }
   }
 


### PR DESCRIPTION
This PR ensures the `PROJECT_VIEWED` event is sent on successful project activation. The event cannot be sent by the activation process as such (the project being activated is not in the TS at the end of the activation process) but only once the `MIN_PROJECT_INFO` is successfully processed.