### PR TITLE
feat: Cross-Entity Search API to read projects from Projects graph

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -33,7 +33,6 @@ import io.renku.triplesstore.client.syntax._
 object DatasetsQuery extends EntityQuery[Entity.Dataset] {
   override val entityType: Filters.EntityType = Filters.EntityType.Dataset
 
-  val entityTypeVar           = VarName("entityType")
   val matchingScoreVar        = VarName("matchingScore")
   val nameVar                 = VarName("name")
   val idsPathsVisibilitiesVar = VarName("idsPathsVisibilities")
@@ -97,7 +96,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
           |          $sameAsVar schema:creator / schema:name ?creatorName.
           |        }
           |
-          |        #keywords, description
+          |        #keywords
           |        $keywords
           |
           |        # resolve project

--- a/entities-search/src/main/scala/io/renku/entities/search/EntitiesFinder.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/EntitiesFinder.scala
@@ -91,7 +91,7 @@ private class EntitiesFinderImpl[F[_]: Async: NonEmptyParallel: Logger: SparqlQu
     import io.circe.DecodingFailure
     import io.renku.triplesstore.ResultsDecoder._
 
-    extract[EntityType]("entityType") >>= { entityType =>
+    read[EntityType](EntityQueryVars.entityTypeVar) >>= { entityType =>
       entityQueries.flatMap(_.getDecoder(entityType)) match {
         case Nil            => DecodingFailure(s"No decoder for $entityType", Nil).asLeft
         case decoder :: Nil => cursor.as(decoder)

--- a/entities-search/src/main/scala/io/renku/entities/search/EntityQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/EntityQuery.scala
@@ -21,8 +21,9 @@ package io.renku.entities.search
 import io.circe.Decoder
 import io.renku.entities.search.Criteria.Filters.EntityType
 import io.renku.triplesstore.ResultsDecoder
+import io.renku.triplesstore.client.sparql.VarName
 
-private[entities] trait EntityQuery[+E <: model.Entity] extends ResultsDecoder {
+private[entities] trait EntityQuery[+E <: model.Entity] extends ResultsDecoder with EntityQueryVars {
   val entityType:      EntityType
   val selectVariables: Set[String]
   def query(criteria: Criteria): Option[String]
@@ -30,4 +31,9 @@ private[entities] trait EntityQuery[+E <: model.Entity] extends ResultsDecoder {
 
   def getDecoder[EE >: E](entityType: EntityType): Option[Decoder[EE]] =
     Option.when(entityType == this.entityType)(decoder[EE])
+}
+
+private[entities] object EntityQueryVars extends EntityQueryVars
+private[entities] trait EntityQueryVars {
+  val entityTypeVar = VarName("entityType")
 }

--- a/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
@@ -22,6 +22,7 @@ import io.circe.Decoder
 import io.renku.entities.search.Criteria.Filters.EntityType
 import io.renku.entities.search.model.{Entity, MatchingScore}
 import io.renku.graph.model.{GraphClass, persons}
+import io.renku.triplesstore.client.sparql.VarName
 
 private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
 
@@ -46,7 +47,7 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
           |          ?id a schema:Person;
           |              schema:name ?name
           |        }
-          |        ${filters.maybeOnCreatorName("?name")}
+          |        ${filters.maybeOnCreatorName(VarName("name")).sparql}
           |      }
           |      GROUP BY ?name
           |    }

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -70,7 +70,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
              |    (GROUP_CONCAT(DISTINCT $keywordVar; separator=',') AS $keywordsVar)
              |    (GROUP_CONCAT($encodedImageUrlVar; separator=',') AS $imagesVar)
              |  WHERE {
-             |    BIND ('project' AS $entityTypeVar)
+             |    BIND (${entityType.value.asTripleObject} AS $entityTypeVar)
              |
              |    # textQuery
              |    ${textQueryPart(criteria.filters.maybeQuery)}

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -21,84 +21,169 @@ package io.renku.entities.search
 import io.circe.Decoder
 import io.renku.entities.search.Criteria.Filters.EntityType
 import io.renku.entities.search.model.{Entity, MatchingScore}
+import io.renku.graph.model.entities.Person
 import io.renku.graph.model.{GraphClass, persons, projects}
+import io.renku.http.server.security.model.AuthUser
+import io.renku.triplesstore.client.sparql.{Fragment, LuceneQuery, VarName}
+import io.renku.triplesstore.client.syntax._
 
 private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
 
   override val entityType: EntityType = EntityType.Project
 
-  override val selectVariables: Set[String] = Set("?entityType",
-                                                  "?matchingScore",
-                                                  "?name",
-                                                  "?path",
-                                                  "?visibility",
-                                                  "?date",
-                                                  "?maybeCreatorName",
-                                                  "?maybeDescription",
-                                                  "?keywords"
-  )
+  private val matchingScoreVar    = VarName("matchingScore")
+  private val nameVar             = VarName("name")
+  private val pathVar             = VarName("path")
+  private val visibilityVar       = VarName("visibility")
+  private val dateVar             = VarName("date")
+  private val maybeCreatorNameVar = VarName("maybeCreatorName")
+  private val maybeDescriptionVar = VarName("maybeDescription")
+  private val keywordsVar         = VarName("keywords")
+  private val imagesVar           = VarName("images")
 
-  override def query(criteria: Criteria) = (criteria.filters whenRequesting entityType) {
+  // local vars
+  private val projectIdVar       = VarName("projectId")
+  private val keywordVar         = VarName("keyword")
+  private val encodedImageUrlVar = VarName("encodedImageUrl")
+
+  override val selectVariables: Set[String] = Set(entityTypeVar,
+                                                  matchingScoreVar,
+                                                  nameVar,
+                                                  pathVar,
+                                                  visibilityVar,
+                                                  dateVar,
+                                                  maybeCreatorNameVar,
+                                                  maybeDescriptionVar,
+                                                  keywordsVar,
+                                                  imagesVar
+  ).map(_.name)
+
+  override def query(criteria: Criteria): Option[String] = (criteria.filters whenRequesting entityType) {
     import criteria._
-    // format: off
-    s"""|{
-        |  SELECT ?entityType ?matchingScore ?name ?path ?visibility ?date ?maybeCreatorName
-        |    ?maybeDescription (GROUP_CONCAT(DISTINCT ?keyword; separator=',') AS ?keywords)
-        |    (GROUP_CONCAT(?encodedImageUrl; separator=',') AS ?images)
-        |  WHERE {
-        |    ${filters.onQuery(
-    s"""|    {
-        |      SELECT ?projectId (MAX(?score) AS ?matchingScore)
-        |      WHERE {
-        |        {
-        |          (?id ?score) text:query (schema:name schema:keywords schema:description renku:projectNamespaces '${filters.query.query}')
-        |        } {
-        |          GRAPH ?id {
-        |            ?id a schema:Project
-        |          }
-        |          BIND (?id AS ?projectId)
-        |        } UNION {
-        |          GRAPH ?projectId {
-        |            ?projectId schema:creator ?id;
-        |                       a schema:Project
-        |          }
-        |        }
-        |      }
-        |      GROUP BY ?projectId
-        |    }
-        |""")}
-        |    BIND ('project' AS ?entityType)
-        |    GRAPH ?projectId {
-        |      ?projectId a schema:Project;
-        |                 schema:name ?name;
-        |                 renku:projectPath ?path;
-        |                 renku:projectNamespace ?namespace;
-        |                 schema:dateCreated ?date.
-        |      ${criteria.maybeOnAccessRightsAndVisibility("?projectId", "?visibility")}
-        |      ${filters.maybeOnNamespace("?namespace")}
-        |      ${filters.maybeOnDateCreated("?date")}
-        |      OPTIONAL { 
-        |        ?projectId schema:creator ?creatorId.
-        |        GRAPH <${GraphClass.Persons.id}> {
-        |          ?creatorId schema:name ?maybeCreatorName
-        |        }
-        |      }
-        |      ${filters.maybeOnCreatorName("?maybeCreatorName")}
-        |      OPTIONAL { ?projectId schema:description ?maybeDescription }
-        |      OPTIONAL { ?projectId schema:keywords ?keyword }
-        |      OPTIONAL {
-        |        ?projectId schema:image ?imageId.
-        |        ?imageId schema:position ?imagePosition;
-        |                 schema:contentUrl ?imageUrl.
-        |        BIND (CONCAT(STR(?imagePosition), STR(':'), STR(?imageUrl)) AS ?encodedImageUrl)
-        |      }
-        |    }
-        |  }
-        |  GROUP BY ?entityType ?matchingScore ?name ?path ?visibility ?date ?maybeCreatorName ?maybeDescription
-        |}
-        |""".stripMargin
-    // format: on
+    sparql"""|{
+             |  SELECT $entityTypeVar $matchingScoreVar $nameVar $pathVar $visibilityVar $dateVar $maybeCreatorNameVar
+             |    $maybeDescriptionVar (GROUP_CONCAT(DISTINCT $keywordVar; separator=',') AS $keywordsVar)
+             |    (GROUP_CONCAT($encodedImageUrlVar; separator=',') AS $imagesVar)
+             |  WHERE {
+             |    BIND ('project' AS $entityTypeVar)
+             |
+             |    # textQuery
+             |    ${textQueryPart(criteria.filters.maybeQuery)}
+             |
+             |    GRAPH ${GraphClass.Projects.id} {
+             |      $projectIdVar a renku:DiscoverableProject;
+             |                    schema:name $nameVar;
+             |                    renku:projectPath $pathVar;
+             |                    schema:dateCreated $dateVar.
+             |
+             |      GRAPH $projectIdVar {
+             |        ${accessRightsAndVisibility(criteria.maybeUser, criteria.filters.visibilities)}
+             |        ${namespacesPart(criteria.filters.namespaces)}
+             |      }
+             |      
+             |      ${filters.maybeOnDateCreated(dateVar)}
+             |      ${filters.maybeOnCreatorName(maybeCreatorNameVar)}
+             |
+             |      OPTIONAL { $projectIdVar schema:creator/schema:name $maybeCreatorNameVar }
+             |      OPTIONAL { $projectIdVar schema:description $maybeDescriptionVar }
+             |      OPTIONAL { $projectIdVar schema:keywords $keywordVar }
+             |      $imagesPart
+             |    }
+             |  }
+             |  GROUP BY $entityTypeVar $matchingScoreVar $nameVar $pathVar
+             |    $visibilityVar $dateVar $maybeCreatorNameVar $maybeDescriptionVar
+             |}
+             |""".stripMargin.sparql
   }
+
+  private def textQueryPart: Option[Criteria.Filters.Query] => Fragment = {
+    case Some(q) =>
+      val luceneQuery = LuceneQuery.fuzzy(q.value)
+      fr"""|{
+           |  SELECT $projectIdVar (MAX(?score) AS $matchingScoreVar)
+           |  WHERE {
+           |    {
+           |      (?id ?score) text:query (schema:name schema:keywords schema:description renku:projectNamespaces $luceneQuery)
+           |    } {
+           |      GRAPH ${GraphClass.Projects.id} {
+           |        ?id a renku:DiscoverableProject
+           |      }
+           |      BIND (?id AS $projectIdVar)
+           |    } UNION {
+           |      GRAPH ${GraphClass.Projects.id} {
+           |        $projectIdVar schema:creator ?id;
+           |                      a renku:DiscoverableProject
+           |      }
+           |    }
+           |  }
+           |  GROUP BY $projectIdVar
+           |}
+           |""".stripMargin
+    case None =>
+      fr"""|BIND (xsd:float(1.0) AS $matchingScoreVar)
+           |""".stripMargin
+  }
+
+  private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[projects.Visibility]): Fragment =
+    maybeUser match {
+      case Some(user) =>
+        val nonPrivateVisibilities =
+          if (visibilities.isEmpty)
+            projects.Visibility.all - projects.Visibility.Private
+          else (projects.Visibility.all - projects.Visibility.Private) intersect visibilities
+
+        val selectPrivateValue =
+          if (visibilities.isEmpty || visibilities.contains(projects.Visibility.Private))
+            projects.Visibility.Private.asObject
+          else "".asTripleObject
+        fr"""|{
+             |  $projectIdVar renku:projectVisibility $visibilityVar.
+             |  {
+             |    VALUES ($visibilityVar) {
+             |      ${nonPrivateVisibilities.map(_.asObject)}
+             |    }
+             |  } UNION {
+             |    VALUES ($visibilityVar) {
+             |      ($selectPrivateValue)
+             |    }
+             |    $projectIdVar schema:member ?memberId.
+             |    GRAPH ${GraphClass.Persons.id} {
+             |      ?memberId schema:sameAs ?memberSameAs.
+             |      ?memberSameAs schema:additionalType ${Person.gitLabSameAsAdditionalType.asTripleObject};
+             |                    schema:identifier ${user.id.asObject}
+             |    }
+             |  }
+             |}
+             |""".stripMargin
+      case None =>
+        visibilities match {
+          case v if v.isEmpty || v.contains(projects.Visibility.Public) =>
+            fr"""|$projectIdVar renku:projectVisibility $visibilityVar.
+                 |VALUES ($visibilityVar) { (${projects.Visibility.Public.asObject}) }""".stripMargin
+          case _ =>
+            fr"""|$projectIdVar renku:projectVisibility $visibilityVar.
+                 |VALUES ($visibilityVar) { ('') }""".stripMargin
+        }
+    }
+
+  private def namespacesPart(ns: Set[projects.Namespace]): Fragment = {
+    val matchFrag =
+      if (ns.isEmpty) Fragment.empty
+      else fr"VALUES (?namespace) { ${ns.map(_.value)} }"
+
+    fr"""|$projectIdVar renku:projectNamespace ?namespace.
+         |$matchFrag
+    """.stripMargin
+  }
+
+  private lazy val imagesPart =
+    fr"""|OPTIONAL {
+         |  $projectIdVar schema:image ?imageId.
+         |  ?imageId schema:position ?imagePosition;
+         |           schema:contentUrl ?imageUrl.
+         |  BIND (CONCAT(STR(?imagePosition), STR(':'), STR(?imageUrl)) AS $encodedImageUrlVar)
+         |}
+         |""".stripMargin
 
   override def decoder[EE >: Entity.Project]: Decoder[EE] = { implicit cursor =>
     import DecodingTools._
@@ -106,16 +191,16 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
     import io.renku.tinytypes.json.TinyTypeDecoders._
 
     for {
-      matchingScore    <- extract[MatchingScore]("matchingScore")
-      path             <- extract[projects.Path]("path")
-      name             <- extract[projects.Name]("name")
-      visibility       <- extract[projects.Visibility]("visibility")
-      dateCreated      <- extract[projects.DateCreated]("date")
-      maybeCreatorName <- extract[Option[persons.Name]]("maybeCreatorName")
+      matchingScore    <- read[MatchingScore](matchingScoreVar)
+      path             <- read[projects.Path](pathVar)
+      name             <- read[projects.Name](nameVar)
+      visibility       <- read[projects.Visibility](visibilityVar)
+      dateCreated      <- read[projects.DateCreated](dateVar)
+      maybeCreatorName <- read[Option[persons.Name]](maybeCreatorNameVar)
+      maybeDescription <- read[Option[projects.Description]](maybeDescriptionVar)
+      images           <- read[Option[String]](imagesVar) >>= toListOfImageUris
       keywords <-
-        extract[Option[String]]("keywords") >>= toListOf[projects.Keyword, projects.Keyword.type](projects.Keyword)
-      maybeDescription <- extract[Option[projects.Description]]("maybeDescription")
-      images           <- extract[Option[String]]("images") >>= toListOfImageUris
+        read[Option[String]](keywordsVar) >>= toListOf[projects.Keyword, projects.Keyword.type](projects.Keyword)
     } yield Entity.Project(matchingScore,
                            path,
                            name,

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -26,7 +26,7 @@ import io.renku.entities.search.model.Entity.Workflow.WorkflowType
 import io.renku.entities.search.model.{Entity, MatchingScore}
 import io.renku.graph.model.entities.{CompositePlan, StepPlan}
 import io.renku.graph.model.{plans, projects}
-import io.renku.triplesstore.client.sparql.LuceneQuery
+import io.renku.triplesstore.client.sparql.{LuceneQuery, VarName}
 
 private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
 
@@ -90,7 +90,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |          ${criteria.maybeOnAccessRightsAndVisibility("?projectId", "?visibility")}
         |          BIND (CONCAT(STR(?projectId), STR('::'), STR(?visibility)) AS ?projectIdVisibility)
         |          ${filters.maybeOnNamespace("?namespace")}
-        |          ${filters.maybeOnDateCreated("?date")}
+        |          ${filters.maybeOnDateCreated(VarName("date")).sparql}
         |          OPTIONAL { ?wkId schema:description ?maybeDescription }
         |          OPTIONAL { ?wkId schema:keywords ?keyword }
         |        }

--- a/entities-search/src/test/scala/io/renku/entities/search/DatasetsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/DatasetsEntitiesFinderSpec.scala
@@ -18,7 +18,6 @@
 
 package io.renku.entities.search
 
-import cats.effect.IO
 import cats.syntax.all._
 import io.renku.entities.search.Criteria.{Filters, Sort}
 import io.renku.entities.search.EntityConverters._
@@ -34,8 +33,6 @@ import io.renku.testtools.IOSpec
 import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 class DatasetsEntitiesFinderSpec
     extends AnyWordSpec
@@ -48,8 +45,6 @@ class DatasetsEntitiesFinderSpec
     with SearchDiffInstances
     with AdditionalMatchers
     with IOSpec {
-
-  implicit val ioLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   "findEntities - in case of a shared datasets" should {
 

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -19,7 +19,6 @@
 package io.renku.entities.search
 
 import cats.data.NonEmptyList
-import cats.effect.IO
 import cats.syntax.all._
 import io.renku.entities.search
 import io.renku.entities.search.Criteria.Filters._
@@ -43,8 +42,6 @@ import io.renku.testtools.IOSpec
 import io.renku.triplesstore._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.time.temporal.ChronoUnit.DAYS
 import java.time.{Instant, LocalDate, ZoneOffset}
@@ -61,8 +58,6 @@ class EntitiesFinderSpec
     with ProjectsDataset
     with SearchInfoDatasets
     with IOSpec {
-
-  implicit val ioLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   "findEntities - no filters" should {
 

--- a/entities-search/src/test/scala/io/renku/entities/search/FinderSpecOps.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/FinderSpecOps.scala
@@ -32,14 +32,17 @@ import io.renku.testtools.IOSpec
 import io.renku.tinytypes.StringTinyType
 import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQueryTimeRecorder}
 import org.scalatest.TestSuite
+import org.typelevel.log4cats.Logger
 
 import java.time.Instant
 
 trait FinderSpecOps {
   self: TestSuite with InMemoryJenaForSpec with ProjectsDataset with IOSpec =>
 
+  protected implicit val logger: TestLogger[IO] = TestLogger[IO]()
+  implicit val ioLogger:         Logger[IO]     = logger
+
   protected[search] trait TestCase {
-    implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
     val finder: EntitiesFinder[IO] = new EntitiesFinderImpl[IO](projectsDSConnectionInfo, EntitiesFinder.newFinders)
   }

--- a/entities-search/src/test/scala/io/renku/entities/search/GraphPopulateSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/GraphPopulateSpec.scala
@@ -18,21 +18,18 @@
 
 package io.renku.entities.search
 
-import cats.effect.IO
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.circe.Decoder
 import io.renku.entities.searchgraphs.SearchInfoDatasets
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.{GraphClass, Schemas}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
-import io.renku.interpreters.TestLogger
+import io.renku.graph.model.{GraphClass, Schemas}
 import io.renku.testtools.IOSpec
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQuery}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import org.typelevel.log4cats.Logger
 
 class GraphPopulateSpec
     extends AnyFlatSpec
@@ -43,8 +40,6 @@ class GraphPopulateSpec
     with ProjectsDataset
     with SearchInfoDatasets
     with IOSpec {
-
-  implicit val ioLogger: Logger[IO] = TestLogger[IO]()
 
   it should "populate the schema:Datasets graph" in {
     val project = renkuProjectEntities(visibilityPublic)

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/search/SearchTestBase.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/search/SearchTestBase.scala
@@ -41,8 +41,6 @@ import io.renku.triplesstore._
 import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import java.time.Instant
 
@@ -58,8 +56,6 @@ abstract class SearchTestBase
     with SearchDiffInstances
     with EntityViewings
     with IOSpec {
-
-  implicit override def ioLogger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
   implicit val queryTimeRecorder: SparqlQueryTimeRecorder[IO] =
     TestSparqlQueryTimeRecorder[IO].unsafeRunSync()

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/StringInterpolator.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/StringInterpolator.scala
@@ -61,7 +61,7 @@ class StringInterpolator(private val sc: StringContext) {
   private def resolveIterable(it: Iterable[Any], idx: Int) = {
     import ClauseDetector.ClauseType
     ClauseDetector
-      .detectClauseContext(sc.parts(idx))
+      .detectClauseContext(findSnippet(idx))
       .map {
         case ClauseType.VALUES_BRACKETED     => it.map(makeValue(_, idx)).map(s => s"($s)").mkString(" ")
         case ClauseType.VALUES_NOT_BRACKETED => it.map(makeValue(_, idx)).mkString(" ")
@@ -75,13 +75,17 @@ class StringInterpolator(private val sc: StringContext) {
       )
       .getOrElse(sys.error("Iterable cannot be resolved in this context"))
   }
+
+  private def findSnippet(idx: Int) =
+    if (idx > 0) s"${sc.parts(idx - 1)}${sc.parts(idx)}"
+    else sc.parts(idx)
 }
 
 private object StringInterpolator {
 
   private object ClauseDetector {
-    private val valuesBracketedClause    = ".*VALUES\\s*\\(\\s*\\?\\w+\\s*\\)\\s*\\{\\s*$".r
-    private val valuesNotBracketedClause = ".*VALUES\\s*\\?\\w+\\s*\\{\\s*$".r
+    private val valuesBracketedClause    = ".*VALUES\\s*\\(\\s*(\\?\\w+)?\\s*\\)\\s*\\{\\s*$".r
+    private val valuesNotBracketedClause = ".*VALUES\\s*(\\?\\w+)?\\s*\\{\\s*$".r
     private val inClause                 = ".*IN\\s*\\(\\s*$".r
 
     sealed trait ClauseType

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/StringInterpolatorSpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/StringInterpolatorSpec.scala
@@ -126,6 +126,20 @@ class StringInterpolatorSpec extends AnyWordSpec with should.Matchers {
       )
     }
 
+    "encode an Iterable if used in a context of VALUES clause where the variable is in a placeholder too" in {
+
+      val variable = nonEmptyStrings().map(VarName(_)).generateOne
+      val col      = nonEmptyStrings().generateNonEmptyList().toList
+
+      fr"VALUES ($variable) { $col }" shouldBe Fragment(
+        s"VALUES (${variable.name}) { ${col.map(v => fr"$v".sparql).map(s => s"($s)").mkString(" ")} }"
+      )
+
+      fr"VALUES $variable { $col }" shouldBe Fragment(
+        s"VALUES ${variable.name} { ${col.map(v => fr"$v".sparql).mkString(" ")} }"
+      )
+    }
+
     "encode an Iterable if used in a context of IN clause" in {
       val col = nonEmptyStrings().generateNonEmptyList().toList
       fr"IN ($col)" shouldBe Fragment(


### PR DESCRIPTION
This PR is the last part of the #1412 endeavour. It modifies the projects query that is behind the Cross-Entity Search API to take advantage of the data stored in the `Projects` graph.

closes #1412 