### PR TITLE
fix: allow all possible secret lenghts for AES crypto

### DIFF
--- a/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
+++ b/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
@@ -70,9 +70,9 @@ object AesCrypto {
   object Secret {
 
     def apply(value: ByteVector): Either[String, Secret] = {
-      val expectedLength = 16
-      if (value.length == expectedLength) Right(new Secret(value))
-      else Left(s"Expected $expectedLength bytes, but got ${value.length}")
+      val expectedLengths = List(16L, 24L, 32L)
+      if (expectedLengths.contains(value.length)) Right(new Secret(value))
+      else Left(s"Expected ${expectedLengths.mkString(" or ")} bytes, but got ${value.length}")
     }
 
     def unsafe(value: ByteVector): Secret = apply(value).fold(sys.error, identity)

--- a/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
@@ -26,23 +26,23 @@ import org.scalacheck.Gen
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pureconfig.ConfigSource
 import scodec.bits.Bases.Alphabets
 import scodec.bits.ByteVector
 
-class SecretSpec extends AnyWordSpec with should.Matchers with EitherValues {
+class SecretSpec extends AnyWordSpec with should.Matchers with EitherValues with ScalaCheckPropertyChecks {
 
   "secretReader" should {
 
     val keyName = "secret"
 
     "decode Base64 encoded secret" in {
+      forAll(aesCryptoSecrets) { secret =>
+        val config = ConfigFactory.parseString(s"""$keyName = "${secret.toBase64}"""")
 
-      val secret = aesCryptoSecrets.generateOne
-
-      val config = ConfigFactory.parseString(s"""$keyName = "${secret.toBase64}"""")
-
-      ConfigSource.fromConfig(config).at(keyName).load[Secret].value.toBase64 shouldBe secret.toBase64
+        ConfigSource.fromConfig(config).at(keyName).load[Secret].value.toBase64 shouldBe secret.toBase64
+      }
     }
 
     "decode Base64 encoded secret ending with LF char" in {

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -65,6 +65,7 @@ object CommonGraphGenerators {
           .listOfN(length * 2, Gen.hexChar)
           .map(_.mkString.toLowerCase)
           .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
+          .retryUntil(_.takeWhile(_ != 10.toByte).length == length) // this is to prevent LF chars to be generated
           .map(Secret.unsafe)
       }
 

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -59,11 +59,14 @@ object CommonGraphGenerators {
 
   implicit val aesCryptoSecrets: Gen[Secret] =
     Gen
-      .listOfN(32, Gen.hexChar)
-      .map(_.mkString.toLowerCase)
-      .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
-      .retryUntil(_.takeWhile(_ != 10.toByte).length == 16)
-      .map(Secret.unsafe)
+      .oneOf(16, 24, 32)
+      .flatMap { length =>
+        Gen
+          .listOfN(length * 2, Gen.hexChar)
+          .map(_.mkString.toLowerCase)
+          .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
+          .map(Secret.unsafe)
+      }
 
   implicit val personalAccessTokens: Gen[PersonalAccessToken] = for {
     length <- Gen.choose(5, 40)

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
@@ -110,7 +110,7 @@ class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableD
       val Failure(exception) = AccessTokenCrypto[Try](config)
 
       exception          shouldBe a[ConfigLoadingException]
-      exception.getMessage should include("Expected 16 bytes, but got 15")
+      exception.getMessage should include("Expected 16 or 24 or 32 bytes, but got 15")
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug that did not envision AES secrets to be of a length different than 16.