### PR TITLE
fix: token revoking to remove all tokens except created one

### DIFF
--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/NewTokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/NewTokensCreator.scala
@@ -91,10 +91,11 @@ private class NewTokensCreatorImpl[F[_]: Async: GitLabClient](
       import TokenDates._
       import io.renku.tinytypes.json.TinyTypeDecoders._
       for {
+        tokenId     <- cursor.downField("id").as[AccessTokenId]
         token       <- cursor.downField("token").as(tokenDecoder)
         createdDate <- cursor.downField("created_at").as[CreatedAt]
         expiryDate  <- cursor.downField("expires_at").as[ExpiryDate]
-      } yield TokenCreationInfo(token, TokenDates(createdDate, expiryDate))
+      } yield TokenCreationInfo(tokenId, token, TokenDates(createdDate, expiryDate))
     }
 
     jsonOf[F, TokenCreationInfo](Sync[F], infoDecoder)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/model.scala
@@ -29,7 +29,10 @@ import io.renku.tinytypes._
 
 import java.time.{Instant, LocalDate}
 
-private[repository] final case class TokenCreationInfo(token: ProjectAccessToken, dates: TokenDates)
+private[repository] final case class TokenCreationInfo(tokenId: AccessTokenId,
+                                                       token:   ProjectAccessToken,
+                                                       dates:   TokenDates
+)
 
 private[repository] final case class TokenDates(createdAt: CreatedAt, expiryDate: ExpiryDate)
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/TokenRemover.scala
@@ -48,6 +48,6 @@ private class TokenRemoverImpl[F[_]: MonadThrow: Logger](dbTokenRemover: Persist
   private def revokeTokens(projectId: GitLabId, maybeAccessToken: Option[AccessToken]) =
     maybeAccessToken match {
       case None              => ().pure[F]
-      case Some(accessToken) => revokeAllTokens(projectId, accessToken)
+      case Some(accessToken) => revokeAllTokens(projectId, except = None, accessToken)
     }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/Generators.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/Generators.scala
@@ -37,7 +37,7 @@ object Generators {
     (tokenCreatedAts, tokenExpiryDates).mapN(TokenDates.apply)
 
   val tokenCreationInfos: Gen[TokenCreationInfo] =
-    (projectAccessTokens, tokenDates).mapN(TokenCreationInfo.apply)
+    (accessTokenIds, projectAccessTokens, tokenDates).mapN(TokenCreationInfo.apply)
 
   val projectObjects: Gen[Project] =
     (projectIds, projectPaths).mapN(Project.apply)

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/NewTokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/NewTokensCreatorSpec.scala
@@ -99,7 +99,7 @@ class NewTokensCreatorSpec
     val projectId   = projectIds.generateOne
     val accessToken = accessTokens.generateOne
 
-    val currentDate = mockFunction[LocalDate]
+    private val currentDate = mockFunction[LocalDate]
     currentDate.expects().returning(now)
     implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
     val projectTokenTTL = Period.ofDays(durations(1 day, 730 days).generateOne.toDays.toInt)
@@ -114,8 +114,9 @@ class NewTokensCreatorSpec
   }
 
   private def glResponsePayload(creationInfo: TokenCreationInfo) = json"""{
+    "id":         ${creationInfo.tokenId},
     "token":      ${creationInfo.token.value},
-    "created_at": ${creationInfo.dates.createdAt.value},
-    "expires_at": ${creationInfo.dates.expiryDate.value}
+    "created_at": ${creationInfo.dates.createdAt},
+    "expires_at": ${creationInfo.dates.expiryDate}
   }"""
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/TokenRemoverSpec.scala
@@ -68,7 +68,7 @@ class TokenRemoverSpec extends AnyFlatSpec with should.Matchers with TryValues w
 
     def givenSuccessfulTokensRevoking(projectId: projects.GitLabId, accessToken: AccessToken) =
       (tokensRevoker.revokeAllTokens _)
-        .expects(projectId, accessToken)
+        .expects(projectId, Option.empty[AccessTokenId], accessToken)
         .returning(().pure[Try])
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/TokensMigratorSpec.scala
@@ -20,7 +20,7 @@ package io.renku.tokenrepository.repository
 package init
 
 import AccessTokenCrypto.EncryptedAccessToken
-import RepositoryGenerators.encryptedAccessTokens
+import RepositoryGenerators.{accessTokenIds, encryptedAccessTokens}
 import cats.data.{Kleisli, OptionT}
 import cats.effect.IO
 import cats.syntax.all._
@@ -162,7 +162,8 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       val projectToken = projectAccessTokens.generateOne
       val creationInfo =
-        TokenCreationInfo(projectToken,
+        TokenCreationInfo(accessTokenIds.generateOne,
+                          projectToken,
                           TokenDates(CreatedAt(Instant.now()), localDates(min = LocalDate.now()).generateAs(ExpiryDate))
         )
 
@@ -197,7 +198,8 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
       )
       val projectToken = projectAccessTokens.generateOne
       val creationInfo =
-        TokenCreationInfo(projectToken,
+        TokenCreationInfo(accessTokenIds.generateOne,
+                          projectToken,
                           TokenDates(CreatedAt(Instant.now()), localDates(min = LocalDate.now()).generateAs(ExpiryDate))
         )
 
@@ -275,6 +277,7 @@ class TokensMigratorSpec extends AnyWordSpec with IOSpec with DbInitSpec with sh
 
       val projectToken = projectAccessTokens.generateOne
       val creationInfo = TokenCreationInfo(
+        accessTokenIds.generateOne,
         projectToken,
         TokenDates(CreatedAt(Instant.now()), localDates(min = LocalDate.now()).generateAs(ExpiryDate))
       )


### PR DESCRIPTION
It was identified that the Project Access Token revoking process was cancelling only tokens with expiry dates due for renewal. That was wrong as in a case there are multiple PATs created for a project and environment:
* if a new PAT was created before the old one was due for renewal, it wouldn't be removed
* if the Delete Project Token API was called on a project with PAT before the due for renewal, the PAT would be removed from the token-repository DB but left in GL.