### PR TITLE
refactor: event-log-api module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val root = project
     renkuCliModel,
     renkuModel,
     graphCommons,
+    eventLogApi,
     eventLog,
     tokenRepository,
     webhookService,
@@ -108,11 +109,19 @@ lazy val graphCommons = project
   .dependsOn(renkuModel % "compile->compile; test->test")
   .enablePlugins(AutomateHeaderPlugin)
 
+lazy val eventLogApi = project
+  .in(file("event-log-api"))
+  .withId("event-log-api")
+  .settings(commonSettings)
+  .dependsOn(graphCommons % "compile->compile; test->test")
+  .enablePlugins(AutomateHeaderPlugin)
+
 lazy val eventLog = project
   .in(file("event-log"))
   .withId("event-log")
   .settings(commonSettings)
   .dependsOn(
+    eventLogApi         % "compile->compile; test->test",
     triplesGeneratorApi % "compile->compile; test->test"
   )
   .enablePlugins(
@@ -124,7 +133,7 @@ lazy val webhookService = project
   .in(file("webhook-service"))
   .withId("webhook-service")
   .settings(commonSettings)
-  .dependsOn(graphCommons % "compile->compile; test->test")
+  .dependsOn(eventLogApi  % "compile->compile; test->test")
   .enablePlugins(
     JavaAppPackaging,
     AutomateHeaderPlugin
@@ -151,7 +160,7 @@ lazy val triplesGeneratorApi = project
   .in(file("triples-generator-api"))
   .withId("triples-generator-api")
   .settings(commonSettings)
-  .dependsOn(graphCommons % "compile->compile; test->test")
+  .dependsOn(eventLogApi  % "compile->compile; test->test")
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val entitiesViewingsCollector = project

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/datasets/commands/EncodersSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/datasets/commands/EncodersSpec.scala
@@ -164,7 +164,10 @@ class EncodersSpec extends AnyWordSpec with should.Matchers {
   private def imagesToQuads(searchInfo: DatasetSearchInfo): Set[Quad] =
     searchInfo.images
       .map(i =>
-        i.asQuads + DatasetsQuad(searchInfo.topmostSameAs, DatasetSearchInfoOntology.imageProperty, i.resourceId.asEntityId)
+        i.asQuads + DatasetsQuad(searchInfo.topmostSameAs,
+                                 DatasetSearchInfoOntology.imageProperty,
+                                 i.resourceId.asEntityId
+        )
       )
       .toSet
       .flatten
@@ -172,7 +175,10 @@ class EncodersSpec extends AnyWordSpec with should.Matchers {
   private def linksToQuads(searchInfo: DatasetSearchInfo): Set[Quad] =
     searchInfo.links
       .map(l =>
-        l.asQuads + DatasetsQuad(searchInfo.topmostSameAs, DatasetSearchInfoOntology.linkProperty, l.resourceId.asEntityId)
+        l.asQuads + DatasetsQuad(searchInfo.topmostSameAs,
+                                 DatasetSearchInfoOntology.linkProperty,
+                                 l.resourceId.asEntityId
+        )
       )
       .toList
       .toSet

--- a/event-log-api/README.md
+++ b/event-log-api/README.md
@@ -1,0 +1,3 @@
+# event-log-api
+
+This module defines event-log API classes

--- a/event-log-api/build.sbt
+++ b/event-log-api/build.sbt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+organization := "io.renku"
+name := "event-log-api"

--- a/event-log-api/build.sbt
+++ b/event-log-api/build.sbt
@@ -18,3 +18,7 @@
 
 organization := "io.renku"
 name := "event-log-api"
+
+libraryDependencies ++=
+  Dependencies.circeGeneric ++
+    Dependencies.circeGenericExtras

--- a/event-log-api/src/main/scala/io/renku/eventlog/api/EventLogClient.scala
+++ b/event-log-api/src/main/scala/io/renku/eventlog/api/EventLogClient.scala
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog
+package io.renku.eventlog.api
 
+import EventLogClient._
 import cats.data.Ior
 import cats.effect.Async
 import cats.syntax.all._
 import fs2.{RaiseThrowable, Stream}
 import io.renku.graph.config.EventLogUrl
-import io.renku.graph.eventlog.EventLogClient._
 import io.renku.graph.model.eventlogapi._
 import io.renku.graph.model.events._
 import io.renku.graph.model.projects

--- a/event-log-api/src/main/scala/io/renku/eventlog/api/Http4sEventLogClient.scala
+++ b/event-log-api/src/main/scala/io/renku/eventlog/api/Http4sEventLogClient.scala
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog
+package io.renku.eventlog.api
 
+import EventLogClient.{EventPayload, Result, SearchCriteria}
+import Http4sEventLogClient.Implicits._
 import cats.effect._
 import cats.syntax.all._
 import io.renku.control.Throttler
-import io.renku.graph.eventlog.EventLogClient.{EventPayload, Result, SearchCriteria}
-import io.renku.graph.eventlog.Http4sEventLogClient.Implicits._
 import io.renku.graph.model.eventlogapi.ServiceStatus
 import io.renku.graph.model.events.{EventId, EventInfo}
 import io.renku.graph.model.projects.{Path => ProjectPath}
 import io.renku.http.client.RestClient
 import io.renku.tinytypes.TinyType
-import org.http4s.{QueryParamEncoder, Uri}
+import org.http4s.Uri.Path.SegmentEncoder
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.dsl.Http4sDsl
-import org.http4s.Uri.Path.SegmentEncoder
+import org.http4s.{QueryParamEncoder, Uri}
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector
 

--- a/event-log-api/src/main/scala/io/renku/eventlog/api/events/Client.scala
+++ b/event-log-api/src/main/scala/io/renku/eventlog/api/events/Client.scala
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog.api.events
+package io.renku.eventlog.api.events
 
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.events.producers.EventSender
 import io.renku.events.EventRequestContent
+import io.renku.events.producers.EventSender
 import io.renku.graph.config.EventLogUrl
 import io.renku.metrics.MetricsRegistry
 import org.typelevel.log4cats.Logger
@@ -38,9 +38,9 @@ object Client {
 
 private class ClientImpl[F[_]](eventSender: EventSender[F]) extends Client[F] {
 
+  import EventSender.EventContext
   import cats.syntax.all._
   import io.circe.syntax._
-  import EventSender.EventContext
 
   override def send(event: CommitSyncRequest): F[Unit] =
     eventSender.sendEvent(

--- a/event-log-api/src/main/scala/io/renku/eventlog/api/events/Client.scala
+++ b/event-log-api/src/main/scala/io/renku/eventlog/api/events/Client.scala
@@ -27,7 +27,8 @@ import io.renku.metrics.MetricsRegistry
 import org.typelevel.log4cats.Logger
 
 trait Client[F[_]] {
-  def send(event: CommitSyncRequest): F[Unit]
+  def send(event: CommitSyncRequest):                           F[Unit]
+  def send(event: StatusChangeEvent.RedoProjectTransformation): F[Unit]
 }
 
 object Client {
@@ -46,5 +47,11 @@ private class ClientImpl[F[_]](eventSender: EventSender[F]) extends Client[F] {
     eventSender.sendEvent(
       EventRequestContent.NoPayload(event.asJson),
       EventContext(CommitSyncRequest.categoryName, show"${CommitSyncRequest.categoryName}: sending event $event failed")
+    )
+
+  override def send(event: StatusChangeEvent.RedoProjectTransformation): F[Unit] =
+    eventSender.sendEvent(
+      EventRequestContent.NoPayload(event.asJson),
+      EventContext(StatusChangeEvent.categoryName, show"${StatusChangeEvent.categoryName}: sending event $event failed")
     )
 }

--- a/event-log-api/src/main/scala/io/renku/eventlog/api/events/CommitSyncRequest.scala
+++ b/event-log-api/src/main/scala/io/renku/eventlog/api/events/CommitSyncRequest.scala
@@ -16,15 +16,15 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog.api.events
+package io.renku.eventlog.api.events
 
-import cats.syntax.all._
 import cats.Show
-import io.circe.{Decoder, DecodingFailure, Encoder}
-import io.circe.literal._
+import cats.syntax.all._
 import io.circe.DecodingFailure.Reason.CustomReason
-import io.renku.events.consumers.Project
+import io.circe.literal._
+import io.circe.{Decoder, DecodingFailure, Encoder}
 import io.renku.events.CategoryName
+import io.renku.events.consumers.Project
 
 final case class CommitSyncRequest(project: Project)
 

--- a/event-log-api/src/main/scala/io/renku/eventlog/api/events/StatusChangeEvent.scala
+++ b/event-log-api/src/main/scala/io/renku/eventlog/api/events/StatusChangeEvent.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.renku.eventlog.events.consumers.statuschange
+package io.renku.eventlog.api.events
 
 import cats.Show
 import cats.syntax.all._
@@ -25,6 +25,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveConfiguredDecoder, deriveConfiguredEncoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
+import io.renku.events.CategoryName
 import io.renku.events.consumers.Project
 import io.renku.graph.model.events._
 import io.renku.graph.model.events.EventStatus._
@@ -40,6 +41,8 @@ sealed trait StatusChangeEvent extends Product {
 }
 
 object StatusChangeEvent {
+
+  val categoryName: CategoryName = CategoryName("EVENTS_STATUS_CHANGE")
 
   final case class ProjectPath(path: projects.Path)
   object ProjectPath {
@@ -59,9 +62,6 @@ object StatusChangeEvent {
 
   final case class ProjectEventsToNew(project: Project) extends StatusChangeEvent
   object ProjectEventsToNew {
-    implicit lazy val eventType: StatusChangeEventsQueue.EventType[ProjectEventsToNew] =
-      StatusChangeEventsQueue.EventType("PROJECT_EVENTS_TO_NEW")
-
     implicit lazy val show: Show[ProjectEventsToNew] = Show.show { event =>
       show"${event.subCategoryName} ${event.project}"
     }
@@ -72,11 +72,9 @@ object StatusChangeEvent {
 
   final case class RedoProjectTransformation(project: ProjectPath) extends StatusChangeEvent
   object RedoProjectTransformation {
+
     def apply(path: projects.Path): RedoProjectTransformation =
       RedoProjectTransformation(ProjectPath(path))
-
-    implicit lazy val eventType: StatusChangeEventsQueue.EventType[RedoProjectTransformation] =
-      StatusChangeEventsQueue.EventType("REDO_PROJECT_TRANSFORMATION")
 
     implicit lazy val show: Show[RedoProjectTransformation] = Show.show { event =>
       show"${event.subCategoryName} projectPath = ${event.project.path}, status = ${EventStatus.TriplesGenerated}"

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/Http4sEventLogClientSpec.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/Http4sEventLogClientSpec.scala
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog
+package io.renku.eventlog.api
 
+import EventLogClient.{Result, SearchCriteria}
+import Http4sEventLogClientSpec.JsonEncoders._
 import cats.effect._
 import cats.syntax.all._
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
@@ -27,19 +29,17 @@ import io.circe.literal._
 import io.renku.events.Generators.categoryNames
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.jsons
-import io.renku.graph.eventlog.EventLogClient.{Result, SearchCriteria}
-import io.renku.graph.eventlog.Http4sEventLogClientSpec.JsonEncoders._
-import io.renku.graph.model._
 import io.renku.graph.model.GraphModelGenerators.{projectIds, projectPaths}
+import io.renku.graph.model._
 import io.renku.graph.model.events.{EventDate, EventInfo, EventStatus, StatusProcessingTime}
 import io.renku.http.client.UrlEncoder
 import io.renku.interpreters.TestLogger
 import io.renku.stubbing.ExternalServiceStubbing
 import io.renku.testtools.IOSpec
 import org.http4s.{Status, Uri}
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.EitherValues
 import org.typelevel.log4cats.Logger
 import scodec.bits.ByteVector
 

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/ClientSpec.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/ClientSpec.scala
@@ -47,6 +47,18 @@ class ClientSpec extends AnyWordSpec with should.Matchers with MockFactory with 
     }
   }
 
+  "send StatusChangeEvent.RedoProjectTransformation" should {
+
+    "send the given event through the EventSender" in new TestCase {
+
+      val event = redoProjectTransformationEvents.generateOne
+
+      givenSending(event, StatusChangeEvent.categoryName, returning = ().pure[Try])
+
+      client.send(event).success.value shouldBe ()
+    }
+  }
+
   private trait TestCase {
 
     private val eventSender = mock[EventSender[Try]]

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/ClientSpec.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/ClientSpec.scala
@@ -16,20 +16,20 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog.api.events
+package io.renku.eventlog.api.events
 
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.TryValues
 import Generators._
-import cats.syntax.all._
 import cats.Show
-import io.circe.syntax.EncoderOps
+import cats.syntax.all._
 import io.circe.Encoder
+import io.circe.syntax.EncoderOps
 import io.renku.events.producers.EventSender
 import io.renku.events.{CategoryName, EventRequestContent}
 import io.renku.generators.Generators.Implicits._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.TryValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Try
 

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/CommitSyncRequestSpec.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/CommitSyncRequestSpec.scala
@@ -16,12 +16,8 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog.api.events
+package io.renku.eventlog.api.events
 
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.EitherValues
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import Generators._
 import io.circe.literal._
 import io.circe.syntax._
@@ -30,6 +26,10 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
 import io.renku.graph.model.RenkuTinyTypeGenerators.{projectIds, projectPaths}
 import io.renku.graph.model.projects
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class CommitSyncRequestSpec extends AnyWordSpec with should.Matchers with EitherValues with ScalaCheckPropertyChecks {
 

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/Generators.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/Generators.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.renku.graph.eventlog.api.events
+package io.renku.eventlog.api.events
 
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import org.scalacheck.Gen

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/Generators.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/Generators.scala
@@ -21,7 +21,7 @@ package io.renku.eventlog.api.events
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import org.scalacheck.Gen
 
-object Generators {
+object Generators extends StatusChangeGenerators {
 
   val commitSyncRequests: Gen[CommitSyncRequest] =
     consumerProjects.map(CommitSyncRequest.apply)

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/StatusChangeEventSpec.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/StatusChangeEventSpec.scala
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-package io.renku.eventlog.events.consumers.statuschange
+package io.renku.eventlog.api.events
 
 import cats.syntax.all._
 import io.circe.Json
 import io.circe.syntax._
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent._
+import io.renku.eventlog.api.events.StatusChangeEvent._
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.events.ZippedEventPayload
 import org.scalatest.matchers.should

--- a/event-log-api/src/test/scala/io/renku/eventlog/api/events/StatusChangeGenerators.scala
+++ b/event-log-api/src/test/scala/io/renku/eventlog/api/events/StatusChangeGenerators.scala
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package io.renku.eventlog.events.consumers.statuschange
+package io.renku.eventlog.api.events
 
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent._
+import io.renku.eventlog.api.events.StatusChangeEvent._
 import io.renku.events.consumers.{ConsumersModelGenerators, Project}
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators._
@@ -28,7 +28,9 @@ import org.scalacheck.Gen
 
 import java.time.{Duration => JDuration}
 
-object StatusChangeGenerators {
+object StatusChangeGenerators extends StatusChangeGenerators
+
+trait StatusChangeGenerators {
 
   val projectEventsToNewEvents: Gen[ProjectEventsToNew] =
     ConsumersModelGenerators.consumerProjects.map(ProjectEventsToNew(_))

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/EventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/EventHandler.scala
@@ -21,10 +21,10 @@ package io.renku.eventlog.events.consumers.commitsyncrequest
 import cats.effect.{Concurrent, MonadCancelThrow}
 import cats.syntax.all._
 import io.renku.eventlog.EventLogDB.SessionResource
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.{consumers, CategoryName}
 import io.renku.events.consumers._
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
 import org.typelevel.log4cats.Logger
 
 private class EventHandler[F[_]: MonadCancelThrow: Logger](

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChanger.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChanger.scala
@@ -23,6 +23,7 @@ import cats.data.Kleisli
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import io.renku.eventlog.EventLogDB.SessionResource
+import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.UpdateOp
 import io.renku.eventlog.metrics.EventStatusGauges
 import skunk.Transaction

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/package.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/package.scala
@@ -22,5 +22,4 @@ import io.renku.events.CategoryName
 
 package object statuschange {
   val categoryName: CategoryName = CategoryName("EVENTS_STATUS_CHANGE")
-
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdater.scala
@@ -21,10 +21,11 @@ package io.renku.eventlog.events.consumers.statuschange.projecteventstonew
 import cats.MonadThrow
 import cats.data.Kleisli
 import io.circe.Encoder
+import io.renku.eventlog.api.events.StatusChangeEvent
+import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ProjectEventsToNew
-import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEvent, StatusChangeEventsQueue}
+import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue}
 import skunk.Session
 
 private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChangeEventsQueue[F])

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandler.scala
@@ -16,32 +16,33 @@
  * limitations under the License.
  */
 
-package io.renku.eventlog.events.consumers.statuschange.projecteventstonew
+package io.renku.eventlog.events.consumers.statuschange
+package projecteventstonew
 
 import cats.data.Kleisli
 import cats.data.Kleisli.liftF
 import cats.effect.Async
 import cats.syntax.all._
+import cleaning.ProjectCleaner
 import eu.timepit.refined.auto._
-import io.renku.db.{DbClient, SqlStatement}
 import io.renku.db.implicits.PreparedQueryOps
+import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers._
-import io.renku.eventlog.events.consumers.statuschange.{categoryName, DBUpdater, DBUpdateResults}
+import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ProjectEventsToNew
-import io.renku.eventlog.events.consumers.statuschange.projecteventstonew.cleaning.ProjectCleaner
+import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DBUpdater, categoryName}
 import io.renku.eventlog.events.producers.minprojectinfo
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.consumers.Project
-import io.renku.graph.model.events.{EventDate, EventStatus, ExecutionDate}
 import io.renku.graph.model.events.EventStatus.{AwaitingDeletion, Deleting, GeneratingTriples, New, Skipped}
+import io.renku.graph.model.events.{EventDate, EventStatus, ExecutionDate}
 import io.renku.graph.model.projects
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.metrics.MetricsRegistry
 import org.typelevel.log4cats.Logger
-import skunk.{~, Session, SqlState}
 import skunk.data.Completion
 import skunk.implicits._
+import skunk.{Session, SqlState, ~}
 
 import java.time.Instant
 import scala.util.control.NonFatal
@@ -49,6 +50,7 @@ import scala.util.control.NonFatal
 trait DequeuedEventHandler[F[_]] extends DBUpdater[F, ProjectEventsToNew]
 
 object DequeuedEventHandler {
+
   def apply[F[_]: Async: AccessTokenFinder: Logger: QueriesExecutionTimes: MetricsRegistry]
       : F[DBUpdater[F, ProjectEventsToNew]] =
     ProjectCleaner[F].map(new DequeuedEventHandlerImpl(_))

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/package.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/package.scala
@@ -18,23 +18,9 @@
 
 package io.renku.eventlog.events.consumers.statuschange
 
-import cats.Applicative
-import cats.data.Kleisli
-import io.renku.eventlog.api.events.StatusChangeEvent
-import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import skunk.Session
+import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 
-private[statuschange] trait DBUpdater[F[_], E <: StatusChangeEvent] {
-  def updateDB(event:   E): UpdateOp[F]
-  def onRollback(event: E): RollbackOp[F]
-}
-
-private[statuschange] object DBUpdater {
-
-  type UpdateOp[F[_]]   = Kleisli[F, Session[F], DBUpdateResults]
-  type RollbackOp[F[_]] = Kleisli[F, Session[F], Unit]
-
-  object RollbackOp {
-    def none[F[_]: Applicative]: RollbackOp[F] = Kleisli.pure(())
-  }
+package object projecteventstonew {
+  private[statuschange] implicit val eventType: StatusChangeEventsQueue.EventType[ProjectEventsToNew] =
+    StatusChangeEventsQueue.EventType("PROJECT_EVENTS_TO_NEW")
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdater.scala
@@ -21,9 +21,10 @@ package io.renku.eventlog.events.consumers.statuschange.redoprojecttransformatio
 import cats.MonadThrow
 import cats.data.Kleisli
 import io.circe.Encoder
+import io.renku.eventlog.api.events.StatusChangeEvent
+import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange._
 import skunk.Session
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-package io.renku.eventlog.events.consumers.statuschange.redoprojecttransformation
+package io.renku.eventlog.events.consumers.statuschange
+package redoprojecttransformation
 
 import cats.data.Kleisli
 import cats.effect.Async
@@ -24,7 +25,7 @@ import cats.syntax.all._
 import io.renku.db.DbClient
 import io.renku.eventlog.TypeSerializers
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RedoProjectTransformation
+import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DBUpdater}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/package.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/package.scala
@@ -18,23 +18,9 @@
 
 package io.renku.eventlog.events.consumers.statuschange
 
-import cats.Applicative
-import cats.data.Kleisli
-import io.renku.eventlog.api.events.StatusChangeEvent
-import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import skunk.Session
+import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 
-private[statuschange] trait DBUpdater[F[_], E <: StatusChangeEvent] {
-  def updateDB(event:   E): UpdateOp[F]
-  def onRollback(event: E): RollbackOp[F]
-}
-
-private[statuschange] object DBUpdater {
-
-  type UpdateOp[F[_]]   = Kleisli[F, Session[F], DBUpdateResults]
-  type RollbackOp[F[_]] = Kleisli[F, Session[F], Unit]
-
-  object RollbackOp {
-    def none[F[_]: Applicative]: RollbackOp[F] = Kleisli.pure(())
-  }
+package object redoprojecttransformation {
+  private[statuschange] implicit val eventType: StatusChangeEventsQueue.EventType[RedoProjectTransformation] =
+    StatusChangeEventsQueue.EventType("REDO_PROJECT_TRANSFORMATION")
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
@@ -26,7 +26,7 @@ import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RollbackToAwaitingDeletion
+import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToAwaitingDeletion
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus.{AwaitingDeletion, Deleting}
 import io.renku.graph.model.events.{EventStatus, ExecutionDate}

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
@@ -24,7 +24,7 @@ import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RollbackToNew
+import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToNew
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DBUpdater}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus.{GeneratingTriples, New}

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
@@ -26,7 +26,7 @@ import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RollbackToTriplesGenerated
+import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToTriplesGenerated
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus.{TransformingTriples, TriplesGenerated}
 import io.renku.graph.model.events.{EventId, ExecutionDate}

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
@@ -27,7 +27,7 @@ import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToAwaitingDeletion
+import io.renku.eventlog.api.events.StatusChangeEvent.ToAwaitingDeletion
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus.AwaitingDeletion
 import io.renku.graph.model.events.{EventId, EventStatus, ExecutionDate}

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdater.scala
@@ -26,7 +26,7 @@ import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.UpdateOp
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToFailure
+import io.renku.eventlog.api.events.StatusChangeEvent.ToFailure
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DeliveryInfoRemover}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus.{FailureStatus, New, ProcessingStatus, TransformationNonRecoverableFailure, TransformationRecoverableFailure, TriplesGenerated}

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdater.scala
@@ -28,7 +28,7 @@ import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.UpdateOp
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToTriplesGenerated
+import io.renku.eventlog.api.events.StatusChangeEvent.ToTriplesGenerated
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DeliveryInfoRemover}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus._

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdater.scala
@@ -28,7 +28,7 @@ import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.UpdateOp
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToTriplesStore
+import io.renku.eventlog.api.events.StatusChangeEvent.ToTriplesStore
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DeliveryInfoRemover}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus._

--- a/event-log/src/test/scala/io/renku/eventlog/MicroserviceRunnerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/MicroserviceRunnerSpec.scala
@@ -18,29 +18,30 @@
 
 package io.renku.eventlog
 
+import MicroserviceRunnerSpec._
 import cats.Show
 import cats.data.Kleisli
 import cats.effect._
 import io.circe.{Decoder, Encoder, Json}
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
-import io.renku.eventlog.events.consumers.statuschange.{StatusChangeEvent, StatusChangeEventsQueue}
+import io.renku.eventlog.api.events.StatusChangeEvent
+import io.renku.eventlog.events.consumers.statuschange.StatusChangeEventsQueue
 import io.renku.eventlog.events.producers.{EventProducerStatus, EventProducersRegistry}
 import io.renku.eventlog.init.DbInitializer
 import io.renku.eventlog.metrics.EventLogMetrics
 import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
+import io.renku.http.server.HttpServer
 import io.renku.interpreters.TestLogger
 import io.renku.metrics.GaugeResetScheduler
 import io.renku.microservices.{AbstractMicroserviceRunnerTest, CallCounter, ServiceReadinessChecker, ServiceRunCounter}
 import io.renku.testtools.IOSpec
-
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import skunk.Session
-import MicroserviceRunnerSpec._
-import io.renku.http.server.HttpServer
+
 import scala.concurrent.duration._
 
 class MicroserviceRunnerSpec extends AnyWordSpec with IOSpec with should.Matchers {
@@ -180,8 +181,9 @@ object MicroserviceRunnerSpec {
     override def getStatus: IO[Set[EventProducerStatus]] = ???
 
     override def register[E <: StatusChangeEvent](
-        handler: E => IO[Unit]
-    )(implicit decoder: Decoder[E], eventType: StatusChangeEventsQueue.EventType[E]): IO[Unit] = ???
+        eventType: StatusChangeEventsQueue.EventType[E],
+        handler:   E => IO[Unit]
+    )(implicit decoder: Decoder[E]): IO[Unit] = ???
 
     override def offer[E <: StatusChangeEvent](event: E)(implicit
         encoder:   Encoder[E],

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/commitsyncrequest/EventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/commitsyncrequest/EventHandlerSpec.scala
@@ -21,15 +21,15 @@ package commitsyncrequest
 
 import cats.effect.IO
 import io.circe.syntax._
+import io.renku.eventlog.api.events.Generators
 import io.renku.events.EventRequestContent
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.eventlog.api.events.Generators
 import io.renku.interpreters.TestLogger
 import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.EitherValues
 
 class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with should.Matchers with EitherValues {
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/EventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/EventHandlerSpec.scala
@@ -22,7 +22,8 @@ package statuschange
 import cats.effect.IO
 import cats.syntax.all._
 import io.circe.syntax._
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent._
+import io.renku.eventlog.api.events.{StatusChangeEvent, StatusChangeGenerators}
+import io.renku.eventlog.api.events.StatusChangeEvent._
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.EventRequestContent
 import io.renku.events.consumers.{EventSchedulingResult, ProcessExecutor}

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangerSpec.scala
@@ -24,8 +24,9 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog._
+import io.renku.eventlog.api.events.{StatusChangeEvent, StatusChangeGenerators}
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent._
+import io.renku.eventlog.api.events.StatusChangeEvent._
 import io.renku.events.Generators.{subscriberIds, subscriberUrls}
 import io.renku.events.consumers.Project
 import io.renku.generators.CommonGraphGenerators.microserviceBaseUrls

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/AllEventsToNewUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/AllEventsToNewUpdaterSpec.scala
@@ -22,7 +22,7 @@ package alleventstonew
 import cats.effect.IO
 import cats.syntax.all._
 import io.circe.literal._
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.{AllEventsToNew, ProjectEventsToNew}
+import io.renku.eventlog.api.events.StatusChangeEvent.AllEventsToNew
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, categoryName}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
@@ -68,8 +68,8 @@ class AllEventsToNewUpdaterSpec
           .sendEvent(_: EventRequestContent.NoPayload, _: EventSender.EventContext))
           .expects(
             EventRequestContent.NoPayload(toEventJson(project)),
-            EventSender.EventContext(CategoryName(ProjectEventsToNew.eventType.show),
-                                     show"$categoryName: generating ${ProjectEventsToNew.eventType} for $project failed"
+            EventSender.EventContext(CategoryName(projecteventstonew.eventType.show),
+                                     show"$categoryName: generating ${projecteventstonew.eventType} for $project failed"
             )
           )
           .returning(().pure[IO])

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdaterSpec.scala
@@ -22,9 +22,10 @@ import cats.Show
 import cats.data.Kleisli
 import cats.syntax.all._
 import io.circe.Encoder
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ProjectEventsToNew
+import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
+import io.renku.eventlog.api.events.StatusChangeGenerators
 import io.renku.eventlog.events.consumers.statuschange.StatusChangeEventsQueue.EventType
-import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue, StatusChangeGenerators}
+import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue}
 import io.renku.generators.Generators.Implicits._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
@@ -23,7 +23,7 @@ import cats.data.Kleisli
 import cats.effect.IO
 import cats.syntax.all._
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ProjectEventsToNew
+import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 import io.renku.eventlog.events.consumers.statuschange.projecteventstonew.cleaning.ProjectCleaner
 import io.renku.eventlog.events.producers.{SubscriptionDataProvisioning, minprojectinfo}
 import io.renku.eventlog.metrics.QueriesExecutionTimes

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdaterSpec.scala
@@ -22,9 +22,10 @@ import cats.Show
 import cats.data.Kleisli
 import cats.syntax.all._
 import io.circe.Encoder
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RedoProjectTransformation
+import io.renku.eventlog.api.events.StatusChangeEvent
+import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange.StatusChangeEventsQueue.EventType
-import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEvent, StatusChangeEventsQueue}
+import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue}
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators
 import org.scalamock.scalatest.MockFactory

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandlerSpec.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange.redoprojecttransformatio
 
 import cats.effect.IO
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.{ProjectPath, RedoProjectTransformation}
+import io.renku.eventlog.api.events.StatusChangeEvent.{ProjectPath, RedoProjectTransformation}
 import io.renku.eventlog.events.producers
 import io.renku.eventlog.events.producers.SubscriptionDataProvisioning
 import io.renku.eventlog.metrics.QueriesExecutionTimes

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdaterSpec.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange.rollbacktoawaitingdeleti
 
 import cats.effect.IO
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RollbackToAwaitingDeletion
+import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToAwaitingDeletion
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.Project

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdaterSpec.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange.rollbacktonew
 
 import cats.effect.IO
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RollbackToNew
+import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToNew
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.Project

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdaterSpec.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange.rollbacktotriplesgenerat
 
 import cats.effect.IO
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.RollbackToTriplesGenerated
+import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToTriplesGenerated
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.Project

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdaterSpec.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange.toawaitingdeletion
 
 import cats.effect.IO
 import io.renku.eventlog.events.consumers.statuschange.DBUpdateResults
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToAwaitingDeletion
+import io.renku.eventlog.api.events.StatusChangeEvent.ToAwaitingDeletion
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.ConsumersModelGenerators

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdaterSpec.scala
@@ -21,7 +21,7 @@ package io.renku.eventlog.events.consumers.statuschange.tofailure
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.syntax.all._
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToFailure
+import io.renku.eventlog.api.events.StatusChangeEvent.ToFailure
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DeliveryInfoRemover}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdaterSpec.scala
@@ -21,7 +21,7 @@ package io.renku.eventlog.events.consumers.statuschange.totriplesgenerated
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.syntax.all._
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToTriplesGenerated
+import io.renku.eventlog.api.events.StatusChangeEvent.ToTriplesGenerated
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DeliveryInfoRemover}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdaterSpec.scala
@@ -21,7 +21,7 @@ package io.renku.eventlog.events.consumers.statuschange.totriplesstore
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.syntax.all._
-import io.renku.eventlog.events.consumers.statuschange.StatusChangeEvent.ToTriplesStore
+import io.renku.eventlog.api.events.StatusChangeEvent.ToTriplesStore
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DeliveryInfoRemover}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/delete/ELProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/delete/ELProjectFinder.scala
@@ -21,9 +21,9 @@ package io.renku.knowledgegraph.projects.delete
 import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
+import io.renku.eventlog.api.EventLogClient
+import io.renku.eventlog.api.EventLogClient.{Result, SearchCriteria}
 import io.renku.events.consumers.Project
-import io.renku.graph.eventlog.EventLogClient
-import io.renku.graph.eventlog.EventLogClient.{Result, SearchCriteria}
 import io.renku.graph.model.events.EventInfo
 import io.renku.graph.model.projects
 import io.renku.http.rest.paging.model.PerPage

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/delete/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/delete/Endpoint.scala
@@ -20,17 +20,16 @@ package io.renku.knowledgegraph.projects.delete
 
 import cats.effect.{Async, Spawn, Temporal}
 import cats.syntax.all._
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.events.consumers.Project
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.projects
 import io.renku.http.InfoMessage._
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.server.security.model.AuthUser
 import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.metrics.MetricsRegistry
-import io.renku.triplesgenerator
 import io.renku.triplesgenerator.api.events.CleanUpEvent
+import io.renku.{eventlog, triplesgenerator}
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
 import org.typelevel.log4cats.Logger

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/ontology/OntologyGeneratorSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/ontology/OntologyGeneratorSpec.scala
@@ -31,7 +31,8 @@ class OntologyGeneratorSpec extends AnyWordSpec with should.Matchers {
   "getOntology" should {
 
     "return generated Renku ontology" in {
-      val types = NonEmptyList.of(Project.Ontology.typeDef, CompositePlan.Ontology.typeDef, DatasetSearchInfoOntology.typeDef)
+      val types =
+        NonEmptyList.of(Project.Ontology.typeDef, CompositePlan.Ontology.typeDef, DatasetSearchInfoOntology.typeDef)
       val ontology = generateOntology(types, Schemas.renku)
 
       new OntologyGeneratorImpl(ontology).getOntology shouldBe ontology

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/delete/ELProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/delete/ELProjectFinderSpec.scala
@@ -19,12 +19,12 @@
 package io.renku.knowledgegraph.projects.delete
 
 import cats.syntax.all._
+import io.renku.eventlog.api.EventLogClient
+import io.renku.eventlog.api.EventLogClient.Result.{Failure, Success}
+import io.renku.eventlog.api.EventLogClient.{Result, SearchCriteria}
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{exceptions, nonEmptyStrings}
-import io.renku.graph.eventlog.EventLogClient
-import io.renku.graph.eventlog.EventLogClient.Result.{Failure, Success}
-import io.renku.graph.eventlog.EventLogClient.{Result, SearchCriteria}
 import io.renku.graph.model.EventContentGenerators.eventInfos
 import io.renku.graph.model.events.EventInfo
 import io.renku.http.rest.paging.model.PerPage

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/delete/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/delete/EndpointSpec.scala
@@ -20,13 +20,12 @@ package io.renku.knowledgegraph.projects.delete
 
 import cats.effect.{Deferred, IO}
 import cats.syntax.all._
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import io.renku.events.consumers.Project
 import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.projects
 import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
@@ -36,7 +35,7 @@ import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
 import io.renku.testtools.IOSpec
-import io.renku.triplesgenerator
+import io.renku.{eventlog, triplesgenerator}
 import io.renku.triplesgenerator.api.events.CleanUpEvent
 import org.http4s.MediaType.application
 import org.http4s.Status.{Accepted, InternalServerError, NotFound}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsDateViewedCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsDateViewedCreator.scala
@@ -24,18 +24,18 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import fs2.Stream
 import io.circe.Decoder
-import io.renku.graph.eventlog.EventLogClient
+import io.renku.eventlog.api.EventLogClient
 import io.renku.graph.model.Schemas.{renku, schema}
 import io.renku.graph.model.projects
 import io.renku.http.rest.paging.model.PerPage
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator
 import io.renku.triplesgenerator.api.events.ProjectViewedEvent
-import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
 import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
-import io.renku.triplesstore._
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
 import io.renku.triplesstore.ResultsDecoder._
 import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
 import org.typelevel.log4cats.Logger
 import tooling.{MigrationExecutionRegister, RecoverableErrorsRecovery, RegisteredMigration}
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/v10migration/EnvReadinessChecker.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/v10migration/EnvReadinessChecker.scala
@@ -20,7 +20,7 @@ package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
 
 import cats.effect.{Async, Temporal}
 import cats.syntax.all._
-import io.renku.graph.eventlog.EventLogClient
+import io.renku.eventlog.api.EventLogClient
 import io.renku.graph.model.eventlogapi.ServiceStatus
 import io.renku.triplesgenerator.events.consumers.awaitinggeneration
 import org.typelevel.log4cats.Logger

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsDateViewedCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsDateViewedCreatorSpec.scala
@@ -18,17 +18,17 @@
 
 package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
 
+import cats.MonadThrow
 import cats.effect.IO
 import cats.syntax.all._
-import cats.MonadThrow
-import io.renku.generators.Generators.{exceptions, timestampsNotInTheFuture}
+import io.renku.eventlog.api.EventLogClient
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.eventlog.EventLogClient
+import io.renku.generators.Generators.{exceptions, timestampsNotInTheFuture}
+import io.renku.graph.model.EventContentGenerators.eventInfos
 import io.renku.graph.model.events
 import io.renku.graph.model.events.{EventDate, EventInfo}
-import io.renku.graph.model.testentities._
-import io.renku.graph.model.EventContentGenerators.eventInfos
 import io.renku.graph.model.projects.DateViewed
+import io.renku.graph.model.testentities._
 import io.renku.http.rest.paging.model.PerPage
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
@@ -38,9 +38,9 @@ import io.renku.triplesgenerator.api.events.ProjectViewedEvent
 import io.renku.triplesgenerator.generators.ErrorGenerators.processingRecoverableErrors
 import io.renku.triplesstore._
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.EitherValues
 import tooling.{MigrationExecutionRegister, RecoverableErrorsRecovery}
 
 class ProjectsDateViewedCreatorSpec

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/v10migration/EnvReadinessCheckerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/v10migration/EnvReadinessCheckerSpec.scala
@@ -21,10 +21,10 @@ package tsmigrationrequest.migrations.v10migration
 
 import cats.effect.{Deferred, IO, Temporal}
 import cats.syntax.all._
-import io.renku.generators.Generators.{ints, positiveInts}
+import io.renku.eventlog.api.EventLogClient
+import io.renku.eventlog.api.EventLogClient.Result
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.eventlog.EventLogClient
-import io.renku.graph.eventlog.EventLogClient.Result
+import io.renku.generators.Generators.{ints, positiveInts}
 import io.renku.graph.model.eventlogapi.ServiceStatus
 import io.renku.graph.model.eventlogapi.ServiceStatus.{Capacity, SubscriptionStatus}
 import io.renku.testtools.IOSpec

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
@@ -23,8 +23,8 @@ import cats.effect._
 import cats.syntax.all._
 import cats.{MonadThrow, NonEmptyParallel}
 import io.circe.syntax._
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
+import io.renku.eventlog
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.projects
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage._

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfoFinder.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/StatusInfoFinder.scala
@@ -21,7 +21,7 @@ package io.renku.webhookservice.eventstatus
 import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.graph.eventlog.EventLogClient
+import io.renku.eventlog.api.EventLogClient
 import io.renku.graph.model.events.EventInfo
 import io.renku.graph.model.projects
 import io.renku.http.rest.paging.model.PerPage

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreator.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreator.scala
@@ -21,8 +21,8 @@ package io.renku.webhookservice.hookcreation
 import cats.Show
 import cats.effect._
 import cats.syntax.all._
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
+import io.renku.eventlog
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.projects
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.client.{AccessToken, GitLabClient}

--- a/webhook-service/src/main/scala/io/renku/webhookservice/webhookevents/Endpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/webhookevents/Endpoint.scala
@@ -22,9 +22,9 @@ import cats.data.NonEmptyList
 import cats.effect._
 import cats.syntax.all._
 import io.circe.Decoder
+import io.renku.eventlog
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.events.consumers.Project
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.projects.{GitLabId, Path}
 import io.renku.http.ErrorMessage._

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/EndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/EndpointSpec.scala
@@ -23,13 +23,13 @@ import cats.effect.IO
 import cats.syntax.all._
 import io.circe.Json
 import io.circe.syntax._
+import io.renku.eventlog
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import io.renku.events.consumers.Project
 import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.graph.model.projects
 import io.renku.graph.model.projects.GitLabId

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/StatusInfoFinderSpec.scala
@@ -19,9 +19,9 @@
 package io.renku.webhookservice.eventstatus
 
 import cats.syntax.all._
+import io.renku.eventlog.api.EventLogClient
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{fixed, nonEmptyStrings}
-import io.renku.graph.eventlog.EventLogClient
 import io.renku.graph.model.EventContentGenerators.eventInfos
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.graph.model.events.EventInfo

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -21,13 +21,13 @@ package io.renku.webhookservice.hookcreation
 import cats.effect.IO
 import cats.effect.std.Queue
 import cats.syntax.all._
+import io.renku.eventlog
+import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import io.renku.events.consumers.Project
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.client.AccessToken
 import io.renku.interpreters.TestLogger

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreatorSpec.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 import cats.effect.std.Queue
 import cats.syntax.all._
 import io.renku.eventlog
-import io.renku.eventlog.api.events.CommitSyncRequest
+import io.renku.eventlog.api.events.{CommitSyncRequest, StatusChangeEvent}
 import io.renku.events.consumers.ConsumersModelGenerators.consumerProjects
 import io.renku.events.consumers.Project
 import io.renku.generators.CommonGraphGenerators._
@@ -207,6 +207,8 @@ class HookCreatorSpec
     private val commitSyncRequestSenderResponse = Queue.bounded[IO, IO[Unit]](1).unsafeRunSync()
     private val elClient = new eventlog.api.events.Client[IO] {
       override def send(event: CommitSyncRequest): IO[Unit] = commitSyncRequestSenderResponse.take.flatten
+      override def send(event: StatusChangeEvent.RedoProjectTransformation): IO[Unit] =
+        sys.error(s"${StatusChangeEvent.RedoProjectTransformation} event shouldn't be sent")
     }
 
     val hookCreation = new HookCreatorImpl[IO](

--- a/webhook-service/src/test/scala/io/renku/webhookservice/webhookevents/EndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/webhookevents/EndpointSpec.scala
@@ -23,11 +23,11 @@ import cats.syntax.all._
 import io.circe.Json
 import io.circe.literal._
 import io.circe.syntax._
+import io.renku.eventlog
+import io.renku.eventlog.api.events.CommitSyncRequest
+import io.renku.eventlog.api.events.Generators.commitSyncRequests
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
-import io.renku.graph.eventlog
-import io.renku.graph.eventlog.api.events.CommitSyncRequest
-import io.renku.graph.eventlog.api.events.Generators.commitSyncRequests
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.graph.model.events.CommitId


### PR DESCRIPTION
This PR extracts event-log API classes from the graph-commons module. It also adds a new `events.Client.send(StatusChangeEvent.RedoProjectTransformation)` method.