### PR TITLE
fix: Throttler not to die losing semaphore permit

### DIFF
--- a/graph-commons/src/main/scala/io/renku/control/Throttler.scala
+++ b/graph-commons/src/main/scala/io/renku/control/Throttler.scala
@@ -19,75 +19,60 @@
 package io.renku.control
 
 import cats.MonadThrow
+import cats.effect._
 import cats.effect.kernel.Clock
 import cats.effect.std.Semaphore
-import cats.effect.{Concurrent, Ref, Temporal}
 import cats.syntax.all._
 
-import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 
 trait Throttler[F[_], +ThrottlingTarget] {
-  def acquire(): F[Unit]
-  def release(): F[Unit]
+  def throttle[O](value: F[O]): F[O]
 }
 
-final class StandardThrottler[F[_]: MonadThrow: Temporal: Clock, ThrottlingTarget] private[control] (
-    rateLimit:         RateLimit[ThrottlingTarget],
-    semaphore:         Semaphore[F],
-    workersStartTimes: Ref[F, List[Long]]
+final class StandardThrottler[F[_]: MonadThrow: Async: Clock, ThrottlingTarget] private[control] (
+    rateLimit: RateLimit[ThrottlingTarget],
+    semaphore: Semaphore[F]
 ) extends Throttler[F, ThrottlingTarget] {
 
-  private val MinTimeGap       = (rateLimit.per.multiplierFor(NANOSECONDS) / rateLimit.items.value).toLong
-  private val NextAttemptSleep = FiniteDuration(MinTimeGap / 10, TimeUnit.NANOSECONDS)
+  private val MinTimeGap        = (rateLimit.per.multiplierFor(NANOSECONDS) / rateLimit.items.value).toLong
+  private val NextAttemptSleep  = FiniteDuration(MinTimeGap / 10, NANOSECONDS)
+  private val previousStartedAt = Ref.unsafe[F, Long](0L)
 
-  override def acquire(): F[Unit] = for {
-    _          <- semaphore.acquire
-    startTimes <- workersStartTimes.get
-    now        <- Clock[F].monotonic
-    _          <- verifyThroughput(startTimes, now.toNanos)
-  } yield ()
+  override def throttle[O](value: F[O]): F[O] =
+    waitIfTooFast >> value
 
-  private def verifyThroughput(startTimes: List[Long], now: Long) =
-    if (notTooEarly(startTimes, now)) for {
-      _ <- workersStartTimes.modify(old => (startTimes :+ now) -> old)
-      _ <- semaphore.release
-    } yield ()
-    else
-      for {
-        _ <- semaphore.release
-        _ <- Temporal[F] sleep NextAttemptSleep
-        _ <- acquire()
-      } yield ()
-
-  private def notTooEarly(startTimes: List[Long], now: Long): Boolean = {
-    val (_, durations) = (startTimes.tail :+ now).foldLeft(startTimes.head -> List.empty[Long]) {
-      case ((previous, durationsSoFar), current) =>
-        current -> (durationsSoFar :+ (current - previous))
+  private def waitIfTooFast: F[Unit] =
+    semaphore.tryPermit.use[Unit] {
+      case true =>
+        waitIfTooEarlyForNext >>
+          updateStartedAt()
+      case false =>
+        Temporal[F].delayBy(waitIfTooFast, NextAttemptSleep)
     }
 
-    durations.forall(_ >= MinTimeGap)
-  }
+  private def waitIfTooEarlyForNext: F[Unit] =
+    (previousStartedAt.get -> now)
+      .flatMapN {
+        case (previousStartedAt, now) if (now - previousStartedAt) >= MinTimeGap => ().pure[F]
+        case _ => Temporal[F].delayBy(waitIfTooEarlyForNext, NextAttemptSleep)
+      }
 
-  override def release(): F[Unit] = for {
-    _ <- semaphore.acquire
-    _ <- workersStartTimes.modify(old => old.tail -> old)
-    _ <- semaphore.release
-  } yield ()
+  private def updateStartedAt() =
+    now >>= previousStartedAt.set
+
+  private def now = Clock[F].monotonic.map(_.toNanos)
 }
 
 object Throttler {
 
-  def apply[F[_]: Concurrent: Temporal: Clock, ThrottlingTarget](
+  def apply[F[_]: Concurrent: Async: Clock, ThrottlingTarget](
       rateLimit: RateLimit[ThrottlingTarget]
-  ): F[Throttler[F, ThrottlingTarget]] = for {
-    semaphore         <- Semaphore[F](1)
-    workersStartTimes <- Clock[F].monotonic flatMap (now => Ref.of(List(now.toNanos)))
-  } yield new StandardThrottler[F, ThrottlingTarget](rateLimit, semaphore, workersStartTimes)
+  ): F[Throttler[F, ThrottlingTarget]] =
+    Semaphore[F](1).map(new StandardThrottler[F, ThrottlingTarget](rateLimit, _))
 
   def noThrottling[F[_]: MonadThrow]: Throttler[F, Nothing] =
     new Throttler[F, Nothing] {
-      override def acquire(): F[Unit] = ().pure[F]
-      override def release(): F[Unit] = ().pure[F]
+      override def throttle[O](value: F[O]): F[O] = value
     }
 }


### PR DESCRIPTION
This is a fix for a really nasty bug we couldn't find for quite some time. It was caused by the wrong usage of a semaphore inside the HTTP client Throttler.