### PR TITLE
feat: DS transformation to delete all publication events before upload

### DIFF
--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/datasets.scala
@@ -150,7 +150,9 @@ object datasets {
     override def hashCode(): Int = value.hashCode
   }
 
-  final class InternalSameAs private[datasets] (val value: String) extends SameAs
+  final class InternalSameAs private[datasets] (val value: String) extends SameAs {
+    lazy val asResourceId: datasets.ResourceId = datasets.ResourceId(value)
+  }
   final class ExternalSameAs private[datasets] (val value: String) extends SameAs
 
   implicit object InternalSameAs
@@ -198,7 +200,7 @@ object datasets {
       case sameAs @ ExternalSameAs(_) => externalSameAsEncoder(sameAs)
     }
 
-    implicit def jsonLDEntityEncoder[S <: SameAs]: EntityIdEncoder[S] = EntityIdEncoder.instance {
+    implicit def jsonLDEntityIdEncoder[S <: SameAs]: EntityIdEncoder[S] = EntityIdEncoder.instance {
       case sameAs @ InternalSameAs(_) => EntityId of s"$sameAs/${sameAs.value.hashCode}"
       case sameAs @ ExternalSameAs(_) => EntityId of s"$sameAs/${sameAs.value.hashCode}"
     }

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/datasetsSpec.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/datasetsSpec.scala
@@ -154,6 +154,13 @@ class datasetsSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should
       instance       shouldBe an[InternalSameAs]
       instance.value shouldBe sameAs.value
     }
