### PR TITLE
fix: PROJECT_VIEWED to be persisted if contains younger date

### DIFF
--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/EventPersister.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/EventPersister.scala
@@ -57,7 +57,7 @@ private[viewings] class EventPersisterImpl[F[_]: MonadThrow](tsClient: TSClient[
   private def persistIfOlderOrNone(event: ProjectViewedEvent, projectId: projects.ResourceId) =
     findStoredDate(projectId) >>= {
       case None => insert(projectId, event)
-      case Some(date) if (date compareTo event.dateViewed) < 0 =>
+      case Some(date) if date < event.dateViewed =>
         deleteOldViewedDate(projectId) >> insert(projectId, event)
       case _ => ().pure[F]
     }


### PR DESCRIPTION
This PR changes the `PROJECT_VIEWED` event handling so the date carried in the event is persisted only if newer than what's in the TS already.