### PR TITLE
fix: secrets config reader for AES crypto to skip the last LF char

### DIFF
--- a/event-log/README.md
+++ b/event-log/README.md
@@ -189,12 +189,12 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "RollbackToNew",
   "id":           "df654c3b1bd105a29d658f78f6380a842feac879",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
-  },
-  "subCategory": "RollbackToNew"
+  }
 }
 ```
 
@@ -207,14 +207,14 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "ToFailure",
   "id":           "df654c3b1bd105a29d658f78f6380a842feac879",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
   },
   "message":   "<failure message>",
-  "newStatus": <failure status>,
-  "subCategory": "ToFailure"
+  "newStatus": <failure status>
 }
 ```
 
@@ -227,12 +227,12 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "RollbackToTriplesGenerated",
   "id":           "df654c3b1bd105a29d658f78f6380a842feac879",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
-  },
-  "newStatus": "RollbackToTriplesGenerated"
+  }
 }
 ```
 
@@ -245,10 +245,10 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "RedoProjectTransformation",
   "project": {
     "path": "namespace/project-name"
-  },
-  "subCategory": "RedoProjectTransformation"
+  }
 }
 ```
 
@@ -261,12 +261,12 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "ToAwaitingDeletion",
   "id":           "df654c3b1bd105a29d658f78f6380a842feac879",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
-  },
-  "subCategory": "ToAwaitingDeletion"
+  }
 }
 ```
 
@@ -279,12 +279,12 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "ToTriplesGenerated",
   "id":           "df654c3b1bd105a29d658f78f6380a842feac879",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
   },
-  "subCategory": "ToTriplesGenerated",
   "processingTime": "PT2.023S"
 }
 ```
@@ -300,12 +300,12 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "ToTriplesStore",
   "id":           "df654c3b1bd105a29d658f78f6380a842feac879",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
   },
-  "subCategory": "ToTriplesStore",
   "processingTime": "PT2.023S"
 }
 ```
@@ -319,11 +319,11 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory": "ProjectEventsToNew",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
-  },
-  "subCategory": "ProjectEventsToNew"
+  }
 }
 ```
 
@@ -336,11 +336,11 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
+  "subCategory":  "RollbackToAwaitingDeletion",
   "project": {
     "id":   12,
     "path": "namespace/project-name"
-  },
-  "subCategory": "RollbackToAwaitingDeletion"
+  }
 }
 ```
 
@@ -353,7 +353,7 @@ payload needed for processing.
 ```json
 {
   "categoryName": "EVENTS_STATUS_CHANGE",
-  "subCategory":    "AllEventsToNew"
+  "subCategory":  "AllEventsToNew"
 }
 ```
 

--- a/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.crypto
+
+import com.typesafe.config.ConfigFactory
+import io.renku.crypto.AesCrypto.Secret
+import io.renku.generators.CommonGraphGenerators.aesCryptoSecrets
+import io.renku.generators.Generators.Implicits._
+import org.scalacheck.Gen
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import pureconfig.ConfigSource
+import scodec.bits.Bases.Alphabets
+import scodec.bits.ByteVector
+
+class SecretSpec extends AnyWordSpec with should.Matchers with EitherValues {
+
+  "secretReader" should {
+
+    val keyName = "secret"
+
+    "decode Base64 encoded secret" in {
+
+      val secret = aesCryptoSecrets.generateOne
+
+      val config = ConfigFactory.parseString(s"""$keyName = "${secret.toBase64}"""")
+
+      ConfigSource.fromConfig(config).at(keyName).load[Secret].value.toBase64 shouldBe secret.toBase64
+    }
+
+    "decode Base64 encoded secret ending with LF char" in {
+
+      val secret = aesCryptoSecrets.generateOne
+
+      val config = ConfigFactory.parseString(s"""$keyName = "${(secret.value :+ 10.toByte).toBase64}"""")
+
+      ConfigSource.fromConfig(config).at(keyName).load[Secret].value.toBase64 shouldBe secret.toBase64
+    }
+
+    "fail and not print the secret if decoding fails" in {
+
+      val value = Gen
+        .listOfN(2, Gen.hexChar)
+        .map(_.mkString.toLowerCase)
+        .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
+        .generateOne
+        .toBase64
+
+      val config = ConfigFactory.parseString(s"""$keyName = "$value"""")
+
+      val failure = ConfigSource.fromConfig(config).at(keyName).load[Secret].left.value.prettyPrint()
+
+      failure should include("Cannot read AES secret")
+      failure should not include value
+    }
+  }
+}

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -62,6 +62,7 @@ object CommonGraphGenerators {
       .listOfN(32, Gen.hexChar)
       .map(_.mkString.toLowerCase)
       .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
+      .retryUntil(_.takeWhile(_ != 10.toByte).length == 16)
       .map(Secret.unsafe)
 
   implicit val personalAccessTokens: Gen[PersonalAccessToken] = for {


### PR DESCRIPTION
The secrets used for the AES crypto in the token-repository may contain an LF char at the end. If not skipped, the AES crypto fails.