### PR TITLE
chore: dev cli version to be installed on startup in background

### DIFF
--- a/graph-commons/src/main/scala/io/renku/config/ConfigLoader.scala
+++ b/graph-commons/src/main/scala/io/renku/config/ConfigLoader.scala
@@ -44,9 +44,7 @@ object ConfigLoader {
     ConfigSource.fromConfig(config).at(key).load[T]
   }
 
-  private def fromEither[F[_]: MonadThrow, T](
-      loadedConfig: ConfigReaderFailures Either T
-  ): F[T] =
+  private def fromEither[F[_]: MonadThrow, T](loadedConfig: ConfigReaderFailures Either T): F[T] =
     MonadThrow[F].fromEither[T] {
       loadedConfig leftMap (new ConfigLoadingException(_))
     }
@@ -77,6 +75,5 @@ object ConfigLoader {
               .leftMap(exception => CannotConvert(stringValue, ttApply.getClass.toString, exception.getMessage))
           }
           .getOrElse(Left(CannotConvert(stringValue, ttApply.getClass.toString, "Not an int value")))
-
       }
 }

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -26,12 +26,11 @@ COPY --from=builder /work/triples-generator/target/universal/stage .
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV TZ UTC
 
-# Installing Renku and other dependencies
+# Installing Renku dependencies other tools
 RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py3-pip py3-wheel openssl-dev libffi-dev linux-headers gcc g++ make libxml2-dev libxslt-dev libc-dev yaml-dev 'rust>1.41.0' cargo tini && \
     python3 -m pip install --ignore-installed 'packaging==21.3 '&& \
     python3 -m pip install --upgrade 'pip==23.0.1' && \
     python3 -m pip install jinja2 && \
-    python3 -m pip install 'renku==2.3.2' 'sentry-sdk==1.5.11'  && \
     chown -R daemon:daemon .
 
 COPY triples-generator/entrypoint.sh /entrypoint.sh
@@ -42,6 +41,9 @@ RUN adduser --disabled-password -g "$GID" -D -u 1000 tguser && \
     chmod 555 -R /entrypoint.sh
 
 USER tguser
+
+# Installing Renku
+RUN python3 -m pip install 'renku==2.3.2' 'sentry-sdk==1.5.11'
 
 RUN git config --global user.name 'renku'  && \
     git config --global user.email 'renku@renkulab.io'  && \

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -29,7 +29,7 @@ ENV TZ UTC
 # Installing Renku dependencies other tools
 RUN apk update && apk add --no-cache tzdata git git-lfs curl bash python3-dev py3-pip py3-wheel openssl-dev libffi-dev linux-headers gcc g++ make libxml2-dev libxslt-dev libc-dev yaml-dev 'rust>1.41.0' cargo tini && \
     python3 -m pip install --ignore-installed 'packaging==21.3 '&& \
-    python3 -m pip install --upgrade 'pip==23.0.1' && \
+    python3 -m pip install --upgrade 'pip==23.1.2' && \
     python3 -m pip install jinja2 && \
     chown -R daemon:daemon .
 
@@ -41,6 +41,8 @@ RUN adduser --disabled-password -g "$GID" -D -u 1000 tguser && \
     chmod 555 -R /entrypoint.sh
 
 USER tguser
+
+ENV PATH=$PATH:/home/tguser/.local/bin
 
 # Installing Renku
 RUN python3 -m pip install 'renku==2.3.2' 'sentry-sdk==1.5.11'

--- a/triples-generator/entrypoint.sh
+++ b/triples-generator/entrypoint.sh
@@ -3,7 +3,7 @@
 if [ ! -z "$RENKU_PYTHON_DEV_VERSION" ]
 then
     /usr/bin/python3 -m pip uninstall --yes renku && \
-    /usr/bin/python3 -m pip install 'renku==${RENKU_PYTHON_DEV_VERSION}' &
+    /usr/bin/python3 -m pip install renku==${RENKU_PYTHON_DEV_VERSION} &
 fi
 
 # run the command

