### PR TITLE
fix: ForeignKeyViolation on inserts to subscription_category_sync_time

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/globalcommitsync/LastSyncedDateUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/globalcommitsync/LastSyncedDateUpdater.scala
@@ -29,9 +29,9 @@ import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.CategoryName
 import io.renku.graph.model.events.LastSyncedDate
 import io.renku.graph.model.projects
+import skunk._
 import skunk.data.Completion
 import skunk.implicits._
-import skunk.{*:, _}
 
 private trait LastSyncedDateUpdater[F[_]] {
   def run(projectId: projects.GitLabId, maybeLastSyncDate: Option[LastSyncedDate]): F[Completion]

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/EventFinder.scala
@@ -93,7 +93,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
           new Exception(s"${categoryName.show}: insert last_synced failed with completion code $completion")
             .raiseError[F, Boolean]
       }
-  }
+  } recoverWith { case SqlState.ForeignKeyViolation(_) => Kleisli.pure(false) }
 
   private def toNoneIfEventAlreadyTaken(event: MinProjectInfoEvent): Boolean => Option[MinProjectInfoEvent] = {
     case true  => Some(event)

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/EventFinder.scala
@@ -105,7 +105,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
           new Exception(s"${categoryName.show}: update last_synced failed with completion code $completion")
             .raiseError[F, Boolean]
       }
-  }
+  } recoverWith { case SqlState.ForeignKeyViolation(_) => Kleisli.pure(false) }
 
   private def insertLastSyncedDate(projectId: projects.GitLabId) = measureExecutionTime {
     SqlStatement
@@ -125,7 +125,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
           new Exception(s"${categoryName.show}: insert last_synced failed with completion code $completion")
             .raiseError[F, Boolean]
       }
-  }
+  } recoverWith { case SqlState.ForeignKeyViolation(_) => Kleisli.pure(false) }
 
   private def toNoneIfEventAlreadyTaken(event: ProjectSyncEvent): Boolean => Option[ProjectSyncEvent] = {
     case true  => Some(event)

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/commitsync/EventFinderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/commitsync/EventFinderSpec.scala
@@ -210,7 +210,6 @@ class EventFinderSpec
         )
 
         finder.popEvent().unsafeRunSync() shouldBe None
-
       }
   }
 


### PR DESCRIPTION
Apparently, there are situations during the project deletion flow being under execution, where other flows are trying to insert to the `subscription_category_sync_time`. In such cases, the Project could be already removed and the insert blows up. This PR makes these cases be handled correctly.

closes #1515 