### PR TITLE
fix: any post sql failure recovery to happen after rollback

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdateResults.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdateResults.scala
@@ -24,7 +24,7 @@ import io.renku.graph.model.events.EventStatus
 import io.renku.graph.model.projects
 
 private sealed trait DBUpdateResults {
-  lazy val widen:DBUpdateResults = this
+  lazy val widen: DBUpdateResults = this
 }
 
 private object DBUpdateResults {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdateResults.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdateResults.scala
@@ -23,7 +23,9 @@ import cats.syntax.all._
 import io.renku.graph.model.events.EventStatus
 import io.renku.graph.model.projects
 
-private sealed trait DBUpdateResults
+private sealed trait DBUpdateResults {
+  lazy val widen:DBUpdateResults = this
+}
 
 private object DBUpdateResults {
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueue.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueue.scala
@@ -121,7 +121,7 @@ private class StatusChangeEventsQueueImpl[F[_]: Async: Logger: SessionResource: 
   private def dequeueEvent[E <: StatusChangeEvent](handler: HandlerDef[E]) = SessionResource[F].useK {
     findEvent[E](handler.eventType) >>= {
       case None                     => Kleisli.pure(Option.empty[String])
-      case Some((eventId, payload)) => deleteEvent(eventId) map (if (_) payload.some else None)
+      case Some((eventId, payload)) => deleteEvent(eventId) map (Option.when(_)(payload))
     }
   }
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/DbUpdater.scala
@@ -50,9 +50,9 @@ private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
 
   override def updateDB(event: AllEventsToNew.type): UpdateOp[F] =
     createEventsResource(sendEventIfFound(_))
-      .map(_ => DBUpdateResults.ForProjects.empty)
+      .as(DBUpdateResults.ForProjects.empty)
 
-  override def onRollback(event: AllEventsToNew.type): RollbackOp[F] = RollbackOp.none[F]
+  override def onRollback(event: AllEventsToNew.type): RollbackOp[F] = RollbackOp.empty[F]
 
   private def createEventsResource(
       f: Cursor[F, ProjectEventsToNew] => F[Unit]

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdater.scala
@@ -19,14 +19,12 @@
 package io.renku.eventlog.events.consumers.statuschange.projecteventstonew
 
 import cats.MonadThrow
-import cats.data.Kleisli
 import io.circe.Encoder
 import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
 import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue}
-import skunk.Session
 
 private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChangeEventsQueue[F])
     extends statuschange.DBUpdater[F, ProjectEventsToNew] {
@@ -37,5 +35,5 @@ private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChang
   override def updateDB(event: ProjectEventsToNew): UpdateOp[F] =
     eventsQueue.offer[ProjectEventsToNew](event).map(_ => DBUpdateResults.ForProjects.empty)
 
-  override def onRollback(event: ProjectEventsToNew): Kleisli[F, Session[F], Unit] = RollbackOp.none[F]
+  override def onRollback(event: ProjectEventsToNew): RollbackOp[F] = RollbackOp.empty[F]
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdater.scala
@@ -19,14 +19,13 @@
 package io.renku.eventlog.events.consumers.statuschange.redoprojecttransformation
 
 import cats.MonadThrow
-import cats.data.Kleisli
+import cats.syntax.all._
 import io.circe.Encoder
 import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
 import io.renku.eventlog.events.consumers.statuschange._
-import skunk.Session
 
 private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChangeEventsQueue[F])
     extends statuschange.DBUpdater[F, RedoProjectTransformation] {
@@ -35,7 +34,7 @@ private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChang
     Encoder[StatusChangeEvent].contramap(identity)
 
   override def updateDB(event: RedoProjectTransformation): UpdateOp[F] =
-    eventsQueue.offer[RedoProjectTransformation](event).map(_ => DBUpdateResults.ForProjects.empty)
+    eventsQueue.offer[RedoProjectTransformation](event).as(DBUpdateResults.ForProjects.empty)
 
-  override def onRollback(event: RedoProjectTransformation): Kleisli[F, Session[F], Unit] = RollbackOp.none
+  override def onRollback(event: RedoProjectTransformation): RollbackOp[F] = RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
@@ -19,7 +19,6 @@
 package io.renku.eventlog.events.consumers.statuschange
 package redoprojecttransformation
 
-import cats.data.Kleisli
 import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.DbClient
@@ -129,5 +128,5 @@ private class DequeuedEventHandlerImpl[F[_]: Async: QueriesExecutionTimes](
       .void
   }
 
-  override def onRollback(event: RedoProjectTransformation): Kleisli[F, Session[F], Unit] = RollbackOp.none
+  override def onRollback(event: RedoProjectTransformation): RollbackOp[F] = RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
@@ -65,5 +65,5 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: RollbackToAwaitingDeletion): RollbackOp[F] = RollbackOp.none
+  override def onRollback(event: RollbackToAwaitingDeletion): RollbackOp[F] = RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
@@ -66,5 +66,5 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: RollbackToNew): RollbackOp[F] = RollbackOp.none
+  override def onRollback(event: RollbackToNew): RollbackOp[F] = RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
@@ -67,5 +67,5 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: RollbackToTriplesGenerated): RollbackOp[F] = RollbackOp.none
+  override def onRollback(event: RollbackToTriplesGenerated): RollbackOp[F] = RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
@@ -70,5 +70,5 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: ToAwaitingDeletion): RollbackOp[F] = RollbackOp.none
+  override def onRollback(event: ToAwaitingDeletion): RollbackOp[F] = RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdater.scala
@@ -49,7 +49,9 @@ private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes
 
   import deliveryInfoRemover._
 
