### PR TITLE
feat: viewing dates to be deduplicated on persist

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,7 @@ lazy val triplesGenerator = project
   .dependsOn(
     triplesGeneratorApi % "compile->compile; test->test",
     entitiesSearch,
-    entitiesViewingsCollector
+    entitiesViewingsCollector % "compile->compile; test->test"
   )
   .enablePlugins(
     JavaAppPackaging,

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/datasets/DSInfoFinder.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/datasets/DSInfoFinder.scala
@@ -35,8 +35,12 @@ private trait DSInfoFinder[F[_]] {
 private final case class DSInfo(projectPath: projects.Path, dataset: Dataset)
 
 private object DSInfoFinder {
+
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[DSInfoFinder[F]] =
-    ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(new DSInfoFinderImpl[F](_))
+    ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(apply(_))
+
+  def apply[F[_]: MonadThrow](tsClient: TSClient[F]): DSInfoFinder[F] =
+    new DSInfoFinderImpl[F](tsClient)
 }
 
 private class DSInfoFinderImpl[F[_]: MonadThrow](tsClient: TSClient[F]) extends DSInfoFinder[F] {

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/persons/Encoder.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/persons/Encoder.scala
@@ -49,7 +49,7 @@ private object Encoder {
   private lazy val viewedProjectEncoder: JsonLDEncoder[PersonViewedProject] =
     JsonLDEncoder.instance { case PersonViewedProject(userId, Project(id, path), date) =>
       JsonLD.entity(
-        EntityId.of(s"$userId/$path"),
+        EntityId of s"$userId/$path",
         EntityTypes of PersonViewedProjectOntology.classType,
         PersonViewedProjectOntology.projectProperty       -> id.asJsonLD,
         PersonViewedProjectOntology.dateViewedProperty.id -> date.asJsonLD
@@ -68,7 +68,7 @@ private object Encoder {
   private lazy val viewedDatasetEncoder: JsonLDEncoder[PersonViewedDataset] =
     JsonLDEncoder.instance { case PersonViewedDataset(userId, Dataset(id, identifier), date) =>
       JsonLD.entity(
-        EntityId.of(s"$userId/datasets/$identifier"),
+        EntityId of s"$userId/datasets/$identifier",
         EntityTypes of PersonViewedProjectOntology.classType,
         PersonViewedDatasetOntology.datasetProperty       -> id.asJsonLD,
         PersonViewedDatasetOntology.dateViewedProperty.id -> date.asJsonLD

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/EventDeduplicator.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/EventDeduplicator.scala
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package io.renku.entities.viewings.collector.projects.viewed
+package io.renku.entities.viewings.collector.projects
 
 import cats.syntax.all._
+import io.renku.events.CategoryName
 import io.renku.graph.model.projects
 import io.renku.triplesstore.TSClient
 
@@ -27,10 +28,12 @@ private trait EventDeduplicator[F[_]] {
 }
 
 private object EventDeduplicator {
-  def apply[F[_]](tsClient: TSClient[F]): EventDeduplicator[F] = new EventDeduplicatorImpl[F](tsClient)
+  def apply[F[_]](tsClient: TSClient[F], categoryName: CategoryName): EventDeduplicator[F] =
+    new EventDeduplicatorImpl[F](tsClient, categoryName)
 }
 
-private class EventDeduplicatorImpl[F[_]](tsClient: TSClient[F]) extends EventDeduplicator[F] {
+private class EventDeduplicatorImpl[F[_]](tsClient: TSClient[F], categoryName: CategoryName)
+    extends EventDeduplicator[F] {
 
   import eu.timepit.refined.auto._
   import io.renku.graph.model.GraphClass

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/viewed/EventDeduplicator.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/viewed/EventDeduplicator.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.projects.viewed
+
+import cats.syntax.all._
+import io.renku.graph.model.projects
+import io.renku.triplesstore.TSClient
+
+private trait EventDeduplicator[F[_]] {
+  def deduplicate(projectId: projects.ResourceId): F[Unit]
+}
+
+private object EventDeduplicator {
+  def apply[F[_]](tsClient: TSClient[F]): EventDeduplicator[F] = new EventDeduplicatorImpl[F](tsClient)
+}
+
+private class EventDeduplicatorImpl[F[_]](tsClient: TSClient[F]) extends EventDeduplicator[F] {
+
+  import eu.timepit.refined.auto._
+  import io.renku.graph.model.GraphClass
+  import io.renku.graph.model.Schemas._
+  import io.renku.jsonld.syntax._
+  import io.renku.triplesstore.SparqlQuery
+  import io.renku.triplesstore.SparqlQuery.Prefixes
+  import io.renku.triplesstore.client.syntax._
+  import tsClient.updateWithNoResult
+
+  override def deduplicate(projectId: projects.ResourceId): F[Unit] = updateWithNoResult(
+    SparqlQuery.ofUnsafe(
+      show"${categoryName.show.toLowerCase}: deduplicate",
+      Prefixes of renku -> "renku",
+      s"""|DELETE {
+          |  GRAPH ${GraphClass.ProjectViewedTimes.id.sparql} { ?id renku:dateViewed ?date }
+          |}
+          |WHERE {
+          |  GRAPH ${GraphClass.ProjectViewedTimes.id.sparql} {
+          |    BIND (${projectId.asEntityId.sparql} AS ?id)
+          |    {
+          |      SELECT ?id (MAX(?date) AS ?maxDate)
+          |      WHERE {
+          |        ?id renku:dateViewed ?date
+          |      }
+          |      GROUP BY ?id
+          |      HAVING (COUNT(?date) > 1)
+          |    }
+          |    ?id renku:dateViewed ?date.
+          |    FILTER (?date != ?maxDate)
+          |  }
+          |}
+          |""".stripMargin
+    )
+  )
+}

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersister.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersister.scala
@@ -37,7 +37,7 @@ private[viewings] object EventPersister {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[EventPersister[F]] =
     ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(apply(_))
 
-  def apply[F[_]: Async](tsClient: TSClient[F]): EventPersister[F] =
+  def apply[F[_]: MonadThrow](tsClient: TSClient[F]): EventPersister[F] =
     new EventPersisterImpl[F](tsClient,
                               EventDeduplicator[F](tsClient, categoryName),
                               PersonViewedProjectPersister(tsClient)

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersister.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersister.scala
@@ -38,7 +38,10 @@ private[viewings] object EventPersister {
     ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(apply(_))
 
   def apply[F[_]: Async](tsClient: TSClient[F]): EventPersister[F] =
-    new EventPersisterImpl[F](tsClient, EventDeduplicator[F](tsClient), PersonViewedProjectPersister(tsClient))
+    new EventPersisterImpl[F](tsClient,
+                              EventDeduplicator[F](tsClient, categoryName),
+                              PersonViewedProjectPersister(tsClient)
+    )
 }
 
 private[viewings] class EventPersisterImpl[F[_]: MonadThrow](

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/EntityViewings.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/EntityViewings.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.triplesgenerator.api.events.{DatasetViewedEvent, ProjectViewedEvent}
+import io.renku.triplesstore.{InMemoryJena, ProjectsDataset, TSClient}
+
+trait EntityViewings {
+  self: ProjectsDataset with InMemoryJena =>
+
+  def provision(event: ProjectViewedEvent): IO[Unit] =
+    projectViewedEventPersister >>= { _.persist(event) }
+
+  def provision(event: DatasetViewedEvent): IO[Unit] =
+    datasetViewedEventUploader >>= { _.upload(event) }
+
+  private def tsClient = {
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    TestSparqlQueryTimeRecorder[IO].map(implicit sqrt => TSClient[IO](projectsDSConnectionInfo))
+  }
+
+  private def projectViewedEventPersister = tsClient.map(collector.projects.viewed.EventPersister[IO](_))
+  private def datasetViewedEventUploader  = tsClient.map(collector.datasets.EventUploader[IO](_))
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/Generators.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/Generators.scala
@@ -25,7 +25,7 @@ import io.renku.graph.model.entities
 import io.renku.graph.model.testentities._
 import io.renku.triplesgenerator.api.events.UserId
 
-private object Generators {
+object Generators {
 
   def generateProjectWithCreatorAndDataset(userId: UserId) =
     anyRenkuProjectEntities

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/Generators.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/Generators.scala
@@ -27,23 +27,27 @@ import io.renku.triplesgenerator.api.events.UserId
 
 private object Generators {
 
-  def generateProjectWithCreator(userId: UserId) = {
-
-    val creator = userId
-      .fold(
-        glId => personEntities(maybeGitLabIds = fixed(glId.some)).map(removeOrcidId),
-        email => personEntities(withoutGitLabId, maybeEmails = fixed(email.some)).map(removeOrcidId)
-      )
-      .generateSome
-
+  def generateProjectWithCreatorAndDataset(userId: UserId) =
     anyRenkuProjectEntities
-      .map(replaceProjectCreator(creator))
+      .map(replaceProjectCreator(generateSomeCreator(userId)))
       .addDataset(datasetEntities(provenanceInternal))
       .generateOne
       .bimap(
         _.to[entities.Dataset[entities.Dataset.Provenance.Internal]],
         _.to[entities.Project]
       )
-  }
 
+  def generateProjectWithCreator(userId: UserId) =
+    anyProjectEntities
+      .map(replaceProjectCreator(generateSomeCreator(userId)))
+      .generateOne
+      .to[entities.Project]
+
+  private def generateSomeCreator(userId: UserId) =
+    userId
+      .fold(
+        glId => personEntities(maybeGitLabIds = fixed(glId.some)).map(removeOrcidId),
+        email => personEntities(withoutGitLabId, maybeEmails = fixed(email.some)).map(removeOrcidId)
+      )
+      .generateSome
 }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/Generators.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/Generators.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.persons
+
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.fixed
+import io.renku.graph.model.entities
+import io.renku.graph.model.testentities._
+import io.renku.triplesgenerator.api.events.UserId
+
+private object Generators {
+
+  def generateProjectWithCreator(userId: UserId) = {
+
+    val creator = userId
+      .fold(
+        glId => personEntities(maybeGitLabIds = fixed(glId.some)).map(removeOrcidId),
+        email => personEntities(withoutGitLabId, maybeEmails = fixed(email.some)).map(removeOrcidId)
+      )
+      .generateSome
+
+    anyRenkuProjectEntities
+      .map(replaceProjectCreator(creator))
+      .addDataset(datasetEntities(provenanceInternal))
+      .generateOne
+      .bimap(
+        _.to[entities.Dataset[entities.Dataset.Provenance.Internal]],
+        _.to[entities.Project]
+      )
+  }
+
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetDeduplicatorSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetDeduplicatorSpec.scala
@@ -19,21 +19,16 @@
 package io.renku.entities.viewings.collector.persons
 
 import cats.effect.IO
-import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector.persons.Generators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
-import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model._
 import io.renku.graph.model.testentities._
 import io.renku.interpreters.TestLogger
-import io.renku.jsonld.syntax._
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.UserId
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
-import io.renku.triplesstore.client.syntax._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should
@@ -146,23 +141,4 @@ class PersonViewedDatasetDeduplicatorSpec
 
     val persister = PersonViewedDatasetPersister[IO](tsClient)
   }
-
-  private def insertOtherDate(datasetId: datasets.ResourceId, dateViewed: datasets.DateViewed) = runUpdate(
-    on = projectsDataset,
-    SparqlQuery.of(
-      "test add another user dataset dateViewed",
-      Prefixes of renku -> "renku",
-      sparql"""|INSERT {
-               |  GRAPH ${GraphClass.PersonViewings.id} {
-               |    ?viewingId renku:dateViewed ${dateViewed.asObject}
-               |  }
-               |}
-               |WHERE {
-               |  GRAPH ${GraphClass.PersonViewings.id} {
-               |    ?viewingId renku:dataset ${datasetId.asEntityId}
-               |  }
-               |}
-               |""".stripMargin
-    )
-  ).unsafeRunSync()
 }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetDeduplicatorSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetDeduplicatorSpec.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.persons
+
+import cats.effect.IO
+import eu.timepit.refined.auto._
+import io.renku.entities.viewings.collector
+import io.renku.entities.viewings.collector.persons.Generators._
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestamps
+import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model._
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.api.events.UserId
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+class PersonViewedDatasetDeduplicatorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with OptionValues
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with MockFactory {
+
+  "deduplicate" should {
+
+    "do nothing if there's only one date for the user and dataset" in new TestCase {
+
+      val userId             = UserId(personGitLabIds.generateOne)
+      val dataset -> project = generateProjectWithCreator(userId)
+      upload(to = projectsDataset, project)
+
+      val event = GLUserViewedDataset(userId,
+                                      toCollectorDataset(dataset),
+                                      datasetViewedDates(dataset.provenance.date.instant).generateOne
+      )
+      persister.persist(event).unsafeRunSync() shouldBe ()
+
+      val userResourceId = project.maybeCreator.value.resourceId
+      deduplicator.deduplicate(userResourceId, dataset.resourceId).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(ViewingRecord(userResourceId, dataset.resourceId, event.date))
+    }
+
+    "leave only the latest date if there are many" in new TestCase {
+
+      val userId             = UserId(personGitLabIds.generateOne)
+      val dataset -> project = generateProjectWithCreator(userId)
+      upload(to = projectsDataset, project)
+
+      val event = GLUserViewedDataset(userId,
+                                      toCollectorDataset(dataset),
+                                      datasetViewedDates(dataset.provenance.date.instant).generateOne
+      )
+      persister.persist(event).unsafeRunSync() shouldBe ()
+
+      val olderDateViewed1 = timestamps(max = event.date.value).generateAs(datasets.DateViewed)
+      insertOtherDate(dataset.resourceId, olderDateViewed1)
+      val olderDateViewed2 = timestamps(max = event.date.value).generateAs(datasets.DateViewed)
+      insertOtherDate(dataset.resourceId, olderDateViewed2)
+
+      val userResourceId = project.maybeCreator.value.resourceId
+
+      findAllViewings shouldBe Set(
+        ViewingRecord(userResourceId, dataset.resourceId, event.date),
+        ViewingRecord(userResourceId, dataset.resourceId, olderDateViewed1),
+        ViewingRecord(userResourceId, dataset.resourceId, olderDateViewed2)
+      )
+
+      deduplicator.deduplicate(userResourceId, dataset.resourceId).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(ViewingRecord(userResourceId, dataset.resourceId, event.date))
+    }
+
+    "do not remove dates for other projects" in new TestCase {
+
+      val userId = UserId(personGitLabIds.generateOne)
+
+      val dataset1 -> project1 = generateProjectWithCreator(userId)
+      upload(to = projectsDataset, project1)
+
+      val dataset2 -> project2 = generateProjectWithCreator(userId)
+      upload(to = projectsDataset, project2)
+
+      val event1 = GLUserViewedDataset(userId,
+                                       toCollectorDataset(dataset1),
+                                       datasetViewedDates(dataset1.provenance.date.instant).generateOne
+      )
+      persister.persist(event1).unsafeRunSync() shouldBe ()
+
+      val event2 = GLUserViewedDataset(userId,
+                                       toCollectorDataset(dataset2),
+                                       datasetViewedDates(dataset2.provenance.date.instant).generateOne
+      )
+      persister.persist(event2).unsafeRunSync() shouldBe ()
+
+      val userResourceId = project1.maybeCreator.value.resourceId
+
+      findAllViewings shouldBe Set(
+        ViewingRecord(userResourceId, dataset1.resourceId, event1.date),
+        ViewingRecord(userResourceId, dataset2.resourceId, event2.date)
+      )
+
+      deduplicator.deduplicate(userResourceId, dataset1.resourceId).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(
+        ViewingRecord(userResourceId, dataset1.resourceId, event1.date),
+        ViewingRecord(userResourceId, dataset2.resourceId, event2.date)
+      )
+    }
+  }
+
+  private trait TestCase {
+
+    private implicit val logger: TestLogger[IO]              = TestLogger[IO]()
+    private implicit val sqtr:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    private val tsClient = TSClient[IO](projectsDSConnectionInfo)
+    val deduplicator     = new PersonViewedDatasetDeduplicatorImpl[IO](tsClient)
+
+    val persister = PersonViewedDatasetPersister[IO](tsClient)
+  }
+
+  private def insertOtherDate(datasetId: datasets.ResourceId, dateViewed: datasets.DateViewed) = runUpdate(
+    on = projectsDataset,
+    SparqlQuery.of(
+      "test add another user dataset dateViewed",
+      Prefixes of renku -> "renku",
+      sparql"""|INSERT {
+               |  GRAPH ${GraphClass.PersonViewings.id} {
+               |    ?viewingId renku:dateViewed ${dateViewed.asObject}
+               |  }
+               |}
+               |WHERE {
+               |  GRAPH ${GraphClass.PersonViewings.id} {
+               |    ?viewingId renku:dataset ${datasetId.asEntityId}
+               |  }
+               |}
+               |""".stripMargin
+    )
+  ).unsafeRunSync()
+
+  private def findAllViewings =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.of(
+        "test find user dataset viewings",
+        Prefixes of renku -> "renku",
+        sparql"""|SELECT ?id ?datasetId ?date
+                 |FROM ${GraphClass.PersonViewings.id} {
+                 |  ?id renku:viewedDataset ?viewingId.
+                 |  ?viewingId renku:dataset ?datasetId;
+                 |             renku:dateViewed ?date.
+                 |}
+                 |""".stripMargin
+      )
+    ).unsafeRunSync()
+      .map(row =>
+        ViewingRecord(persons.ResourceId(row("id")),
+                      datasets.ResourceId(row("datasetId")),
+                      datasets.DateViewed(Instant.parse(row("date")))
+        )
+      )
+      .toSet
+
+  private case class ViewingRecord(userId:    persons.ResourceId,
+                                   datasetId: datasets.ResourceId,
+                                   date:      datasets.DateViewed
+  )
+
+  private def toCollectorDataset(ds: entities.Dataset[entities.Dataset.Provenance]) =
+    collector.persons.Dataset(ds.resourceId, ds.identification.identifier)
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetPersisterSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetPersisterSpec.scala
@@ -22,19 +22,21 @@ import cats.effect.IO
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector
-import io.renku.generators.Generators.{fixed, timestamps, timestampsNotInTheFuture}
+import io.renku.entities.viewings.collector.persons.Generators._
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
+import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model._
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.Schemas.renku
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.Generators.userIds
 import io.renku.triplesgenerator.api.events.UserId
+import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
 import io.renku.triplesstore.client.syntax._
-import io.renku.triplesstore.SparqlQuery.Prefixes
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -47,12 +49,14 @@ class PersonViewedDatasetPersisterSpec
     with OptionValues
     with IOSpec
     with InMemoryJenaForSpec
-    with ProjectsDataset {
+    with ProjectsDataset
+    with MockFactory {
 
   "persist" should {
 
-    "insert the given GLUserViewedDataset to the TS if it doesn't exist yet " +
-      "case with a user identified with GitLab id" in new TestCase {
+    "insert the given GLUserViewedDataset to the TS and run the deduplicate query " +
+      "if the viewing doesn't exist yet " +
+      "- case with a user identified with GitLab id" in new TestCase {
 
         val userId             = UserId(personGitLabIds.generateOne)
         val dataset -> project = generateProjectWithCreator(userId)
@@ -62,6 +66,8 @@ class PersonViewedDatasetPersisterSpec
         val dateViewed = datasetViewedDates(dataset.provenance.date.instant).generateOne
         val event      = GLUserViewedDataset(userId, toCollectorDataset(dataset), dateViewed)
 
+        givenEventDeduplication(project.maybeCreator.value.resourceId, dataset.resourceId, returning = ().pure[IO])
+
         persister.persist(event).unsafeRunSync() shouldBe ()
 
         findAllViewings shouldBe Set(
@@ -69,8 +75,9 @@ class PersonViewedDatasetPersisterSpec
         )
       }
 
-    "insert the given GLUserViewedDataset to the TS if it doesn't exist yet " +
-      "case with a user identified with email" in new TestCase {
+    "insert the given GLUserViewedDataset to the TS and run the deduplicate query " +
+      "if the viewing doesn't exist yet " +
+      "- case with a user identified with email" in new TestCase {
 
         val userId             = UserId(personEmails.generateOne)
         val dataset -> project = generateProjectWithCreator(userId)
@@ -80,6 +87,8 @@ class PersonViewedDatasetPersisterSpec
         val dateViewed = datasetViewedDates(dataset.provenance.date.instant).generateOne
         val event      = GLUserViewedDataset(userId, toCollectorDataset(dataset), dateViewed)
 
+        givenEventDeduplication(project.maybeCreator.value.resourceId, dataset.resourceId, returning = ().pure[IO])
+
         persister.persist(event).unsafeRunSync() shouldBe ()
 
         findAllViewings shouldBe Set(
@@ -87,7 +96,7 @@ class PersonViewedDatasetPersisterSpec
         )
       }
 
-    "update the date for the user and ds from the GLUserViewedDataset " +
+    "update the date for the user and ds from the GLUserViewedDataset and run the deduplicate query " +
       "if an event for the ds already exists in the TS " +
       "and the date from the new event is newer than this in the TS" in new TestCase {
 
@@ -99,6 +108,8 @@ class PersonViewedDatasetPersisterSpec
         val dateViewed = datasetViewedDates(dataset.provenance.date.instant).generateOne
         val event      = GLUserViewedDataset(userId, toCollectorDataset(dataset), dateViewed)
 
+        givenEventDeduplication(project.maybeCreator.value.resourceId, dataset.resourceId, returning = ().pure[IO])
+
         persister.persist(event).unsafeRunSync() shouldBe ()
 
         findAllViewings shouldBe Set(
@@ -106,6 +117,8 @@ class PersonViewedDatasetPersisterSpec
         )
 
         val newDate = timestampsNotInTheFuture(butYoungerThan = event.date.value).generateAs(datasets.DateViewed)
+
+        givenEventDeduplication(project.maybeCreator.value.resourceId, dataset.resourceId, returning = ().pure[IO])
 
         persister.persist(event.copy(date = newDate)).unsafeRunSync() shouldBe ()
 
@@ -122,6 +135,8 @@ class PersonViewedDatasetPersisterSpec
       val dateViewed = datasetViewedDates(dataset.provenance.date.instant).generateOne
       val event      = GLUserViewedDataset(userId, toCollectorDataset(dataset), dateViewed)
 
+      givenEventDeduplication(project.maybeCreator.value.resourceId, dataset.resourceId, returning = ().pure[IO])
+
       persister.persist(event).unsafeRunSync() shouldBe ()
 
       findAllViewings shouldBe Set(
@@ -135,7 +150,7 @@ class PersonViewedDatasetPersisterSpec
       findAllViewings shouldBe Set(ViewingRecord(project.maybeCreator.value.resourceId, dataset.resourceId, dateViewed))
     }
 
-    "update the date for the user and project from the GLUserViewedProject " +
+    "update the date for the user and project from the GLUserViewedProject and run the deduplicate query" +
       "and leave other user viewings if they exist" in new TestCase {
 
         val userId               = userIds.generateOne
@@ -147,11 +162,13 @@ class PersonViewedDatasetPersisterSpec
         val dataset1DateViewed = datasetViewedDates(dataset1.provenance.date.instant).generateOne
         val dataset1Event =
           collector.persons.GLUserViewedDataset(userId, toCollectorDataset(dataset1), dataset1DateViewed)
+        givenEventDeduplication(project1.maybeCreator.value.resourceId, dataset1.resourceId, returning = ().pure[IO])
         persister.persist(dataset1Event).unsafeRunSync() shouldBe ()
 
         val dataset2DateViewed = datasetViewedDates(dataset2.provenance.date.instant).generateOne
         val dataset2Event =
           collector.persons.GLUserViewedDataset(userId, toCollectorDataset(dataset2), dataset2DateViewed)
+        givenEventDeduplication(project2.maybeCreator.value.resourceId, dataset2.resourceId, returning = ().pure[IO])
         persister.persist(dataset2Event).unsafeRunSync() shouldBe ()
 
         findAllViewings shouldBe Set(
@@ -162,6 +179,7 @@ class PersonViewedDatasetPersisterSpec
         val newDate =
           timestampsNotInTheFuture(butYoungerThan = dataset1Event.date.value).generateAs(datasets.DateViewed)
 
+        givenEventDeduplication(project1.maybeCreator.value.resourceId, dataset1.resourceId, returning = ().pure[IO])
         persister.persist(dataset1Event.copy(date = newDate)).unsafeRunSync() shouldBe ()
 
         findAllViewings shouldBe Set(
@@ -188,27 +206,16 @@ class PersonViewedDatasetPersisterSpec
   private trait TestCase {
     private implicit val logger: TestLogger[IO]              = TestLogger[IO]()
     private implicit val sqtr:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
-    private val tsClient = TSClient[IO](projectsDSConnectionInfo)
-    val persister        = new PersonViewedDatasetPersisterImpl[IO](tsClient, PersonFinder(tsClient))
-  }
+    private val tsClient          = TSClient[IO](projectsDSConnectionInfo)
+    private val eventDeduplicator = mock[PersonViewedDatasetDeduplicator[IO]]
+    val persister = new PersonViewedDatasetPersisterImpl[IO](tsClient, PersonFinder(tsClient), eventDeduplicator)
 
-  private def generateProjectWithCreator(userId: UserId) = {
-
-    val creator = userId
-      .fold(
-        glId => personEntities(maybeGitLabIds = fixed(glId.some)).map(removeOrcidId),
-        email => personEntities(withoutGitLabId, maybeEmails = fixed(email.some)).map(removeOrcidId)
-      )
-      .generateSome
-
-    anyRenkuProjectEntities
-      .map(replaceProjectCreator(creator))
-      .addDataset(datasetEntities(provenanceInternal))
-      .generateOne
-      .bimap(
-        _.to[entities.Dataset[entities.Dataset.Provenance.Internal]],
-        _.to[entities.Project]
-      )
+    def givenEventDeduplication(personResourceId:  persons.ResourceId,
+                                datasetResourceId: datasets.ResourceId,
+                                returning:         IO[Unit]
+    ) = (eventDeduplicator.deduplicate _)
+      .expects(personResourceId, datasetResourceId)
+      .returning(returning)
   }
 
   private def findAllViewings =

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetPersisterSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetPersisterSpec.scala
@@ -20,12 +20,10 @@ package io.renku.entities.viewings.collector.persons
 
 import cats.effect.IO
 import cats.syntax.all._
-import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector
 import io.renku.entities.viewings.collector.persons.Generators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
-import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model._
 import io.renku.graph.model.testentities._
 import io.renku.interpreters.TestLogger
@@ -33,20 +31,17 @@ import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.Generators.userIds
 import io.renku.triplesgenerator.api.events.UserId
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
-import io.renku.triplesstore.client.syntax._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.time.Instant
-
 class PersonViewedDatasetPersisterSpec
     extends AnyWordSpec
     with should.Matchers
     with OptionValues
+    with PersonViewedDatasetSpecTools
     with IOSpec
     with InMemoryJenaForSpec
     with ProjectsDataset
@@ -59,7 +54,7 @@ class PersonViewedDatasetPersisterSpec
       "- case with a user identified with GitLab id" in new TestCase {
 
         val userId             = UserId(personGitLabIds.generateOne)
-        val dataset -> project = generateProjectWithCreator(userId)
+        val dataset -> project = generateProjectWithCreatorAndDataset(userId)
 
         upload(to = projectsDataset, project)
 
@@ -80,7 +75,7 @@ class PersonViewedDatasetPersisterSpec
       "- case with a user identified with email" in new TestCase {
 
         val userId             = UserId(personEmails.generateOne)
-        val dataset -> project = generateProjectWithCreator(userId)
+        val dataset -> project = generateProjectWithCreatorAndDataset(userId)
 
         upload(to = projectsDataset, project)
 
@@ -101,7 +96,7 @@ class PersonViewedDatasetPersisterSpec
       "and the date from the new event is newer than this in the TS" in new TestCase {
 
         val userId             = userIds.generateOne
-        val dataset -> project = generateProjectWithCreator(userId)
+        val dataset -> project = generateProjectWithCreatorAndDataset(userId)
 
         upload(to = projectsDataset, project)
 
@@ -128,7 +123,7 @@ class PersonViewedDatasetPersisterSpec
     "do nothing if the event date is older than the date in the TS" in new TestCase {
 
       val userId             = userIds.generateOne
-      val dataset -> project = generateProjectWithCreator(userId)
+      val dataset -> project = generateProjectWithCreatorAndDataset(userId)
 
       upload(to = projectsDataset, project)
 
@@ -150,12 +145,12 @@ class PersonViewedDatasetPersisterSpec
       findAllViewings shouldBe Set(ViewingRecord(project.maybeCreator.value.resourceId, dataset.resourceId, dateViewed))
     }
 
-    "update the date for the user and project from the GLUserViewedProject and run the deduplicate query" +
+    "update the date for the user and project from the GLUserViewedProject, run the deduplicate query" +
       "and leave other user viewings if they exist" in new TestCase {
 
         val userId               = userIds.generateOne
-        val dataset1 -> project1 = generateProjectWithCreator(userId)
-        val dataset2 -> project2 = generateProjectWithCreator(userId)
+        val dataset1 -> project1 = generateProjectWithCreatorAndDataset(userId)
+        val dataset2 -> project2 = generateProjectWithCreatorAndDataset(userId)
 
         upload(to = projectsDataset, project1, project2)
 
@@ -190,7 +185,7 @@ class PersonViewedDatasetPersisterSpec
 
     "do nothing if the given event is for a non-existing user" in new TestCase {
 
-      val dataset -> _ = generateProjectWithCreator(userIds.generateOne)
+      val dataset -> _ = generateProjectWithCreatorAndDataset(userIds.generateOne)
 
       val event = collector.persons.GLUserViewedDataset(userIds.generateOne,
                                                         toCollectorDataset(dataset),
@@ -217,35 +212,4 @@ class PersonViewedDatasetPersisterSpec
       .expects(personResourceId, datasetResourceId)
       .returning(returning)
   }
-
-  private def findAllViewings =
-    runSelect(
-      on = projectsDataset,
-      SparqlQuery.of(
-        "test find user project viewings",
-        Prefixes of renku -> "renku",
-        sparql"""|SELECT ?id ?datasetId ?date
-                 |FROM ${GraphClass.PersonViewings.id} {
-                 |  ?id renku:viewedDataset ?viewingId.
-                 |  ?viewingId renku:dataset ?datasetId;
-                 |             renku:dateViewed ?date.
-                 |}
-                 |""".stripMargin
-      )
-    ).unsafeRunSync()
-      .map(row =>
-        ViewingRecord(persons.ResourceId(row("id")),
-                      datasets.ResourceId(row("datasetId")),
-                      datasets.DateViewed(Instant.parse(row("date")))
-        )
-      )
-      .toSet
-
-  private case class ViewingRecord(userId:    persons.ResourceId,
-                                   datasetId: datasets.ResourceId,
-                                   date:      datasets.DateViewed
-  )
-
-  private def toCollectorDataset(ds: entities.Dataset[entities.Dataset.Provenance]) =
-    collector.persons.Dataset(ds.resourceId, ds.identification.identifier)
 }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetSpecTools.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedDatasetSpecTools.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.persons
+
+import eu.timepit.refined.auto._
+import io.renku.entities.viewings.collector
+import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.{GraphClass, datasets, entities, persons}
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+
+import java.time.Instant
+
+trait PersonViewedDatasetSpecTools {
+  self: InMemoryJenaForSpec with ProjectsDataset with IOSpec =>
+
+  protected def findAllViewings =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.of(
+        "test find user dataset viewings",
+        Prefixes of renku -> "renku",
+        sparql"""|SELECT ?id ?datasetId ?date
+                 |FROM ${GraphClass.PersonViewings.id} {
+                 |  ?id renku:viewedDataset ?viewingId.
+                 |  ?viewingId renku:dataset ?datasetId;
+                 |             renku:dateViewed ?date.
+                 |}
+                 |""".stripMargin
+      )
+    ).unsafeRunSync()
+      .map(row =>
+        ViewingRecord(persons.ResourceId(row("id")),
+                      datasets.ResourceId(row("datasetId")),
+                      datasets.DateViewed(Instant.parse(row("date")))
+        )
+      )
+      .toSet
+
+  protected case class ViewingRecord(userId:    persons.ResourceId,
+                                     datasetId: datasets.ResourceId,
+                                     date:      datasets.DateViewed
+  )
+
+  protected def toCollectorDataset(ds: entities.Dataset[entities.Dataset.Provenance]) =
+    collector.persons.Dataset(ds.resourceId, ds.identification.identifier)
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedProjectDeduplicatorSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedProjectDeduplicatorSpec.scala
@@ -19,21 +19,16 @@
 package io.renku.entities.viewings.collector.persons
 
 import cats.effect.IO
-import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector.persons.Generators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
-import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model._
 import io.renku.graph.model.testentities._
 import io.renku.interpreters.TestLogger
-import io.renku.jsonld.syntax._
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.UserId
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
-import io.renku.triplesstore.client.syntax._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should
@@ -146,23 +141,4 @@ class PersonViewedProjectDeduplicatorSpec
 
     val persister = PersonViewedProjectPersister[IO](tsClient)
   }
-
-  private def insertOtherDate(projectId: projects.ResourceId, dateViewed: projects.DateViewed) = runUpdate(
-    on = projectsDataset,
-    SparqlQuery.of(
-      "test add another user project dateViewed",
-      Prefixes of renku -> "renku",
-      sparql"""|INSERT {
-               |  GRAPH ${GraphClass.PersonViewings.id} {
-               |    ?viewingId renku:dateViewed ${dateViewed.asObject}
-               |  }
-               |}
-               |WHERE {
-               |  GRAPH ${GraphClass.PersonViewings.id} {
-               |    ?viewingId renku:project ${projectId.asEntityId}
-               |  }
-               |}
-               |""".stripMargin
-    )
-  ).unsafeRunSync()
 }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedProjectSpecTools.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/persons/PersonViewedProjectSpecTools.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.persons
+
+import eu.timepit.refined.auto._
+import io.renku.entities.viewings.collector
+import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.{GraphClass, entities, persons, projects}
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+
+import java.time.Instant
+
+trait PersonViewedProjectSpecTools {
+  self: InMemoryJenaForSpec with ProjectsDataset with IOSpec =>
+
+  protected def findAllViewings =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.of(
+        "test find user project viewings",
+        Prefixes of renku -> "renku",
+        sparql"""|SELECT ?id ?projectId ?date
+                 |FROM ${GraphClass.PersonViewings.id} {
+                 |  ?id renku:viewedProject ?viewingId.
+                 |  ?viewingId renku:project ?projectId;
+                 |             renku:dateViewed ?date.
+                 |}
+                 |""".stripMargin
+      )
+    ).unsafeRunSync()
+      .map(row =>
+        ViewingRecord(persons.ResourceId(row("id")),
+                      projects.ResourceId(row("projectId")),
+                      projects.DateViewed(Instant.parse(row("date")))
+        )
+      )
+      .toSet
+
+  protected case class ViewingRecord(userId:    persons.ResourceId,
+                                     projectId: projects.ResourceId,
+                                     date:      projects.DateViewed
+  )
+
+  protected def toCollectorProject(project: entities.Project) =
+    collector.persons.Project(project.resourceId, project.path)
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/EventDeduplicatorSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/EventDeduplicatorSpec.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import io.renku.entities.viewings.collector.ProjectViewedTimeOntology.dataViewedProperty
 import io.renku.entities.viewings.collector.persons.PersonViewedProjectPersister
 import io.renku.entities.viewings.collector.projects.viewed.EventPersisterImpl
+import io.renku.events.Generators.categoryNames
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
 import io.renku.graph.model.testentities._
@@ -119,7 +120,7 @@ class EventDeduplicatorSpec
     private implicit val logger: TestLogger[IO]              = TestLogger[IO]()
     private implicit val sqtr:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
     private val tsClient = TSClient[IO](projectsDSConnectionInfo)
-    val deduplicator     = new EventDeduplicatorImpl[IO](tsClient)
+    val deduplicator     = new EventDeduplicatorImpl[IO](tsClient, categoryNames.generateOne)
 
     private val personViewingPersister = mock[PersonViewedProjectPersister[IO]]
     (personViewingPersister.persist _).expects(*).returning(().pure[IO]).anyNumberOfTimes()

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/EventDeduplicatorSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/EventDeduplicatorSpec.scala
@@ -16,16 +16,15 @@
  * limitations under the License.
  */
 
-package io.renku.entities.viewings.collector.projects.viewed
+package io.renku.entities.viewings.collector.projects
 
 import cats.effect.IO
 import cats.syntax.all._
-import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector.ProjectViewedTimeOntology.dataViewedProperty
 import io.renku.entities.viewings.collector.persons.PersonViewedProjectPersister
+import io.renku.entities.viewings.collector.projects.viewed.EventPersisterImpl
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.timestamps
-import io.renku.graph.model.Schemas.renku
 import io.renku.graph.model.testentities._
 import io.renku.graph.model.{GraphClass, projects}
 import io.renku.interpreters.TestLogger
@@ -33,7 +32,6 @@ import io.renku.jsonld.syntax._
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.Generators._
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
 import io.renku.triplesstore.client.model.Quad
 import io.renku.triplesstore.client.syntax._
@@ -41,11 +39,10 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.time.Instant
-
 class EventDeduplicatorSpec
     extends AnyWordSpec
     with should.Matchers
+    with EventPersisterSpecTools
     with IOSpec
     with InMemoryJenaForSpec
     with ProjectsDataset
@@ -134,20 +131,4 @@ class EventDeduplicatorSpec
       to = projectsDataset,
       Quad(GraphClass.ProjectViewedTimes.id, project.resourceId.asEntityId, dataViewedProperty.id, dateViewed.asObject)
     )
-
-  private def findAllViewings =
-    runSelect(
-      on = projectsDataset,
-      SparqlQuery.of(
-        "test find project viewing",
-        Prefixes of renku -> "renku",
-        s"""|SELECT ?id ?date
-            |FROM ${GraphClass.ProjectViewedTimes.id.asSparql.sparql} {
-            |  ?id renku:dateViewed ?date.
-            |}
-            |""".stripMargin
-      )
-    ).unsafeRunSync()
-      .map(row => projects.ResourceId(row("id")) -> projects.DateViewed(Instant.parse(row("date"))))
-      .toSet
 }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/EventPersisterSpecTools.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/EventPersisterSpecTools.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.projects
+
+import eu.timepit.refined.auto._
+import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.{GraphClass, projects}
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+
+import java.time.Instant
+
+trait EventPersisterSpecTools {
+  self: InMemoryJenaForSpec with ProjectsDataset with IOSpec =>
+
+  protected def findAllViewings =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.of(
+        "test find project viewing",
+        Prefixes of renku -> "renku",
+        sparql"""|SELECT ?id ?date
+                 |FROM ${GraphClass.ProjectViewedTimes.id} {
+                 |  ?id renku:dateViewed ?date.
+                 |}
+                 |""".stripMargin
+      )
+    ).unsafeRunSync()
+      .map(row => projects.ResourceId(row("id")) -> projects.DateViewed(Instant.parse(row("date"))))
+      .toSet
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/viewed/EventDeduplicatorSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/viewed/EventDeduplicatorSpec.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.entities.viewings.collector.projects.viewed
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.entities.viewings.collector.ProjectViewedTimeOntology.dataViewedProperty
+import io.renku.entities.viewings.collector.persons.PersonViewedProjectPersister
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestamps
+import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.{GraphClass, projects}
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.api.events.Generators._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.model.Quad
+import io.renku.triplesstore.client.syntax._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+class EventDeduplicatorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with MockFactory {
+
+  "deduplicate" should {
+
+    "do nothing if there's only one date for the project" in new TestCase {
+
+      val project = anyProjectEntities.generateOne
+      upload(to = projectsDataset, project)
+
+      val event = projectViewedEvents.generateOne.copy(path = project.path)
+
+      persister.persist(event).unsafeRunSync() shouldBe ()
+
+      deduplicator.deduplicate(project.resourceId).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(project.resourceId -> event.dateViewed)
+    }
+
+    "leave only the latest date if there are many" in new TestCase {
+
+      val project = anyProjectEntities.generateOne
+      upload(to = projectsDataset, project)
+
+      val event = projectViewedEvents.generateOne.copy(path = project.path)
+      persister.persist(event).unsafeRunSync() shouldBe ()
+
+      val olderDateViewed1 = timestamps(max = event.dateViewed.value).generateAs(projects.DateViewed)
+      insertOtherDate(project, olderDateViewed1)
+      val olderDateViewed2 = timestamps(max = event.dateViewed.value).generateAs(projects.DateViewed)
+      insertOtherDate(project, olderDateViewed2)
+
+      findAllViewings shouldBe Set(
+        project.resourceId -> event.dateViewed,
+        project.resourceId -> olderDateViewed1,
+        project.resourceId -> olderDateViewed2
+      )
+
+      deduplicator.deduplicate(project.resourceId).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(project.resourceId -> event.dateViewed)
+    }
+
+    "do not remove dates for other projects" in new TestCase {
+
+      val project1 = anyProjectEntities.generateOne
+      upload(to = projectsDataset, project1)
+      val project2 = anyProjectEntities.generateOne
+      upload(to = projectsDataset, project2)
+
+      val event1 = projectViewedEvents.generateOne.copy(path = project1.path)
+      persister.persist(event1).unsafeRunSync() shouldBe ()
+      val event2 = projectViewedEvents.generateOne.copy(path = project2.path)
+      persister.persist(event2).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(
+        project1.resourceId -> event1.dateViewed,
+        project2.resourceId -> event2.dateViewed
+      )
+
+      deduplicator.deduplicate(project1.resourceId).unsafeRunSync() shouldBe ()
+
+      findAllViewings shouldBe Set(
+        project1.resourceId -> event1.dateViewed,
+        project2.resourceId -> event2.dateViewed
+      )
+    }
+  }
+
+  private trait TestCase {
+
+    private implicit val logger: TestLogger[IO]              = TestLogger[IO]()
+    private implicit val sqtr:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    private val tsClient = TSClient[IO](projectsDSConnectionInfo)
+    val deduplicator     = new EventDeduplicatorImpl[IO](tsClient)
+
+    private val personViewingPersister = mock[PersonViewedProjectPersister[IO]]
+    (personViewingPersister.persist _).expects(*).returning(().pure[IO]).anyNumberOfTimes()
+    val persister = new EventPersisterImpl[IO](tsClient, deduplicator, personViewingPersister)
+  }
+
+  private def insertOtherDate(project: Project, dateViewed: projects.DateViewed) =
+    insert(
+      to = projectsDataset,
+      Quad(GraphClass.ProjectViewedTimes.id, project.resourceId.asEntityId, dataViewedProperty.id, dateViewed.asObject)
+    )
+
+  private def findAllViewings =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.of(
+        "test find project viewing",
+        Prefixes of renku -> "renku",
+        s"""|SELECT ?id ?date
+            |FROM ${GraphClass.ProjectViewedTimes.id.asSparql.sparql} {
+            |  ?id renku:dateViewed ?date.
+            |}
+            |""".stripMargin
+      )
+    ).unsafeRunSync()
+      .map(row => projects.ResourceId(row("id")) -> projects.DateViewed(Instant.parse(row("date"))))
+      .toSet
+}

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersisterSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersisterSpec.scala
@@ -24,19 +24,19 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector
 import io.renku.entities.viewings.collector.persons.{GLUserViewedProject, PersonViewedProjectPersister}
-import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.{projects, GraphClass}
-import io.renku.graph.model.testentities._
+import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
 import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.{GraphClass, projects}
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.Generators._
 import io.renku.triplesgenerator.api.events.ProjectViewedEvent
+import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
 import io.renku.triplesstore.client.syntax._
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -53,13 +53,17 @@ class EventPersisterSpec
 
   "persist" should {
 
-    "insert the given ProjectViewedEvent to the TS and persist it in the PersonViewing " +
+    "insert the given ProjectViewedEvent to the TS, " +
+      "run the deduplication query and " +
+      "persist a PersonViewing event " +
       "if there's no event for the project yet" in new TestCase {
 
         val project = anyProjectEntities.generateOne
         upload(to = projectsDataset, project)
 
         val event = projectViewedEvents.generateOne.copy(path = project.path)
+
+        givenEventDeduplication(project, returning = ().pure[IO])
 
         givenPersonViewingPersisting(event, project, returning = ().pure[IO])
 
@@ -68,7 +72,8 @@ class EventPersisterSpec
         findAllViewings shouldBe Set(project.resourceId -> event.dateViewed)
       }
 
-    "update the date for the project from the ProjectViewedEvent " +
+    "update the date for the project from the ProjectViewedEvent, " +
+      "run the deduplication query " +
       "if an event for the project already exists in the TS " +
       "and the date from the event is newer than this in the TS" in new TestCase {
 
@@ -76,7 +81,7 @@ class EventPersisterSpec
         upload(to = projectsDataset, project)
 
         val event = projectViewedEvents.generateOne.copy(path = project.path)
-
+        givenEventDeduplication(project, returning = ().pure[IO])
         givenPersonViewingPersisting(event, project, returning = ().pure[IO])
 
         persister.persist(event).unsafeRunSync() shouldBe ()
@@ -86,6 +91,7 @@ class EventPersisterSpec
         val newDate  = timestampsNotInTheFuture(butYoungerThan = event.dateViewed.value).generateAs(projects.DateViewed)
         val newEvent = event.copy(dateViewed = newDate)
 
+        givenEventDeduplication(project, returning = ().pure[IO])
         givenPersonViewingPersisting(newEvent, project, returning = ().pure[IO])
 
         persister.persist(newEvent).unsafeRunSync() shouldBe ()
@@ -100,6 +106,7 @@ class EventPersisterSpec
 
       val event = projectViewedEvents.generateOne.copy(path = project.path)
 
+      givenEventDeduplication(project, returning = ().pure[IO])
       givenPersonViewingPersisting(event, project, returning = ().pure[IO])
 
       persister.persist(event).unsafeRunSync() shouldBe ()
@@ -129,8 +136,15 @@ class EventPersisterSpec
   private trait TestCase {
     private implicit val logger: TestLogger[IO]              = TestLogger[IO]()
     private implicit val sqtr:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    private val eventDeduplicator      = mock[EventDeduplicator[IO]]
     private val personViewingPersister = mock[PersonViewedProjectPersister[IO]]
-    val persister = new EventPersisterImpl[IO](TSClient[IO](projectsDSConnectionInfo), personViewingPersister)
+    val persister =
+      new EventPersisterImpl[IO](TSClient[IO](projectsDSConnectionInfo), eventDeduplicator, personViewingPersister)
+
+    def givenEventDeduplication(project: Project, returning: IO[Unit]) =
+      (eventDeduplicator.deduplicate _)
+        .expects(project.resourceId)
+        .returning(returning)
 
     def givenPersonViewingPersisting(event: ProjectViewedEvent, project: Project, returning: IO[Unit]) =
       event.maybeUserId.map(userId =>

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersisterSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/collector/projects/viewed/EventPersisterSpec.scala
@@ -21,31 +21,26 @@ package viewed
 
 import cats.effect.IO
 import cats.syntax.all._
-import eu.timepit.refined.auto._
 import io.renku.entities.viewings.collector
 import io.renku.entities.viewings.collector.persons.{GLUserViewedProject, PersonViewedProjectPersister}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
-import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.projects
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.{GraphClass, projects}
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.api.events.Generators._
 import io.renku.triplesgenerator.api.events.ProjectViewedEvent
-import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
-import io.renku.triplesstore.client.syntax._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.time.Instant
-
 class EventPersisterSpec
     extends AnyWordSpec
     with should.Matchers
+    with EventPersisterSpecTools
     with IOSpec
     with InMemoryJenaForSpec
     with ProjectsDataset
@@ -155,20 +150,4 @@ class EventPersisterSpec
           .returning(returning)
       )
   }
-
-  private def findAllViewings =
-    runSelect(
-      on = projectsDataset,
-      SparqlQuery.of(
-        "test find project viewing",
-        Prefixes of renku -> "renku",
-        s"""|SELECT ?id ?date
-            |FROM ${GraphClass.ProjectViewedTimes.id.asSparql.sparql} {
-            |  ?id renku:dateViewed ?date.
-            |}
-            |""".stripMargin
-      )
-    ).unsafeRunSync()
-      .map(row => projects.ResourceId(row("id")) -> projects.DateViewed(Instant.parse(row("date"))))
-      .toSet
 }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/deletion/projects/ViewingRemoverSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/deletion/projects/ViewingRemoverSpec.scala
@@ -21,26 +21,25 @@ package deletion.projects
 
 import cats.effect.IO
 import cats.syntax.all._
-import collector.persons.PersonViewedProjectPersister
-import collector.projects.viewed.EventPersisterImpl
 import eu.timepit.refined.auto._
+import io.renku.entities.viewings.collector.projects.viewed.EventPersister
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.fixed
-import io.renku.graph.model.{persons, projects, GraphClass}
-import io.renku.graph.model.testentities._
 import io.renku.graph.model.Schemas.renku
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.{GraphClass, persons, projects}
 import io.renku.interpreters.TestLogger
 import io.renku.jsonld.syntax._
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
-import io.renku.triplesgenerator.api.events.{ProjectViewingDeletion, UserId}
 import io.renku.triplesgenerator.api.events.Generators._
+import io.renku.triplesgenerator.api.events.{ProjectViewingDeletion, UserId}
+import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
 import io.renku.triplesstore.client.syntax._
-import io.renku.triplesstore.SparqlQuery.Prefixes
+import org.scalatest.OptionValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.OptionValues
 
 class ViewingRemoverSpec
     extends AnyWordSpec
@@ -139,7 +138,7 @@ class ViewingRemoverSpec
     val remover = new ViewingRemoverImpl[IO](TSClient[IO](projectsDSConnectionInfo))
 
     private val tsClient = TSClient[IO](projectsDSConnectionInfo)
-    val eventPersister   = new EventPersisterImpl[IO](tsClient, PersonViewedProjectPersister[IO](tsClient))
+    val eventPersister   = EventPersister[IO](tsClient)
 
     def insertViewing(project: Project, userId: UserId): Unit = {
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -42,6 +42,7 @@ private[tsmigrationrequest] object Migrations {
     migrationToV10                 <- v10migration.MigrationToV10[F]
     v10VersionSetter               <- V10VersionUpdater[F]
     projectsDateViewedCreator      <- ProjectsDateViewedCreator[F]
+    projectDateViewedDeduplicator  <- ProjectDateViewedDeduplicator[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -51,7 +52,8 @@ private[tsmigrationrequest] object Migrations {
                     addRenkuPlanWhereMissing,
                     migrationToV10,
                     v10VersionSetter,
-                    projectsDateViewedCreator
+                    projectsDateViewedCreator,
+                    projectDateViewedDeduplicator
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -43,6 +43,7 @@ private[tsmigrationrequest] object Migrations {
     v10VersionSetter               <- V10VersionUpdater[F]
     projectsDateViewedCreator      <- ProjectsDateViewedCreator[F]
     projectDateViewedDeduplicator  <- ProjectDateViewedDeduplicator[F]
+    personViewedEntityDeduplicator <- PersonViewedEntityDeduplicator[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -53,7 +54,8 @@ private[tsmigrationrequest] object Migrations {
                     migrationToV10,
                     v10VersionSetter,
                     projectsDateViewedCreator,
-                    projectDateViewedDeduplicator
+                    projectDateViewedDeduplicator,
+                    personViewedEntityDeduplicator
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/PersonViewedEntityDeduplicator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/PersonViewedEntityDeduplicator.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas.renku
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling.UpdateQueryMigration
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import org.typelevel.log4cats.Logger
+
+private object PersonViewedEntityDeduplicator {
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    UpdateQueryMigration[F](name, query).widen
+
+  private lazy val name = Migration.Name("Remove Project DateViewed duplicates")
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of renku -> "renku",
+    sparql"""|DELETE {
+             |  GRAPH ${GraphClass.PersonViewings.id} {
+             |    ?viewingId renku:dateViewed ?date
+             |  }
+             |}
+             |WHERE {
+             |  GRAPH ${GraphClass.PersonViewings.id} {
+             |    {
+             |      SELECT ?viewingId (MAX(?date) AS ?maxDate)
+             |      WHERE {
+             |        ?viewingId renku:dateViewed ?date.
+             |      }
+             |      GROUP BY ?viewingId
+             |      HAVING (COUNT(?date) > 1)
+             |    }
+             |    ?viewingId renku:dateViewed ?date.
+             |    FILTER (?date != ?maxDate)
+             |  }
+             |}
+             |""".stripMargin
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/PersonViewedEntityDeduplicator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/PersonViewedEntityDeduplicator.scala
@@ -36,7 +36,7 @@ private object PersonViewedEntityDeduplicator {
   def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
     UpdateQueryMigration[F](name, query).widen
 
-  private lazy val name = Migration.Name("Remove Project DateViewed duplicates")
+  private lazy val name = Migration.Name("Remove Person Viewed Entity duplicates")
 
   private[migrations] lazy val query = SparqlQuery.of(
     name.asRefined,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectDateViewedDeduplicator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectDateViewedDeduplicator.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas.renku
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.tooling.UpdateQueryMigration
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import org.typelevel.log4cats.Logger
+
+private object ProjectDateViewedDeduplicator {
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    UpdateQueryMigration[F](name, query).widen
+
+  private lazy val name = Migration.Name("Remove Project DateViewed duplicates")
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of renku -> "renku",
+    sparql"""|DELETE {
+             |  GRAPH ${GraphClass.ProjectViewedTimes.id} {
+             |    ?id renku:dateViewed ?date
+             |  }
+             |}
+             |WHERE {
+             |  GRAPH ${GraphClass.ProjectViewedTimes.id} {
+             |    {
+             |      SELECT ?id (MAX(?date) AS ?maxDate)
+             |      WHERE {
+             |        ?id renku:dateViewed ?date
+             |      }
+             |      GROUP BY ?id
+             |      HAVING (COUNT(?date) > 1)
+             |    }
+             |    ?id renku:dateViewed ?date.
+             |    FILTER (?date != ?maxDate)
+             |  }
+             |}
+             |""".stripMargin
+  )
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/PersonViewedEntityDeduplicatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/PersonViewedEntityDeduplicatorSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.syntax.all._
+import io.renku.entities.viewings.EntityViewings
+import io.renku.entities.viewings.collector.persons.Generators.{generateProjectWithCreator, generateProjectWithCreatorAndDataset}
+import io.renku.entities.viewings.collector.persons.{PersonViewedDatasetSpecTools, PersonViewedProjectSpecTools}
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestamps
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.{datasets, projects}
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.api.events.{DatasetViewedEvent, ProjectViewedEvent, UserId}
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class PersonViewedProjectDeduplicatorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with OptionValues
+    with IOSpec
+    with InMemoryJenaForSpec
+    with PersonViewedProjectSpecTools
+    with ProjectsDataset
+    with EntityViewings {
+
+  "run" should {
+
+    "remove obsolete project viewing dates when multiple exist for a single user and project" in {
+
+      // project1
+      val project1UserId = UserId(personGitLabIds.generateOne)
+      val project1       = generateProjectWithCreator(project1UserId)
+      upload(to = projectsDataset, project1)
+
+      val eventProject1 = ProjectViewedEvent(
+        project1.path,
+        projectViewedDates(project1.dateCreated.value).generateOne,
+        project1UserId.some
+      )
+      provision(eventProject1).unsafeRunSync()
+
+      val olderDateDataset1 = timestamps(max = eventProject1.dateViewed.value).generateAs(projects.DateViewed)
+      insertOtherDate(project1.resourceId, olderDateDataset1)
+
+      // project2
+      val project2UserId = UserId(personGitLabIds.generateOne)
+      val project2       = generateProjectWithCreator(project2UserId)
+      upload(to = projectsDataset, project2)
+
+      val eventProject2 = ProjectViewedEvent(
+        project2.path,
+        projectViewedDates(project2.dateCreated.value).generateOne,
+        project2UserId.some
+      )
+      provision(eventProject2).unsafeRunSync()
+
+      // assumptions check
+      val project1UserResourceId = project1.maybeCreator.value.resourceId
+      val project2UserResourceId = project2.maybeCreator.value.resourceId
+
+      findAllViewings shouldBe Set(
+        ViewingRecord(project1UserResourceId, project1.resourceId, eventProject1.dateViewed),
+        ViewingRecord(project1UserResourceId, project1.resourceId, olderDateDataset1),
+        ViewingRecord(project2UserResourceId, project2.resourceId, eventProject2.dateViewed)
+      )
+
+      runUpdate(projectsDataset, PersonViewedEntityDeduplicator.query).unsafeRunSync()
+
+      // verification
+      findAllViewings shouldBe Set(
+        ViewingRecord(project1UserResourceId, project1.resourceId, eventProject1.dateViewed),
+        ViewingRecord(project2UserResourceId, project2.resourceId, eventProject2.dateViewed)
+      )
+    }
+  }
+}
+
+class PersonViewedDatasetDeduplicatorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with OptionValues
+    with IOSpec
+    with InMemoryJenaForSpec
+    with PersonViewedDatasetSpecTools
+    with ProjectsDataset
+    with EntityViewings {
+
+  "run" should {
+
+    "remove obsolete dataset viewing dates when multiple exist for a single user and dataset on a project" in {
+
+      // project1
+      val project1UserId              = personGitLabIds.generateOne
+      val datasetProject1 -> project1 = generateProjectWithCreatorAndDataset(UserId(project1UserId))
+      upload(to = projectsDataset, project1)
+
+      val eventDatasetProject1 = DatasetViewedEvent(
+        datasetProject1.identification.identifier,
+        datasetViewedDates(datasetProject1.provenance.date.instant).generateOne,
+        project1UserId.some
+      )
+      provision(eventDatasetProject1).unsafeRunSync()
+
+      val olderDateDataset1 = timestamps(max = eventDatasetProject1.dateViewed.value).generateAs(datasets.DateViewed)
+      insertOtherDate(datasetProject1.resourceId, olderDateDataset1)
+
+      // project2
+      val project2UserId              = personGitLabIds.generateOne
+      val datasetProject2 -> project2 = generateProjectWithCreatorAndDataset(UserId(project2UserId))
+      upload(to = projectsDataset, project2)
+
+      val eventDatasetProject2 = DatasetViewedEvent(
+        datasetProject2.identification.identifier,
+        datasetViewedDates(datasetProject2.provenance.date.instant).generateOne,
+        project2UserId.some
+      )
+      provision(eventDatasetProject2).unsafeRunSync()
+
+      // assumptions check
+      val project1UserResourceId = project1.maybeCreator.value.resourceId
+      val project2UserResourceId = project2.maybeCreator.value.resourceId
+
+      findAllViewings shouldBe Set(
+        ViewingRecord(project1UserResourceId, datasetProject1.resourceId, eventDatasetProject1.dateViewed),
+        ViewingRecord(project1UserResourceId, datasetProject1.resourceId, olderDateDataset1),
+        ViewingRecord(project2UserResourceId, datasetProject2.resourceId, eventDatasetProject2.dateViewed)
+      )
+
+      runUpdate(projectsDataset, PersonViewedEntityDeduplicator.query).unsafeRunSync()
+
+      // verification
+      findAllViewings shouldBe Set(
+        ViewingRecord(project1UserResourceId, datasetProject1.resourceId, eventDatasetProject1.dateViewed),
+        ViewingRecord(project2UserResourceId, datasetProject2.resourceId, eventDatasetProject2.dateViewed)
+      )
+    }
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectDateViewedDeduplicatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectDateViewedDeduplicatorSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import io.renku.entities.viewings.collector.ProjectViewedTimeOntology
+import io.renku.entities.viewings.collector.projects.EventPersisterSpecTools
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.timestamps
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.{GraphClass, projects}
+import io.renku.jsonld.syntax._
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.api.events.Generators.projectViewedEvents
+import io.renku.triplesgenerator.api.events.ProjectViewedEvent
+import io.renku.triplesstore.client.model.Quad
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class ProjectDateViewedDeduplicatorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with EventPersisterSpecTools
+    with ProjectsDataset {
+
+  "run" should {
+
+    "remove obsolete project viewing dates when multiple exist for a single project" in {
+
+      val event1Project1 = projectViewedEvents.generateOne
+      insertEvent(event1Project1)
+
+      val event2Project1 = projectViewedEvents.generateOne.copy(
+        path = event1Project1.path,
+        dateViewed = timestamps(max = event1Project1.dateViewed.value).generateAs(projects.DateViewed)
+      )
+      insertEvent(event2Project1)
+
+      val eventProject2 = projectViewedEvents.generateOne
+      insertEvent(eventProject2)
+
+      findAllViewings shouldBe Set(
+        projects.ResourceId(event1Project1.path) -> event1Project1.dateViewed,
+        projects.ResourceId(event2Project1.path) -> event2Project1.dateViewed,
+        projects.ResourceId(eventProject2.path)  -> eventProject2.dateViewed
+      )
+
+      runUpdate(projectsDataset, ProjectDateViewedDeduplicator.query).unsafeRunSync()
+
+      findAllViewings shouldBe Set(
+        projects.ResourceId(event1Project1.path) -> event1Project1.dateViewed,
+        projects.ResourceId(eventProject2.path)  -> eventProject2.dateViewed
+      )
+    }
+  }
+
+  private def insertEvent(event: ProjectViewedEvent) =
+    insert(
+      to = projectsDataset,
+      Quad(
+        GraphClass.ProjectViewedTimes.id,
+        projects.ResourceId(event.path).asEntityId,
+        ProjectViewedTimeOntology.dataViewedProperty.id,
+        event.dateViewed.asObject
+      )
+    )
+}


### PR DESCRIPTION
Storing viewing events can end up with duplicate dates in the TS. That's due to a lack of transactions on the REST Jena API we use. This PR adds deduplication queries to be executed after a successful event persists. 