### PR TITLE
fix: Retain gitlab images when converting from cli payload

### DIFF
--- a/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
@@ -52,6 +52,7 @@ private[entities] object CliProjectConverter {
       case s              => s
     }
     val dateCreated = (gitLabInfo.dateCreated :: cliProject.dateCreated :: Nil).min
+    val gitlabImage = gitLabInfo.avatarUrl.map(Image.projectImage(ResourceId(gitLabInfo.path), _))
     val all         = (creatorV, allPersonV, datasetV, activityV, planV).mapN(Tuple5.apply)
     all.andThen { case (creator, persons, datasets, activities, plans) =>
       newProject(
@@ -65,7 +66,7 @@ private[entities] object CliProjectConverter {
         activities.sortBy(_.startTime),
         datasets,
         plans,
-        cliProject.images
+        (cliProject.images ::: gitlabImage.toList).distinct
       )
     }
   }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/triplesgenerated/EntityBuilder.scala
@@ -48,7 +48,6 @@ private class EntityBuilderImpl[F[_]: MonadThrow](
   private val applicative:               Applicative[F] = Applicative[F]
 
   import applicative._
-  import projectInfoFinder._
 
   override def buildEntity(event: TriplesGeneratedEvent)(implicit
       maybeAccessToken: Option[AccessToken]
@@ -59,7 +58,7 @@ private class EntityBuilderImpl[F[_]: MonadThrow](
 
   private def findValidProjectInfo(event: TriplesGeneratedEvent)(implicit
       maybeAccessToken: Option[AccessToken]
-  ) = findProjectInfo(event.project.path) semiflatMap {
+  ) = projectInfoFinder.findProjectInfo(event.project.path) semiflatMap {
     case Some(projectInfo) => projectInfo.pure[F]
     case None =>
       ProcessingNonRecoverableError


### PR DESCRIPTION
The images must be taken from gitlab's project info as well when converting a cli payload.

/deploy #persist