### PR TITLE
fix: project members to be found from project/id/members/all

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
@@ -120,7 +120,7 @@ final class GitLabApiStub[F[_]: Async: Logger](private val stateRef: Ref[F, Stat
         case HEAD -> Root / ProjectPath(path) =>
           query(findProjectByPath(path, maybeAuthedReq)).flatMap(EmptyOkOrNotFound(_))
 
-        case GET -> Root / ProjectPath(path) / ("users" | "members") =>
+        case GET -> Root / ProjectPath(path) / "members" / "all" =>
           query(findProjectByPath(path, maybeAuthedReq))
             .map(_.toList.flatMap(_.members.toList))
             .flatMap(Ok(_))

--- a/graph-commons/src/main/scala/io/renku/graph/http/server/security/GitLabPathRecordsFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/http/server/security/GitLabPathRecordsFinder.scala
@@ -89,7 +89,7 @@ private trait MembersFinder[F[_]] {
 private class MembersFinderImpl[F[_]: Async: GitLabClient: Logger] extends MembersFinder[F] {
 
   override def findMembers(path: projects.Path)(implicit mat: Option[AccessToken]): F[Set[persons.GitLabId]] =
-    fetch(uri"projects" / path / "members")
+    fetch(uri"projects" / path / "members" / "all")
 
   private def fetch(
       uri:        Uri,

--- a/graph-commons/src/test/scala/io/renku/graph/http/server/security/MembersFinderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/graph/http/server/security/MembersFinderSpec.scala
@@ -113,7 +113,7 @@ class MembersFinderSpec
       val endpointName: String Refined NonEmpty = "project-members"
 
       val uri = {
-        val uri = uri"projects" / projectPath / "members"
+        val uri = uri"projects" / projectPath / "members" / "all"
         maybePage match {
           case Some(page) => uri withQueryParam ("page", page.toString)
           case None       => uri

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/EventHandler.scala
@@ -63,7 +63,7 @@ private object EventHandler {
   ): F[consumers.EventHandler[F]] = for {
     tsReadinessChecker  <- TSReadinessForEventsChecker[F]
     membersSynchronizer <- MembersSynchronizer[F]
-    processExecutor     <- ProcessExecutor.concurrent(processesCount = 10)
+    processExecutor     <- ProcessExecutor.concurrent(processesCount = 1)
   } yield new EventHandler[F](categoryName,
                               tsReadinessChecker,
                               membersSynchronizer,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGPersonFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGPersonFinder.scala
@@ -21,22 +21,29 @@ package namedgraphs
 
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.graph.model.{persons, GraphClass}
 import io.renku.graph.model.Schemas.schema
 import io.renku.graph.model.entities.Person
 import io.renku.graph.model.persons.{GitLabId, ResourceId}
-import io.renku.triplesstore._
+import io.renku.graph.model.{GraphClass, persons}
 import io.renku.triplesstore.ResultsDecoder._
 import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
 import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
 
 private trait KGPersonFinder[F[_]] {
   def findPersonIds(membersToAdd: Set[GitLabProjectMember]): F[Set[(GitLabProjectMember, Option[ResourceId])]]
 }
 
 private class KGPersonFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    connectionConfig: ProjectsConnectionConfig
-) extends TSClientImpl(connectionConfig)
+    connectionConfig: ProjectsConnectionConfig,
+    idleTimeout:      Duration = 21 minutes,
+    requestTimeout:   Duration = 20 minutes
+) extends TSClientImpl(connectionConfig,
+                       idleTimeoutOverride = idleTimeout.some,
+                       requestTimeoutOverride = requestTimeout.some
+    )
     with KGPersonFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGProjectMembersFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGProjectMembersFinder.scala
@@ -32,15 +32,21 @@ import io.renku.triplesstore._
 import io.renku.triplesstore.ResultsDecoder._
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import org.typelevel.log4cats.Logger
+import scala.concurrent.duration._
 
 private trait KGProjectMembersFinder[F[_]] {
   def findProjectMembers(path: projects.Path): F[Set[KGProjectMember]]
 }
 
 private class KGProjectMembersFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
-    connectionConfig: ProjectsConnectionConfig
+    connectionConfig: ProjectsConnectionConfig,
+    idleTimeout:      Duration = 21 minutes,
+    requestTimeout:   Duration = 20 minutes
 )(implicit renkuUrl: RenkuUrl)
-    extends TSClientImpl(connectionConfig)
+    extends TSClientImpl(connectionConfig,
+                         idleTimeoutOverride = idleTimeout.some,
+                         requestTimeoutOverride = requestTimeout.some
+    )
     with KGProjectMembersFinder[F] {
 
   import eu.timepit.refined.auto._

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGSynchronizer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGSynchronizer.scala
@@ -36,8 +36,8 @@ private[membersync] object KGSynchronizer {
       updatesCreator         <- UpdatesCreator[F]
       connectionConfig       <- ProjectsConnectionConfig[F]()
       tsClient <- TSClient[F](connectionConfig,
-                              idleTimeoutOverride = (11 minutes).some,
-                              requestTimeoutOverride = (10 minutes).some
+                              idleTimeoutOverride = (21 minutes).some,
+                              requestTimeoutOverride = (20 minutes).some
                   ).pure[F]
     } yield new KGSynchronizerImpl[F](kgProjectMembersFinder, kgPersonFinder, updatesCreator, tsClient)
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/projectinfo/ProjectMembersFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/projectinfo/ProjectMembersFinder.scala
@@ -26,8 +26,8 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection.NonEmpty
 import io.circe.Decoder
-import io.renku.graph.model.{persons, projects}
 import io.renku.graph.model.entities.Project.ProjectMember
+import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
 import io.renku.triplesgenerator.events.consumers.tsprovisioning.RecoverableErrorsRecovery
@@ -53,15 +53,13 @@ private class ProjectMembersFinderImpl[F[_]: Async: NonEmptyParallel: GitLabClie
     recoveryStrategy: RecoverableErrorsRecovery = RecoverableErrorsRecovery
 ) extends ProjectMembersFinder[F] {
 
+  import io.renku.http.tinytypes.TinyTypeURIEncoder._
   import io.renku.tinytypes.json.TinyTypeDecoders._
 
-  override def findProjectMembers(path: projects.Path)(implicit
-      maybeAccessToken: Option[AccessToken]
-  ): EitherT[F, ProcessingRecoverableError, Set[ProjectMember]] = EitherT {
-    (
-      fetch(uri"projects" / path.show / "members", "project-members"),
-      fetch(uri"projects" / path.show / "users", "project-users")
-    ).parMapN(_ ++ _)
+  override def findProjectMembers(
+      path: projects.Path
+  )(implicit mat: Option[AccessToken]): EitherT[F, ProcessingRecoverableError, Set[ProjectMember]] = EitherT {
+    fetch(uri"projects" / path / "members" / "all")
       .map(_.asRight[ProcessingRecoverableError])
       .recoverWith(recoveryStrategy.maybeRecoverableError)
   }
@@ -75,15 +73,16 @@ private class ProjectMembersFinderImpl[F[_]: Async: NonEmptyParallel: GitLabClie
 
   private implicit lazy val membersDecoder: EntityDecoder[F, List[ProjectMember]] = jsonOf[F, List[ProjectMember]]
 
+  private val endpointName: String Refined NonEmpty = "project-members"
+
   private def fetch(
-      uri:          Uri,
-      endpointName: String Refined NonEmpty,
-      maybePage:    Option[Int] = None,
-      allMembers:   Set[ProjectMember] = Set.empty
+      uri:        Uri,
+      maybePage:  Option[Int] = None,
+      allMembers: Set[ProjectMember] = Set.empty
   )(implicit maybeAccessToken: Option[AccessToken]): F[Set[ProjectMember]] = for {
     uri                     <- uriWithPage(uri, maybePage).pure[F]
     fetchedUsersAndNextPage <- GitLabClient[F].get(uri, endpointName)(mapResponse)
-    allMembers              <- addNextPage(uri, endpointName, allMembers, fetchedUsersAndNextPage)
+    allMembers              <- addNextPage(uri, allMembers, fetchedUsersAndNextPage)
   } yield allMembers
 
   private def uriWithPage(uri: Uri, maybePage: Option[Int]) = maybePage match {
@@ -101,13 +100,11 @@ private class ProjectMembersFinderImpl[F[_]: Async: NonEmptyParallel: GitLabClie
 
   private def addNextPage(
       url:                          Uri,
-      endpointName:                 String Refined NonEmpty,
       allMembers:                   Set[ProjectMember],
       fetchedUsersAndMaybeNextPage: (Set[ProjectMember], Option[Int])
   )(implicit maybeAccessToken: Option[AccessToken]): F[Set[ProjectMember]] =
     fetchedUsersAndMaybeNextPage match {
-      case (fetchedUsers, maybeNextPage @ Some(_)) =>
-        fetch(url, endpointName, maybeNextPage, allMembers ++ fetchedUsers)
-      case (fetchedUsers, None) => (allMembers ++ fetchedUsers).pure[F]
+      case (fetchedUsers, maybeNextPage @ Some(_)) => fetch(url, maybeNextPage, allMembers ++ fetchedUsers)
+      case (fetchedUsers, None)                    => (allMembers ++ fetchedUsers).pure[F]
     }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/GitLabProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/GitLabProjectMembersFinderSpec.scala
@@ -126,8 +126,7 @@ class GitLabProjectMembersFinderSpec
         override val mapResponse =
           captureMapping(gitLabClient)(
             finder.findProjectMembers(path)(maybeAccessToken).unsafeRunSync(),
-            Gen.const((Set.empty[GitLabProjectMember], Option.empty[Int])),
-            expectedNumberOfCalls = 2
+            Gen.const((Set.empty[GitLabProjectMember], Option.empty[Int]))
           )
 
         setGitLabClientExpectation(path, maybePage = None, maybeAccessTokenOverride = None, returning = (members, None))
@@ -142,8 +141,7 @@ class GitLabProjectMembersFinderSpec
         override val mapResponse =
           captureMapping(gitLabClient)(
             finder.findProjectMembers(path)(maybeAccessToken).unsafeRunSync(),
-            Gen.const((Set.empty[GitLabProjectMember], Option.empty[Int])),
-            expectedNumberOfCalls = 2
+            Gen.const((Set.empty[GitLabProjectMember], Option.empty[Int]))
           )
 
         val actual   = mapResponse(status, Request(), Response()).unsafeRunSync()
@@ -188,8 +186,7 @@ class GitLabProjectMembersFinderSpec
     val mapResponse =
       captureMapping(gitLabClient)(
         finder.findProjectMembers(path)(maybeAccessToken).unsafeRunSync(),
-        Gen.const((Set.empty[GitLabProjectMember], Option.empty[Int])),
-        expectedNumberOfCalls = 2
+        Gen.const((Set.empty[GitLabProjectMember], Option.empty[Int]))
       )
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/projectinfo/ProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/projectinfo/ProjectMembersFinderSpec.scala
@@ -150,8 +150,7 @@ class ProjectMembersFinderSpec
     val mapResponse =
       captureMapping(gitLabClient)(
         finder.findProjectMembers(projectPath)(maybeAccessToken).value.unsafeRunSync(),
-        Gen.const((Set.empty[ProjectMemberNoEmail], Option.empty[Int])),
-        expectedNumberOfCalls = 2
+        Gen.const((Set.empty[ProjectMemberNoEmail], Option.empty[Int]))
       )
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/projectinfo/ProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/projectinfo/ProjectMembersFinderSpec.scala
@@ -36,6 +36,7 @@ import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.http.client.RestClientError.UnexpectedResponseException
 import io.renku.http.client.{AccessToken, GitLabClient}
+import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.interpreters.TestLogger
 import io.renku.stubbing.ExternalServiceStubbing
 import io.renku.testtools.{GitLabClientTools, IOSpec}
@@ -46,17 +47,17 @@ import org.http4s.implicits.http4sLiteralsSyntax
 import org.http4s.{Request, Response, Status, Uri}
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-
-import scala.util.Random
 
 class ProjectMembersFinderSpec
     extends AnyWordSpec
     with IOSpec
     with ExternalServiceStubbing
     with should.Matchers
+    with EitherValues
     with GitLabClientTools[IO]
     with MockFactory
     with ScalaCheckPropertyChecks {
@@ -64,41 +65,28 @@ class ProjectMembersFinderSpec
   "findProject" should {
 
     "fetch and merge project users and members" in new TestCase {
-      forAll { (members: Set[ProjectMemberNoEmail], users: Set[ProjectMemberNoEmail]) =>
-        setGitLabClientExpectationUsers(projectPath, returning = (users, None).pure[IO])
-        setGitLabClientExpectationMembers(projectPath, returning = (members, None).pure[IO])
+      forAll { members: Set[ProjectMemberNoEmail] =>
+        setGitLabClientExpectation(projectPath, returning = (members, None).pure[IO])
 
-        finder.findProjectMembers(projectPath).value.unsafeRunSync() shouldBe (members ++ users).asRight
+        finder.findProjectMembers(projectPath).value.unsafeRunSync().value shouldBe members
       }
     }
 
     "collect members from all the pages" in new TestCase {
-      val allMembers = projectMembersNoEmail.generateFixedSizeList(4)
 
-      val (users, members) = allMembers.splitAt(allMembers.size / 2)
+      val members = projectMembersNoEmail.generateFixedSizeSet(ofSize = 4)
 
-      setGitLabClientExpectationUsers(projectPath, returning = (Set(users.head), 2.some).pure[IO])
-      setGitLabClientExpectationUsers(projectPath, maybePage = 2.some, returning = (users.tail.toSet, None).pure[IO])
-      setGitLabClientExpectationMembers(projectPath, returning = (Set(members.head), 2.some).pure[IO])
-      setGitLabClientExpectationMembers(projectPath,
-                                        maybePage = 2.some,
-                                        returning = (members.tail.toSet, None).pure[IO]
-      )
+      setGitLabClientExpectation(projectPath, returning = (Set(members.head), 2.some).pure[IO])
+      setGitLabClientExpectation(projectPath, maybePage = 2.some, returning = (members.tail, None).pure[IO])
 
-      finder.findProjectMembers(projectPath).value.unsafeRunSync() shouldBe allMembers.toSet.asRight
+      finder.findProjectMembers(projectPath).value.unsafeRunSync().value shouldBe members
     }
 
-    "return members even if one of the endpoints responds with NOT_FOUND" in new TestCase {
-      val members = projectMembersNoEmail.generateSet()
-      if (Random.nextBoolean()) {
-        setGitLabClientExpectationUsers(projectPath, returning = (Set.empty[ProjectMemberNoEmail], None).pure[IO])
-        setGitLabClientExpectationMembers(projectPath, returning = (members, None).pure[IO])
-      } else {
-        setGitLabClientExpectationUsers(projectPath, returning = (members, None).pure[IO])
-        setGitLabClientExpectationMembers(projectPath, returning = (Set.empty[ProjectMemberNoEmail], None).pure[IO])
-      }
+    "return an empty set even if GL endpoint responds with NOT_FOUND" in new TestCase {
 
-      finder.findProjectMembers(projectPath).value.unsafeRunSync() shouldBe members.asRight
+      setGitLabClientExpectation(projectPath, returning = (Set.empty[ProjectMemberNoEmail], None).pure[IO])
+
+      finder.findProjectMembers(projectPath).value.unsafeRunSync().value shouldBe Set.empty
     }
 
     val errorMessage = nonEmptyStrings().generateOne
@@ -108,19 +96,11 @@ class ProjectMembersFinderSpec
       "Forbidden"          -> UnexpectedResponseException(Forbidden, errorMessage),
       "Unauthorized"       -> UnexpectedResponseException(Unauthorized, errorMessage)
     ) foreach { case (problemName, error) =>
-      s"return a Recoverable Failure for $problemName when fetching project members or users" in new TestCase {
-        if (Random.nextBoolean()) {
-          setGitLabClientExpectationUsers(projectPath, returning = (Set.empty[ProjectMemberNoEmail], None).pure[IO])
-            .noMoreThanOnce()
-          setGitLabClientExpectationMembers(projectPath, returning = IO.raiseError(error))
-        } else {
-          setGitLabClientExpectationUsers(projectPath, returning = IO.raiseError(error))
-          setGitLabClientExpectationMembers(projectPath, returning = (Set.empty[ProjectMemberNoEmail], None).pure[IO])
-            .noMoreThanOnce()
-        }
+      s"return a Recoverable Failure for $problemName when fetching project members" in new TestCase {
 
-        val Left(failure) = finder.findProjectMembers(projectPath).value.unsafeRunSync()
-        failure shouldBe a[ProcessingRecoverableError]
+        setGitLabClientExpectation(projectPath, returning = IO.raiseError(error))
+
+        finder.findProjectMembers(projectPath).value.unsafeRunSync().left.value shouldBe a[ProcessingRecoverableError]
       }
     }
 
@@ -146,24 +126,13 @@ class ProjectMembersFinderSpec
     implicit val gitLabClient:   GitLabClient[IO] = mock[GitLabClient[IO]]
     val finder = new ProjectMembersFinderImpl[IO]
 
-    def setGitLabClientExpectationUsers(projectPath: projects.Path,
-                                        maybePage:   Option[Int] = None,
-                                        returning:   IO[(Set[ProjectMemberNoEmail], Option[Int])]
-    ) = setGitLabClientExpectation(projectPath, "users", "project-users", maybePage, returning)
-
-    def setGitLabClientExpectationMembers(projectPath: projects.Path,
-                                          maybePage:   Option[Int] = None,
-                                          returning:   IO[(Set[ProjectMemberNoEmail], Option[Int])]
-    ) = setGitLabClientExpectation(projectPath, "members", "project-members", maybePage, returning)
-
-    private def setGitLabClientExpectation(projectPath:  projects.Path,
-                                           endpoint:     String,
-                                           endpointName: String Refined NonEmpty,
-                                           maybePage:    Option[Int] = None,
-                                           returning:    IO[(Set[ProjectMemberNoEmail], Option[Int])]
+    def setGitLabClientExpectation(projectPath: projects.Path,
+                                   maybePage:   Option[Int] = None,
+                                   returning:   IO[(Set[ProjectMemberNoEmail], Option[Int])]
     ) = {
+      val endpointName: String Refined NonEmpty = "project-members"
       val uri = {
-        val uri = uri"projects" / projectPath.show / endpoint
+        val uri = uri"projects" / projectPath / "members" / "all"
         maybePage match {
           case Some(page) => uri withQueryParam ("page", page.toString)
           case None       => uri
@@ -193,5 +162,4 @@ class ProjectMembersFinderSpec
       "username": ${member.username}
     }"""
   }
-
 }


### PR DESCRIPTION
The GL's `/projects/:id/members` API that was used to fetch project members does return only direct project members. The `/projects/:id/members/all` should be used instead.