### PR TITLE
feat: Project Status API to return failure stacktrace

### DIFF
--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -82,7 +82,8 @@ Response examples:
   },
   "details": {
     "status":  "in-progress|success|failure",
-    "message": "generating triples"
+    "message": "generating triples",
+    "details": "some stack trace" // optional
   }
 }
 ```

--- a/webhook-service/README.md
+++ b/webhook-service/README.md
@@ -81,9 +81,9 @@ Response examples:
     "percentage": 40.00
   },
   "details": {
-    "status":  "in-progress|success|failure",
-    "message": "generating triples",
-    "details": "some stack trace" // optional
+    "status":     "in-progress|success|failure",
+    "message":    "generating triples",
+    "stacktrace": "some stack trace" // optional
   }
 }
 ```

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfo.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfo.scala
@@ -121,7 +121,7 @@ private object Details {
   implicit val jsonEncoder: Encoder[Details] =
     Encoder.instance { d =>
       Json
-        .obj("status" -> d.status.asJson, "message" -> d.message.asJson, "details" -> d.maybeDetails.asJson)
+        .obj("status" -> d.status.asJson, "message" -> d.message.asJson, "stacktrace" -> d.maybeDetails.asJson)
         .deepDropNullValues
     }
 }

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfo.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfo.scala
@@ -19,12 +19,12 @@
 package io.renku.webhookservice.eventstatus
 
 import cats.syntax.all._
-import io.circe.{Encoder, Json}
 import io.circe.literal._
-import io.renku.graph.model.events.{EventStatus, EventStatusProgress}
-import EventStatus._
 import io.circe.syntax.EncoderOps
+import io.circe.{Encoder, Json}
+import io.renku.graph.model.events.EventStatus._
 import io.renku.graph.model.events.EventStatusProgress.Stage