-  override def onRollback(event: ToFailure): RollbackOp[F] = deleteDelivery(event.eventId)
+  override def onRollback(event: ToFailure): RollbackOp[F] = { _ =>
+    deleteDelivery(event.eventId).as(DBUpdateResults.ForProjects.empty)
+  }
 
   override def updateDB(event: ToFailure): UpdateOp[F] = for {
     _                     <- deleteDelivery(event.eventId)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdater.scala
@@ -50,7 +50,9 @@ private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
 
   import deliveryInfoRemover._
 
-  override def onRollback(event: ToTriplesGenerated): RollbackOp[F] = deleteDelivery(event.eventId)
+  override def onRollback(event: ToTriplesGenerated): RollbackOp[F] = { _ =>
+    deleteDelivery(event.eventId).as(DBUpdateResults.ForProjects.empty)
+  }
 
   override def updateDB(event: ToTriplesGenerated): UpdateOp[F] =
     deleteDelivery(event.eventId) >> updateStatus(event) >>= {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdater.scala
@@ -49,7 +49,9 @@ private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
 
   import deliveryInfoRemover._
 
-  override def onRollback(event: ToTriplesStore): RollbackOp[F] = deleteDelivery(event.eventId)
+  override def onRollback(event: ToTriplesStore): RollbackOp[F] = { _ =>
+    deleteDelivery(event.eventId).as(DBUpdateResults.ForProjects.empty)
+  }
 
   override def updateDB(event: ToTriplesStore): UpdateOp[F] = for {
     _                      <- deleteDelivery(event.eventId)

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdaterSpec.scala
@@ -18,23 +18,16 @@
 
 package io.renku.eventlog.events.consumers.statuschange
 
-import DBUpdater._
-import cats.ApplicativeThrow
-import cats.data.Kleisli
-import io.renku.eventlog.api.events.StatusChangeEvent
-import skunk.Session
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 
-private[statuschange] trait DBUpdater[F[_], E <: StatusChangeEvent] {
-  def updateDB(event:   E): UpdateOp[F]
-  def onRollback(event: E): RollbackOp[F]
-}
+import scala.util.Try
 
-private[statuschange] object DBUpdater {
+class DBUpdaterSpec extends AnyWordSpec with should.Matchers {
 
-  type UpdateOp[F[_]]   = Kleisli[F, Session[F], DBUpdateResults]
-  type RollbackOp[F[_]] = PartialFunction[Throwable, UpdateOp[F]]
-
-  object RollbackOp {
-    def empty[F[_]: ApplicativeThrow]: RollbackOp[F] = PartialFunction.empty[Throwable, UpdateOp[F]]
+  "RollbackOp.empty" should {
+    "be an empty PartialFunction" in {
+      DBUpdater.RollbackOp.empty[Try] shouldBe PartialFunction.empty[Throwable, DBUpdater.UpdateOp[Try]]
+    }
   }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/SkunkExceptionsGenerators.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/SkunkExceptionsGenerators.scala
@@ -18,23 +18,22 @@
 
 package io.renku.eventlog.events.consumers.statuschange
 
-import DBUpdater._
-import cats.ApplicativeThrow
-import cats.data.Kleisli
-import io.renku.eventlog.api.events.StatusChangeEvent
-import skunk.Session
+import io.renku.generators.Generators.nonEmptyStrings
+import org.scalacheck.Gen
+import skunk.SqlState
+import skunk.exception.PostgresErrorException
 
-private[statuschange] trait DBUpdater[F[_], E <: StatusChangeEvent] {
-  def updateDB(event:   E): UpdateOp[F]
-  def onRollback(event: E): RollbackOp[F]
-}
+object SkunkExceptionsGenerators {
 
-private[statuschange] object DBUpdater {
-
-  type UpdateOp[F[_]]   = Kleisli[F, Session[F], DBUpdateResults]
-  type RollbackOp[F[_]] = PartialFunction[Throwable, UpdateOp[F]]
-
-  object RollbackOp {
-    def empty[F[_]: ApplicativeThrow]: RollbackOp[F] = PartialFunction.empty[Throwable, UpdateOp[F]]
-  }
+  def postgresErrors(sqlState: SqlState): Gen[PostgresErrorException] =
+    nonEmptyStrings().map(postgresMessage =>
+      new PostgresErrorException(sql = "SELECT 1",
+                                 sqlOrigin = None,
+                                 info = Map(
+                                   'C' -> sqlState.code,
+                                   'M' -> postgresMessage
+                                 ),
+                                 history = Nil
+      )
+    )
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdaterSpec.scala
@@ -25,16 +25,17 @@ import io.circe.Encoder
 import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 import io.renku.eventlog.api.events.StatusChangeGenerators
 import io.renku.eventlog.events.consumers.statuschange.StatusChangeEventsQueue.EventType
-import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue}
+import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DBUpdater, StatusChangeEventsQueue}
 import io.renku.generators.Generators.Implicits._
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.TryValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import skunk.Session
 
 import scala.util.Try
 
-class DbUpdaterSpec extends AnyWordSpec with should.Matchers with MockFactory {
+class DbUpdaterSpec extends AnyWordSpec with should.Matchers with TryValues with MockFactory {
 
   "updateDB" should {
 
@@ -52,8 +53,8 @@ class DbUpdaterSpec extends AnyWordSpec with should.Matchers with MockFactory {
   }
 
   "onRollback" should {
-    "return unit Kleisli" in new TestCase {
-      handler.onRollback(event)(session) shouldBe ().pure[Try]
+    "return RollbackOp.empty" in new TestCase {
+      handler.onRollback(event) shouldBe DBUpdater.RollbackOp.empty[Try]
     }
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdaterSpec.scala
@@ -25,7 +25,7 @@ import io.circe.Encoder
 import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange.StatusChangeEventsQueue.EventType
-import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, StatusChangeEventsQueue}
+import io.renku.eventlog.events.consumers.statuschange.{DBUpdateResults, DBUpdater, StatusChangeEventsQueue}
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.GraphModelGenerators
 import org.scalamock.scalatest.MockFactory
@@ -53,8 +53,8 @@ class DbUpdaterSpec extends AnyWordSpec with should.Matchers with MockFactory {
   }
 
   "onRollback" should {
-    "return unit Kleisli" in new TestCase {
-      handler.onRollback(event)(session) shouldBe ().pure[Try]
+    "return RollbackOp.empty" in new TestCase {
+      handler.onRollback(event) shouldBe DBUpdater.RollbackOp.empty[Try]
     }
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdaterSpec.scala
@@ -27,7 +27,7 @@ import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.ConsumersModelGenerators
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.{timestamps, timestampsNotInTheFuture}
+import io.renku.generators.Generators.{exceptions, timestamps, timestampsNotInTheFuture}
 import io.renku.graph.model.EventContentGenerators.{eventDates, eventMessages}
 import io.renku.graph.model.EventsGenerators.{compoundEventIds, eventBodies, eventIds}
 import io.renku.graph.model.events.EventStatus._
@@ -237,8 +237,8 @@ class DbUpdaterSpec
       (deliveryInfoRemover.deleteDelivery _).expects(event.eventId).returning(Kleisli.pure(()))
 
       sessionResource
-        .useK(dbUpdater onRollback event)
-        .unsafeRunSync() shouldBe ()
+        .useK((dbUpdater onRollback event)(exceptions.generateOne))
+        .unsafeRunSync() shouldBe DBUpdateResults.ForProjects.empty
     }
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdaterSpec.scala
@@ -27,7 +27,7 @@ import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.ConsumersModelGenerators
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.timestamps
+import io.renku.generators.Generators.{exceptions, timestamps}
 import io.renku.graph.model.EventContentGenerators.eventDates
 import io.renku.graph.model.EventsGenerators.{eventIds, eventProcessingTimes, zippedEventPayloads}
 import io.renku.graph.model.events.EventStatus._
@@ -193,8 +193,8 @@ class DbUpdaterSpec
       (deliveryInfoRemover.deleteDelivery _).expects(event.eventId).returning(Kleisli.pure(()))
 
       sessionResource
-        .useK(dbUpdater onRollback event)
-        .unsafeRunSync() shouldBe ()
+        .useK((dbUpdater onRollback event)(exceptions.generateOne))
+        .unsafeRunSync() shouldBe DBUpdateResults.ForProjects.empty
     }
   }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdaterSpec.scala
@@ -27,7 +27,7 @@ import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.eventlog.{InMemoryEventLogDbSpec, TypeSerializers}
 import io.renku.events.consumers.ConsumersModelGenerators
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.timestamps
+import io.renku.generators.Generators.{exceptions, timestamps}
 import io.renku.graph.model.EventContentGenerators.eventDates
 import io.renku.graph.model.EventsGenerators
 import io.renku.graph.model.EventsGenerators.eventProcessingTimes
@@ -173,7 +173,9 @@ class DbUpdaterSpec
 
       (deliveryInfoRemover.deleteDelivery _).expects(event.eventId).returning(Kleisli.pure(()))
 
-      sessionResource.useK(dbUpdater onRollback event).unsafeRunSync() shouldBe ()
+      sessionResource
+        .useK((dbUpdater onRollback event)(exceptions.generateOne))
+        .unsafeRunSync() shouldBe DBUpdateResults.ForProjects.empty
     }
   }
 


### PR DESCRIPTION
Apparently, a few `DBUpdater` classes (`STATUS_CHANGE_EVENT` flow) were handling certain errors and executing some onFailure queries. However, these can only be run once the failed transaction is rolled back.
This PR takes the error handling to the `DBUpdater.onRollback` method which are executed by the `StatusChanger` after the rollback.

closes #1464 