### PR TITLE
fix: PAT leakage for non-activated projects

### DIFF
--- a/graph-commons/src/main/scala/io/renku/http/server/security/Authentication.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/security/Authentication.scala
@@ -36,7 +36,7 @@ private class AuthenticationImpl[F[_]: MonadThrow](authenticator: Authenticator[
 
   override val authenticateIfNeeded: Kleisli[F, Request[F], Either[EndpointSecurityException, MaybeAuthUser]] =
     Kleisli { request =>
-      getBearerToken(request) orElse getPrivateAccessToken(request) match {
+      getAccessToken(request) match {
         case Some(token) => authenticator.authenticate(token).map(_.map(MaybeAuthUser.apply))
         case None        => MaybeAuthUser.noUser.asRight[EndpointSecurityException].pure[F]
       }

--- a/graph-commons/src/main/scala/io/renku/http/server/security/RequestTokenFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/security/RequestTokenFinder.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.http.server.security
+
+import cats.syntax.all._
+import io.renku.http.client.AccessToken.{PersonalAccessToken, UserOAuthAccessToken}
+import io.renku.http.client.UserAccessToken
+import org.http4s.AuthScheme.Bearer
+import org.http4s.Credentials.Token
+import org.http4s.Header.Select._
+import org.http4s.headers.Authorization
+import org.http4s.{Header, Request}
+import org.typelevel.ci._
+
+object RequestTokenFinder {
+
+  def getBearerToken[F[_]](request: Request[F]): Option[UserAccessToken] =
+    request.headers.get(singleHeaders(Authorization.headerInstance)) >>= {
+      case Authorization(Token(Bearer, token)) => UserOAuthAccessToken(token).some
+      case _                                   => None
+    }
+
+  def getPrivateAccessToken[F[_]](request: Request[F]): Option[UserAccessToken] =
+    request.headers.get(ci"PRIVATE-TOKEN").map(_.toList) >>= {
+      case Header.Raw(_, token) :: _ => PersonalAccessToken(token).some
+      case _                         => None
+    }
+}

--- a/graph-commons/src/main/scala/io/renku/http/server/security/RequestTokenFinder.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/security/RequestTokenFinder.scala
@@ -30,13 +30,16 @@ import org.typelevel.ci._
 
 object RequestTokenFinder {
 
-  def getBearerToken[F[_]](request: Request[F]): Option[UserAccessToken] =
+  def getAccessToken[F[_]](request: Request[F]): Option[UserAccessToken] =
+    getBearerToken(request) orElse getPrivateAccessToken(request)
+
+  private def getBearerToken[F[_]](request: Request[F]): Option[UserAccessToken] =
     request.headers.get(singleHeaders(Authorization.headerInstance)) >>= {
       case Authorization(Token(Bearer, token)) => UserOAuthAccessToken(token).some
       case _                                   => None
     }
 
-  def getPrivateAccessToken[F[_]](request: Request[F]): Option[UserAccessToken] =
+  private def getPrivateAccessToken[F[_]](request: Request[F]): Option[UserAccessToken] =
     request.headers.get(ci"PRIVATE-TOKEN").map(_.toList) >>= {
       case Header.Raw(_, token) :: _ => PersonalAccessToken(token).some
       case _                         => None

--- a/token-repository/README.md
+++ b/token-repository/README.md
@@ -91,10 +91,11 @@ Deletes the association of a token and a project id. The deletion is successful 
 
 **Response**
 
-| Status                     | Description                                            |
-|----------------------------|--------------------------------------------------------|
-| NO_CONTENT (204)           | When deletion was successful                           |
-| INTERNAL SERVER ERROR (500)| When there were problems with deleting the association |
+| Status                      | Description                                            |
+|-----------------------------|--------------------------------------------------------|
+| NO_CONTENT (204)            | When deletion was successful                           |
+| UNAUTHORIZED (401)          | When no access token given                             |
+| INTERNAL SERVER ERROR (500) | When there were problems with deleting the association |
 
 #### GET /version
 

--- a/token-repository/README.md
+++ b/token-repository/README.md
@@ -88,13 +88,16 @@ The endpoint requires a token to sent in the request JSON body. Allowed payloads
 #### DELETE /projects/:id/tokens
 
 Deletes the association of a token and a project id. The deletion is successful regardless the association existed or not.
+The API also tries to revoke Project Access Tokens created for the project in GitLab. For that to happen, a valid access token needs to be passed in the header as follows:
+- `Authorization: Bearer <token>` with oauth token obtained from GitLab
+- `PRIVATE-TOKEN: <token>` with user's personal access token in GitLab
+
 
 **Response**
 
 | Status                      | Description                                            |
 |-----------------------------|--------------------------------------------------------|
 | NO_CONTENT (204)            | When deletion was successful                           |
-| UNAUTHORIZED (401)          | When no access token given                             |
 | INTERNAL SERVER ERROR (500) | When there were problems with deleting the association |
 
 #### GET /version

--- a/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
@@ -22,9 +22,8 @@ import cats.MonadThrow
 import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.http.server.binders.{ProjectId, ProjectPath}
-import io.renku.http.ErrorMessage
 import io.renku.http.client.{AccessToken, GitLabClient}
-import io.renku.http.server.security.RequestTokenFinder.{getBearerToken, getPrivateAccessToken}
+import io.renku.http.server.security.RequestTokenFinder.getAccessToken
 import io.renku.http.server.version
 import io.renku.metrics.{MetricsRegistry, RoutesMetrics}
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
@@ -33,7 +32,7 @@ import io.renku.tokenrepository.repository.deletion.DeleteTokenEndpoint
 import io.renku.tokenrepository.repository.fetching.FetchTokenEndpoint
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
 import org.http4s.dsl.Http4sDsl
-import org.http4s.{HttpRoutes, Request, Response, Status}
+import org.http4s.{HttpRoutes, Request, Response}
 import org.typelevel.log4cats.Logger
 
 private trait MicroserviceRoutes[F[_]] {
@@ -67,7 +66,7 @@ private class MicroserviceRoutesImpl[F[_]: MonadThrow](
     case       GET    -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(fetchToken(projectId))
     case       GET    -> Root / "projects" / ProjectPath(projectPath) / "tokens" => whenDBReady(fetchToken(projectPath))
     case req @ POST   -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(createToken(projectId, req))
-    case req @ DELETE -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(whenAuthHeaderPresent(req)(deleteToken(projectId, _)))
+    case req @ DELETE -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(withAccessToken(req)(deleteToken(projectId, _)))
   }.withMetrics.map(_ <+> versionRoutes())
   // format: on
 
@@ -76,11 +75,8 @@ private class MicroserviceRoutesImpl[F[_]: MonadThrow](
     case false => ServiceUnavailable(InfoMessage("DB migration running"))
   }
 
-  private def whenAuthHeaderPresent(request: Request[F])(f: AccessToken => F[Response[F]]): F[Response[F]] =
-    getBearerToken(request) orElse getPrivateAccessToken(request) match {
-      case None        => Response[F](Status.Unauthorized).withEntity(ErrorMessage("No Auth header")).pure[F]
-      case Some(token) => f(token)
-    }
+  private def withAccessToken(request: Request[F])(f: Option[AccessToken] => F[Response[F]]): F[Response[F]] =
+    f(getAccessToken(request))
 }
 
 private object MicroserviceRoutes {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/MicroserviceRoutes.scala
@@ -22,7 +22,9 @@ import cats.MonadThrow
 import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.http.server.binders.{ProjectId, ProjectPath}
-import io.renku.http.client.GitLabClient
+import io.renku.http.ErrorMessage
+import io.renku.http.client.{AccessToken, GitLabClient}
+import io.renku.http.server.security.RequestTokenFinder.{getBearerToken, getPrivateAccessToken}
 import io.renku.http.server.version
 import io.renku.metrics.{MetricsRegistry, RoutesMetrics}
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
@@ -31,7 +33,7 @@ import io.renku.tokenrepository.repository.deletion.DeleteTokenEndpoint
 import io.renku.tokenrepository.repository.fetching.FetchTokenEndpoint
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
 import org.http4s.dsl.Http4sDsl
-import org.http4s.{HttpRoutes, Response}
+import org.http4s.{HttpRoutes, Request, Response, Status}
 import org.typelevel.log4cats.Logger
 
 private trait MicroserviceRoutes[F[_]] {
@@ -46,8 +48,7 @@ private class MicroserviceRoutesImpl[F[_]: MonadThrow](
     routesMetrics:          RoutesMetrics[F],
     versionRoutes:          version.Routes[F],
     dbReady:                Ref[F, Boolean]
-)(implicit clock: Clock[F])
-    extends Http4sDsl[F]
+) extends Http4sDsl[F]
     with MicroserviceRoutes[F] {
 
   import associateTokenEndpoint._
@@ -66,7 +67,7 @@ private class MicroserviceRoutesImpl[F[_]: MonadThrow](
     case       GET    -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(fetchToken(projectId))
     case       GET    -> Root / "projects" / ProjectPath(projectPath) / "tokens" => whenDBReady(fetchToken(projectPath))
     case req @ POST   -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(createToken(projectId, req))
-    case       DELETE -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(deleteToken(projectId))
+    case req @ DELETE -> Root / "projects" / ProjectId(projectId) / "tokens"     => whenDBReady(whenAuthHeaderPresent(req)(deleteToken(projectId, _)))
   }.withMetrics.map(_ <+> versionRoutes())
   // format: on
 
@@ -74,6 +75,12 @@ private class MicroserviceRoutesImpl[F[_]: MonadThrow](
     case true  => thunk
     case false => ServiceUnavailable(InfoMessage("DB migration running"))
   }
+
+  private def whenAuthHeaderPresent(request: Request[F])(f: AccessToken => F[Response[F]]): F[Response[F]] =
+    getBearerToken(request) orElse getPrivateAccessToken(request) match {
+      case None        => Response[F](Status.Unauthorized).withEntity(ErrorMessage("No Auth header")).pure[F]
+      case Some(token) => f(token)
+    }
 }
 
 private object MicroserviceRoutes {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/NewTokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/NewTokensCreator.scala
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository
+package creation
 
 import cats.data.OptionT
 import cats.effect.Async

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/RevokeCandidatesFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/RevokeCandidatesFinder.scala
@@ -23,6 +23,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
+import io.renku.http.rest.paging.model.{Page, PerPage}
 
 import java.time.LocalDate.now
 import java.time.Period
@@ -34,32 +35,58 @@ private trait RevokeCandidatesFinder[F[_]] {
 private object RevokeCandidatesFinder {
   def apply[F[_]: Async: GitLabClient]: F[RevokeCandidatesFinder[F]] =
     (ProjectTokenDuePeriod[F](), RenkuAccessTokenName[F]())
-      .mapN(new RevokeCandidatesFinderImpl[F](_, _))
+      .mapN(new RevokeCandidatesFinderImpl[F](PerPage(50), _, _))
 }
 
-private class RevokeCandidatesFinderImpl[F[_]: Async: GitLabClient](tokenDuePeriod: Period,
+private class RevokeCandidatesFinderImpl[F[_]: Async: GitLabClient](pageSize: PerPage,
+                                                                    tokenDuePeriod: Period,
                                                                     renkuTokenName: RenkuAccessTokenName
 ) extends RevokeCandidatesFinder[F] {
 
+  import eu.timepit.refined.api.Refined
   import eu.timepit.refined.auto._
+  import eu.timepit.refined.collection.NonEmpty
+  import fs2.Stream
   import io.circe.Decoder
   import io.circe.Decoder._
+  import io.renku.http.tinytypes.TinyTypeURIEncoder._
   import org.http4s.Status.{Forbidden, NotFound, Ok, Unauthorized}
   import org.http4s.circe.jsonOf
   import org.http4s.implicits._
   import org.http4s.{EntityDecoder, Request, Response, Status}
+  import org.typelevel.ci._
+
+  private val endpointName: String Refined NonEmpty = "project-access-tokens"
 
   override def findTokensToRemove(projectId: projects.GitLabId, accessToken: AccessToken): F[List[AccessTokenId]] =
+    Stream
+      .iterate(1)(_ + 1)
+      .evalMap(fetch(_, projectId, accessToken))
+      .map { case (tokens, maybeNextPage) =>
+        tokens.filter(renkuTokens).filter(dueToRefresh).map(_._1) -> maybeNextPage
+      }
+      .takeThrough { case (_, maybeNextPage) => maybeNextPage.nonEmpty }
+      .map(_._1)
+      .compile
+      .toList
+      .map(_.flatten)
+
+  private def fetch(page: Int, projectId: projects.GitLabId, accessToken: AccessToken) =
     GitLabClient[F]
-      .get(uri"projects" / projectId.value / "access_tokens", "project-access-tokens")(mapResponse)(accessToken.some)
-      .map(_.filter(renkuTokens).filter(dueToRefresh).map(_._1))
+      .get(uri"projects" / projectId / "access_tokens" +? ("per_page" -> pageSize) +? ("page" -> page), endpointName)(
+        mapResponse
+      )(accessToken.some)
 
   private type TokenInfo = (AccessTokenId, String, Option[ExpiryDate])
 
-  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[List[TokenInfo]]] = {
-    case (Ok, _, response)                           => response.as[List[TokenInfo]]
-    case (Unauthorized | Forbidden | NotFound, _, _) => List.empty[TokenInfo].pure[F]
+  private lazy val mapResponse
+      : PartialFunction[(Status, Request[F], Response[F]), F[(List[TokenInfo], Option[Page])]] = {
+    case (Ok, _, response)                           => response.as[List[TokenInfo]].map(_ -> maybeNextPage(response))
+    case (Unauthorized | Forbidden | NotFound, _, _) => (List.empty[TokenInfo] -> Option.empty[Page]).pure[F]
   }
+
+  private def maybeNextPage(response: Response[F]): Option[Page] =
+    response.headers.get(ci"X-Next-Page").flatMap(_.head.value.toIntOption.map(Page))
 
   private implicit lazy val decoder: EntityDecoder[F, List[TokenInfo]] = {
     import io.renku.tinytypes.json.TinyTypeDecoders._

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
@@ -84,7 +84,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
     case Some(token) =>
       checkValid(projectId, token) >>= {
         case true  => token.some.pure[F]
-        case false => tokenRemover.delete(projectId, userToken).as(Option.empty)
+        case false => tokenRemover.delete(projectId, userToken.some).as(Option.empty)
       }
   }
 
@@ -103,7 +103,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
           }
         )
         .cataF(
-          default = tokenRemover.delete(projectId, userToken).as(Option.empty),
+          default = tokenRemover.delete(projectId, userToken.some).as(Option.empty),
           _ => token.some.pure[F]
         )
   }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
@@ -31,7 +31,7 @@ import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
-import io.renku.tokenrepository.repository.deletion.TokenRemover
+import io.renku.tokenrepository.repository.deletion.{RevokeCandidatesFinder, TokenRemover, TokenRevoker}
 import io.renku.tokenrepository.repository.fetching.PersistedTokensFinder
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
 import org.typelevel.log4cats.Logger
@@ -43,18 +43,18 @@ private trait TokensCreator[F[_]] {
 }
 
 private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
-    projectPathFinder:      ProjectPathFinder[F],
-    accessTokenCrypto:      AccessTokenCrypto[F],
-    tokenValidator:         TokenValidator[F],
-    tokenDueChecker:        TokenDueChecker[F],
-    newTokensCreator:       NewTokensCreator[F],
-    tokensPersister:        TokensPersister[F],
-    persistedPathFinder:    PersistedPathFinder[F],
-    tokenRemover:           TokenRemover[F],
-    tokenFinder:            PersistedTokensFinder[F],
-    revokeCandidatesFinder: RevokeCandidatesFinder[F],
-    tokensRevoker:          TokensRevoker[F],
-    maxRetries:             Int Refined NonNegative
+                                                           projectPathFinder:      ProjectPathFinder[F],
+                                                           accessTokenCrypto:      AccessTokenCrypto[F],
+                                                           tokenValidator:         TokenValidator[F],
+                                                           tokenDueChecker:        TokenDueChecker[F],
+                                                           newTokensCreator:       NewTokensCreator[F],
+                                                           tokensPersister:        TokensPersister[F],
+                                                           persistedPathFinder:    PersistedPathFinder[F],
+                                                           tokenRemover:           TokenRemover[F],
+                                                           tokenFinder:            PersistedTokensFinder[F],
+                                                           revokeCandidatesFinder: RevokeCandidatesFinder[F],
+                                                           tokensRevoker:          TokenRevoker[F],
+                                                           maxRetries:             Int Refined NonNegative
 ) extends TokensCreator[F] {
 
   import newTokensCreator._
@@ -69,7 +69,10 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
   override def create(projectId: projects.GitLabId, userToken: AccessToken): F[Unit] =
     findStoredToken(projectId)
       .flatMapF(
-        decrypt >=> removeWhenInvalid(projectId) >=> replacePathIfChangedOrRemove(projectId) >=> checkIfDue(projectId)
+        decrypt >=>
+          removeWhenInvalid(projectId, userToken) >=>
+          replacePathIfChangedOrRemove(projectId, userToken) >=>
+          checkIfDue(projectId)
       )
       .void
       .getOrElseF(createNew(projectId, userToken))
@@ -77,17 +80,20 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
   private lazy val decrypt: EncryptedAccessToken => F[Option[AccessToken]] = encryptedToken =>
     accessTokenCrypto.decrypt(encryptedToken).map(_.some)
 
-  private def removeWhenInvalid(projectId: projects.GitLabId): Option[AccessToken] => F[Option[AccessToken]] = {
+  private def removeWhenInvalid(projectId: projects.GitLabId,
+                                userToken: AccessToken
+  ): Option[AccessToken] => F[Option[AccessToken]] = {
     case None => Option.empty[AccessToken].pure[F]
     case Some(token) =>
       checkValid(projectId, token) >>= {
         case true  => token.some.pure[F]
-        case false => tokenRemover.delete(projectId).as(Option.empty)
+        case false => tokenRemover.delete(projectId, userToken).as(Option.empty)
       }
   }
 
   private def replacePathIfChangedOrRemove(
-      projectId: projects.GitLabId
+      projectId: projects.GitLabId,
+      userToken: AccessToken
   ): Option[AccessToken] => F[Option[AccessToken]] = {
     case None => Option.empty[AccessToken].pure[F]
     case Some(token) =>
@@ -100,7 +106,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
           }
         )
         .cataF(
-          default = tokenRemover.delete(projectId).as(Option.empty),
+          default = tokenRemover.delete(projectId, userToken).as(Option.empty),
           _ => token.some.pure[F]
         )
   }
@@ -142,9 +148,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
     findTokensToRemove(project.id, userToken)
       .flatMap(_.map(revokeToken(project.id, _, userToken)).sequence)
       .void
-      .recoverWith { case NonFatal(ex) =>
-        Logger[F].warn(ex)(show"removing old token in GitLab for project $project failed")
-      }
+      .recoverWith { case ex => Logger[F].warn(ex)(show"removing old token in GitLab for project $project failed") }
 
   private def persistWithRetry(storingInfo:     TokenStoringInfo,
                                newToken:        ProjectAccessToken,
@@ -186,6 +190,7 @@ private object TokensCreator {
     tokenValidator            <- TokenValidator[F]
     tokenDueChecker           <- TokenDueChecker[F]
     projectAccessTokenCreator <- NewTokensCreator[F]()
+    tokenRemover              <- TokenRemover[F]
     revokeCandidatesFinder    <- RevokeCandidatesFinder[F]
   } yield new TokensCreatorImpl[F](
     pathFinder,
@@ -195,10 +200,10 @@ private object TokensCreator {
     projectAccessTokenCreator,
     TokensPersister[F],
     PersistedPathFinder[F],
-    TokenRemover[F],
+    tokenRemover,
     PersistedTokensFinder[F],
     revokeCandidatesFinder,
-    TokensRevoker[F],
+    TokenRevoker[F],
     maxRetries
   )
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
@@ -21,20 +21,13 @@ package creation
 
 import AccessTokenCrypto.EncryptedAccessToken
 import TokenDates._
-import cats.syntax.all._
-import cats.{MonadThrow, Show}
-import com.typesafe.config.{Config, ConfigFactory}
-import io.circe.Decoder
-import io.renku.config.ConfigLoader.find
+import cats.Show
 import io.renku.graph.model.projects
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.tinytypes._
-import io.renku.tinytypes.constraints.NonNegativeInt
-import io.renku.tinytypes.json.TinyTypeDecoders
-import pureconfig.ConfigReader
 
-import java.time.{Instant, LocalDate, Period}
+import java.time.{Instant, LocalDate}
 
 private[repository] final case class TokenCreationInfo(token: ProjectAccessToken, dates: TokenDates)
 
@@ -62,29 +55,4 @@ private[repository] object Project {
   implicit lazy val show: Show[Project] = { case Project(id, path) =>
     s"projectId = $id, projectPath = $path"
   }
-}
-
-private final class AccessTokenId private (val value: Int) extends AnyVal with IntTinyType
-private object AccessTokenId
-    extends TinyTypeFactory[AccessTokenId](new AccessTokenId(_))
-    with NonNegativeInt[AccessTokenId] {
-  implicit val jsonDecoder: Decoder[AccessTokenId] = TinyTypeDecoders.intDecoder(this)
-}
-
-private object ProjectTokenDuePeriod {
-
-  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[Period] =
-    find[F, Period]("project-token-due-period", config)
-}
-
-final class RenkuAccessTokenName private (val value: String) extends StringTinyType
-private object RenkuAccessTokenName {
-
-  private implicit val reader: ConfigReader[RenkuAccessTokenName] =
-    ConfigReader.fromString(new RenkuAccessTokenName(_).asRight)
-
-  def apply(v: String): RenkuAccessTokenName = new RenkuAccessTokenName(v)
-
-  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[RenkuAccessTokenName] =
-    find[F, RenkuAccessTokenName]("project-token-name", config)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
@@ -30,7 +30,7 @@ import io.renku.graph.model.projects
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.tinytypes._
-import io.renku.tinytypes.constraints.{InstantNotInTheFuture, NonNegativeInt}
+import io.renku.tinytypes.constraints.NonNegativeInt
 import io.renku.tinytypes.json.TinyTypeDecoders
 import pureconfig.ConfigReader
 
@@ -45,7 +45,6 @@ private[repository] object TokenDates {
 
   implicit object CreatedAt
       extends TinyTypeFactory[CreatedAt](new CreatedAt(_))
-      with InstantNotInTheFuture[CreatedAt]
       with TinyTypeJsonLDOps[CreatedAt]
 
   final class ExpiryDate private (val value: LocalDate) extends AnyVal with LocalDateTinyType

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
@@ -36,9 +36,7 @@ private[repository] final case class TokenDates(createdAt: CreatedAt, expiryDate
 private[repository] object TokenDates {
   final class CreatedAt private (val value: Instant) extends AnyVal with InstantTinyType
 
-  implicit object CreatedAt
-      extends TinyTypeFactory[CreatedAt](new CreatedAt(_))
-      with TinyTypeJsonLDOps[CreatedAt]
+  implicit object CreatedAt extends TinyTypeFactory[CreatedAt](new CreatedAt(_)) with TinyTypeJsonLDOps[CreatedAt]
 
   final class ExpiryDate private (val value: LocalDate) extends AnyVal with LocalDateTinyType
   implicit object ExpiryDate extends TinyTypeFactory[ExpiryDate](new ExpiryDate(_)) with TinyTypeJsonLDOps[ExpiryDate]

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -50,8 +50,8 @@ class DeleteTokenEndpointImpl[F[_]: MonadThrow: Logger](
   private def httpResult(projectId: GitLabId): PartialFunction[Throwable, F[Response[F]]] = {
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage(s"Deleting token for projectId: $projectId failed")
-      Logger[F].error(exception)(errorMessage.value)
-      InternalServerError(errorMessage)
+      Logger[F].error(exception)(errorMessage.value) >>
+        InternalServerError(errorMessage)
   }
 }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -18,12 +18,12 @@
 
 package io.renku.tokenrepository.repository.deletion
 
-import cats.MonadThrow
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage
 import io.renku.http.ErrorMessage._
+import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
 import org.http4s.Response
@@ -33,17 +33,16 @@ import org.typelevel.log4cats.Logger
 import scala.util.control.NonFatal
 
 trait DeleteTokenEndpoint[F[_]] {
-  def deleteToken(projectId: GitLabId): F[Response[F]]
+  def deleteToken(projectId: GitLabId, accessToken: AccessToken): F[Response[F]]
 }
 
-class DeleteTokenEndpointImpl[F[_]: MonadThrow: Logger](
-    tokenRemover: TokenRemover[F]
-) extends Http4sDsl[F]
+class DeleteTokenEndpointImpl[F[_]: Async: Logger](tokenRemover: TokenRemover[F])
+    extends Http4sDsl[F]
     with DeleteTokenEndpoint[F] {
 
-  override def deleteToken(projectId: GitLabId): F[Response[F]] =
+  override def deleteToken(projectId: GitLabId, accessToken: AccessToken): F[Response[F]] =
     tokenRemover
-      .delete(projectId)
+      .delete(projectId, accessToken)
       .flatMap(_ => NoContent())
       .recoverWith(httpResult(projectId))
 
@@ -56,8 +55,6 @@ class DeleteTokenEndpointImpl[F[_]: MonadThrow: Logger](
 }
 
 object DeleteTokenEndpoint {
-  def apply[F[_]: MonadCancelThrow: Logger: SessionResource: QueriesExecutionTimes]: F[DeleteTokenEndpoint[F]] =
-    MonadThrow[F].catchNonFatal {
-      new DeleteTokenEndpointImpl[F](TokenRemover[F])
-    }
+  def apply[F[_]: Async: GitLabClient: Logger: SessionResource: QueriesExecutionTimes]: F[DeleteTokenEndpoint[F]] =
+    TokenRemover[F].map(new DeleteTokenEndpointImpl[F](_))
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemover.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.deletion
+
+import cats.effect.MonadCancelThrow
+import cats.syntax.all._
+import io.renku.db.{DbClient, SqlStatement}
+import io.renku.graph.model.projects.GitLabId
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
+import io.renku.tokenrepository.repository.TokenRepositoryTypeSerializers
+import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
+import org.typelevel.log4cats.Logger
+import skunk.data.Completion
+import skunk.implicits._
+
+private[repository] trait PersistedTokenRemover[F[_]] {
+  def delete(projectId: GitLabId): F[Unit]
+}
+
+private[repository] object PersistedTokenRemover {
+  def apply[F[_]: MonadCancelThrow: SessionResource: Logger: QueriesExecutionTimes]: PersistedTokenRemover[F] =
+    new PersistedTokenRemoverImpl[F]
+}
+
+private class PersistedTokenRemoverImpl[F[_]: MonadCancelThrow: SessionResource: Logger: QueriesExecutionTimes]
+    extends DbClient[F](Some(QueriesExecutionTimes[F]))
+    with PersistedTokenRemover[F]
+    with TokenRepositoryTypeSerializers {
+
+  override def delete(projectId: GitLabId): F[Unit] =
+    SessionResource[F].useK {
+      query(projectId)
+    }
+
+  private def query(projectId: GitLabId) = measureExecutionTime {
+    SqlStatement
+      .named("remove token")
+      .command[GitLabId](sql"""DELETE FROM projects_tokens
+                         WHERE project_id = $projectIdEncoder""".command)
+      .arguments(projectId)
+      .build
+      .flatMapResult(failIfMultiUpdate(projectId))
+  }
+
+  private def failIfMultiUpdate(projectId: GitLabId): Completion => F[Unit] = {
+    case Completion.Delete(0) => ().pure[F]
+    case Completion.Delete(1) => Logger[F].info(show"token removed for $projectId")
+    case Completion.Delete(n) =>
+      new RuntimeException(s"Deleting token for a projectId: $projectId removed $n records")
+        .raiseError[F, Unit]
+    case completion =>
+      new RuntimeException(s"Deleting token for a projectId: $projectId failed with completion code $completion")
+        .raiseError[F, Unit]
+  }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinder.scala
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository
+package deletion
 
-import TokenDates.ExpiryDate
 import cats.effect.Async
 import cats.syntax.all._
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.rest.paging.model.{Page, PerPage}
+import io.renku.tokenrepository.repository.creation.TokenDates.ExpiryDate
 
 import java.time.LocalDate.now
 import java.time.Period
 
-private trait RevokeCandidatesFinder[F[_]] {
+private[repository] trait RevokeCandidatesFinder[F[_]] {
   def findTokensToRemove(projectId: projects.GitLabId, accessToken: AccessToken): F[List[AccessTokenId]]
 }
 
-private object RevokeCandidatesFinder {
+private[repository] object RevokeCandidatesFinder {
   def apply[F[_]: Async: GitLabClient]: F[RevokeCandidatesFinder[F]] =
     (ProjectTokenDuePeriod[F](), RenkuAccessTokenName[F]())
       .mapN(new RevokeCandidatesFinderImpl[F](PerPage(50), _, _))

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinder.scala
@@ -29,11 +29,11 @@ import io.renku.tokenrepository.repository.creation.TokenDates.ExpiryDate
 import java.time.LocalDate.now
 import java.time.Period
 
-private[repository] trait RevokeCandidatesFinder[F[_]] {
-  def findTokensToRemove(projectId: projects.GitLabId, accessToken: AccessToken): F[List[AccessTokenId]]
+private trait RevokeCandidatesFinder[F[_]] {
+  def findProjectAccessTokens(projectId: projects.GitLabId, accessToken: AccessToken): F[List[AccessTokenId]]
 }
 
-private[repository] object RevokeCandidatesFinder {
+private object RevokeCandidatesFinder {
   def apply[F[_]: Async: GitLabClient]: F[RevokeCandidatesFinder[F]] =
     (ProjectTokenDuePeriod[F](), RenkuAccessTokenName[F]())
       .mapN(new RevokeCandidatesFinderImpl[F](PerPage(50), _, _))
@@ -59,7 +59,7 @@ private class RevokeCandidatesFinderImpl[F[_]: Async: GitLabClient](pageSize: Pe
 
   private val endpointName: String Refined NonEmpty = "project-access-tokens"
 
-  override def findTokensToRemove(projectId: projects.GitLabId, accessToken: AccessToken): F[List[AccessTokenId]] =
+  override def findProjectAccessTokens(projectId: projects.GitLabId, accessToken: AccessToken): F[List[AccessTokenId]] =
     Stream
       .iterate(1)(_ + 1)
       .evalMap(fetch(_, projectId, accessToken))

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRevoker.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRevoker.scala
@@ -25,7 +25,7 @@ import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 
 private trait TokenRevoker[F[_]] {
-  def revokeToken(projectId: projects.GitLabId, tokenId: AccessTokenId, accessToken: AccessToken): F[Unit]
+  def revokeToken(tokenId: AccessTokenId, projectId: projects.GitLabId, accessToken: AccessToken): F[Unit]
 }
 
 private object TokenRevoker {
@@ -40,7 +40,7 @@ private class TokenRevokerImpl[F[_]: Async: GitLabClient] extends TokenRevoker[F
   import org.http4s.implicits._
   import org.http4s.{Request, Response, Status}
 
-  override def revokeToken(projectId: projects.GitLabId, tokenId: AccessTokenId, accessToken: AccessToken): F[Unit] =
+  override def revokeToken(tokenId: AccessTokenId, projectId: projects.GitLabId, accessToken: AccessToken): F[Unit] =
     GitLabClient[F]
       .delete(uri"projects" / projectId / "access_tokens" / tokenId, "revoke-project-access-token")(mapResponse)(
         accessToken.some

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRevoker.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRevoker.scala
@@ -24,11 +24,11 @@ import cats.syntax.all._
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 
-private[repository] trait TokenRevoker[F[_]] {
+private trait TokenRevoker[F[_]] {
   def revokeToken(projectId: projects.GitLabId, tokenId: AccessTokenId, accessToken: AccessToken): F[Unit]
 }
 
-private[repository] object TokenRevoker {
+private object TokenRevoker {
   def apply[F[_]: Async: GitLabClient]: TokenRevoker[F] = new TokenRevokerImpl[F]
 }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRevoker.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRevoker.scala
@@ -16,22 +16,23 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository
+package deletion
 
 import cats.effect.Async
 import cats.syntax.all._
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 
-private trait TokensRevoker[F[_]] {
+private[repository] trait TokenRevoker[F[_]] {
   def revokeToken(projectId: projects.GitLabId, tokenId: AccessTokenId, accessToken: AccessToken): F[Unit]
 }
 
-private object TokensRevoker {
-  def apply[F[_]: Async: GitLabClient] = new TokensRevokerImpl[F]
+private[repository] object TokenRevoker {
+  def apply[F[_]: Async: GitLabClient]: TokenRevoker[F] = new TokenRevokerImpl[F]
 }
 
-private class TokensRevokerImpl[F[_]: Async: GitLabClient] extends TokensRevoker[F] {
+private class TokenRevokerImpl[F[_]: Async: GitLabClient] extends TokenRevoker[F] {
 
   import eu.timepit.refined.auto._
   import io.renku.http.tinytypes.TinyTypeURIEncoder._

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
@@ -24,7 +24,7 @@ import ProjectsTokensDB.SessionResource
 import cats.effect.{Async, Temporal}
 import cats.syntax.all._
 import creation._
-import deletion.TokenRemover
+import deletion.PersistedTokenRemover
 import io.renku.db.DbClient
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
@@ -38,7 +38,7 @@ private object TokensMigrator {
   def apply[F[_]: Async: GitLabClient: SessionResource: Logger: QueriesExecutionTimes]: F[DBMigration[F]] = for {
     accessTokenCrypto    <- AccessTokenCrypto[F]()
     tokenValidator       <- TokenValidator[F]
-    tokenRemover         <- TokenRemover[F].pure[F]
+    tokenRemover         <- PersistedTokenRemover[F].pure[F]
     tokensCreator        <- NewTokensCreator[F]()
     associationPersister <- TokensPersister[F].pure[F]
   } yield new TokensMigrator[F](accessTokenCrypto, tokenValidator, tokenRemover, tokensCreator, associationPersister)
@@ -47,7 +47,7 @@ private object TokensMigrator {
 private class TokensMigrator[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes](
     tokenCrypto:          AccessTokenCrypto[F],
     tokenValidator:       TokenValidator[F],
-    tokenRemover:         TokenRemover[F],
+    tokenRemover:         PersistedTokenRemover[F],
     tokensCreator:        NewTokensCreator[F],
     associationPersister: TokensPersister[F],
     retryInterval:        Duration = 5 seconds

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/model.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+
+import cats.MonadThrow
+import cats.syntax.all._
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.Decoder
+import io.renku.config.ConfigLoader.find
+import io.renku.tinytypes.constraints.NonNegativeInt
+import io.renku.tinytypes.json.TinyTypeDecoders
+import io.renku.tinytypes.{IntTinyType, StringTinyType, TinyTypeFactory}
+import pureconfig.ConfigReader
+
+import java.time.Period
+
+private object ProjectTokenDuePeriod {
+
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[Period] =
+    find[F, Period]("project-token-due-period", config)
+}
+
+final class RenkuAccessTokenName private (val value: String) extends StringTinyType
+private object RenkuAccessTokenName {
+
+  private implicit val reader: ConfigReader[RenkuAccessTokenName] =
+    ConfigReader.fromString(new RenkuAccessTokenName(_).asRight)
+
+  def apply(v: String): RenkuAccessTokenName = new RenkuAccessTokenName(v)
+
+  def apply[F[_]: MonadThrow](config: Config = ConfigFactory.load): F[RenkuAccessTokenName] =
+    find[F, RenkuAccessTokenName]("project-token-name", config)
+}
+
+private final class AccessTokenId private (val value: Int) extends AnyVal with IntTinyType
+private object AccessTokenId
+    extends TinyTypeFactory[AccessTokenId](new AccessTokenId(_))
+    with NonNegativeInt[AccessTokenId] {
+  implicit val jsonDecoder: Decoder[AccessTokenId] = TinyTypeDecoders.intDecoder(this)
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/RepositoryGenerators.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/RepositoryGenerators.scala
@@ -20,6 +20,7 @@ package io.renku.tokenrepository.repository
 
 import AccessTokenCrypto.EncryptedAccessToken
 import eu.timepit.refined.api.RefType
+import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import org.scalacheck.Gen
 
@@ -34,4 +35,7 @@ private object RepositoryGenerators {
             throw new IllegalArgumentException("Invalid value generated for EncryptedAccessToken")
           }
       }
+
+  val accessTokenIds: Gen[AccessTokenId] =
+    positiveInts().toGeneratorOf(v => AccessTokenId(v.value))
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/CreateTokenEndpointSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/CreateTokenEndpointSpec.scala
@@ -123,12 +123,6 @@ class CreateTokenEndpointSpec extends AnyWordSpec with IOSpec with MockFactory w
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     val endpoint = new CreateTokenEndpointImpl[IO](tokensCreator)
 
-    def givenTokenValidation(projectId: projects.GitLabId, accessToken: AccessToken, returning: IO[Boolean]) =
-      (tokenValidator
-        .checkValid(_: GitLabId, _: AccessToken))
-        .expects(projectId, accessToken)
-        .returning(returning)
-
     def givenTokenCreation(projectId: projects.GitLabId, accessToken: AccessToken, returning: IO[Unit]) =
       (tokensCreator
         .create(_: GitLabId, _: AccessToken))

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/Generators.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/Generators.scala
@@ -24,7 +24,7 @@ import TokenDates._
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators.projectAccessTokens
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.{localDates, positiveInts, timestampsNotInTheFuture}
+import io.renku.generators.Generators.{localDates, timestampsNotInTheFuture}
 import io.renku.graph.model.GraphModelGenerators.{projectIds, projectPaths}
 import org.scalacheck.Gen
 
@@ -44,7 +44,4 @@ object Generators {
 
   val tokenStoringInfos: Gen[TokenStoringInfo] =
     (projectObjects, encryptedAccessTokens, tokenDates).mapN(TokenStoringInfo.apply)
-
-  private[creation] val accessTokenIds: Gen[AccessTokenId] =
-    positiveInts().toGeneratorOf(v => AccessTokenId(v.value))
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/NewTokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/NewTokensCreatorSpec.scala
@@ -16,7 +16,8 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository
+package creation
 
 import Generators._
 import cats.effect.IO

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/RevokeCandidatesFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/RevokeCandidatesFinderSpec.scala
@@ -34,7 +34,9 @@ import io.renku.generators.Generators.{emptyOptionOf, fixed, localDates, nonEmpt
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.http.client.{AccessToken, GitLabClient}
+import io.renku.http.rest.paging.model.{Page, PerPage}
 import io.renku.http.server.EndpointTester._
+import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.testtools.{GitLabClientTools, IOSpec}
 import org.http4s._
 import org.http4s.implicits._
@@ -42,9 +44,11 @@ import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+import org.typelevel.ci._
 
 import java.time.LocalDate.now
 import java.time.{LocalDate, Period}
+import scala.util.Random
 
 class RevokeCandidatesFinderSpec
     extends AnyWordSpec
@@ -55,9 +59,7 @@ class RevokeCandidatesFinderSpec
 
   "checkTokenDue" should {
 
-    "do GET projects/:id/access_tokens to find expired tokens with RenkuAccessTokenName" in new TestCase {
-
-      val endpointName: String Refined NonEmpty = "project-access-tokens"
+    "call GET projects/:id/access_tokens to find expired tokens with RenkuAccessTokenName" in new TestCase {
 
       val allTokens = List(
         tokenInfosWithExpiry(fixed(renkuTokenName.value), localDates(max = now() plus tokenDuePeriod)),
@@ -68,27 +70,50 @@ class RevokeCandidatesFinderSpec
         tokenInfosWithExpiry()
       ).map(_.generateOne)
 
-      (gitLabClient
-        .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, List[TokenInfo]])(_: Option[AccessToken]))
-        .expects(uri"projects" / projectId.value / "access_tokens", endpointName, *, Option(accessToken))
-        .returning(allTokens.pure[IO])
+      fetchProjectTokens(Page(1), returning = (allTokens -> Option.empty[Page]).pure[IO])
 
       finder.findTokensToRemove(projectId, accessToken).unsafeRunSync() shouldBe allTokens.take(3).map(_._1)
+    }
+
+    "go through all the pages of project tokens" in new TestCase {
+
+      val tokensToFind1 =
+        tokenInfosWithExpiry(fixed(renkuTokenName.value), localDates(max = now() plus tokenDuePeriod)).generateOne
+      val tokensToFind2 =
+        tokenInfosWithExpiry(fixed(renkuTokenName.value), fixed(now() plus tokenDuePeriod)).generateOne
+
+      val otherTokensPage1 =
+        Random.shuffle(tokensToFind1 :: tokenInfosWithExpiry().generateFixedSizeList(ofSize = pageSize.value - 1))
+      val otherTokensPage2 =
+        Random.shuffle(tokensToFind2 :: tokenInfosWithExpiry().generateFixedSizeList(ofSize = pageSize.value - 1))
+
+      fetchProjectTokens(Page(1), returning = (otherTokensPage1 -> Page(2).some).pure[IO])
+      fetchProjectTokens(Page(2), returning = (otherTokensPage2 -> Option.empty[Page]).pure[IO])
+
+      finder.findTokensToRemove(projectId, accessToken).unsafeRunSync() shouldBe
+        List(tokensToFind1, tokensToFind2).map(_._1)
     }
 
     "map OK response body to TokenInfo tuples" in new TestCase {
 
       val tokens = Gen
         .oneOf(tokenInfosWithExpiry(), tokenInfosWithoutExpiry(fixed(renkuTokenName.value)))
-        .generateList()
+        .generateList(max = pageSize.value)
+      val nextPage = Page(2)
 
-      mapResponse(Status.Ok, Request[IO](), Response[IO](Status.Ok).withEntity(tokens.asJson))
-        .unsafeRunSync() shouldBe tokens
+      mapResponse(
+        Status.Ok,
+        Request[IO](),
+        Response[IO](Status.Ok)
+          .withEntity(tokens.asJson)
+          .withHeaders(Header.Raw(ci"X-Next-Page", nextPage.value.toString))
+      ).unsafeRunSync() shouldBe (tokens -> nextPage.some)
     }
 
     Status.Unauthorized :: Status.Forbidden :: Status.NotFound :: Nil foreach { status =>
       s"map $status response to None" in new TestCase {
-        mapResponse(status, Request[IO](), Response[IO](status)).unsafeRunSync() shouldBe Nil
+        mapResponse(status, Request[IO](), Response[IO](status))
+          .unsafeRunSync() shouldBe (List.empty[TokenInfo] -> Option.empty[Page])
       }
     }
   }
@@ -100,15 +125,32 @@ class RevokeCandidatesFinderSpec
     val projectId   = projectIds.generateOne
     val accessToken = accessTokens.generateOne
 
-    implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
+    private implicit val gitLabClient: GitLabClient[IO]        = mock[GitLabClient[IO]]
+    private val endpointName:          String Refined NonEmpty = "project-access-tokens"
+
     val tokenDuePeriod = Period.ofDays(5)
+    val pageSize       = PerPage(50)
     val renkuTokenName = nonEmptyStrings().generateAs(RenkuAccessTokenName(_))
-    val finder         = new RevokeCandidatesFinderImpl[IO](tokenDuePeriod, renkuTokenName)
+    val finder         = new RevokeCandidatesFinderImpl[IO](pageSize, tokenDuePeriod, renkuTokenName)
 
     lazy val mapResponse = captureMapping(gitLabClient)(
-      findingMethod = finder.findTokensToRemove(projectId, accessTokens.generateOne).unsafeRunSync(),
-      resultGenerator = tokenInfosWithoutExpiry().generateList()
+      findingMethod = finder.findTokensToRemove(projectIds.generateOne, accessTokens.generateOne).unsafeRunSync(),
+      resultGenerator = tokenInfosWithoutExpiry().generateList() -> Option.empty[Page]
     )
+
+    def fetchProjectTokens(page: Page, returning: IO[(List[TokenInfo], Option[Page])]) =
+      (gitLabClient
+        .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, (List[TokenInfo], Option[Page])])(
+          _: Option[AccessToken]
+        ))
+        .expects((uri"projects" / projectId / "access_tokens")
+                   .withQueryParam("per_page", pageSize)
+                   .withQueryParam("page", page),
+                 endpointName,
+                 *,
+                 accessToken.some
+        )
+        .returning(returning)
   }
 
   private def tokenInfosWithoutExpiry(names: Gen[String] = nonEmptyStrings()): Gen[TokenInfo] =

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -33,11 +33,10 @@ import io.renku.graph.model.projects.GitLabId
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.{AccessToken, UserAccessToken}
 import io.renku.interpreters.TestLogger
-import io.renku.interpreters.TestLogger.Level.Warn
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.RepositoryGenerators._
 import io.renku.tokenrepository.repository.creation.Generators._
-import io.renku.tokenrepository.repository.deletion.{RevokeCandidatesFinder, TokenRemover, TokenRevoker}
+import io.renku.tokenrepository.repository.deletion.{TokenRemover, TokensRevoker}
 import io.renku.tokenrepository.repository.fetching.PersistedTokensFinder
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.TryValues
@@ -83,7 +82,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
       givenSuccessfulTokenCreation(projectPath)
-      givenSuccessfulOldTokenRevoking(projectId, userAccessToken)
+      givenSuccessfulTokensRevoking(projectId, userAccessToken)
 
       tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
     }
@@ -129,7 +128,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
       givenSuccessfulTokenCreation(projectPath)
-      givenSuccessfulOldTokenRevoking(projectId, userAccessToken)
+      givenSuccessfulTokensRevoking(projectId, userAccessToken)
 
       tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
     }
@@ -142,7 +141,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
       givenSuccessfulTokenCreation(projectPath)
-      givenSuccessfulOldTokenRevoking(projectId, userAccessToken)
+      givenSuccessfulTokensRevoking(projectId, userAccessToken)
 
       tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
     }
@@ -213,7 +212,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
 
-      givenSuccessfulOldTokenRevoking(projectId, userAccessToken)
+      givenSuccessfulTokensRevoking(projectId, userAccessToken)
 
       tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
     }
@@ -243,7 +242,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
 
-      givenSuccessfulOldTokenRevoking(projectId, userAccessToken)
+      givenSuccessfulTokensRevoking(projectId, userAccessToken)
 
       tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
     }
@@ -285,32 +284,6 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
         .exception
         .getMessage shouldBe show"Token associator - just saved token cannot be found for project: $projectId"
     }
-
-    "log a warning and succeed when token revoking fails" in new TestCase {
-
-      val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
-
-      val storedToken = accessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[Try])
-
-      givenTokenValidation(storedToken, returning = false.pure[Try])
-      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[Try])
-
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
-      val projectPath = projectPaths.generateOne
-      givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
-      givenSuccessfulTokenCreation(projectPath)
-
-      val exception = exceptions.generateOne
-      givenTokensToRevokeFinding(projectId, userAccessToken, exception.raiseError[Try, List[AccessTokenId]])
-
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
-
-      logger.logged(
-        Warn(show"removing old token in GitLab for project ${Project(projectId, projectPath)} failed", exception)
-      )
-    }
   }
 
   private trait TestCase {
@@ -319,17 +292,16 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
     implicit val logger:    TestLogger[Try]         = TestLogger[Try]()
     private val maxRetries: Int Refined NonNegative = 2
-    private val projectPathFinder      = mock[ProjectPathFinder[Try]]
-    private val accessTokenCrypto      = mock[AccessTokenCrypto[Try]]
-    private val tokenValidator         = mock[TokenValidator[Try]]
-    private val tokenDueChecker        = mock[TokenDueChecker[Try]]
-    private val newTokensCreator       = mock[NewTokensCreator[Try]]
-    private val tokensPersister        = mock[TokensPersister[Try]]
-    private val persistedPathFinder    = mock[PersistedPathFinder[Try]]
-    private val tokenRemover           = mock[TokenRemover[Try]]
-    private val tokensFinder           = mock[PersistedTokensFinder[Try]]
-    private val revokeCandidatesFinder = mock[RevokeCandidatesFinder[Try]]
-    private val tokensRevoker          = mock[TokenRevoker[Try]]
+    private val projectPathFinder   = mock[ProjectPathFinder[Try]]
+    private val accessTokenCrypto   = mock[AccessTokenCrypto[Try]]
+    private val tokenValidator      = mock[TokenValidator[Try]]
+    private val tokenDueChecker     = mock[TokenDueChecker[Try]]
+    private val newTokensCreator    = mock[NewTokensCreator[Try]]
+    private val tokensPersister     = mock[TokensPersister[Try]]
+    private val persistedPathFinder = mock[PersistedPathFinder[Try]]
+    private val tokenRemover        = mock[TokenRemover[Try]]
+    private val tokensFinder        = mock[PersistedTokensFinder[Try]]
+    private val tokensRevoker       = mock[TokensRevoker[Try]]
     val tokensCreator = new TokensCreatorImpl[Try](
       projectPathFinder,
       accessTokenCrypto,
@@ -340,7 +312,6 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       persistedPathFinder,
       tokenRemover,
       tokensFinder,
-      revokeCandidatesFinder,
       tokensRevoker,
       maxRetries
     )
@@ -441,22 +412,9 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
     }
 
-    def givenSuccessfulOldTokenRevoking(projectId: projects.GitLabId, accessToken: AccessToken) = {
-      val tokensToRevoke = accessTokenIds.generateList()
-      givenTokensToRevokeFinding(projectId, accessToken, returning = tokensToRevoke.pure[Try])
-
-      tokensToRevoke foreach { tokenId =>
-        (tokensRevoker.revokeToken _)
-          .expects(projectId, tokenId, accessToken)
-          .returning(().pure[Try])
-      }
-    }
-
-    def givenTokensToRevokeFinding(projectId:   projects.GitLabId,
-                                   accessToken: AccessToken,
-                                   returning:   Try[List[AccessTokenId]]
-    ) = (revokeCandidatesFinder.findTokensToRemove _)
-      .expects(projectId, accessToken)
-      .returning(returning)
+    def givenSuccessfulTokensRevoking(projectId: projects.GitLabId, accessToken: AccessToken) =
+      (tokensRevoker.revokeAllTokens _)
+        .expects(projectId, accessToken)
+        .returning(().pure[Try])
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -384,7 +384,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
     def givenTokenRemoval(projectId: projects.GitLabId, userAccessToken: UserAccessToken, returning: Try[Unit]) =
       (tokenRemover.delete _)
-        .expects(projectId, userAccessToken)
+        .expects(projectId, userAccessToken.some)
         .returning(returning)
 
     def givenIntegrityCheckPasses(projectId:            projects.GitLabId,

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -37,7 +37,7 @@ import io.renku.interpreters.TestLogger.Level.Warn
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.RepositoryGenerators._
 import io.renku.tokenrepository.repository.creation.Generators._
-import io.renku.tokenrepository.repository.deletion.TokenRemover
+import io.renku.tokenrepository.repository.deletion.{RevokeCandidatesFinder, TokenRemover, TokenRevoker}
 import io.renku.tokenrepository.repository.fetching.PersistedTokensFinder
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.TryValues
@@ -77,7 +77,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[Try])
 
       givenTokenValidation(of = projectAccessToken, returning = false.pure[Try])
-      givenTokenRemoval(projectId, returning = ().pure[Try])
+      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[Try])
 
       givenTokenValidation(userAccessToken, returning = true.pure[Try])
       val projectPath = projectPaths.generateOne
@@ -155,7 +155,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       val storedToken = userAccessTokens.generateOne
       givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[Try])
       givenTokenValidation(storedToken, returning = false.pure[Try])
-      givenTokenRemoval(projectId, returning = ().pure[Try])
+      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[Try])
 
       givenTokenValidation(userAccessToken, returning = false.pure[Try])
 
@@ -295,7 +295,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[Try])
 
       givenTokenValidation(storedToken, returning = false.pure[Try])
-      givenTokenRemoval(projectId, returning = ().pure[Try])
+      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[Try])
 
       givenTokenValidation(userAccessToken, returning = true.pure[Try])
       val projectPath = projectPaths.generateOne
@@ -319,17 +319,17 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
     implicit val logger:    TestLogger[Try]         = TestLogger[Try]()
     private val maxRetries: Int Refined NonNegative = 2
-    val projectPathFinder      = mock[ProjectPathFinder[Try]]
-    val accessTokenCrypto      = mock[AccessTokenCrypto[Try]]
-    val tokenValidator         = mock[TokenValidator[Try]]
-    val tokenDueChecker        = mock[TokenDueChecker[Try]]
-    val newTokensCreator       = mock[NewTokensCreator[Try]]
-    val tokensPersister        = mock[TokensPersister[Try]]
-    val persistedPathFinder    = mock[PersistedPathFinder[Try]]
-    val tokenRemover           = mock[TokenRemover[Try]]
-    val tokensFinder           = mock[PersistedTokensFinder[Try]]
-    val revokeCandidatesFinder = mock[RevokeCandidatesFinder[Try]]
-    val tokensRevoker          = mock[TokensRevoker[Try]]
+    private val projectPathFinder      = mock[ProjectPathFinder[Try]]
+    private val accessTokenCrypto      = mock[AccessTokenCrypto[Try]]
+    private val tokenValidator         = mock[TokenValidator[Try]]
+    private val tokenDueChecker        = mock[TokenDueChecker[Try]]
+    private val newTokensCreator       = mock[NewTokensCreator[Try]]
+    private val tokensPersister        = mock[TokensPersister[Try]]
+    private val persistedPathFinder    = mock[PersistedPathFinder[Try]]
+    private val tokenRemover           = mock[TokenRemover[Try]]
+    private val tokensFinder           = mock[PersistedTokensFinder[Try]]
+    private val revokeCandidatesFinder = mock[RevokeCandidatesFinder[Try]]
+    private val tokensRevoker          = mock[TokenRevoker[Try]]
     val tokensCreator = new TokensCreatorImpl[Try](
       projectPathFinder,
       accessTokenCrypto,
@@ -381,10 +381,9 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     def givenPathFinder(projectId:   projects.GitLabId,
                         accessToken: AccessToken,
                         returning:   OptionT[Try, projects.Path]
-    ) =
-      (projectPathFinder.findProjectPath _)
-        .expects(projectId, accessToken)
-        .returning(returning)
+    ) = (projectPathFinder.findProjectPath _)
+      .expects(projectId, accessToken)
+      .returning(returning)
 
     def givenPathHasNotChanged(projectId: projects.GitLabId, accessToken: AccessToken) = {
       val projectPath = projectPaths.generateOne
@@ -412,9 +411,9 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
         .expects(project)
         .returning(returning)
 
-    def givenTokenRemoval(projectId: projects.GitLabId, returning: Try[Unit]) =
+    def givenTokenRemoval(projectId: projects.GitLabId, userAccessToken: UserAccessToken, returning: Try[Unit]) =
       (tokenRemover.delete _)
-        .expects(projectId)
+        .expects(projectId, userAccessToken)
         .returning(returning)
 
     def givenIntegrityCheckPasses(projectId:            projects.GitLabId,

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemoverSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.deletion
+
+import cats.effect.IO
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators._
+import io.renku.metrics.TestMetricsRegistry
+import io.renku.testtools.IOSpec
+import io.renku.tokenrepository.repository.InMemoryProjectsTokensDbSpec
+import io.renku.tokenrepository.repository.RepositoryGenerators.encryptedAccessTokens
+import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class PersistedTokenRemoverSpec
+    extends AnyWordSpec
+    with IOSpec
+    with InMemoryProjectsTokensDbSpec
+    with should.Matchers
+    with MockFactory {
+
+  "delete" should {
+
+    "succeed if token does not exist" in new TestCase {
+      remover.delete(projectId).unsafeRunSync() shouldBe ()
+    }
+
+    "succeed if token exists" in new TestCase {
+
+      val encryptedToken = encryptedAccessTokens.generateOne
+      insert(projectId, projectPath, encryptedToken)
+      findToken(projectId) shouldBe Some(encryptedToken.value)
+
+      remover.delete(projectId).unsafeRunSync() shouldBe ()
+
+      findToken(projectId) shouldBe None
+    }
+  }
+
+  private trait TestCase {
+    val projectId   = projectIds.generateOne
+    val projectPath = projectPaths.generateOne
+
+    private implicit val metricsRegistry:  TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
+    private implicit val queriesExecTimes: QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()
+    val remover = new PersistedTokenRemoverImpl[IO]
+  }
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinderSpec.scala
@@ -58,7 +58,7 @@ class RevokeCandidatesFinderSpec
     with IOSpec
     with should.Matchers {
 
-  "checkTokenDue" should {
+  "findProjectAccessTokens" should {
 
     "call GET projects/:id/access_tokens to find expired tokens with RenkuAccessTokenName" in new TestCase {
 
@@ -73,7 +73,7 @@ class RevokeCandidatesFinderSpec
 
       fetchProjectTokens(Page(1), returning = (allTokens -> Option.empty[Page]).pure[IO])
 
-      finder.findTokensToRemove(projectId, accessToken).unsafeRunSync() shouldBe allTokens.take(3).map(_._1)
+      finder.findProjectAccessTokens(projectId, accessToken).unsafeRunSync() shouldBe allTokens.take(3).map(_._1)
     }
 
     "go through all the pages of project tokens" in new TestCase {
@@ -91,7 +91,7 @@ class RevokeCandidatesFinderSpec
       fetchProjectTokens(Page(1), returning = (otherTokensPage1 -> Page(2).some).pure[IO])
       fetchProjectTokens(Page(2), returning = (otherTokensPage2 -> Option.empty[Page]).pure[IO])
 
-      finder.findTokensToRemove(projectId, accessToken).unsafeRunSync() shouldBe
+      finder.findProjectAccessTokens(projectId, accessToken).unsafeRunSync() shouldBe
         List(tokensToFind1, tokensToFind2).map(_._1)
     }
 
@@ -135,7 +135,7 @@ class RevokeCandidatesFinderSpec
     val finder         = new RevokeCandidatesFinderImpl[IO](pageSize, tokenDuePeriod, renkuTokenName)
 
     lazy val mapResponse = captureMapping(gitLabClient)(
-      findingMethod = finder.findTokensToRemove(projectIds.generateOne, accessTokens.generateOne).unsafeRunSync(),
+      findingMethod = finder.findProjectAccessTokens(projectIds.generateOne, accessTokens.generateOne).unsafeRunSync(),
       resultGenerator = tokenInfosWithoutExpiry().generateList() -> Option.empty[Page]
     )
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/RevokeCandidatesFinderSpec.scala
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository
+package deletion
 
-import Generators._
-import TokenDates.ExpiryDate
 import cats.effect.IO
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
@@ -38,6 +37,8 @@ import io.renku.http.rest.paging.model.{Page, PerPage}
 import io.renku.http.server.EndpointTester._
 import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.testtools.{GitLabClientTools, IOSpec}
+import io.renku.tokenrepository.repository.RepositoryGenerators.accessTokenIds
+import io.renku.tokenrepository.repository.creation.TokenDates.ExpiryDate
 import org.http4s._
 import org.http4s.implicits._
 import org.scalacheck.Gen

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
@@ -35,7 +35,7 @@ import scala.util.Try
 
 class TokenRemoverSpec extends AnyFlatSpec with should.Matchers with TryValues with MockFactory {
 
-  it should "remove the token from DB" in new TestCase {
+  it should "remove the token from DB and revoke project tokens from GL if user access token is given" in new TestCase {
 
     val projectId = projectIds.generateOne
     givenDBRemoval(projectId, returning = ().pure[Try])
@@ -43,7 +43,15 @@ class TokenRemoverSpec extends AnyFlatSpec with should.Matchers with TryValues w
     val accessToken = accessTokens.generateOne
     givenSuccessfulTokensRevoking(projectId, accessToken)
 
-    tokenRemover.delete(projectId, accessToken).success.value shouldBe ()
+    tokenRemover.delete(projectId, accessToken.some).success.value shouldBe ()
+  }
+
+  it should "just remove the token from DB if no user access token is given" in new TestCase {
+
+    val projectId = projectIds.generateOne
+    givenDBRemoval(projectId, returning = ().pure[Try])
+
+    tokenRemover.delete(projectId, maybeAccessToken = None).success.value shouldBe ()
   }
 
   private trait TestCase {

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRevokerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRevokerSpec.scala
@@ -57,7 +57,7 @@ class TokenRevokerSpec
         .expects(uri"projects" / projectId / "access_tokens" / tokenId, endpointName, *, Option(accessToken))
         .returning(().pure[IO])
 
-      tokensRevoker.revokeToken(projectId, tokenId, accessToken).unsafeRunSync() shouldBe ()
+      tokensRevoker.revokeToken(tokenId, projectId, accessToken).unsafeRunSync() shouldBe ()
     }
 
     Status.Ok :: Status.NoContent :: Status.Unauthorized :: Status.Forbidden :: Status.NotFound :: Nil foreach {
@@ -78,7 +78,7 @@ class TokenRevokerSpec
     val tokensRevoker = new TokenRevokerImpl[IO]
 
     lazy val mapResponse = captureMapping(gitLabClient)(
-      findingMethod = tokensRevoker.revokeToken(projectId, tokenId, accessTokens.generateOne).unsafeRunSync(),
+      findingMethod = tokensRevoker.revokeToken(tokenId, projectId, accessTokens.generateOne).unsafeRunSync(),
       resultGenerator = fixed(()),
       method = DELETE
     )

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRevokerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRevokerSpec.scala
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository.deletion
 
-import Generators._
 import cats.effect.IO
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
@@ -32,6 +31,7 @@ import io.renku.http.client.RestClient.ResponseMappingF
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.testtools.{GitLabClientTools, IOSpec}
+import io.renku.tokenrepository.repository.RepositoryGenerators.accessTokenIds
 import org.http4s.Method.DELETE
 import org.http4s._
 import org.http4s.implicits._
@@ -39,7 +39,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class TokensRevokerSpec
+class TokenRevokerSpec
     extends AnyWordSpec
     with MockFactory
     with GitLabClientTools[IO]
@@ -75,7 +75,7 @@ class TokensRevokerSpec
     val accessToken = accessTokens.generateOne
 
     implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
-    val tokensRevoker = new TokensRevokerImpl[IO]
+    val tokensRevoker = new TokenRevokerImpl[IO]
 
     lazy val mapResponse = captureMapping(gitLabClient)(
       findingMethod = tokensRevoker.revokeToken(projectId, tokenId, accessTokens.generateOne).unsafeRunSync(),

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokensRevokerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokensRevokerSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.deletion
+
+import cats.syntax.all._
+import io.renku.generators.CommonGraphGenerators.accessTokens
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.exceptions
+import io.renku.graph.model.RenkuTinyTypeGenerators.projectIds
+import io.renku.graph.model.projects
+import io.renku.http.client.AccessToken
+import io.renku.interpreters.TestLogger
+import io.renku.interpreters.TestLogger.Level.Warn
+import io.renku.tokenrepository.repository.AccessTokenId
+import io.renku.tokenrepository.repository.RepositoryGenerators.accessTokenIds
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.TryValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+import scala.util.Try
+
+class TokensRevokerSpec extends AnyFlatSpec with should.Matchers with TryValues with MockFactory {
+
+  it should "succeed and revoke all found project tokens" in new TestCase {
+
+    val projectId     = projectIds.generateOne
+    val accessToken   = accessTokens.generateOne
+    val projectTokens = accessTokenIds.generateList()
+
+    givenTokensToRevokeFinding(projectId, accessToken, returning = projectTokens.pure[Try])
+
+    projectTokens foreach (givenTokenRevoking(projectId, _: AccessTokenId, accessToken, returning = ().pure[Try]))
+
+    tokensRevoker.revokeAllTokens(projectId, accessToken).success.value shouldBe ()
+  }
+
+  it should "log a warning and succeed when token revoking process fails" in new TestCase {
+
+    val projectId   = projectIds.generateOne
+    val accessToken = accessTokens.generateOne
+
+    val exception = exceptions.generateOne
+    givenTokensToRevokeFinding(projectId, accessToken, returning = exception.raiseError[Try, Nothing])
+
+    tokensRevoker.revokeAllTokens(projectId, accessToken).success.value shouldBe ()
+
+    logger.logged(
+      Warn(show"removing old token in GitLab for project $projectId failed", exception)
+    )
+  }
+
+  private trait TestCase {
+
+    implicit val logger: TestLogger[Try] = TestLogger[Try]()
+    private val revokeCandidatesFinder = mock[RevokeCandidatesFinder[Try]]
+    private val tokenRevoker           = mock[TokenRevoker[Try]]
+    val tokensRevoker                  = new TokensRevokerImpl[Try](revokeCandidatesFinder, tokenRevoker)
+
+    def givenTokenRevoking(projectId:   projects.GitLabId,
+                           tokenId:     AccessTokenId,
+                           accessToken: AccessToken,
+                           returning:   Try[Unit]
+    ) = (tokenRevoker.revokeToken _)
+      .expects(projectId, tokenId, accessToken)
+      .returning(returning)
+
+    def givenTokensToRevokeFinding(projectId:   projects.GitLabId,
+                                   accessToken: AccessToken,
+                                   returning:   Try[List[AccessTokenId]]
+    ) = (revokeCandidatesFinder.findProjectAccessTokens _)
+      .expects(projectId, accessToken)
+      .returning(returning)
+  }
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
@@ -26,7 +26,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import creation.TokenDates.{CreatedAt, ExpiryDate}
 import creation._
-import deletion.TokenRemover
+import deletion.PersistedTokenRemover
 import io.renku.generators.CommonGraphGenerators.{accessTokens, projectAccessTokens}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{exceptions, localDates, timestampsNotInTheFuture}
@@ -228,7 +228,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
     implicit val logger: TestLogger[IO] = TestLogger[IO]()
     private val tokenCrypto     = mock[AccessTokenCrypto[IO]]
     private val tokenValidator  = mock[TokenValidator[IO]]
-    private val tokenRemover    = TokenRemover[IO]
+    private val tokenRemover    = PersistedTokenRemover[IO]
     private val tokensCreator   = mock[NewTokensCreator[IO]]
     private val tokensPersister = TokensPersister[IO]
     val migration = new TokensMigrator[IO](tokenCrypto,

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/modelSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/modelSpec.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.creation
+package io.renku.tokenrepository.repository
 
 import cats.syntax.all._
 import com.typesafe.config.ConfigFactory

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -98,7 +98,7 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
                             returning = false.some.pure[Try]
       )
 
-      givenTokenRemoving(returning = ().pure[Try])
+      givenTokenRemoving(givenAccessToken.some, returning = ().pure[Try])
 
       validator.validateHook(projectId, givenAccessToken.some) shouldBe HookMissing.some.pure[Try]
 
@@ -160,7 +160,7 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       val exception = exceptions.generateOne
       val error     = exception.raiseError[Try, Nothing]
-      givenTokenRemoving(returning = error)
+      givenTokenRemoving(givenAccessToken.some, returning = error)
 
       validator.validateHook(projectId, givenAccessToken.some) shouldBe error
 
@@ -195,7 +195,7 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
                             returning = false.some.pure[Try]
       )
 
-      givenTokenRemoving(returning = ().pure[Try])
+      givenTokenRemoving(accessToken = None, returning = ().pure[Try])
 
       validator.validateHook(projectId, maybeAccessToken = None) shouldBe HookMissing.some.pure[Try]
 
@@ -240,7 +240,7 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       val exception = exceptions.generateOne
       val error     = exception.raiseError[Try, Nothing]
-      givenTokenRemoving(returning = error)
+      givenTokenRemoving(accessToken = None, returning = error)
 
       validator.validateHook(projectId, maybeAccessToken = None) shouldBe error
 
@@ -284,10 +284,9 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
         .expects(projectId, accessToken)
         .returning(returning)
 
-    def givenTokenRemoving(returning: Try[Unit]) =
-      (accessTokenRemover
-        .removeAccessToken(_: GitLabId))
-        .expects(projectId)
+    def givenTokenRemoving(accessToken: Option[AccessToken], returning: Try[Unit]) =
+      (accessTokenRemover.removeAccessToken _)
+        .expects(projectId, accessToken)
         .returning(returning)
   }
 }


### PR DESCRIPTION
It was identified that we create a new Project Access Token for a project each time the Project Status API is called for a non-activated project. This causes a proliferation of PATs that were unknown for the KG (not stored by token-repository), hence, still active on GL. As a result, the user was able to see a long list of tokens as well as observe reduced responsiveness on certain GL APIs.

This PR fixes the issue by:
1. Moving the PAT revoking functionality to the Delete Project Token API
2. Making sure all Project's PATs are checked while revoking (not just the ones from the first page of the GL's Projects Tokens API response)