### PR TITLE
fix: ADD_MIN_PROJECT_INFO to be skipped if project graph exists

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
@@ -30,10 +30,11 @@ import io.renku.graph.model.events
 import io.renku.graph.model.testentities._
 import io.renku.http.client.AccessToken
 import io.renku.http.rest.Links
-import io.renku.http.server.EndpointTester.{JsonOps, jsonEntityDecoder}
+import io.renku.http.server.EndpointTester.{jsonEntityDecoder, JsonOps}
 import io.renku.webhookservice.model
-import knowledgegraph.{DatasetsApiEncoders, fullJson}
+import knowledgegraph.{fullJson, DatasetsApiEncoders}
 import org.http4s.Status._
+import org.scalatest.EitherValues
 import tooling.{AcceptanceSpec, ApplicationServices}
 
 import java.lang.Thread.sleep
@@ -43,13 +44,14 @@ class CommitHistoryChangesSpec
     extends AcceptanceSpec
     with ApplicationServices
     with TSProvisioning
-    with DatasetsApiEncoders {
+    with DatasetsApiEncoders
+    with EitherValues {
 
   private val user = authUsers.generateOne
 
-  Feature("Changes in the commit history to trigger re-provisioning") {
+  Feature("Changes in the commit history to trigger re-provisioning for the Project") {
 
-    Scenario("A change in the commit history should trigger the re-provisioning process") {
+    Scenario("A change in the commit history should trigger the re-provisioning process for the Project") {
 
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
@@ -125,7 +127,7 @@ class CommitHistoryChangesSpec
 
       knowledgeGraphClient.GET(s"knowledge-graph/projects/${project.path}", user.accessToken).status shouldBe NotFound
 
-      project.entitiesProject.datasets.foreach { dataset =>
+      project.entitiesProject.datasets foreach { dataset =>
         knowledgeGraphClient
           .GET(s"knowledge-graph/datasets/${dataset.identification.identifier}", user.accessToken)
           .status shouldBe NotFound
@@ -141,8 +143,7 @@ class CommitHistoryChangesSpec
     val projectDetails = projectDetailsResponse.jsonBody
     projectDetails shouldBe fullJson(project)
 
-    val datasetsLink = projectDetails._links
-      .fold(throw _, identity)
+    val datasetsLink = projectDetails._links.value
       .get(Links.Rel("datasets"))
       .getOrElse(fail("No link with rel 'datasets'"))
 
@@ -152,7 +153,7 @@ class CommitHistoryChangesSpec
       .unsafeRunSync()
 
     datasetsResponse._1 shouldBe Ok
-    val Right(foundDatasets) = datasetsResponse._2.as[List[Json]]
+    val foundDatasets = datasetsResponse._2.as[List[Json]].value
     foundDatasets should contain theSameElementsAs testProject.datasets.map(briefJson(_, project.path))
   }
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/ProjectExistenceChecker.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/ProjectExistenceChecker.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsprovisioning.minprojectinfo
+
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.model.projects
+import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder, TSClient}
+import org.typelevel.log4cats.Logger
+
+private trait ProjectExistenceChecker[F[_]] {
+  def checkProjectExists(projectId: projects.ResourceId): F[Boolean]
+}
+
+private object ProjectExistenceChecker {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectExistenceChecker[F]] =
+    ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(new ProjectExistenceCheckerImpl[F](_))
+}
+
+private class ProjectExistenceCheckerImpl[F[_]](tsClient: TSClient[F]) extends ProjectExistenceChecker[F] {
+
+  import eu.timepit.refined.auto._
+  import io.circe.Decoder
+  import io.renku.graph.model.Schemas.schema
+  import io.renku.jsonld.syntax._
+  import io.renku.triplesstore.client.syntax._
+  import io.renku.triplesstore.ResultsDecoder._
+  import io.renku.triplesstore.{ResultsDecoder, SparqlQuery}
+  import io.renku.triplesstore.SparqlQuery.Prefixes
+
+  override def checkProjectExists(projectId: projects.ResourceId): F[Boolean] = tsClient.queryExpecting[Boolean] {
+    SparqlQuery.ofUnsafe(
+      s"${categoryName.value.toLowerCase} - project existence check",
+      Prefixes of schema -> "schema",
+      sparql"""|SELECT ?id
+               |WHERE {
+               |  BIND (${projectId.asEntityId} AS ?id)
+               |  GRAPH ?id { ?id a schema:Project }
+               |}
+               |LIMIT 1
+               |""".stripMargin.sparql
+    )
+  }(decoder)
+
+  private lazy val decoder: Decoder[Boolean] = ResultsDecoder[List, projects.ResourceId] { implicit cur =>
+    import io.renku.tinytypes.json.TinyTypeDecoders._
+    extract[projects.ResourceId]("id")
+  }.map(_.nonEmpty)
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/projects/UpdatesCreator.scala
@@ -19,6 +19,8 @@
 package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation.namedgraphs.projects
 
 import cats.syntax.all._
+import io.renku.triplesstore.client.syntax._
+import io.renku.jsonld.syntax._
 import eu.timepit.refined.auto._
 import io.renku.graph.model.Schemas._
 import io.renku.graph.model.entities._
@@ -161,23 +163,23 @@ private object UpdatesCreator extends UpdatesCreator {
 
   private def imageDeletion(project: Project, kgData: ProjectMutableData) =
     Option.when(kgData.images.toSet != project.images.map(_.resourceId).toSet) {
-      val resource = project.resourceId.showAs[RdfResource]
+      val resource = project.resourceId.asEntityId
       SparqlQuery.of(
         name = "transformation - delete project images",
-        Prefixes.of(schema -> "schema"),
-        s"""|DELETE {
-            |  GRAPH $resource {
-            |    $resource schema:image ?img.
-            |    ?img ?p ?s
-            |  } 
-            |}
-            |WHERE  {
-            |  GRAPH $resource {
-            |    $resource schema:image ?img.
-            |    ?img ?p ?s
-            |  }
-            |}
-            |""".stripMargin
+        Prefixes of schema -> "schema",
+        sparql"""|DELETE {
+                 |  GRAPH $resource {
+                 |    $resource schema:image ?img.
+                 |    ?img ?p ?s
+                 |  } 
+                 |}
+                 |WHERE  {
+                 |  GRAPH $resource {
+                 |    $resource schema:image ?img.
+                 |    ?img ?p ?s
+                 |  }
+                 |}
+                 |""".stripMargin.sparql
       )
     }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/ProjectExistenceCheckerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/ProjectExistenceCheckerSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsprovisioning.minprojectinfo
+
+import cats.effect.IO
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore._
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class ProjectExistenceCheckerSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset {
+
+  "checkProjectExists" should {
+
+    "return false if project does not exist in the TS; true otherwise" in {
+
+      val project = anyProjectEntities.generateOne
+
+      checker.checkProjectExists(project.resourceId).unsafeRunSync() shouldBe false
+
+      upload(to = projectsDataset, project)
+
+      checker.checkProjectExists(project.resourceId).unsafeRunSync() shouldBe true
+    }
+  }
+
+  private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
+  private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val checker = new ProjectExistenceCheckerImpl[IO](TSClient[IO](projectsDSConnectionInfo))
+}


### PR DESCRIPTION
Apparently, it may happen that the `ADD_MIN_PROJECT_INFO` event is delivered after data for a project is put into the TS. In such a case it's both discouraged and unnecessary for the event to be producing data for the TS. This PR adds a check to the `ADD_MIN_PROJECT_INFO` handling process to skip the standard event processing algorithm in case the project exists in the TS already.

closes #1400 