+import io.renku.graph.model.events.{EventInfo, EventStatus, EventStatusProgress}
 
 private sealed trait StatusInfo extends Product {
   def activated: Boolean
@@ -42,11 +42,11 @@ private object StatusInfo {
     def fold[A](whenActivated: StatusInfo.ActivatedProject => A, notActivated: => A): A = whenActivated(this)
   }
 
-  def activated(eventStatus: EventStatus): StatusInfo.ActivatedProject =
-    ActivatedProject(Progress.from(eventStatus), Details.fromStatus(eventStatus))
+  def activated(event: EventInfo): StatusInfo.ActivatedProject =
+    ActivatedProject(Progress.from(event.status), Details.from(event))
 
   def webhookReady: StatusInfo.ActivatedProject =
-    ActivatedProject(Progress.Zero, Details("in-progress", "Webhook has been installed."))
+    ActivatedProject(Progress.Zero, Details("in-progress", "Webhook has been installed.", maybeDetails = None))
 
   final case object NotActivated extends StatusInfo {
     override val activated: Boolean  = false
@@ -99,11 +99,13 @@ private object Progress {
   }
 }
 
-private final case class Details(status: String, message: String)
+private final case class Details(status: String, message: String, maybeDetails: Option[String])
 
 private object Details {
-  def fromStatus(eventStatus: EventStatus): Details = {
-    val status: String = eventStatus match {
+
+  def from(event: EventInfo): Details = {
+
+    val status: String = event.status match {
       case New | GeneratingTriples | GenerationRecoverableFailure | TriplesGenerated | TransformingTriples |
           TransformationRecoverableFailure | AwaitingDeletion | Deleting =>
         "in-progress"
@@ -111,10 +113,15 @@ private object Details {
       case GenerationNonRecoverableFailure | TransformationNonRecoverableFailure => "failure"
     }
 
-    val message: String = eventStatus.show.toLowerCase.replace('_', ' ')
-    Details(status, message)
+    val message: String = event.status.show.toLowerCase.replace('_', ' ')
+
+    Details(status, message, event.maybeMessage.map(_.value))
   }
 
   implicit val jsonEncoder: Encoder[Details] =
-    Encoder.instance(d => Json.obj("status" -> d.status.asJson, "message" -> d.message.asJson))
+    Encoder.instance { d =>
+      Json
+        .obj("status" -> d.status.asJson, "message" -> d.message.asJson, "details" -> d.maybeDetails.asJson)
+        .deepDropNullValues
+    }
 }

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfoFinder.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfoFinder.scala
@@ -53,6 +53,6 @@ private class StatusInfoFinderImpl[F[_]: MonadThrow](eventLogClient: EventLogCli
   private def toStatusInfo(events: List[EventInfo]): Option[StatusInfo] =
     events match {
       case Nil        => None
-      case event :: _ => StatusInfo.activated(event.status).some
+      case event :: _ => StatusInfo.activated(event).some
     }
 }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/Generators.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/Generators.scala
@@ -18,7 +18,7 @@
 
 package io.renku.webhookservice.eventstatus
 
-import io.renku.graph.model.EventsGenerators.eventStatuses
+import io.renku.graph.model.EventContentGenerators.eventInfos
 import org.scalacheck.Gen
 
 private object Generators {
@@ -26,7 +26,7 @@ private object Generators {
   implicit val statusInfos: Gen[StatusInfo] =
     Gen
       .either(
-        eventStatuses.map(StatusInfo.activated),
+        eventInfos().map(StatusInfo.activated),
         StatusInfo.NotActivated
       )
       .map(_.merge)

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoFinderSpec.scala
@@ -42,7 +42,7 @@ class StatusInfoFinderSpec extends AnyWordSpec with should.Matchers with MockFac
       val eventInfo = eventInfos(projectIdGen = fixed(projectId)).generateOne
       givenGetEvents(projectId, returning = EventLogClient.Result.Success(List(eventInfo)).pure[Try])
 
-      fetcher.findStatusInfo(projectId) shouldBe StatusInfo.activated(eventInfo.status).some.pure[Try]
+      fetcher.findStatusInfo(projectId) shouldBe StatusInfo.activated(eventInfo).some.pure[Try]
     }
 
     "return activated project StatusInfo when no events found for the project" in new TestCase {

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoSpec.scala
@@ -48,9 +48,9 @@ class StatusInfoSpec extends AnyWordSpec with should.Matchers with ScalaCheckPro
             "percentage": ${info.progress.percentage}
           },
           "details": {
-             "status":  ${info.details.status},
-             "message": ${info.details.message},
-             "details": ${info.details.maybeDetails}
+             "status":     ${info.details.status},
+             "message":    ${info.details.message},
+             "stacktrace": ${info.details.maybeDetails}
           }
         }""".deepDropNullValues
       }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoSpec.scala
@@ -22,9 +22,10 @@ import cats.syntax.all._
 import io.circe.literal._
 import io.circe.syntax._
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.EventContentGenerators.{eventInfos, eventMessages}
 import io.renku.graph.model.EventsGenerators.eventStatuses
-import io.renku.graph.model.events.{EventStatus, EventStatusProgress}
-import EventStatus._
+import io.renku.graph.model.events.EventStatus._
+import io.renku.graph.model.events.{EventMessage, EventStatus, EventStatusProgress}
 import org.scalatest.matchers.should
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
@@ -35,8 +36,9 @@ class StatusInfoSpec extends AnyWordSpec with should.Matchers with ScalaCheckPro
   "encode" should {
 
     "produce Json from a StatusInfo of an activated project with a NonZero progress" in {
-      forAll { eventStatus: EventStatus =>
-        val info = StatusInfo.activated(eventStatus)
+
+      forAll(eventInfos()) { eventInfo =>
+        val info = StatusInfo.activated(eventInfo)
 
         info.asJson shouldBe json"""{
           "activated": true,
@@ -47,9 +49,10 @@ class StatusInfoSpec extends AnyWordSpec with should.Matchers with ScalaCheckPro
           },
           "details": {
              "status":  ${info.details.status},
-             "message": ${info.details.message}
+             "message": ${info.details.message},
+             "details": ${info.details.maybeDetails}
           }
-        }"""
+        }""".deepDropNullValues
       }
     }
 
@@ -95,26 +98,36 @@ class DetailsSpec extends AnyWordSpec with should.Matchers with TableDrivenPrope
 
     forAll(
       Table(
-        ("eventStatus", "status", "message"),
-        (New, "in-progress", "new"),
-        (Skipped, "success", "skipped"),
-        (GeneratingTriples, "in-progress", "generating triples"),
-        (GenerationRecoverableFailure, "in-progress", "generation recoverable failure"),
-        (GenerationNonRecoverableFailure, "failure", "generation non recoverable failure"),
-        (TriplesGenerated, "in-progress", "triples generated"),
-        (TransformingTriples, "in-progress", "transforming triples"),
-        (TransformationRecoverableFailure, "in-progress", "transformation recoverable failure"),
-        (TransformationNonRecoverableFailure, "failure", "transformation non recoverable failure"),
-        (TriplesStore, "success", "triples store"),
-        (AwaitingDeletion, "in-progress", "awaiting deletion"),
-        (Deleting, "in-progress", "deleting")
+        ("eventStatus", "status", "message", "maybeMessage"),
+        (New, "in-progress", "new", Option.empty[EventMessage]),
+        (Skipped, "success", "skipped", eventMessages.generateSome),
+        (GeneratingTriples, "in-progress", "generating triples", Option.empty[EventMessage]),
+        (GenerationRecoverableFailure, "in-progress", "generation recoverable failure", eventMessages.generateSome),
+        (GenerationNonRecoverableFailure, "failure", "generation non recoverable failure", eventMessages.generateSome),
+        (TriplesGenerated, "in-progress", "triples generated", Option.empty[EventMessage]),
+        (TransformingTriples, "in-progress", "transforming triples", Option.empty[EventMessage]),
+        (TransformationRecoverableFailure,
+         "in-progress",
+         "transformation recoverable failure",
+         eventMessages.generateSome
+        ),
+        (TransformationNonRecoverableFailure,
+         "failure",
+         "transformation non recoverable failure",
+         eventMessages.generateSome
+        ),
+        (TriplesStore, "success", "triples store", Option.empty[EventMessage]),
+        (AwaitingDeletion, "in-progress", "awaiting deletion", Option.empty[EventMessage]),
+        (Deleting, "in-progress", "deleting", Option.empty[EventMessage])
       )
-    ) { (eventStatus, status, message) =>
+    ) { (eventStatus, status, message, maybeEventMessage) =>
       show"provide '$status' as status and '$message' as message for the '$eventStatus' status" in {
-        val details = Details.fromStatus(eventStatus)
+        val details =
+          Details.from(eventInfos().generateOne.copy(status = eventStatus, maybeMessage = maybeEventMessage))
 
-        details.status  shouldBe status
-        details.message shouldBe message
+        details.status       shouldBe status
+        details.message      shouldBe message
+        details.maybeDetails shouldBe maybeEventMessage.map(_.value)
       }
     }
   }


### PR DESCRIPTION
It was identified that troubleshooting provisioning failures might be a difficult task. Most of the time it requires fetching project events by calling the EL API. However, to do that access to the deployment internal EL API has to be obtained.

It seems to be much better if a new `stacktrace` property is added to the response of the publicly available Project Status API.