--- a/triples-generator/entrypoint.sh
+++ b/triples-generator/entrypoint.sh
@@ -3,7 +3,7 @@
 if [ ! -z "$RENKU_PYTHON_DEV_VERSION" ]
 then
     /usr/bin/python3 -m pip uninstall --yes renku && \
-    /usr/bin/python3 -m pip install ${RENKU_PYTHON_DEV_VERSION} &
+    /usr/bin/python3 -m pip install 'renku==${RENKU_PYTHON_DEV_VERSION}' &
 fi
 
 # run the command

--- a/triples-generator/entrypoint.sh
+++ b/triples-generator/entrypoint.sh
@@ -2,8 +2,8 @@
 
 if [ ! -z "$RENKU_PYTHON_DEV_VERSION" ]
 then
-    /usr/bin/python3 -m pip uninstall --yes renku
-    /usr/bin/python3 -m pip install ${RENKU_PYTHON_DEV_VERSION}
+    /usr/bin/python3 -m pip uninstall --yes renku && \
+    /usr/bin/python3 -m pip install ${RENKU_PYTHON_DEV_VERSION} &
 fi
 
 # run the command

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/config/RenkuPythonDevVersionConfig.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/config/RenkuPythonDevVersionConfig.scala
@@ -18,11 +18,14 @@
 
 package io.renku.triplesgenerator.config
 
-import cats.MonadThrow
+import cats.{MonadThrow, Show}
 import com.typesafe.config.{Config, ConfigFactory}
 import pureconfig.ConfigReader
 
-final case class RenkuPythonDevVersion(version: String) extends Product with Serializable
+final case class RenkuPythonDevVersion(version: String)
+object RenkuPythonDevVersion {
+  implicit lazy val show: Show[RenkuPythonDevVersion] = Show.show(_.version)
+}
 
 object RenkuPythonDevVersionConfig {
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/config/RenkuPythonDevVersionConfigSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/config/RenkuPythonDevVersionConfigSpec.scala
@@ -20,7 +20,7 @@ package io.renku.triplesgenerator.config
 
 import com.typesafe.config.ConfigFactory
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.nonEmptyStrings
+import io.renku.generators.Generators.{blankStrings, nonEmptyStrings}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -28,13 +28,19 @@ import scala.jdk.CollectionConverters._
 import scala.util.{Success, Try}
 
 class RenkuPythonDevVersionConfigSpec extends AnyWordSpec with should.Matchers {
+
   "apply" should {
+
     "return Some(version) if there is a value set" in {
       val version = nonEmptyStrings().generateOne
       val config = ConfigFactory.parseMap(
         Map("renku-python-dev-version" -> version).asJava
       )
       RenkuPythonDevVersionConfig[Try](config) shouldBe Success(Some(RenkuPythonDevVersion(version)))
+    }
+
+    "return None if there is no entry" in {
+      RenkuPythonDevVersionConfig[Try](ConfigFactory.empty) shouldBe Success(None)
     }
 
     "return None if there is no value set" in {
@@ -47,7 +53,7 @@ class RenkuPythonDevVersionConfigSpec extends AnyWordSpec with should.Matchers {
     "return None if there is an empty string" in {
 
       val config = ConfigFactory.parseMap(
-        Map("renku-python-dev-version" -> nonEmptyStrings().generateOne.map(_ => ' ')).asJava
+        Map("renku-python-dev-version" -> blankStrings().generateOne).asJava
       )
       RenkuPythonDevVersionConfig[Try](config) shouldBe Success(None)
     }


### PR DESCRIPTION
There's a requirement that renku acceptance tests should be able to use a renku cli release candidate version. For this reason TG would have to be running the same rc version as other components in the deployment. This PR changes TG's `entry-point.sh` to make the cli version swapping be done in the background to ensure TG starts (and provides the /ping endpoint for k8s) while the cli re-installation is done.

/deploy #persist