### PR TITLE
fix: TS_MIGRATION_REQUEST producer to deliver to url from the event

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/EventsDistributor.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/EventsDistributor.scala
@@ -85,8 +85,9 @@ private class EventsDistributorImpl[F[_]: MonadThrow: Temporal: Logger, Category
     case result @ TemporarilyUnavailable =>
       (markBusy(subscriber) recover withNothing) >> (returnToQueue(event, result) recoverWith logError(event))
     case result @ Misdelivered =>
-      Logger[F].info(show"$categoryName: $event, subscriber = $subscriber -> $result")
-      (delete(subscriber) recover withNothing) >> (returnToQueue(event, result) recoverWith logError(event))
+      Logger[F].info(show"$categoryName: $event, subscriber = $subscriber -> $result") >>
+        (delete(subscriber) recover withNothing) >>
+        (returnToQueue(event, result) recoverWith logError(event))
   }
 
   private lazy val withNothing: PartialFunction[Throwable, Unit] = { case NonFatal(_) => () }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationEventsDistributor.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationEventsDistributor.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.eventlog.events.producers
+package tsmigrationrequest
+
+import EventsSender.SendingResult
+import cats.data.OptionT
+import cats.effect.{Async, Temporal}
+import cats.syntax.all._
+import io.renku.events.CategoryName
+import io.renku.metrics.MetricsRegistry
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
+
+private trait MigrationEventsDistributor[F[_]] {
+  def run(): F[Unit]
+}
+
+private class MigrationEventsDistributorImpl[F[_]: Temporal: Logger](
+    categoryName:     CategoryName,
+    subscribers:      Subscribers[F, _],
+    eventsFinder:     EventFinder[F],
+    eventsSender:     EventsSender[F, MigrationRequestEvent],
+    dispatchRecovery: DispatchRecovery[F, MigrationRequestEvent],
+    noEventSleep:     FiniteDuration,
+    onErrorSleep:     FiniteDuration
+) extends EventsDistributor[F] {
+
+  import EventsSender.SendingResult._
+  import dispatchRecovery._
+  import eventsSender._
+  import subscribers._
+
+  def run(): F[Unit] = {
+    for {
+      _ <- ().pure[F]
+      _ <- (popEvent semiflatMap dispatch).value
+    } yield ()
+  }.foreverM[Unit]
+
+  private def popEvent: OptionT[F, MigrationRequestEvent] = OptionT {
+    eventsFinder.popEvent() handleErrorWith logError
+  }.flatTapNone(Temporal[F] sleep noEventSleep)
+
+  private lazy val dispatch: MigrationRequestEvent => F[Unit] = { case event @ MigrationRequestEvent(url, _) =>
+    (sendEvent(url, event) >>= handleResult(event))
+      .recoverWith(recover(event.subscriberUrl, event))
+  }
+
+  private def handleResult(event: MigrationRequestEvent): SendingResult => F[Unit] = {
+    case result @ Delivered =>
+      Logger[F].info(show"$categoryName: $event, subscriber = ${event.subscriberUrl} -> $result")
+    case result @ TemporarilyUnavailable =>
+      returnToQueue(event, result) handleErrorWith logError(event, "returning event to the queue failed")
+    case result @ Misdelivered =>
+      Logger[F].info(show"$categoryName: $event, subscriber = ${event.subscriberUrl} -> $result") >>
+        delete(event.subscriberUrl) handleErrorWith logError(event, "deleting subscriber failed")
+  }
+
+  private def logError(event: MigrationRequestEvent, message: String): PartialFunction[Throwable, F[Unit]] =
+    Logger[F].error(_)(show"$categoryName: $event -> $message")
+
+  private lazy val logError: Throwable => F[Option[MigrationRequestEvent]] = { exception =>
+    for {
+      _ <- Logger[F].error(exception)(show"$categoryName: finding events to dispatch failed")
+      _ <- Temporal[F] sleep onErrorSleep
+    } yield Option.empty[MigrationRequestEvent]
+  }
+}
+
+private object MigrationEventsDistributor {
+  private val NoEventSleep: FiniteDuration = 1 minute
+  private val OnErrorSleep: FiniteDuration = 1 minute
+
+  def apply[F[_]: Async: Logger: MetricsRegistry](
+      subscribers:          Subscribers[F, _],
+      eventsFinder:         EventFinder[F],
+      categoryEventEncoder: EventEncoder[MigrationRequestEvent],
+      dispatchRecovery:     DispatchRecovery[F, MigrationRequestEvent]
+  ): F[EventsDistributor[F]] =
+    EventsSender[F, MigrationRequestEvent](categoryName, categoryEventEncoder).map(
+      new MigrationEventsDistributorImpl(categoryName,
+                                         subscribers,
+                                         eventsFinder,
+                                         _,
+                                         dispatchRecovery,
+                                         noEventSleep = NoEventSleep,
+                                         onErrorSleep = OnErrorSleep
+      )
+    )
+}

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationRequestEvent.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationRequestEvent.scala
@@ -36,7 +36,7 @@ private object MigrationRequestEvent {
     }
   }"""
 
-  implicit lazy val show: Show[MigrationRequestEvent] = Show.show { event =>
-    show"subscriberVersion = ${event.subscriberVersion}"
+  implicit lazy val show: Show[MigrationRequestEvent] = Show.show { case MigrationRequestEvent(url, version) =>
+    show"subscriberUrl = $url, subscriberVersion = $version"
   }
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationSubscribers.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationSubscribers.scala
@@ -19,11 +19,9 @@
 package io.renku.eventlog.events.producers
 package tsmigrationrequest
 
-import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
 import io.renku.eventlog.events.producers.Subscribers
-import io.renku.events.CategoryName
 import org.typelevel.log4cats.Logger
 
 private object MigrationSubscribers {
@@ -32,9 +30,6 @@ private object MigrationSubscribers {
 
   def apply[F[_]](implicit subscribers: MigrationSubscribers[F]): MigrationSubscribers[F] = subscribers
 
-  def apply[F[_]: Async: MigrationSubscriberTracker: Logger](categoryName: CategoryName): F[MigrationSubscribers[F]] =
-    for {
-      subscribersRegistry <- SubscribersRegistry[F](categoryName)
-      subscribers         <- MonadThrow[F].catchNonFatal(new SubscribersImpl(categoryName, subscribersRegistry))
-    } yield subscribers
+  def apply[F[_]: Async: MigrationSubscriberTracker: Logger](): F[MigrationSubscribers[F]] =
+    SubscribersRegistry[F](categoryName).map(new SubscribersImpl(categoryName, _))
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/EventFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/EventFinderSpec.scala
@@ -323,7 +323,7 @@ class EventFinderSpec
     private implicit val metricsRegistry:  TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
     private implicit val queriesExecTimes: QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()
     val currentTime = mockFunction[Instant]
-    val finder      = new EventFinder[IO](currentTime)
+    val finder      = new EventFinderImpl[IO](currentTime)
 
     currentTime.expects().returning(now).anyNumberOfTimes()
   }

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/Generators.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/Generators.scala
@@ -18,8 +18,10 @@
 
 package io.renku.eventlog.events.producers.tsmigrationrequest
 
+import cats.syntax.all._
 import io.renku.events.Generators.{subscriberIds, subscriberUrls}
 import io.renku.generators.CommonGraphGenerators.serviceVersions
+import io.renku.generators.Generators.Implicits._
 import org.scalacheck.Gen
 
 private object Generators {
@@ -29,4 +31,7 @@ private object Generators {
     id      <- subscriberIds
     version <- serviceVersions
   } yield MigrationSubscriber(url, id, version)
+
+  val migrationRequestEvents: Gen[MigrationRequestEvent] =
+    (subscriberUrls -> serviceVersions).mapN(MigrationRequestEvent(_, _))
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationEventsDistributorSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationEventsDistributorSpec.scala
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.eventlog.events
+package producers
+package tsmigrationrequest
+
+import EventsSender.SendingResult
+import EventsSender.SendingResult._
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.events.Subscription
+import io.renku.events.Subscription._
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.exceptions
+import io.renku.interpreters.TestLogger
+import io.renku.interpreters.TestLogger.Level.{Error, Info}
+import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import Generators.migrationRequestEvents
+
+import scala.concurrent.duration._
+
+class MigrationEventsDistributorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with MockFactory
+    with Eventually
+    with IntegrationPatience {
+
+  "run" should {
+
+    "continue dispatching events from the queue to the subscriber from the event" in new TestCase {
+
+      val event      = migrationRequestEvents.generateOne
+      val otherEvent = migrationRequestEvents.generateOne
+
+      inSequence {
+
+        givenEventFinder(returns = Some(event))
+        givenSending(event, to = event.subscriberUrl, got = Delivered)
+        givenDispatchRecoveryExists(event)
+
+        givenEventFinder(returns = Some(otherEvent))
+        givenSending(otherEvent, to = otherEvent.subscriberUrl, got = Delivered)
+        givenDispatchRecoveryExists(otherEvent)
+
+        givenNoMoreEvents()
+      }
+
+      distributor.run().unsafeRunAndForget()
+
+      eventually {
+        logger.loggedOnly(
+          Info(show"$categoryName: $event, subscriber = ${event.subscriberUrl} -> $Delivered"),
+          Info(show"$categoryName: $otherEvent, subscriber = ${otherEvent.subscriberUrl} -> $Delivered")
+        )
+      }
+    }
+
+    "return the event back to the queue " +
+      s"if delivery resulted in $TemporarilyUnavailable" in new TestCase {
+
+        val event = migrationRequestEvents.generateOne
+
+        inSequence {
+          givenEventFinder(returns = Some(event))
+          givenSending(event, to = event.subscriberUrl, got = TemporarilyUnavailable)
+          givenDispatchRecoveryExists(event)
+          expectEventReturnedToTheQueue(event, reason = TemporarilyUnavailable, got = ().pure[IO])
+
+          givenEventFinder(returns = Some(event))
+          givenSending(event, to = event.subscriberUrl, got = Delivered)
+          givenDispatchRecoveryExists(event)
+
+          givenNoMoreEvents()
+        }
+
+        distributor.run().unsafeRunAndForget()
+
+        eventually {
+          logger.loggedOnly(
+            Info(show"$categoryName: $event, subscriber = ${event.subscriberUrl} -> $Delivered")
+          )
+        }
+      }
+
+    s"remove subscriber which returned $Misdelivered on dispatching " +
+      "and return the event to the queue" in new TestCase {
+
+        val failingEvent    = migrationRequestEvents.generateOne
+        val succeedingEvent = migrationRequestEvents.generateOne
+
+        inSequence {
+          givenEventFinder(returns = Some(failingEvent))
+          givenSending(failingEvent, to = failingEvent.subscriberUrl, got = Misdelivered)
+          givenDispatchRecoveryExists(failingEvent)
+          expectRemoval(failingEvent.subscriberUrl)
+
+          givenEventFinder(returns = Some(succeedingEvent))
+          givenSending(succeedingEvent, to = succeedingEvent.subscriberUrl, got = Delivered)
+          givenDispatchRecoveryExists(succeedingEvent)
+
+          givenNoMoreEvents()
+        }
+
+        distributor.run().unsafeRunAndForget()
+
+        eventually {
+          logger.loggedOnly(
+            Info(show"$categoryName: $failingEvent, subscriber = ${failingEvent.subscriberUrl} -> $Misdelivered"),
+            Info(show"$categoryName: $succeedingEvent, subscriber = ${succeedingEvent.subscriberUrl} -> $Delivered")
+          )
+        }
+      }
+
+    "recover using the given DispatchRecovery mechanism when sending an event fails " +
+      "and continue processing some next event" in new TestCase {
+
+        val failingEvent    = migrationRequestEvents.generateOne
+        val exception       = exceptions.generateOne
+        val succeedingEvent = migrationRequestEvents.generateOne
+
+        inSequence {
+
+          givenEventFinder(returns = Some(failingEvent))
+
+          (eventsSender.sendEvent _)
+            .expects(failingEvent.subscriberUrl, failingEvent)
+            .returning(exception.raiseError[IO, SendingResult])
+
+          givenDispatchRecoveryExists(failingEvent)
+          dispatchRecoveryStrategy
+            .expects(exception)
+            .returning(IO.unit)
+
+          givenEventFinder(returns = Some(succeedingEvent))
+          givenSending(succeedingEvent, to = succeedingEvent.subscriberUrl, got = Delivered)
+          givenDispatchRecoveryExists(succeedingEvent)
+
+          givenNoMoreEvents()
+        }
+
+        distributor.run().unsafeRunAndForget()
+
+        eventually {
+          logger.loggedOnly(
+            Info(show"$categoryName: $succeedingEvent, subscriber = ${succeedingEvent.subscriberUrl} -> $Delivered")
+          )
+        }
+      }
+
+    "log an error if finding an event fails" in new TestCase {
+
+      val exception = exceptions.generateOne
+      val event     = migrationRequestEvents.generateOne
+
+      inSequence {
+
+        (eventsFinder.popEvent _)
+          .expects()
+          .returning(exception.raiseError[IO, Option[MigrationRequestEvent]])
+
+        givenEventFinder(returns = Some(event))
+        givenSending(event, to = event.subscriberUrl, got = Delivered)
+        givenDispatchRecoveryExists(event)
+
+        givenNoMoreEvents()
+      }
+
+      distributor.run().unsafeRunAndForget()
+
+      eventually {
+        logger.loggedOnly(
+          Error(show"$categoryName: finding events to dispatch failed", exception),
+          Info(show"$categoryName: $event, subscriber = ${event.subscriberUrl} -> $Delivered")
+        )
+      }
+    }
+
+    "log an error if removing a subscriber fails" in new TestCase {
+
+      val event      = migrationRequestEvents.generateOne
+      val exception  = exceptions.generateOne
+      val otherEvent = migrationRequestEvents.generateOne
+
+      inSequence {
+        givenEventFinder(returns = Some(event))
+        givenSending(event, to = event.subscriberUrl, got = Misdelivered)
+        givenDispatchRecoveryExists(event)
+        (subscribers.delete _)
+          .expects(event.subscriberUrl)
+          .returning(exception.raiseError[IO, Unit])
+
+        givenEventFinder(returns = Some(otherEvent))
+        givenSending(otherEvent, to = otherEvent.subscriberUrl, got = Delivered)
+        givenDispatchRecoveryExists(otherEvent)
+
+        givenNoMoreEvents()
+      }
+
+      distributor.run().unsafeRunAndForget()
+
+      eventually {
+        logger.loggedOnly(
+          Info(show"$categoryName: $event, subscriber = ${event.subscriberUrl} -> $Misdelivered"),
+          Error(show"$categoryName: $event -> deleting subscriber failed", exception),
+          Info(show"$categoryName: $otherEvent, subscriber = ${otherEvent.subscriberUrl} -> $Delivered")
+        )
+      }
+    }
+
+    "log an error when returning event back to the queue fails" in new TestCase {
+
+      val event                   = migrationRequestEvents.generateOne
+      val backToTheQueueException = exceptions.generateOne
+      val otherEvent              = migrationRequestEvents.generateOne
+
+      inSequence {
+
+        givenEventFinder(returns = Some(event))
+        givenSending(event, to = event.subscriberUrl, got = TemporarilyUnavailable)
+        givenDispatchRecoveryExists(event)
+        expectEventReturnedToTheQueue(event,
+                                      reason = TemporarilyUnavailable,
+                                      got = backToTheQueueException.raiseError[IO, Unit]
+        )
+
+        givenEventFinder(returns = Some(otherEvent))
+        givenSending(otherEvent, to = otherEvent.subscriberUrl, got = Delivered)
+        givenDispatchRecoveryExists(otherEvent)
+
+        givenNoMoreEvents()
+      }
+
+      distributor.run().unsafeRunAndForget()
+
+      eventually {
+        logger.loggedOnly(
+          Error(show"$categoryName: $event -> returning event to the queue failed", backToTheQueueException),
+          Info(show"$categoryName: $otherEvent, subscriber = ${otherEvent.subscriberUrl} -> $Delivered")
+        )
+      }
+    }
+  }
+
+  private trait TestCase {
+
+    val subscribers              = mock[Subscribers[IO, Subscription.Subscriber]]
+    val eventsFinder             = mock[EventFinder[IO]]
+    val eventsSender             = mock[EventsSender[IO, MigrationRequestEvent]]
+    private val dispatchRecovery = mock[DispatchRecovery[IO, MigrationRequestEvent]]
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val distributor = new MigrationEventsDistributorImpl[IO](
+      categoryName,
+      subscribers,
+      eventsFinder,
+      eventsSender,
+      dispatchRecovery,
+      noEventSleep = 250 millis,
+      onErrorSleep = 250 millis
+    )
+
+    val dispatchRecoveryStrategy = mockFunction[Throwable, IO[Unit]]
+
+    def expectEventReturnedToTheQueue(event: MigrationRequestEvent, reason: SendingResult, got: IO[Unit]) =
+      (dispatchRecovery.returnToQueue _)
+        .expects(event, reason)
+        .returning(got)
+
+    def givenDispatchRecoveryExists(event: MigrationRequestEvent,
+                                    returning: PartialFunction[Throwable, IO[Unit]] =
+                                      new PartialFunction[Throwable, IO[Unit]] {
+                                        override def isDefinedAt(x: Throwable) = true
+
+                                        override def apply(throwable: Throwable) = dispatchRecoveryStrategy(throwable)
+                                      }
+    ) = (dispatchRecovery.recover _)
+      .expects(event.subscriberUrl, event)
+      .returning(returning)
+
+    def givenNoMoreEvents() =
+      (eventsFinder.popEvent _)
+        .expects()
+        .returning(Option.empty[MigrationRequestEvent].pure[IO])
+        .anyNumberOfTimes()
+
+    def expectRemoval(of: SubscriberUrl) =
+      (subscribers.delete _)
+        .expects(of)
+        .returning(IO.unit)
+
+    def givenEventFinder(returns: Option[MigrationRequestEvent]) =
+      (eventsFinder.popEvent _)
+        .expects()
+        .returning(returns.pure[IO])
+
+    def givenSending(event: MigrationRequestEvent, to: SubscriberUrl, got: SendingResult): Any =
+      (eventsSender.sendEvent _)
+        .expects(to, event)
+        .returning(got.pure[IO])
+  }
+}

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationRequestEventSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationRequestEventSpec.scala
@@ -20,10 +20,8 @@ package io.renku.eventlog.events.producers.tsmigrationrequest
 
 import cats.syntax.all._
 import io.circe.literal._
-import io.renku.events.Generators.subscriberUrls
-import io.renku.generators.CommonGraphGenerators.serviceVersions
 import io.renku.generators.Generators.Implicits._
-import org.scalacheck.Gen
+import Generators.migrationRequestEvents
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -32,7 +30,8 @@ class MigrationRequestEventSpec extends AnyWordSpec with should.Matchers {
   "encodeEvent" should {
 
     "serialize MemberSyncEvent to Json" in {
-      val event = events.generateOne
+
+      val event = migrationRequestEvents.generateOne
 
       MigrationRequestEvent.encodeEvent(event) shouldBe json"""{
         "categoryName": "TS_MIGRATION_REQUEST",
@@ -46,14 +45,10 @@ class MigrationRequestEventSpec extends AnyWordSpec with should.Matchers {
   "show" should {
 
     "return String representation of the event containing url and version" in {
-      val event = events.generateOne
 
-      event.show shouldBe show"""subscriberVersion = ${event.subscriberVersion}"""
+      val event = migrationRequestEvents.generateOne
+
+      event.show shouldBe show"""subscriberUrl = ${event.subscriberUrl}, subscriberVersion = ${event.subscriberVersion}"""
     }
   }
-
-  private lazy val events: Gen[MigrationRequestEvent] = for {
-    url     <- subscriberUrls
-    version <- serviceVersions
-  } yield MigrationRequestEvent(url, version)
 }


### PR DESCRIPTION
There is a bug where ts `TS_MIGRATION_REQUEST` events producer sends an event not to the subscriber specified in the found event but to any free subscriber in the registry. This PR changes the logic so that once an event is scheduled for execution on a subscriber, the event will never be sent to another subscriber as long as the initial subscriber is busy running the task