### PR TITLE
fix: Location.FileOrFolder to allow \ at the end

### DIFF
--- a/tiny-types/src/main/scala/io/renku/tinytypes/constraints/RelativePath.scala
+++ b/tiny-types/src/main/scala/io/renku/tinytypes/constraints/RelativePath.scala
@@ -25,7 +25,7 @@ trait RelativePath[TT <: TinyType { type V = String }] extends Constraints[TT] w
   self: TinyTypeFactory[TT] =>
 
   addConstraint(
-    check = value => !value.startsWith("/") && !value.endsWith("/") && !value.matches("^\\w+://.*"),
+    check = value => !value.startsWith("/") && !value.matches("^\\w+://.*"),
     message = value => s"'$value' is not a valid $typeName"
   )
 }

--- a/tiny-types/src/test/scala/io/renku/tinytypes/constraints/RelativePathSpec.scala
+++ b/tiny-types/src/test/scala/io/renku/tinytypes/constraints/RelativePathSpec.scala
@@ -40,8 +40,8 @@ class RelativePathSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
       }
     }
 
-    "be instantiatable when values are not starting and ending with '/' but have the '/' sign inside" in {
-      forAll(relativePaths()) { someValue =>
+    "be instantiatable when values are not starting but ending with '/' and having the '/' sign inside" in {
+      forAll(relativePaths().map(v => s"$v/")) { someValue =>
         RelativePathString(someValue).toString shouldBe someValue
       }
     }


### PR DESCRIPTION
This PR relaxes validation of a RelativePath constraints so `\` is allowed at the end.

closes #1509 