### PR TITLE
fix: Avoid shared javax.crypto instances

### DIFF
--- a/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
+++ b/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
@@ -70,5 +70,11 @@ object AesCrypto {
       else Left(s"Expected 16 bytes, but got ${value.length}")
 
     def unsafe(value: ByteVector): Secret = apply(value).fold(sys.error, identity)
+
+    def fromBase64(b64: String): Either[String, Secret] =
+      ByteVector.fromBase64Descriptive(b64).flatMap(apply)
+
+    def unsafeFromBase64(b64: String): Secret =
+      fromBase64(b64).fold(sys.error, identity)
   }
 }

--- a/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
+++ b/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
@@ -19,10 +19,8 @@
 package io.renku.crypto
 
 import cats.MonadThrow
-import eu.timepit.refined.W
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.MinSize
 import io.renku.crypto.AesCrypto.Secret
+import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Base64
@@ -37,7 +35,6 @@ abstract class AesCrypto[F[_]: MonadThrow, NONENCRYPTED, ENCRYPTED](
   private val base64Decoder = Base64.getDecoder
   private val base64Encoder = Base64.getEncoder
   private val algorithm     = "AES/CBC/PKCS5Padding"
-  private def key           = new SecretKeySpec(base64Decoder.decode(secret.value).takeWhile(_ != 10), "AES")
   private val ivSpec        = new IvParameterSpec(new Array[Byte](16))
 
   def encrypt(nonEncrypted: NONENCRYPTED): F[ENCRYPTED]
@@ -45,15 +42,12 @@ abstract class AesCrypto[F[_]: MonadThrow, NONENCRYPTED, ENCRYPTED](
 
   private def cipher(mode: Int): Cipher = {
     val c = Cipher.getInstance(algorithm)
-    c.init(mode, key, ivSpec)
+    c.init(mode, new SecretKeySpec(secret.value.toArray, "AES"), ivSpec)
     c
   }
 
   protected def encryptAndEncode(toEncryptAndEncode: String): F[String] = MonadThrow[F].catchNonFatal {
-    new String(
-      base64Encoder.encode(cipher(ENCRYPT_MODE).doFinal(toEncryptAndEncode.getBytes(UTF_8))),
-      UTF_8
-    )
+    base64Encoder.encodeToString(cipher(ENCRYPT_MODE).doFinal(toEncryptAndEncode.getBytes(UTF_8)))
   }
 
   protected def decodeAndDecrypt(toDecodeAndDecrypt: String): F[String] = MonadThrow[F].catchNonFatal {
@@ -65,5 +59,16 @@ abstract class AesCrypto[F[_]: MonadThrow, NONENCRYPTED, ENCRYPTED](
 }
 
 object AesCrypto {
-  type Secret = String Refined MinSize[W.`16`.T]
+  final class Secret private (val value: ByteVector) extends AnyVal {
+    override def toString: String = "Secret(***)"
+
+    def toBase64 = value.toBase64
+  }
+  object Secret {
+    def apply(value: ByteVector): Either[String, Secret] =
+      if (value.length == 16) Right(new Secret(value))
+      else Left(s"Expected 16 bytes, but got ${value.length}")
+
+    def unsafe(value: ByteVector): Secret = apply(value).fold(sys.error, identity)
+  }
 }

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -26,7 +26,7 @@ import io.renku.config.certificates.Certificate
 import io.renku.config.sentry.SentryConfig
 import io.renku.config.sentry.SentryConfig.{Dsn, Environment}
 import io.renku.control.{RateLimit, RateLimitUnit}
-import io.renku.crypto.AesCrypto
+import io.renku.crypto.AesCrypto.Secret
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.http.server.security.Authorizer.AuthContext
@@ -49,20 +49,20 @@ import io.renku.triplesstore._
 import org.http4s.Status
 import org.http4s.Status._
 import org.scalacheck.{Arbitrary, Gen}
+import scodec.bits.Bases.Alphabets
+import scodec.bits.ByteVector
 
-import java.nio.charset.StandardCharsets.UTF_8
-import java.util.Base64
 import scala.language.implicitConversions
 import scala.util.Try
 
 object CommonGraphGenerators {
 
-  implicit val aesCryptoSecrets: Gen[AesCrypto.Secret] =
-    stringsOfLength(16)
-      .map(_.getBytes(UTF_8))
-      .map(Base64.getEncoder.encode)
-      .map(new String(_, UTF_8))
-      .map(Refined.unsafeApply)
+  implicit val aesCryptoSecrets: Gen[Secret] =
+    Gen
+      .listOfN(32, Gen.hexChar)
+      .map(_.mkString.toLowerCase)
+      .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
+      .map(Secret.unsafe)
 
   implicit val personalAccessTokens: Gen[PersonalAccessToken] = for {
     length <- Gen.choose(5, 40)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/AccessTokenCrypto.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/AccessTokenCrypto.scala
@@ -24,7 +24,6 @@ import cats.syntax.all._
 import com.typesafe.config.{Config, ConfigFactory}
 import eu.timepit.refined.W
 import eu.timepit.refined.api.{RefType, Refined}
-import eu.timepit.refined.pureconfig._
 import eu.timepit.refined.string.MatchesRegex
 import io.circe._
 import io.circe.parser._

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
@@ -20,24 +20,25 @@ package io.renku.tokenrepository.repository
 
 import cats.syntax.all._
 import com.typesafe.config.ConfigFactory
-import eu.timepit.refined.api.RefType
+import io.renku.config.ConfigLoader.ConfigLoadingException
 import io.renku.crypto.AesCrypto.Secret
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.http.client.AccessToken
+import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import org.scalatest.matchers.should
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
+import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets.UTF_8
-import java.security.InvalidKeyException
 import java.util.Base64
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
-class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableDrivenPropertyChecks {
+class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableDrivenPropertyChecks with IOSpec {
 
   "encrypt/decrypt" should {
 
@@ -67,7 +68,7 @@ class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableD
       val config = ConfigFactory.parseMap(
         Map(
           "projects-tokens" -> Map(
-            "secret" -> aesCryptoSecrets.generateOne.value
+            "secret" -> aesCryptoSecrets.generateOne.toBase64
           ).asJava
         ).asJava
       )
@@ -90,19 +91,15 @@ class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableD
 
       val Failure(exception) = AccessTokenCrypto[Try](config)
 
-      exception            shouldBe a[InvalidKeyException]
-      exception.getMessage shouldBe "Invalid AES key length: 15 bytes"
+      exception          shouldBe a[ConfigLoadingException]
+      exception.getMessage should include("Expected 16 bytes, but got 15")
     }
   }
 
   private trait TestCase {
 
-    private val secret = new String(Base64.getEncoder.encode("1234567890123456".getBytes(UTF_8)), UTF_8)
-    val hookTokenCrypto = new AccessTokenCryptoImpl[Try](
-      RefType
-        .applyRef[Secret](secret)
-        .getOrElse(throw new IllegalArgumentException("Wrong secret"))
-    )
+    private val secret  = Secret.unsafe(ByteVector.view("1234567890123456".getBytes(UTF_8)))
+    val hookTokenCrypto = new AccessTokenCryptoImpl[Try](secret)
   }
 
   private lazy val tokenScenarios = Table(

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
@@ -26,6 +26,7 @@ import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.http.client.AccessToken
+import io.renku.http.client.AccessToken.{PersonalAccessToken, UserOAuthAccessToken}
 import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import org.scalatest.matchers.should
@@ -59,6 +60,23 @@ class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableD
 
       decryptException            shouldBe an[Exception]
       decryptException.getMessage shouldBe "AccessToken decryption failed"
+    }
+
+    "decrypt existing values" in {
+      val usedSecret  = Secret.unsafeFromBase64("YWJjZGVmZzEyMzQ1Njc4OQ==")
+      val tokenCrypto = new AccessTokenCryptoImpl[Try](usedSecret)
+      val token1      = PersonalAccessToken("lhcrr5dkerm69osrrujlubkkw0ysx8io0e")
+      val encToken1 = EncryptedAccessToken
+        .from("jmamuPCm4R0Rr/ZuVRrYffwBHWdJt8siwuVYJ7WVrLgDIR6RzcCJcpuuvCWcVnlPRsXi2wFHfM+OBOsbt2erZQ==")
+        .fold(throw _, identity)
+
+      val token2 = UserOAuthAccessToken("q2f4t4ph7atcfh08eau1g35")
+      val encToken2 = EncryptedAccessToken
+        .from("QXK4EOJLgdqQdh8MLkS+vCtsJFU0wsnpD9QZuu5qyWROFCzFfUr81xv6f1mN1r3T")
+        .fold(throw _, identity)
+
+      tokenCrypto.decrypt(encToken1) shouldBe Success(token1)
+      tokenCrypto.decrypt(encToken2) shouldBe Success(token2)
     }
   }
 

--- a/webhook-service/src/main/scala/io/renku/webhookservice/crypto/HookTokenCrypto.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/crypto/HookTokenCrypto.scala
@@ -23,7 +23,6 @@ import cats.syntax.all._
 import com.typesafe.config.{Config, ConfigFactory}
 import eu.timepit.refined.W
 import eu.timepit.refined.api.{RefType, Refined}
-import eu.timepit.refined.pureconfig._
 import eu.timepit.refined.string.MatchesRegex
 import io.circe.parser._
 import io.circe.{Decoder, HCursor, Json}

--- a/webhook-service/src/test/scala/io/renku/webhookservice/crypto/HookTokenCryptoSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/crypto/HookTokenCryptoSpec.scala
@@ -58,6 +58,18 @@ class HookTokenCryptoSpec extends AnyWordSpec with should.Matchers {
       decryptException            shouldBe an[Exception]
       decryptException.getMessage shouldBe "HookToken decryption failed"
     }
+
+    "decrypt existing values" in {
+      val usedSecret      = Secret.unsafeFromBase64("YWJjZGVmZzEyMzQ1Njc4OQ==")
+      val hookTokenCrypto = new HookTokenCryptoImpl[Try](usedSecret)
+
+      val plain =
+        hookTokenCrypto.decrypt(
+          SerializedHookToken.from("4TV8A81+1+U3dfa8sVO9TUuMvGHLaerySYpxEIkVT/U=").fold(throw _, identity)
+        )
+
+      plain shouldBe Success(HookToken(123456))
+    }
   }
 
   "apply" should {

--- a/webhook-service/src/test/scala/io/renku/webhookservice/crypto/HookTokenCryptoSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/crypto/HookTokenCryptoSpec.scala
@@ -19,7 +19,7 @@
 package io.renku.webhookservice.crypto
 
 import com.typesafe.config.ConfigFactory
-import eu.timepit.refined.api.RefType
+import io.renku.config.ConfigLoader.ConfigLoadingException
 import io.renku.crypto.AesCrypto.Secret
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
@@ -29,9 +29,9 @@ import io.renku.webhookservice.crypto.HookTokenCrypto.SerializedHookToken
 import io.renku.webhookservice.model.HookToken
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets.UTF_8
-import java.security.InvalidKeyException
 import java.util.Base64
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -67,7 +67,7 @@ class HookTokenCryptoSpec extends AnyWordSpec with should.Matchers {
         Map(
           "services" -> Map(
             "gitlab" -> Map(
-              "hook-token-secret" -> aesCryptoSecrets.generateOne.value
+              "hook-token-secret" -> aesCryptoSecrets.generateOne.toBase64
             ).asJava
           ).asJava
         ).asJava
@@ -93,18 +93,14 @@ class HookTokenCryptoSpec extends AnyWordSpec with should.Matchers {
 
       val Failure(exception) = HookTokenCrypto[Try](config)
 
-      exception            shouldBe a[InvalidKeyException]
-      exception.getMessage shouldBe "Invalid AES key length: 15 bytes"
+      exception          shouldBe a[ConfigLoadingException]
+      exception.getMessage should include("Expected 16 bytes, but got 15")
     }
   }
 
   private trait TestCase {
 
-    private val secret = new String(Base64.getEncoder.encode("1234567890123456".getBytes("utf-8")), "utf-8")
-    val hookTokenCrypto = new HookTokenCryptoImpl[Try](
-      RefType
-        .applyRef[Secret](secret)
-        .getOrElse(throw new IllegalArgumentException("Wrong secret"))
-    )
+    private val secret  = Secret.unsafe(ByteVector.fromValidHex(List.fill(4)("caffee00").mkString))
+    val hookTokenCrypto = new HookTokenCryptoImpl[Try](secret)
   }
 }


### PR DESCRIPTION
This is an attempt to fix #1327. The javax.crypto.Cipher class is not safe to use from multiple threads which may happen when we assign it to a val. Additionally, the secret for the aes is now based on a ByteVector.

closes #1327 