### PR TITLE
fix: plan transformation to deal with dateCreated duplicates

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/plans/PlanTransformer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/plans/PlanTransformer.scala
@@ -62,10 +62,11 @@ private class PlanTransformerImpl[F[_]: MonadThrow](kgInfoFinder: KGInfoFinder[F
 
   private lazy val updateDateCreated: ((Project, Queries)) => F[(Project, Queries)] = { case (project, queries) =>
     collectStepPlans(project.plans)
-      .map(plan =>
-        findDateCreated(project.resourceId, plan.resourceId)
-          .map(queriesDeletingDate(project.resourceId, plan, _))
-      )
+      .map { plan =>
+        findCreatedDates(project.resourceId, plan.resourceId).map {
+          queriesDeletingDate(project.resourceId, plan, _)
+        }
+      }
       .sequence
       .map(_.flatten)
       .map(quers => project -> (queries |+| Queries.preDataQueriesOnly(quers)))


### PR DESCRIPTION
This PR fixes the transformation process so it can deal with cases when there are multiple values in TS for plan dateCreated. The new behaviour simply removes all the dates if there's more than one.