### PR TITLE
feat: emails to be sensitive and so not printed on toString or show

### DIFF
--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/persons.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/persons.scala
@@ -188,7 +188,7 @@ object persons {
     )
   }
 
-  final class Email private (val value: String) extends AnyVal with StringTinyType
+  final class Email private (val value: String) extends AnyVal with StringTinyType with Sensitive
   implicit object Email
       extends TinyTypeFactory[Email](new Email(_))
       with NonBlank[Email]

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/persons.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/persons.scala
@@ -108,7 +108,7 @@ object persons {
     def apply(orcidId: OrcidId)(implicit renkuUrl: RenkuUrl, ev: OrcidId.type): OrcidIdBased =
       new OrcidIdBased((renkuUrl / "persons" / "orcid" / orcidId.id).show)
 
-    def apply(email: Email): EmailBased = new EmailBased(show"mailto:$email")
+    def apply(email: Email): EmailBased = new EmailBased(show"mailto:${email.value}")
 
     def apply(name: Name)(implicit renkuUrl: RenkuUrl): NameBased =
       new NameBased((renkuUrl / "persons" / name).show)

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/personsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/personsSpec.scala
@@ -23,6 +23,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.persons.{Email, ResourceId}
 import io.renku.graph.model.views.RdfResource
+import io.renku.tinytypes.Sensitive
 import io.renku.tinytypes.constraints.NonBlank
 import org.apache.jena.util.URIref
 import org.scalacheck.Gen
@@ -37,6 +38,10 @@ class EmailSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.Ma
 
     "be a NonBlank" in {
       Email shouldBe a[NonBlank[_]]
+    }
+
+    "be Sensitive" in {
+      personEmails.generateOne shouldBe a[Sensitive]
     }
   }
 

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/personsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/personsSpec.scala
@@ -122,7 +122,7 @@ class PersonResourceIdSpec
   "apply(Email)" should {
     "generate 'mailto:email' ResourceId" in {
       val email = personEmails.generateOne
-      ResourceId(email).show shouldBe show"mailto:$email"
+      ResourceId(email).show shouldBe show"mailto:${email.value}"
     }
   }
 


### PR DESCRIPTION
This PR makes the `persons.Email` class `Sensitive` which means that it's content won't be printed when `toString` or `show` is called on it.

/deploy #persist