### PR TITLE
fix: DS graph provisioning when many DS on one project with same sameAs

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/CommandsCalculator.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/CommandsCalculator.scala
@@ -125,8 +125,10 @@ private class CommandsCalculatorImpl[F[_]: MonadThrow] extends CommandsCalculato
 
   private object `DS exists on TS only on the single project` {
     def unapply(infoSet: CalculatorInfoSet): Option[DatasetSearchInfo] = infoSet match {
-      case CalculatorInfoSet.TSInfoOnly(proj, tsInfo, _)
-          if tsInfo.findLink(proj.resourceId).nonEmpty && tsInfo.links.size == 1 =>
+      case CalculatorInfoSet.TSInfoOnly(proj, tsInfo, tsVisibilities)
+          if tsInfo
+            .findLink(proj.resourceId)
+            .nonEmpty && (tsInfo.links.size == 1 || (tsVisibilities - proj.resourceId).isEmpty) =>
         tsInfo.some
       case _ => None
     }
@@ -163,8 +165,7 @@ private class CommandsCalculatorImpl[F[_]: MonadThrow] extends CommandsCalculato
 
   private def maxVisibilityAfter(tsVisibilities: Map[projects.ResourceId, projects.Visibility],
                                  modelInfo:      DatasetSearchInfo
-  ) =
-    findMax(tsVisibilities + (modelInfo.links.head.projectId -> modelInfo.visibility))
+  ) = findMax(tsVisibilities + (modelInfo.links.head.projectId -> modelInfo.visibility))
 
   private def findMax(visibilities: Map[projects.ResourceId, projects.Visibility]): projects.Visibility =
     visibilities.maxBy(_._2)._2

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/VisibilityFinder.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/VisibilityFinder.scala
@@ -19,7 +19,6 @@
 package io.renku.entities.searchgraphs.datasets.commands
 
 import cats.effect.Async
-import cats.syntax.all._
 import io.renku.graph.model.projects
 import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder, TSClientImpl}
 import org.typelevel.log4cats.Logger
@@ -33,9 +32,6 @@ private object VisibilityFinder {
       connectionConfig: ProjectsConnectionConfig
   ): VisibilityFinder[F] =
     new VisibilityFinderImpl[F](connectionConfig)
-
-  def default[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[VisibilityFinder[F]] =
-    ProjectsConnectionConfig[F]().map(apply(_))
 }
 
 private class VisibilityFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](storeConfig: ProjectsConnectionConfig)
@@ -47,9 +43,9 @@ private class VisibilityFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder]
   import io.renku.graph.model.GraphClass
   import io.renku.graph.model.Schemas._
   import io.renku.jsonld.syntax._
-  import io.renku.triplesstore._
   import io.renku.triplesstore.ResultsDecoder._
   import io.renku.triplesstore.SparqlQuery.Prefixes
+  import io.renku.triplesstore._
   import io.renku.triplesstore.client.syntax._
 
   override def findVisibility(projectId: projects.ResourceId): F[Option[projects.Visibility]] =
@@ -58,14 +54,14 @@ private class VisibilityFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder]
   private def query(resourceId: projects.ResourceId) = SparqlQuery.of(
     name = "project visibility",
     Prefixes of (renku -> "renku", schema -> "schema"),
-    s"""|SELECT DISTINCT ?visibility
-        |WHERE {
-        |  GRAPH ${GraphClass.Project.id(resourceId).asSparql.sparql} {
-        |    ${resourceId.asEntityId.asSparql.sparql} a schema:Project;
-        |                                             renku:projectVisibility ?visibility.
-        |  }
-        |}
-        |""".stripMargin
+    sparql"""|SELECT DISTINCT ?visibility
+             |WHERE {
+             |  GRAPH ${GraphClass.Project.id(resourceId)} {
+             |    ${resourceId.asEntityId} a schema:Project;
+             |                             renku:projectVisibility ?visibility.
+             |  }
+             |}
+             |""".stripMargin
   )
 
   private implicit lazy val recordsDecoder: Decoder[Option[projects.Visibility]] =

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/commands/SearchInfoFetcher.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/commands/SearchInfoFetcher.scala
@@ -57,8 +57,8 @@ private class SearchInfoFetcherImpl[F[_]](tsClient: TSClient[F]) extends SearchI
     Prefixes of (renku -> "renku", schema -> "schema"),
     sparql"""|SELECT DISTINCT ?id ?name ?path ?visibility ?dateCreated ?maybeDescription
              |                ?maybeCreatorId ?maybeCreatorName
-             |                (GROUP_CONCAT(?keyword; separator=${rowsSeparator.asTripleObject}) AS ?keywords)
-             |                (GROUP_CONCAT(?image; separator=${rowsSeparator.asTripleObject}) AS ?images)
+             |                (GROUP_CONCAT(?keyword; separator=$rowsSeparator) AS ?keywords)
+             |                (GROUP_CONCAT(?image; separator=$rowsSeparator) AS ?images)
              |WHERE {
              |  BIND (${resourceId.asEntityId} AS ?id)
              |  GRAPH ${GraphClass.Projects.id} {

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/datasets/commands/CommandsCalculatorSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/datasets/commands/CommandsCalculatorSpec.scala
@@ -272,6 +272,24 @@ class CommandsCalculatorSpec extends AnyWordSpec with should.Matchers {
         calculateCommands(infoSet) should produce(tsInfo.asQuads.map(Delete).toList)
       }
 
+    "create Deletes for the info and the links " +
+      "when it does not exist on this Project but there were multiple DS on the same project with the same sameAs" in {
+
+        val project = newProject()
+
+        val tsInfo = {
+          val info = datasetSearchInfoObjects(withLinkTo = project).generateOne
+          info.copy(links =
+            info.links.append(linkObjectsGen(info.topmostSameAs, projectIdGen = project.resourceId).generateOne)
+          )
+        }
+
+        val infoSet =
+          CalculatorInfoSet.TSInfoOnly(project.identification, tsInfo, Map(project.resourceId -> tsInfo.visibility))
+
+        calculateCommands(infoSet) should produce(tsInfo.asQuads.map(Delete).toList)
+      }
+
     "create Deletes for the link only " +
       "when the info found in the TS is associated also with other projects - the other projects' visibilities are broader or same" in {
 


### PR DESCRIPTION
Apparently, the Dataset graph provisioning flow could not cope with a case when there were multiple Datasets on a single project having the same topmostSameAs and they all get removed.

closes #1479 