+
+    "asResourceId" should {
+      "return sameAs to ResourceId" in {
+        val sameAs = datasetInternalSameAs.generateOne
+        sameAs.asResourceId shouldBe datasets.ResourceId(sameAs.value)
+      }
+    }
   }
 
   "SameAs.from" should {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/RecoverableErrorsRecovery.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/RecoverableErrorsRecovery.scala
@@ -30,10 +30,11 @@ private trait RecoverableErrorsRecovery {
 
   private type RecoveryStrategy[F[_], OUT] = PartialFunction[Throwable, F[Either[ProcessingRecoverableError, OUT]]]
 
-  def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = maybeRecoverableError(None)
-  def maybeRecoverableError[F[_]: MonadThrow, OUT](message: String): RecoveryStrategy[F, OUT] = maybeRecoverableError(
-    Some(message)
-  )
+  def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] =
+    maybeRecoverableError(None)
+
+  def maybeRecoverableError[F[_]: MonadThrow, OUT](message: String): RecoveryStrategy[F, OUT] =
+    maybeRecoverableError(Some(message))
 
   def maybeRecoverableError[F[_]: MonadThrow, OUT](maybeMessage: Option[String]): RecoveryStrategy[F, OUT] = {
     case exception @ (_: ConnectivityException | _: ClientException) =>

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/DatasetTransformer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/DatasetTransformer.scala
@@ -86,6 +86,7 @@ private[transformation] object DatasetTransformer {
     descriptionUpdater             <- DescriptionUpdater[F]
     personLinksUpdater             <- PersonLinksUpdater[F]
     hierarchyOnInvalidationUpdater <- HierarchyOnInvalidationUpdater[F]
+    publicationEventsUpdater       <- PublicationEventsUpdater[F]
   } yield new DatasetTransformerImpl[F](
     derivationHierarchyUpdater,
     sameAsUpdater,
@@ -95,6 +96,6 @@ private[transformation] object DatasetTransformer {
     descriptionUpdater,
     personLinksUpdater,
     hierarchyOnInvalidationUpdater,
-    PublicationEventsUpdater[F]
+    publicationEventsUpdater
   )
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/KGDatasetInfoFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/KGDatasetInfoFinder.scala
@@ -21,23 +21,25 @@ package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation
 import cats.effect.Async
 import cats.syntax.all._
 import io.circe.Decoder
-import io.renku.graph.model.{persons, projects, GraphClass}
-import io.renku.graph.model.datasets.{DateCreated, Description, InternalSameAs, OriginalIdentifier, ResourceId, SameAs, TopmostSameAs}
-import io.renku.graph.model.views.RdfResource
-import io.renku.triplesstore._
+import io.renku.graph.model._
 import io.renku.triplesstore.ResultsDecoder._
 import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
 import org.typelevel.log4cats.Logger
 
 private trait KGDatasetInfoFinder[F[_]] {
-  def findParentTopmostSameAs(idSameAs:         InternalSameAs): F[Option[TopmostSameAs]]
-  def findTopmostSameAs(projectId:              projects.ResourceId, resourceId: ResourceId): F[Set[TopmostSameAs]]
-  def findDatasetCreators(projectId:            projects.ResourceId, resourceId: ResourceId): F[Set[persons.ResourceId]]
-  def findDatasetOriginalIdentifiers(projectId: projects.ResourceId, resourceId: ResourceId): F[Set[OriginalIdentifier]]
-  def findDatasetDateCreated(projectId:         projects.ResourceId, resourceId: ResourceId): F[Set[DateCreated]]
-  def findDatasetDescriptions(projectId:        projects.ResourceId, resourceId: ResourceId): F[Set[Description]]
-  def findDatasetSameAs(projectId:              projects.ResourceId, resourceId: ResourceId): F[Set[SameAs]]
-  def findWhereNotInvalidated(resourceId:       ResourceId): F[Set[projects.ResourceId]]
+
+  def findParentTopmostSameAs(idSameAs: datasets.InternalSameAs): F[Option[datasets.TopmostSameAs]]
+  def findTopmostSameAs(projectId:      projects.ResourceId, dsId: datasets.ResourceId): F[Set[datasets.TopmostSameAs]]
+  def findDatasetCreators(projectId:    projects.ResourceId, dsId: datasets.ResourceId): F[Set[persons.ResourceId]]
+  def findDatasetOriginalIdentifiers(projectId: projects.ResourceId,
+                                     dsId:      datasets.ResourceId
+  ): F[Set[datasets.OriginalIdentifier]]
+  def findDatasetDateCreated(projectId:  projects.ResourceId, dsId: datasets.ResourceId): F[Set[datasets.DateCreated]]
+  def findDatasetDescriptions(projectId: projects.ResourceId, dsId: datasets.ResourceId): F[Set[datasets.Description]]
+  def findDatasetSameAs(projectId:       projects.ResourceId, dsId: datasets.ResourceId): F[Set[datasets.SameAs]]
+  def findWhereNotInvalidated(dsId:      datasets.ResourceId): F[Set[projects.ResourceId]]
+  def checkPublicationEventsExist(projectId: projects.ResourceId, dsId: datasets.ResourceId): F[Boolean]
 }
 
 private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
@@ -48,56 +50,60 @@ private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecord
   import cats.syntax.all._
   import eu.timepit.refined.auto._
   import io.renku.graph.model.Schemas._
+  import io.renku.jsonld.syntax._
   import io.renku.tinytypes.json.TinyTypeDecoders._
+  import io.renku.triplesstore.client.syntax._
 
-  override def findParentTopmostSameAs(sameAs: InternalSameAs): F[Option[TopmostSameAs]] = {
-    implicit val decoder: Decoder[Option[TopmostSameAs]] = ResultsDecoder[Option, TopmostSameAs] { implicit cur =>
-      extract[TopmostSameAs]("topmostSameAs")
+  override def findParentTopmostSameAs(sameAs: datasets.InternalSameAs): F[Option[datasets.TopmostSameAs]] = {
+    implicit val decoder: Decoder[Option[datasets.TopmostSameAs]] = ResultsDecoder[Option, datasets.TopmostSameAs] {
+      implicit cur => extract[datasets.TopmostSameAs]("topmostSameAs")
     }(toOption(onMultiple = show"Multiple topmostSameAs found for dataset ${sameAs.show}"))
 
-    queryExpecting[Option[TopmostSameAs]](
+    queryExpecting[Option[datasets.TopmostSameAs]](
       SparqlQuery.of(
         name = "transformation - find parent topmostSameAs",
         Prefixes of (renku -> "renku", schema -> "schema", xsd -> "xsd"),
-        s"""|SELECT ?topmostSameAs
-            |WHERE {
-            |  GRAPH ?g {
-            |    <$sameAs> a schema:Dataset;
-            |                renku:topmostSameAs ?topmostSameAs;
-            |                ^renku:hasDataset ?projectId.
-            |    ?projectId schema:dateCreated ?projectDateCreated
-            |  }
-            |}
-            |ORDER BY ASC(xsd:date(?projectDateCreated))
-            |LIMIT 1
-            |""".stripMargin
+        sparql"""|SELECT ?topmostSameAs
+                 |WHERE {
+                 |  GRAPH ?g {
+                 |    ${sameAs.asResourceId.asEntityId} a schema:Dataset;
+                 |                                      renku:topmostSameAs ?topmostSameAs;
+                 |                                      ^renku:hasDataset ?projectId.
+                 |    ?projectId schema:dateCreated ?projectDateCreated
+                 |  }
+                 |}
+                 |ORDER BY ASC(xsd:date(?projectDateCreated))
+                 |LIMIT 1
+                 |""".stripMargin
       )
     )
   }
 
-  override def findTopmostSameAs(projectId: projects.ResourceId, resourceId: ResourceId): F[Set[TopmostSameAs]] = {
-    implicit val decoder: Decoder[Set[TopmostSameAs]] = ResultsDecoder[Set, TopmostSameAs] { implicit cur =>
-      extract[TopmostSameAs]("topmostSameAs")
+  override def findTopmostSameAs(projectId: projects.ResourceId,
+                                 dsId:      datasets.ResourceId
+  ): F[Set[datasets.TopmostSameAs]] = {
+    implicit val decoder: Decoder[Set[datasets.TopmostSameAs]] = ResultsDecoder[Set, datasets.TopmostSameAs] {
+      implicit cur => extract[datasets.TopmostSameAs]("topmostSameAs")
     }
 
-    queryExpecting[Set[TopmostSameAs]](
+    queryExpecting[Set[datasets.TopmostSameAs]](
       SparqlQuery.of(
         name = "transformation - find topmostSameAs",
         Prefixes of (renku -> "renku", schema -> "schema"),
-        s"""|SELECT ?topmostSameAs
-            |WHERE {
-            |  GRAPH <${GraphClass.Project.id(projectId)}> {
-            |    <$resourceId> a schema:Dataset;
-            |                  renku:topmostSameAs ?topmostSameAs.
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT ?topmostSameAs
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ${dsId.asEntityId} a schema:Dataset;
+                 |                       renku:topmostSameAs ?topmostSameAs.
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     )
   }
 
-  override def findDatasetCreators(projectId:  projects.ResourceId,
-                                   resourceId: ResourceId
+  override def findDatasetCreators(projectId: projects.ResourceId,
+                                   dsId:      datasets.ResourceId
   ): F[Set[persons.ResourceId]] = {
     implicit val creatorsDecoder: Decoder[Set[persons.ResourceId]] = ResultsDecoder[Set, persons.ResourceId] {
       implicit cur => extract[persons.ResourceId]("personId")
@@ -107,101 +113,105 @@ private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecord
       SparqlQuery.of(
         name = "transformation - find ds creators",
         Prefixes of schema -> "schema",
-        s"""|SELECT ?personId
-            |WHERE {
-            |  GRAPH <${GraphClass.Project.id(projectId)}> {
-            |    ${resourceId.showAs[RdfResource]} a schema:Dataset;
-            |                                      schema:creator ?personId
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT ?personId
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ${dsId.asEntityId} a schema:Dataset;
+                 |                       schema:creator ?personId
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     }
   }
 
-  override def findDatasetOriginalIdentifiers(projectId:  projects.ResourceId,
-                                              resourceId: ResourceId
-  ): F[Set[OriginalIdentifier]] = {
-    implicit val decoder: Decoder[Set[OriginalIdentifier]] = ResultsDecoder[Set, OriginalIdentifier] {
+  override def findDatasetOriginalIdentifiers(projectId: projects.ResourceId,
+                                              dsId:      datasets.ResourceId
+  ): F[Set[datasets.OriginalIdentifier]] = {
+    implicit val decoder: Decoder[Set[datasets.OriginalIdentifier]] = ResultsDecoder[Set, datasets.OriginalIdentifier] {
       implicit cursor => extract("originalId")
     }
-    queryExpecting[Set[OriginalIdentifier]] {
+    queryExpecting[Set[datasets.OriginalIdentifier]] {
       SparqlQuery.of(
         name = "transformation - find ds originalIdentifiers",
         Prefixes of (renku -> "renku", schema -> "schema"),
-        s"""|SELECT ?originalId
-            |WHERE {
-            |  GRAPH <${GraphClass.Project.id(projectId)}> {
-            |    ${resourceId.showAs[RdfResource]} a schema:Dataset;
-            |                                      renku:originalIdentifier ?originalId.
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT ?originalId
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ${dsId.asEntityId} a schema:Dataset;
+                 |                       renku:originalIdentifier ?originalId.
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     }
   }
 
-  def findDatasetDateCreated(projectId: projects.ResourceId, resourceId: ResourceId): F[Set[DateCreated]] = {
-    implicit val decoder: Decoder[Set[DateCreated]] = ResultsDecoder[Set, DateCreated] { implicit cursor =>
-      extract("date")
+  def findDatasetDateCreated(projectId: projects.ResourceId,
+                             dsId:      datasets.ResourceId
+  ): F[Set[datasets.DateCreated]] = {
+    implicit val decoder: Decoder[Set[datasets.DateCreated]] = ResultsDecoder[Set, datasets.DateCreated] {
+      implicit cursor => extract("date")
     }
-    queryExpecting[Set[DateCreated]] {
+    queryExpecting[Set[datasets.DateCreated]] {
       SparqlQuery.of(
         name = "transformation - find ds originalIdentifiers",
         Prefixes of schema -> "schema",
-        s"""|SELECT ?date
-            |WHERE {
-            |  GRAPH <${GraphClass.Project.id(projectId)}> {
-            |    ${resourceId.showAs[RdfResource]} a schema:Dataset;
-            |                                      schema:dateCreated ?date.
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT ?date
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ${dsId.asEntityId} a schema:Dataset;
+                 |                       schema:dateCreated ?date.
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     }
   }
 
-  override def findDatasetDescriptions(projectId: projects.ResourceId, resourceId: ResourceId): F[Set[Description]] = {
-    implicit val decoder: Decoder[Set[Description]] = ResultsDecoder[Set, Description] { implicit cursor =>
-      extract("desc")
+  override def findDatasetDescriptions(projectId: projects.ResourceId,
+                                       dsId:      datasets.ResourceId
+  ): F[Set[datasets.Description]] = {
+    implicit val decoder: Decoder[Set[datasets.Description]] = ResultsDecoder[Set, datasets.Description] {
+      implicit cursor => extract("desc")
     }
-    queryExpecting[Set[Description]] {
+    queryExpecting[Set[datasets.Description]] {
       SparqlQuery.of(
         name = "transformation - find ds descriptions",
         Prefixes of schema -> "schema",
-        s"""|SELECT ?desc
-            |WHERE {
-            |  GRAPH <${GraphClass.Project.id(projectId)}> {
-            |    ${resourceId.showAs[RdfResource]} a schema:Dataset;
-            |                                      schema:description ?desc.
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT ?desc
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ${dsId.asEntityId} a schema:Dataset;
+                 |                       schema:description ?desc.
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     }
   }
 
-  override def findDatasetSameAs(projectId: projects.ResourceId, resourceId: ResourceId): F[Set[SameAs]] = {
-    implicit val decoder: Decoder[Set[SameAs]] = ResultsDecoder[Set, SameAs] { implicit cursor =>
+  override def findDatasetSameAs(projectId: projects.ResourceId, dsId: datasets.ResourceId): F[Set[datasets.SameAs]] = {
+    implicit val decoder: Decoder[Set[datasets.SameAs]] = ResultsDecoder[Set, datasets.SameAs] { implicit cursor =>
       extract("sameAs")
     }
-    queryExpecting[Set[SameAs]] {
+    queryExpecting[Set[datasets.SameAs]] {
       SparqlQuery.of(
         name = "transformation - find ds sameAs",
         Prefixes of schema -> "schema",
-        s"""|SELECT ?sameAs
-            |WHERE {
-            |  GRAPH <${GraphClass.Project.id(projectId)}> {
-            |    ${resourceId.showAs[RdfResource]} a schema:Dataset;
-            |                                      schema:sameAs ?sameAs.
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT ?sameAs
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ${dsId.asEntityId} a schema:Dataset;
+                 |                       schema:sameAs ?sameAs.
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     }
   }
 
-  override def findWhereNotInvalidated(resourceId: ResourceId): F[Set[projects.ResourceId]] = {
+  override def findWhereNotInvalidated(dsId: datasets.ResourceId): F[Set[projects.ResourceId]] = {
     implicit val decoder: Decoder[Set[projects.ResourceId]] = ResultsDecoder[Set, projects.ResourceId] {
       implicit cursor => extract("projectId")
     }
@@ -209,19 +219,41 @@ private class KGDatasetInfoFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecord
       SparqlQuery.of(
         name = "transformation - find where DS not invalidated",
         Prefixes of (prov -> "prov", renku -> "renku", schema -> "schema"),
-        s"""|SELECT DISTINCT ?projectId
-            |WHERE {
-            |  GRAPH ?projectId {
-            |    BIND (${resourceId.showAs[RdfResource]} AS ?invalidatedDS)
-            |    ?invalidatedDS a schema:Dataset;
-            |                   ^renku:hasDataset ?projectId.
-            |    FILTER NOT EXISTS {
-            |      ?invalidationDS prov:wasDerivedFrom/schema:url ?invalidatedDS;
-            |                      prov:invalidatedAtTime ?invalidationTime.
-            |    }
-            |  }
-            |}
-            |""".stripMargin
+        sparql"""|SELECT DISTINCT ?projectId
+                 |WHERE {
+                 |  GRAPH ?projectId {
+                 |    BIND (${dsId.asEntityId} AS ?invalidatedDS)
+                 |    ?invalidatedDS a schema:Dataset;
+                 |                   ^renku:hasDataset ?projectId.
+                 |    FILTER NOT EXISTS {
+                 |      ?invalidationDS prov:wasDerivedFrom/schema:url ?invalidatedDS;
+                 |                      prov:invalidatedAtTime ?invalidationTime.
+                 |    }
+                 |  }
+                 |}
+                 |""".stripMargin
+      )
+    }
+  }
+
+  override def checkPublicationEventsExist(projectId: projects.ResourceId, dsId: datasets.ResourceId): F[Boolean] = {
+
+    implicit val decoder: Decoder[Boolean] = ResultsDecoder
+      .single[Int](implicit cursor => extract[Int]("idsCount"))
+      .map(_ > 0)
+
+    queryExpecting[Boolean] {
+      SparqlQuery.of(
+        name = "transformation - check publicationEvents exist",
+        Prefixes of schema -> "schema",
+        sparql"""|SELECT (COUNT(?peId) AS ?idsCount)
+                 |WHERE {
+                 |  GRAPH ${GraphClass.Project.id(projectId)} {
+                 |    ?peId a schema:PublicationEvent;
+                 |          schema:about/schema:url ${dsId.asEntityId}
+                 |  }
+                 |}
+                 |""".stripMargin
       )
     }
   }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/PublicationEventsUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/PublicationEventsUpdater.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsprovisioning.transformation.namedgraphs.datasets
+
+import cats.Monad
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.model.entities.Project
+import io.renku.triplesgenerator.events.consumers.tsprovisioning.TransformationStep.Queries
+import io.renku.triplesstore.SparqlQueryTimeRecorder
+import org.typelevel.log4cats.Logger
+
+private trait PublicationEventsUpdater[F[_]] {
+  def updatePublicationEvents: ((Project, Queries)) => F[(Project, Queries)]
+}
+
+private object PublicationEventsUpdater {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: PublicationEventsUpdater[F] =
+    new PublicationEventsUpdaterImpl[F](UpdatesCreator)
+}
+
+private class PublicationEventsUpdaterImpl[F[_]: Monad](updatesCreator: UpdatesCreator)
+    extends PublicationEventsUpdater[F] {
+
+  override def updatePublicationEvents: ((Project, Queries)) => F[(Project, Queries)] = { case (project, queries) =>
+    val preUpdateQueries = project.datasets.flatMap(updatesCreator.deletePublicationEvents(project.resourceId, _))
+    (project -> (queries ++ Queries.preDataQueriesOnly(preUpdateQueries))).pure[F]
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/PublicationEventsUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/transformation/namedgraphs/datasets/PublicationEventsUpdaterSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsprovisioning
+package transformation.namedgraphs.datasets
+
+import TransformationStep.Queries
+import cats.syntax.all._
+import io.renku.generators.CommonGraphGenerators.sparqlQueries
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.entities
+import io.renku.graph.model.testentities._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.TryValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import transformation.Generators.queriesGen
+
+import scala.util.Try
+
+class PublicationEventsUpdaterSpec extends AnyFlatSpec with should.Matchers with TryValues with MockFactory {
+
+  it should "leave the project unchanged and add delete queries for all datasets' publicationEvents" in {
+
+    val initialProject = {
+      val p = anyRenkuProjectEntities.generateOne
+      p.addDatasets(datasetEntities(provenanceNonModified).generateList(p.dateCreated): _*)
+      p.to[entities.Project]
+    }
+
+    val deletionQueries = initialProject.datasets >>= { ds =>
+      val dsDeletionQueries = sparqlQueries.generateList()
+
+      (updatesCreator.deletePublicationEvents _)
+        .expects(initialProject.resourceId, ds)
+        .returning(dsDeletionQueries)
+
+      dsDeletionQueries
+    }
+
+    val initialQueries = queriesGen.generateOne
+
+    val (updatedProject, updatedQueries) =
+      updater.updatePublicationEvents(initialProject -> initialQueries).success.value
+
+    updatedProject shouldBe initialProject
+    updatedQueries shouldBe initialQueries ++ Queries.preDataQueriesOnly(deletionQueries)
+  }
+
+  private lazy val updatesCreator = mock[UpdatesCreator]
+  private lazy val updater        = new PublicationEventsUpdaterImpl[Try](updatesCreator)
+}


### PR DESCRIPTION
This PR makes sure the DS Transformation process removes all Datasets' PublicationEvents before the upload.

closes #1531 