### PR TITLE
fix: Fix several missed logging statements

### DIFF
--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchGraphsProvisionerSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchGraphsProvisionerSpec.scala
@@ -18,57 +18,56 @@
 
 package io.renku.entities.searchgraphs
 
+import cats.effect._
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
 import io.renku.graph.model.entities
 import io.renku.graph.model.testentities._
 import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.TryValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class SearchGraphsProvisionerSpec extends AnyWordSpec with should.Matchers with TryValues with MockFactory {
+class SearchGraphsProvisionerSpec extends AnyWordSpec with should.Matchers with IOSpec with MockFactory {
 
   "provisionSearchGraphs" should {
 
     "provision the Datasets and Projects graphs" in new TestCase {
 
-      givenProjectsGraphProvisioning(project, returning = ().pure[Try])
-      givenDatasetsGraphProvisioning(project, returning = ().pure[Try])
+      givenProjectsGraphProvisioning(project, returning = ().pure[IO])
+      givenDatasetsGraphProvisioning(project, returning = ().pure[IO])
 
-      provisioner.provisionSearchGraphs(project).success.value shouldBe ()
+      provisioner.provisionSearchGraphs(project).unsafeRunSync() shouldBe ()
     }
 
     "fail if provisioning Projects graph fails" in new TestCase {
 
       val exception = exceptions.generateOne
-      givenProjectsGraphProvisioning(project, returning = exception.raiseError[Try, Nothing])
-      givenDatasetsGraphProvisioning(project, returning = ().pure[Try])
+      givenProjectsGraphProvisioning(project, returning = exception.raiseError[IO, Nothing])
+      givenDatasetsGraphProvisioning(project, returning = ().pure[IO])
 
-      provisioner.provisionSearchGraphs(project).failure.exception shouldBe exception
+      intercept[Exception](provisioner.provisionSearchGraphs(project).unsafeRunSync()) shouldBe exception
     }
 
     "fail if provisioning Datasets graph fails" in new TestCase {
 
-      givenProjectsGraphProvisioning(project, returning = ().pure[Try])
+      givenProjectsGraphProvisioning(project, returning = ().pure[IO])
       val exception = exceptions.generateOne
-      givenDatasetsGraphProvisioning(project, returning = exception.raiseError[Try, Nothing])
+      givenDatasetsGraphProvisioning(project, returning = exception.raiseError[IO, Nothing])
 
-      provisioner.provisionSearchGraphs(project).failure.exception shouldBe exception
+      intercept[Exception](provisioner.provisionSearchGraphs(project).unsafeRunSync()) shouldBe exception
     }
 
     "fail with the Projects provisioning failure if both processes fails" in new TestCase {
 
       val projectsException = exceptions.generateOne
-      givenProjectsGraphProvisioning(project, returning = projectsException.raiseError[Try, Nothing])
+      givenProjectsGraphProvisioning(project, returning = projectsException.raiseError[IO, Nothing])
       val datasetsException = exceptions.generateOne
-      givenDatasetsGraphProvisioning(project, returning = datasetsException.raiseError[Try, Nothing])
+      givenDatasetsGraphProvisioning(project, returning = datasetsException.raiseError[IO, Nothing])
 
-      provisioner.provisionSearchGraphs(project).failure.exception shouldBe projectsException
+      intercept[Exception](provisioner.provisionSearchGraphs(project).unsafeRunSync()) shouldBe projectsException
     }
   }
 
@@ -76,17 +75,17 @@ class SearchGraphsProvisionerSpec extends AnyWordSpec with should.Matchers with 
 
     val project = anyProjectEntities.generateOne.to[entities.Project]
 
-    private implicit val logger: TestLogger[Try] = new TestLogger[Try]()
-    private val projectsGraphProvisioner = mock[projects.ProjectsGraphProvisioner[Try]]
-    private val datasetsGraphProvisioner = mock[datasets.DatasetsGraphProvisioner[Try]]
-    val provisioner = new SearchGraphsProvisionerImpl[Try](projectsGraphProvisioner, datasetsGraphProvisioner)
+    private implicit val logger: TestLogger[IO] = new TestLogger[IO]()
+    private val projectsGraphProvisioner = mock[projects.ProjectsGraphProvisioner[IO]]
+    private val datasetsGraphProvisioner = mock[datasets.DatasetsGraphProvisioner[IO]]
+    val provisioner = new SearchGraphsProvisionerImpl[IO](projectsGraphProvisioner, datasetsGraphProvisioner)
 
-    def givenDatasetsGraphProvisioning(project: entities.Project, returning: Try[Unit]) =
+    def givenDatasetsGraphProvisioning(project: entities.Project, returning: IO[Unit]) =
       (datasetsGraphProvisioner.provisionDatasetsGraph _)
         .expects(project)
         .returning(returning)
 
-    def givenProjectsGraphProvisioning(project: entities.Project, returning: Try[Unit]) =
+    def givenProjectsGraphProvisioning(project: entities.Project, returning: IO[Unit]) =
       (projectsGraphProvisioner.provisionProjectsGraph _)
         .expects(project)
         .returning(returning)

--- a/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsEndpoint.scala
@@ -52,8 +52,7 @@ class EventDetailsEndpointImpl[F[_]: Concurrent: Logger](eventDetailsFinder: Eve
 
   private lazy val internalServerError: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage("Finding event details failed")
-    Logger[F].error(exception)(errorMessage.value)
-    InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.value) *> InternalServerError(errorMessage)
   }
 
   private implicit lazy val encoder: Encoder[EventDetails] = Encoder.instance[EventDetails] { eventDetails =>

--- a/event-log/src/main/scala/io/renku/eventlog/events/EventsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/EventsEndpoint.scala
@@ -58,8 +58,9 @@ class EventsEndpointImpl[F[_]: MonadThrow: Logger](eventsFinder: EventsFinder[F]
 
   private def httpResponse(request: Request[F]): PartialFunction[Throwable, F[Response[F]]] = {
     case NonFatal(exception) =>
-      Logger[F].error(exception)(show"Finding events for '${request.uri}' failed")
-      InternalServerError(ErrorMessage(exception))
+      Logger[F].error(exception)(show"Finding events for '${request.uri}' failed") *> InternalServerError(
+        ErrorMessage(exception)
+      )
   }
 }
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/EventsDistributor.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/EventsDistributor.scala
@@ -80,8 +80,8 @@ private class EventsDistributorImpl[F[_]: MonadThrow: Temporal: Logger, Category
 
   private def handleResult(subscriber: SubscriberUrl, event: CategoryEvent): SendingResult => F[Unit] = {
     case result @ Delivered =>
-      Logger[F].info(show"$categoryName: $event, subscriber = $subscriber -> $result")
-      eventDelivery.registerSending(event, subscriber) recoverWith logError(event, subscriber)
+      Logger[F].info(show"$categoryName: $event, subscriber = $subscriber -> $result") *>
+        eventDelivery.registerSending(event, subscriber) recoverWith logError(event, subscriber)
     case result @ TemporarilyUnavailable =>
       (markBusy(subscriber) recover withNothing) >> (returnToQueue(event, result) recoverWith logError(event))
     case result @ Misdelivered =>

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/SubscriptionsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/SubscriptionsEndpoint.scala
@@ -73,8 +73,7 @@ class SubscriptionsEndpointImpl[F[_]: Concurrent: Logger](
       }
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage("Registering subscriber failed")
-      Logger[F].error(exception)(errorMessage.value)
-      InternalServerError(errorMessage)
+      Logger[F].error(exception)(errorMessage.value) *> InternalServerError(errorMessage)
   }
 }
 

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/LoggingDispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/LoggingDispatchRecoverySpec.scala
@@ -40,7 +40,7 @@ class LoggingDispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Ma
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne
 
-      recovery.unsafeRunSync().recover(subscriber, event)(exception) shouldBe ().pure[IO]
+      recovery.unsafeRunSync().recover(subscriber, event)(exception).unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
         Error(s"$categoryName: $event, url = $subscriber failed", exception)

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/LoggingDispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/LoggingDispatchRecoverySpec.scala
@@ -20,6 +20,7 @@ package io.renku.eventlog.events.producers
 
 import Generators._
 import TestCategoryEvent.testCategoryEvents
+import cats.effect._
 import cats.syntax.all._
 import io.renku.events.Generators.{categoryNames, subscriberUrls}
 import io.renku.generators.Generators.Implicits._
@@ -31,8 +32,6 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.{Success, Try}
-
 class LoggingDispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Matchers with MockFactory {
 
   "recover" should {
@@ -41,7 +40,7 @@ class LoggingDispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Ma
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne
 
-      recovery.recover(subscriber, event)(exception) shouldBe ().pure[Try]
+      recovery.unsafeRunSync().recover(subscriber, event)(exception) shouldBe ().pure[IO]
 
       logger.loggedOnly(
         Error(s"$categoryName: $event, url = $subscriber failed", exception)
@@ -51,7 +50,7 @@ class LoggingDispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Ma
 
   "returnToQueue" should {
     "return unit" in new TestCase {
-      recovery.returnToQueue(event, sendingResults.generateOne) shouldBe ().pure[Try]
+      recovery.unsafeRunSync().returnToQueue(event, sendingResults.generateOne) shouldBe ().pure[IO]
     }
   }
 
@@ -59,7 +58,7 @@ class LoggingDispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Ma
     val event = testCategoryEvents.generateOne
 
     val categoryName = categoryNames.generateOne
-    protected implicit val logger: TestLogger[Try] = TestLogger[Try]()
-    val Success(recovery) = LoggingDispatchRecovery[Try, TestCategoryEvent](categoryName)
+    protected implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val recovery = LoggingDispatchRecovery[IO, TestCategoryEvent](categoryName)
   }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/awaitinggeneration/DispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/awaitinggeneration/DispatchRecoverySpec.scala
@@ -69,7 +69,7 @@ class DispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Matchers 
 
   "recovery" should {
 
-    "reIO changing event status if status update failed initially" in new TestCase {
+    "retry changing event status if status update failed initially" in new TestCase {
 
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/awaitinggeneration/DispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/awaitinggeneration/DispatchRecoverySpec.scala
@@ -20,6 +20,7 @@ package io.renku.eventlog.events.producers
 package awaitinggeneration
 
 import Generators.sendingResults
+import cats.effect._
 import cats.syntax.all._
 import io.circe.literal._
 import io.renku.events.{CategoryName, EventRequestContent}
@@ -31,13 +32,12 @@ import io.renku.graph.model.events.EventMessage
 import io.renku.graph.model.events.EventStatus._
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
+import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFactory {
+class DispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Matchers with MockFactory {
 
   "returnToQueue" should {
 
@@ -61,15 +61,15 @@ class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFac
                                    s"${SubscriptionCategory.categoryName}: Marking event as $New failed"
           )
         )
-        .returning(().pure[Try])
+        .returning(().pure[IO])
 
-      dispatchRecovery.returnToQueue(event, sendingResults.generateOne) shouldBe ().pure[Try]
+      dispatchRecovery.returnToQueue(event, sendingResults.generateOne) shouldBe ().pure[IO]
     }
   }
 
   "recovery" should {
 
-    "retry changing event status if status update failed initially" in new TestCase {
+    "reIO changing event status if status update failed initially" in new TestCase {
 
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne
@@ -95,9 +95,9 @@ class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFac
             s"${SubscriptionCategory.categoryName}: $event, url = $subscriber -> $GenerationNonRecoverableFailure"
           )
         )
-        .returning(().pure[Try])
+        .returning(().pure[IO])
 
-      dispatchRecovery.recover(subscriber, event)(exception) shouldBe ().pure[Try]
+      dispatchRecovery.recover(subscriber, event)(exception).unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
         Error(s"${SubscriptionCategory.categoryName}: $event, url = $subscriber -> $GenerationNonRecoverableFailure",
@@ -110,8 +110,8 @@ class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFac
   private trait TestCase {
     val event = awaitingGenerationEvents.generateOne
 
-    val eventSender = mock[EventSender[Try]]
-    implicit val logger: TestLogger[Try] = TestLogger[Try]()
-    val dispatchRecovery = new DispatchRecoveryImpl[Try](eventSender)
+    val eventSender = mock[EventSender[IO]]
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val dispatchRecovery = new DispatchRecoveryImpl[IO](eventSender)
   }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/cleanup/DispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/cleanup/DispatchRecoverySpec.scala
@@ -69,7 +69,7 @@ class DispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Matchers 
 
   "recovery" should {
 
-    "reIO changing event status if status update failed initially" in new TestCase {
+    "retry changing event status if status update failed initially" in new TestCase {
 
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/triplesgenerated/DispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/triplesgenerated/DispatchRecoverySpec.scala
@@ -69,7 +69,7 @@ class DispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Matchers 
 
   "recovery" should {
 
-    "reIO changing event status if status update failed initially" in new TestCase {
+    "retry changing event status if status update failed initially" in new TestCase {
 
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne

--- a/event-log/src/test/scala/io/renku/eventlog/events/producers/triplesgenerated/DispatchRecoverySpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/producers/triplesgenerated/DispatchRecoverySpec.scala
@@ -20,6 +20,7 @@ package io.renku.eventlog.events.producers
 package triplesgenerated
 
 import Generators.sendingResults
+import cats.effect._
 import cats.syntax.all._
 import io.circe.literal._
 import io.renku.events.{CategoryName, EventRequestContent}
@@ -31,13 +32,12 @@ import io.renku.graph.model.events.EventMessage
 import io.renku.graph.model.events.EventStatus._
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
+import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFactory {
+class DispatchRecoverySpec extends AnyWordSpec with IOSpec with should.Matchers with MockFactory {
 
   "returnToQueue" should {
 
@@ -61,15 +61,15 @@ class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFac
                                    s"${SubscriptionCategory.categoryName}: Marking event as $TriplesGenerated failed"
           )
         )
-        .returning(().pure[Try])
+        .returning(().pure[IO])
 
-      dispatchRecovery.returnToQueue(event, sendingResults.generateOne) shouldBe ().pure[Try]
+      dispatchRecovery.returnToQueue(event, sendingResults.generateOne).unsafeRunSync() shouldBe ()
     }
   }
 
   "recovery" should {
 
-    "retry changing event status if status update failed initially" in new TestCase {
+    "reIO changing event status if status update failed initially" in new TestCase {
 
       val exception  = exceptions.generateOne
       val subscriber = subscriberUrls.generateOne
@@ -95,9 +95,9 @@ class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFac
             s"${SubscriptionCategory.categoryName}: $event, url = $subscriber -> $TransformationNonRecoverableFailure"
           )
         )
-        .returning(().pure[Try])
+        .returning(().pure[IO])
 
-      dispatchRecovery.recover(subscriber, event)(exception) shouldBe ().pure[Try]
+      dispatchRecovery.recover(subscriber, event)(exception).unsafeRunSync() shouldBe ()
 
       logger.loggedOnly(
         Error(
@@ -111,8 +111,8 @@ class DispatchRecoverySpec extends AnyWordSpec with should.Matchers with MockFac
   private trait TestCase {
     val event = triplesGeneratedEvents.generateOne
 
-    implicit val logger: TestLogger[Try] = TestLogger[Try]()
-    val eventSender      = mock[EventSender[Try]]
-    val dispatchRecovery = new DispatchRecoveryImpl[Try](eventSender)
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val eventSender      = mock[EventSender[IO]]
+    val dispatchRecovery = new DispatchRecoveryImpl[IO](eventSender)
   }
 }

--- a/graph-commons/src/main/scala/io/renku/config/certificates/CertificateLoader.scala
+++ b/graph-commons/src/main/scala/io/renku/config/certificates/CertificateLoader.scala
@@ -65,7 +65,6 @@ class CertificateLoaderImpl[F[_]: MonadThrow: Logger] private[certificates] (
   } yield ()
 
   private lazy val loggingError: PartialFunction[Throwable, F[Unit]] = { case NonFatal(exception) =>
-    Logger[F].error(exception)("Loading client certificate failed")
-    exception.raiseError[F, Unit]
+    Logger[F].error(exception)("Loading client certificate failed") *> exception.raiseError[F, Unit]
   }
 }

--- a/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
+++ b/graph-commons/src/main/scala/io/renku/http/client/RestClient.scala
@@ -128,7 +128,7 @@ abstract class RestClient[F[_]: Async: Logger, ThrottlingTarget](
       case Some(timeRecorder) =>
         timeRecorder
           .measureExecutionTime(block, request.toHistogramLabel)
-          .map(timeRecorder.logExecutionTime(withMessage = LogMessage(request, "finished")))
+          .flatMap(timeRecorder.logExecutionTime(withMessage = LogMessage(request, "finished")))
     }
 
   private def callRemote[ResultType](httpClient:  Client[F],

--- a/graph-commons/src/test/scala/io/renku/logging/ExecutionTimeRecorderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/logging/ExecutionTimeRecorderSpec.scala
@@ -40,7 +40,6 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.util.Try
 
 class ExecutionTimeRecorderSpec
     extends AnyWordSpec
@@ -151,9 +150,12 @@ class ExecutionTimeRecorderSpec
         val blockOut              = nonEmptyStrings().generateOne
         val blockExecutionMessage = "block executed"
 
-        (elapsedTime -> blockOut).pure[Try] map logExecutionTimeWhen { case _ =>
-          blockExecutionMessage
-        } shouldBe blockOut.pure[Try]
+        (elapsedTime -> blockOut)
+          .pure[IO]
+          .flatMap(logExecutionTimeWhen { case _ =>
+            blockExecutionMessage
+          })
+          .unsafeRunSync() shouldBe blockOut
 
         logger.loggedOnly(Warn(s"$blockExecutionMessage in ${elapsedTime}ms"))
       }
@@ -166,9 +168,12 @@ class ExecutionTimeRecorderSpec
         val blockOut              = nonEmptyStrings().generateOne
         val blockExecutionMessage = "block executed"
 
-        (elapsedTime -> blockOut).pure[Try] map logExecutionTimeWhen { case _ =>
-          blockExecutionMessage
-        } shouldBe blockOut.pure[Try]
+        (elapsedTime -> blockOut)
+          .pure[IO]
+          .flatMap(logExecutionTimeWhen { case _ =>
+            blockExecutionMessage
+          })
+          .unsafeRunSync() shouldBe blockOut
 
         logger.expectNoLogs()
       }
@@ -180,9 +185,12 @@ class ExecutionTimeRecorderSpec
       val blockOut              = nonEmptyStrings().generateOne
       val blockExecutionMessage = "block executed"
 
-      (elapsedTime -> blockOut).pure[Try] map logExecutionTimeWhen { case "" =>
-        blockExecutionMessage
-      } shouldBe blockOut.pure[Try]
+      (elapsedTime -> blockOut)
+        .pure[IO]
+        .flatMap(logExecutionTimeWhen { case "" =>
+          blockExecutionMessage
+        })
+        .unsafeRunSync() shouldBe blockOut
 
       logger.expectNoLogs()
     }
@@ -198,8 +206,9 @@ class ExecutionTimeRecorderSpec
       val blockExecutionMessage = "block executed"
 
       (elapsedTime -> blockOut)
-        .pure[Try]
-        .map(logExecutionTime(blockExecutionMessage)) shouldBe blockOut.pure[Try]
+        .pure[IO]
+        .flatMap(logExecutionTime(blockExecutionMessage))
+        .unsafeRunSync() shouldBe blockOut
 
       logger.loggedOnly(Warn(s"$blockExecutionMessage in ${elapsedTime}ms"))
     }
@@ -212,8 +221,9 @@ class ExecutionTimeRecorderSpec
       val blockExecutionMessage = "block executed"
 
       (elapsedTime -> blockOut)
-        .pure[Try]
-        .map(logExecutionTime(blockExecutionMessage)) shouldBe blockOut.pure[Try]
+        .pure[IO]
+        .flatMap(logExecutionTime(blockExecutionMessage))
+        .unsafeRunSync() shouldBe blockOut
 
       logger.expectNoLogs()
     }
@@ -240,7 +250,7 @@ class ExecutionTimeRecorderSpec
 
         (elapsedTime -> blockOut)
           .pure[IO]
-          .map(executionTimeRecorder.logExecutionTimeWhen { case _ => blockExecutionMessage })
+          .flatMap(executionTimeRecorder.logExecutionTimeWhen { case _ => blockExecutionMessage })
           .unsafeRunSync() shouldBe blockOut
 
         logger.loggedOnly(Warn(s"$blockExecutionMessage in ${elapsedTime}ms"))

--- a/graph-commons/src/test/scala/io/renku/logging/TestExecutionTimeRecorder.scala
+++ b/graph-commons/src/test/scala/io/renku/logging/TestExecutionTimeRecorder.scala
@@ -18,7 +18,7 @@
 
 package io.renku.logging
 
-import cats.MonadThrow
+import cats.{Monad, MonadThrow}
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
@@ -36,7 +36,7 @@ object TestExecutionTimeRecorder {
     new TestExecutionTimeRecorder[F](threshold = elapsedTimes.generateOne, maybeHistogram)
 }
 
-class TestExecutionTimeRecorder[F[_]: MonadThrow: Logger](
+class TestExecutionTimeRecorder[F[_]: Monad](
     threshold:      ElapsedTime,
     maybeHistogram: Option[Histogram]
 ) extends ExecutionTimeRecorder[F](threshold) {
@@ -45,10 +45,10 @@ class TestExecutionTimeRecorder[F[_]: MonadThrow: Logger](
   lazy val executionTimeInfo: String      = s" in ${threshold}ms"
 
   override def measureExecutionTime[BlockOut](
-      block:               => F[BlockOut],
+      block:               F[BlockOut],
       maybeHistogramLabel: Option[String Refined NonEmpty] = None
   ): F[(ElapsedTime, BlockOut)] = for {
-    _ <- MonadThrow[F].unit
+    _ <- Monad[F].unit // why?
     maybeHistogramTimer = startTimer(maybeHistogramLabel)
     result <- block
     _ = maybeHistogramTimer map (_.observeDuration())

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/Endpoint.scala
@@ -70,13 +70,13 @@ class EndpointImpl[F[_]: Parallel: MonadThrow: Logger](
                         sort:        Sorting[Sort.type],
                         paging:      PagingRequest,
                         maybeUser:   Option[AuthUser]
-  ): F[Response[F]] = measureExecutionTime {
+  ): F[Response[F]] = measureAndLogTime(finishedSuccessfully(maybePhrase)) {
     implicit val datasetsUrl: renku.ResourceUrl = requestedUrl(maybePhrase, sort, paging)
     datasetsFinder
       .findDatasets(maybePhrase, sort, paging, maybeUser)
       .map(_.toHttpResponse[F, renku.ResourceUrl])
       .recoverWith(httpResult(maybePhrase))
-  } map logExecutionTimeWhen(finishedSuccessfully(maybePhrase))
+  }
 
   private def requestedUrl(
       maybePhrase: Option[Phrase],

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Endpoint.scala
@@ -63,13 +63,13 @@ class EndpointImpl[F[_]: MonadThrow: Logger](
   private implicit lazy val glUrl:  GitLabUrl    = gitLabUrl
 
   def `GET /datasets/:id`(identifier: RequestedDataset, authContext: AuthContext[RequestedDataset]): F[Response[F]] =
-    measureExecutionTime {
+    measureAndLogTime(finishedSuccessfully(identifier)) {
       datasetFinder
         .findDataset(identifier, authContext)
         .flatTap(sendDatasetViewedEvent(authContext))
         .flatMap(toHttpResult(identifier))
         .recoverWith(httpResult(identifier))
-    } map logExecutionTimeWhen(finishedSuccessfully(identifier))
+    }
 
   private def sendDatasetViewedEvent(authContext: AuthContext[RequestedDataset]): Option[Dataset] => F[Unit] = {
     case None => ().pure[F]

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/Endpoint.scala
@@ -55,14 +55,15 @@ class EndpointImpl[F[_]: MonadCancelThrow: Logger](
   private implicit lazy val apiUrl: renku.ApiUrl = renkuApiUrl
   private implicit lazy val glUrl:  GitLabUrl    = gitLabUrl
 
-  def getProjectDatasets(projectPath: projects.Path): F[Response[F]] = measureExecutionTime {
-    implicit val encoder: Encoder[ProjectDataset] = ProjectDatasetEncoder.encoder(projectPath)
+  def getProjectDatasets(projectPath: projects.Path): F[Response[F]] =
+    measureAndLogTime(finishedSuccessfully(projectPath)) {
+      implicit val encoder: Encoder[ProjectDataset] = ProjectDatasetEncoder.encoder(projectPath)
 
-    projectDatasetsFinder
-      .findProjectDatasets(projectPath)
-      .flatMap(datasets => Ok(datasets.asJson))
-      .recoverWith(httpResult(projectPath))
-  } map logExecutionTimeWhen(finishedSuccessfully(projectPath))
+      projectDatasetsFinder
+        .findProjectDatasets(projectPath)
+        .flatMap(datasets => Ok(datasets.asJson))
+        .recoverWith(httpResult(projectPath))
+    }
 
   private def httpResult(
       projectPath: projects.Path

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/Endpoint.scala
@@ -72,13 +72,13 @@ class EndpointImpl[F[_]: MonadThrow: Logger](
 
   def `GET /projects/:path`(path: projects.Path, maybeAuthUser: Option[AuthUser])(implicit
       request: Request[F]
-  ): F[Response[F]] = measureExecutionTime {
+  ): F[Response[F]] = measureAndLogTime(finishedSuccessfully(path)) {
     projectFinder
       .findProject(path, maybeAuthUser)
       .flatTap(sendProjectViewedEvent(maybeAuthUser))
       .flatMap(toHttpResult(path))
       .recoverWith(httpResult(path))
-  } map logExecutionTimeWhen(finishedSuccessfully(path))
+  }
 
   private def sendProjectViewedEvent(maybeAuthUser: Option[AuthUser]): Option[Project] => F[Unit] = {
     case None => ().pure[F]

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/LineageFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/LineageFinder.scala
@@ -81,8 +81,7 @@ class LineageFinderImpl[F[_]: MonadThrow: Logger](
   private def loggingError(projectPath: Path, location: Location): PartialFunction[Throwable, F[Option[Lineage]]] = {
     case NonFatal(ex) =>
       val message = s"Finding lineage for '$projectPath' and '$location' failed"
-      Logger[F].error(ex)(message)
-      new Exception(message, ex).raiseError[F, Option[Lineage]]
+      Logger[F].error(ex)(message) *> new Exception(message, ex).raiseError[F, Option[Lineage]]
   }
 }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
@@ -67,8 +67,7 @@ class FetchTokenEndpointImpl[F[_]: MonadThrow: Logger](tokenFinder: TokenFinder[
       projectIdentifier: ID
   ): PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage(s"Finding token for project: $projectIdentifier failed")
-    Logger[F].error(exception)(errorMessage.value)
-    InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.value) *> InternalServerError(errorMessage)
   }
 
   implicit val findById:   projects.GitLabId => OptionT[F, AccessToken] = tokenFinder.findToken

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -183,7 +183,7 @@ class TokensCreatorSpec extends AnyWordSpec with IOSpec with MockFactory with sh
       tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
-    "reIO if the token couldn't be decrypted after storing (token sanity check failed)" in new TestCase {
+    "retry if the token couldn't be decrypted after storing (token sanity check failed)" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 
@@ -216,7 +216,7 @@ class TokensCreatorSpec extends AnyWordSpec with IOSpec with MockFactory with sh
       tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
-    "reIO if the token after storing couldn't be found" in new TestCase {
+    "retry if the token after storing couldn't be found" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 
@@ -259,7 +259,7 @@ class TokensCreatorSpec extends AnyWordSpec with IOSpec with MockFactory with sh
       ex shouldBe exception
     }
 
-    "fail if reIO process hit the max number of attempts" in new TestCase {
+    "fail if retry process hit the max number of attempts" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -20,6 +20,7 @@ package io.renku.tokenrepository.repository
 package creation
 
 import cats.data.OptionT
+import cats.effect._
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
@@ -33,19 +34,17 @@ import io.renku.graph.model.projects.GitLabId
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.{AccessToken, UserAccessToken}
 import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.RepositoryGenerators._
 import io.renku.tokenrepository.repository.creation.Generators._
 import io.renku.tokenrepository.repository.deletion.{TokenRemover, TokensRevoker}
 import io.renku.tokenrepository.repository.fetching.PersistedTokensFinder
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.TryValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matchers with TryValues {
+class TokensCreatorSpec extends AnyWordSpec with IOSpec with MockFactory with should.Matchers {
 
   "create" should {
 
@@ -53,18 +52,18 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       "and the project path has not changed" in new TestCase {
 
         val encryptedToken = encryptedAccessTokens.generateOne
-        givenStoredTokenFinder(projectId, returning = OptionT.some[Try](encryptedToken))
+        givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
 
         val storedAccessToken = accessTokens.generateOne
-        givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[Try])
+        givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
 
-        givenTokenValidation(of = storedAccessToken, returning = true.pure[Try])
+        givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
 
         givenPathHasNotChanged(projectId, storedAccessToken)
 
-        givenTokenDueCheck(projectId, returning = false.pure[Try])
+        givenTokenDueCheck(projectId, returning = false.pure[IO])
 
-        tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+        tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
       }
 
     "replace the stored token when it's invalid" in new TestCase {
@@ -73,18 +72,18 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
 
       val projectAccessToken = projectAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[Try])
+      givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[IO])
 
-      givenTokenValidation(of = projectAccessToken, returning = false.pure[Try])
-      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[Try])
+      givenTokenValidation(of = projectAccessToken, returning = false.pure[IO])
+      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[IO])
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
       val tokenInfo = givenSuccessfulTokenCreation(projectPath)
       givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
     "leave the stored Access Token untouched but update the path if " +
@@ -92,22 +91,22 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       "but the path has changed" in new TestCase {
 
         val encryptedToken = encryptedAccessTokens.generateOne
-        givenStoredTokenFinder(projectId, returning = OptionT.some[Try](encryptedToken))
+        givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
 
         val projectAccessToken = projectAccessTokens.generateOne
-        givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[Try])
+        givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[IO])
 
-        givenTokenValidation(of = projectAccessToken, returning = true.pure[Try])
+        givenTokenValidation(of = projectAccessToken, returning = true.pure[IO])
 
         val newProjectPath = projectPaths.generateOne
-        givenPathFinder(projectId, projectAccessToken, OptionT.some[Try](newProjectPath))
-        givenStoredPathFinder(projectId, returning = projectPaths.generateOne.pure[Try])
+        givenPathFinder(projectId, projectAccessToken, OptionT.some[IO](newProjectPath))
+        givenStoredPathFinder(projectId, returning = projectPaths.generateOne.pure[IO])
 
-        givenPathUpdate(Project(projectId, newProjectPath), returning = ().pure[Try])
+        givenPathUpdate(Project(projectId, newProjectPath), returning = ().pure[IO])
 
-        givenTokenDueCheck(projectId, returning = false.pure[Try])
+        givenTokenDueCheck(projectId, returning = false.pure[IO])
 
-        tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+        tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
       }
 
     "replace the stored token if it's due for refresh" in new TestCase {
@@ -116,79 +115,79 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
 
       val storedAccessToken = projectAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[Try])
+      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
 
-      givenTokenValidation(of = storedAccessToken, returning = true.pure[Try])
+      givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
 
       givenPathHasNotChanged(projectId, storedAccessToken)
 
-      givenTokenDueCheck(projectId, returning = true.pure[Try])
+      givenTokenDueCheck(projectId, returning = true.pure[IO])
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
       val tokenInfo = givenSuccessfulTokenCreation(projectPath)
       givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
     "store a new Project Access Token if there's none stored" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
       val tokenInfo = givenSuccessfulTokenCreation(projectPath)
       givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
     "remove the stored token if project with the given id does not exist" in new TestCase {
 
       val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some[Try](encryptedToken))
+      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
 
       val storedToken = userAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[Try])
-      givenTokenValidation(storedToken, returning = false.pure[Try])
-      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[Try])
+      givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[IO])
+      givenTokenValidation(storedToken, returning = false.pure[IO])
+      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[IO])
 
-      givenTokenValidation(userAccessToken, returning = false.pure[Try])
+      givenTokenValidation(userAccessToken, returning = false.pure[IO])
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
     "do nothing if new token creation failed with NotFound or Forbidden" in new TestCase {
 
       val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some[Try](encryptedToken))
+      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
 
       val storedAccessToken = projectAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[Try])
+      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
 
-      givenTokenValidation(of = storedAccessToken, returning = true.pure[Try])
+      givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
 
       givenPathHasNotChanged(projectId, storedAccessToken)
 
-      givenTokenDueCheck(projectId, returning = true.pure[Try])
+      givenTokenDueCheck(projectId, returning = true.pure[IO])
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
       val newProjectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(newProjectPath))
 
       givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.none)
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
-    "retry if the token couldn't be decrypted after storing (token sanity check failed)" in new TestCase {
+    "reIO if the token couldn't be decrypted after storing (token sanity check failed)" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
 
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
@@ -197,31 +196,31 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
 
       val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[Try])
+      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
 
       givenTokenStoring(Project(projectId, projectPath),
                         newTokenEncrypted,
                         tokenCreationInfo.dates,
-                        returning = ().pure[Try]
+                        returning = ().pure[IO]
       ).twice()
 
       val invalidEncryptedAfterStoring = encryptedAccessTokens.generateOne
       givenStoredTokenFinder(projectId, returning = OptionT.some(invalidEncryptedAfterStoring))
       val exception = exceptions.generateOne
-      givenTokenDecryption(of = invalidEncryptedAfterStoring, returning = exception.raiseError[Try, AccessToken])
+      givenTokenDecryption(of = invalidEncryptedAfterStoring, returning = exception.raiseError[IO, AccessToken])
 
       givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
 
       givenSuccessfulTokensRevoking(projectId, tokenCreationInfo, userAccessToken)
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
-    "retry if the token after storing couldn't be found" in new TestCase {
+    "reIO if the token after storing couldn't be found" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
 
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
@@ -230,12 +229,12 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
 
       val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[Try])
+      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
 
       givenTokenStoring(Project(projectId, projectPath),
                         newTokenEncrypted,
                         tokenCreationInfo.dates,
-                        returning = ().pure[Try]
+                        returning = ().pure[IO]
       ).twice()
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
@@ -244,22 +243,27 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       givenSuccessfulTokensRevoking(projectId, tokenCreationInfo, userAccessToken)
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe ().pure[Try]
+      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
     }
 
     "fail if finding stored token fails" in new TestCase {
 
-      val exception = exceptions.generateOne.raiseError[Try, EncryptedAccessToken]
-      givenStoredTokenFinder(projectId, returning = OptionT.liftF(exception))
+      val exception = exceptions.generateOne
+      givenStoredTokenFinder(projectId, returning = OptionT.liftF(exception.raiseError[IO, EncryptedAccessToken]))
 
-      tokensCreator.create(projectId, userAccessToken) shouldBe exception
+      val ex =
+        intercept[Exception] {
+          tokensCreator.create(projectId, userAccessToken).unsafeRunSync()
+        }
+
+      ex shouldBe exception
     }
 
-    "fail if retry process hit the max number of attempts" in new TestCase {
+    "fail if reIO process hit the max number of attempts" in new TestCase {
 
       givenStoredTokenFinder(projectId, returning = OptionT.none)
 
-      givenTokenValidation(userAccessToken, returning = true.pure[Try])
+      givenTokenValidation(userAccessToken, returning = true.pure[IO])
 
       val projectPath = projectPaths.generateOne
       givenPathFinder(projectId, userAccessToken, returning = OptionT.some(projectPath))
@@ -268,21 +272,23 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
 
       val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[Try])
+      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
 
       givenTokenStoring(Project(projectId, projectPath),
                         newTokenEncrypted,
                         tokenCreationInfo.dates,
-                        returning = ().pure[Try]
+                        returning = ().pure[IO]
       ).repeated(3)
 
       givenStoredTokenFinder(projectId, returning = OptionT.none).repeated(3)
 
-      tokensCreator
-        .create(projectId, userAccessToken)
-        .failure
-        .exception
-        .getMessage shouldBe show"Token associator - just saved token cannot be found for project: $projectId"
+      val exception = intercept[Exception] {
+        tokensCreator
+          .create(projectId, userAccessToken)
+          .unsafeRunSync()
+      }
+
+      exception.getMessage shouldBe show"Token associator - just saved token cannot be found for project: $projectId"
     }
   }
 
@@ -290,19 +296,19 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     val projectId       = projectIds.generateOne
     val userAccessToken = userAccessTokens.generateOne
 
-    implicit val logger:    TestLogger[Try]         = TestLogger[Try]()
+    implicit val logger:    TestLogger[IO]          = TestLogger[IO]()
     private val maxRetries: Int Refined NonNegative = 2
-    private val projectPathFinder   = mock[ProjectPathFinder[Try]]
-    private val accessTokenCrypto   = mock[AccessTokenCrypto[Try]]
-    private val tokenValidator      = mock[TokenValidator[Try]]
-    private val tokenDueChecker     = mock[TokenDueChecker[Try]]
-    private val newTokensCreator    = mock[NewTokensCreator[Try]]
-    private val tokensPersister     = mock[TokensPersister[Try]]
-    private val persistedPathFinder = mock[PersistedPathFinder[Try]]
-    private val tokenRemover        = mock[TokenRemover[Try]]
-    private val tokensFinder        = mock[PersistedTokensFinder[Try]]
-    private val tokensRevoker       = mock[TokensRevoker[Try]]
-    val tokensCreator = new TokensCreatorImpl[Try](
+    private val projectPathFinder   = mock[ProjectPathFinder[IO]]
+    private val accessTokenCrypto   = mock[AccessTokenCrypto[IO]]
+    private val tokenValidator      = mock[TokenValidator[IO]]
+    private val tokenDueChecker     = mock[TokenDueChecker[IO]]
+    private val newTokensCreator    = mock[NewTokensCreator[IO]]
+    private val tokensPersister     = mock[TokensPersister[IO]]
+    private val persistedPathFinder = mock[PersistedPathFinder[IO]]
+    private val tokenRemover        = mock[TokenRemover[IO]]
+    private val tokensFinder        = mock[PersistedTokensFinder[IO]]
+    private val tokensRevoker       = mock[TokensRevoker[IO]]
+    val tokensCreator = new TokensCreatorImpl[IO](
       projectPathFinder,
       accessTokenCrypto,
       tokenValidator,
@@ -316,55 +322,53 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       maxRetries
     )
 
-    def givenStoredTokenFinder(projectId: projects.GitLabId, returning: OptionT[Try, EncryptedAccessToken]) =
+    def givenStoredTokenFinder(projectId: projects.GitLabId, returning: OptionT[IO, EncryptedAccessToken]) =
       (tokensFinder
         .findStoredToken(_: GitLabId))
         .expects(projectId)
         .returning(returning)
         .noMoreThanOnce()
 
-    def givenTokenDecryption(of: EncryptedAccessToken, returning: Try[AccessToken]) =
+    def givenTokenDecryption(of: EncryptedAccessToken, returning: IO[AccessToken]) =
       (accessTokenCrypto
         .decrypt(_: EncryptedAccessToken))
         .expects(of)
         .returning(returning)
 
-    def givenTokenEncryption(projectAccessToken: ProjectAccessToken, returning: Try[EncryptedAccessToken]) =
+    def givenTokenEncryption(projectAccessToken: ProjectAccessToken, returning: IO[EncryptedAccessToken]) =
       (accessTokenCrypto.encrypt _)
         .expects(projectAccessToken)
         .returning(returning)
 
-    def givenTokenValidation(of: AccessToken, returning: Try[Boolean]) =
+    def givenTokenValidation(of: AccessToken, returning: IO[Boolean]) =
       (tokenValidator.checkValid _)
         .expects(projectId, of)
         .returning(returning)
 
-    def givenTokenDueCheck(projectId: projects.GitLabId, returning: Try[Boolean]) =
+    def givenTokenDueCheck(projectId: projects.GitLabId, returning: IO[Boolean]) =
       (tokenDueChecker.checkTokenDue _)
         .expects(projectId)
         .returning(returning)
 
-    def givenStoredPathFinder(projectId: projects.GitLabId, returning: Try[projects.Path]) =
+    def givenStoredPathFinder(projectId: projects.GitLabId, returning: IO[projects.Path]) =
       (persistedPathFinder.findPersistedProjectPath _)
         .expects(projectId)
         .returning(returning)
 
-    def givenPathFinder(projectId:   projects.GitLabId,
-                        accessToken: AccessToken,
-                        returning:   OptionT[Try, projects.Path]
-    ) = (projectPathFinder.findProjectPath _)
-      .expects(projectId, accessToken)
-      .returning(returning)
+    def givenPathFinder(projectId: projects.GitLabId, accessToken: AccessToken, returning: OptionT[IO, projects.Path]) =
+      (projectPathFinder.findProjectPath _)
+        .expects(projectId, accessToken)
+        .returning(returning)
 
     def givenPathHasNotChanged(projectId: projects.GitLabId, accessToken: AccessToken) = {
       val projectPath = projectPaths.generateOne
-      givenPathFinder(projectId, accessToken, OptionT.some[Try](projectPath))
-      givenStoredPathFinder(projectId, returning = projectPath.pure[Try])
+      givenPathFinder(projectId, accessToken, OptionT.some[IO](projectPath))
+      givenStoredPathFinder(projectId, returning = projectPath.pure[IO])
     }
 
     def givenProjectTokenCreator(projectId:       projects.GitLabId,
                                  userAccessToken: UserAccessToken,
-                                 returning:       OptionT[Try, TokenCreationInfo]
+                                 returning:       OptionT[IO, TokenCreationInfo]
     ) = (newTokensCreator.createProjectAccessToken _)
       .expects(projectId, userAccessToken)
       .returning(returning)
@@ -372,17 +376,17 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     def givenTokenStoring(project:        Project,
                           encryptedToken: EncryptedAccessToken,
                           dates:          TokenDates,
-                          returning:      Try[Unit]
+                          returning:      IO[Unit]
     ) = (tokensPersister.persistToken _)
       .expects(TokenStoringInfo(project, encryptedToken, dates))
       .returning(returning)
 
-    def givenPathUpdate(project: Project, returning: Try[Unit]) =
+    def givenPathUpdate(project: Project, returning: IO[Unit]) =
       (tokensPersister.updatePath _)
         .expects(project)
         .returning(returning)
 
-    def givenTokenRemoval(projectId: projects.GitLabId, userAccessToken: UserAccessToken, returning: Try[Unit]) =
+    def givenTokenRemoval(projectId: projects.GitLabId, userAccessToken: UserAccessToken, returning: IO[Unit]) =
       (tokenRemover.delete _)
         .expects(projectId, userAccessToken.some)
         .returning(returning)
@@ -392,7 +396,7 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
                                   encryptedAccessToken: EncryptedAccessToken
     ) = {
       givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedAccessToken))
-      givenTokenDecryption(of = encryptedAccessToken, returning = token.pure[Try])
+      givenTokenDecryption(of = encryptedAccessToken, returning = token.pure[IO])
     }
 
     def givenSuccessfulTokenCreation(projectPath: projects.Path): TokenCreationInfo = {
@@ -401,12 +405,12 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
 
       val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[Try])
+      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
 
       givenTokenStoring(Project(projectId, projectPath),
                         newTokenEncrypted,
                         tokenCreationInfo.dates,
-                        returning = ().pure[Try]
+                        returning = ().pure[IO]
       )
 
       givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
@@ -419,6 +423,6 @@ class TokensCreatorSpec extends AnyWordSpec with MockFactory with should.Matcher
                                       accessToken: AccessToken
     ) = (tokensRevoker.revokeAllTokens _)
       .expects(projectId, tokenInfo.tokenId.some, accessToken)
-      .returning(().pure[Try])
+      .returning(().pure[IO])
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpointSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpointSpec.scala
@@ -136,7 +136,7 @@ class FetchTokenEndpointSpec extends AnyWordSpec with IOSpec with MockFactory wi
         .expects(projectId)
         .returning(OptionT(IO.raiseError[Option[AccessToken]](exception)))
 
-      val response = fetchToken(projectId).unsafeRunSync()
+      val response = endpoint.fetchToken(projectId).unsafeRunSync()
 
       response.status      shouldBe Status.InternalServerError
       response.contentType shouldBe Some(`Content-Type`(MediaType.application.json))

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/config/TriplesGenerationSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/config/TriplesGenerationSpec.scala
@@ -18,21 +18,22 @@
 
 package io.renku.triplesgenerator.config
 
+import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.config.TriplesGeneration._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters._
-import scala.util.{Success, Try}
 
-class TriplesGenerationSpec extends AnyWordSpec with should.Matchers {
+class TriplesGenerationSpec extends AnyWordSpec with IOSpec with should.Matchers {
 
   "apply" should {
 
     "return RenkuLog with the defaults from application.conf" in {
-      TriplesGeneration[Try]() shouldBe Success(RenkuLog)
+      TriplesGeneration[IO]().unsafeRunSync() shouldBe RenkuLog
     }
 
     "return RenkuLog if 'triples-generation' config value is set to 'renku-log'" in {
@@ -40,7 +41,7 @@ class TriplesGenerationSpec extends AnyWordSpec with should.Matchers {
         Map("triples-generation" -> "renku-log").asJava
       )
 
-      TriplesGeneration[Try](config) shouldBe Success(RenkuLog)
+      TriplesGeneration[IO](config).unsafeRunSync() shouldBe RenkuLog
     }
 
     "return an instance of RemoteTriplesGeneration if 'triples-generation' config value is set to 'remote-generator'" in {
@@ -49,9 +50,9 @@ class TriplesGenerationSpec extends AnyWordSpec with should.Matchers {
         Map("triples-generation" -> "remote-generator").asJava
       )
 
-      TriplesGeneration[Try](config) shouldBe Success(RemoteTriplesGeneration)
+      TriplesGeneration[IO](config).unsafeRunSync() shouldBe RemoteTriplesGeneration
     }
   }
 
-  private implicit val logger: TestLogger[Try] = TestLogger[Try]()
+  private implicit val logger: TestLogger[IO] = TestLogger[IO]()
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisionJudgeSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/reprovisioning/ReProvisionJudgeSpec.scala
@@ -18,6 +18,7 @@
 
 package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning
 
+import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators.microserviceBaseUrls
 import io.renku.generators.Generators.Implicits._
@@ -26,15 +27,14 @@ import io.renku.graph.model.versions.RenkuVersionPair
 import io.renku.http.client.ServiceHealthChecker
 import io.renku.interpreters.TestLogger
 import io.renku.microservices.{MicroserviceBaseUrl, MicroserviceUrlFinder}
+import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.config.VersionCompatibilityConfig
 import io.renku.triplesgenerator.generators.VersionGenerators._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class ReProvisionJudgeSpec extends AnyWordSpec with should.Matchers with MockFactory {
+class ReProvisionJudgeSpec extends AnyWordSpec with IOSpec with should.Matchers with MockFactory {
 
   "reProvisioningNeeded" should {
 
@@ -42,45 +42,45 @@ class ReProvisionJudgeSpec extends AnyWordSpec with should.Matchers with MockFac
       val compatConfig1 = compatibilityGen.generateOne.copy(reProvisioningNeeded = false)
       val compatConfig2 = compatibilityGen.suchThat(_ != compatConfig1).generateOne.asVersionPair
 
-      (versionPairFinder.find _).expects().returning(Try(compatConfig2.some))
-      (reProvisioningStatus.underReProvisioning _).expects().returning(false.pure[Try])
-      judge(compatConfig1).reProvisioningNeeded() shouldBe Try(false)
+      (versionPairFinder.find _).expects().returning(IO(compatConfig2.some))
+      (reProvisioningStatus.underReProvisioning _).expects().returning(false.pure[IO])
+      judge(compatConfig1).reProvisioningNeeded().unsafeRunSync() shouldBe false
     }
 
     "return false when versions match while re-provisioning-needed is set to true" in new TestCase {
       val compatConfig = compatibilityGen.generateOne.copy(reProvisioningNeeded = true)
-      (versionPairFinder.find _).expects().returning(Try(compatConfig.asVersionPair.some))
-      (reProvisioningStatus.underReProvisioning _).expects().returning(false.pure[Try])
-      judge(compatConfig).reProvisioningNeeded() shouldBe Try(false)
+      (versionPairFinder.find _).expects().returning(IO(compatConfig.asVersionPair.some))
+      (reProvisioningStatus.underReProvisioning _).expects().returning(false.pure[IO])
+      judge(compatConfig).reProvisioningNeeded().unsafeRunSync() shouldBe false
     }
 
     "return true when TS schema version cannot be found" in new TestCase {
-      (versionPairFinder.find _).expects().returning(Option.empty[RenkuVersionPair].pure[Try])
+      (versionPairFinder.find _).expects().returning(Option.empty[RenkuVersionPair].pure[IO])
 
-      judge(compatibilityGen.generateOne).reProvisioningNeeded() shouldBe true.pure[Try]
+      judge(compatibilityGen.generateOne).reProvisioningNeeded().unsafeRunSync() shouldBe true
     }
 
     "return true when TS schema version is different than the config schema version and re-provisioning-needed is true" in new TestCase {
       val tsVersionPair = renkuVersionPairs.generateOne
-      (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[Try])
+      (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[IO])
 
       val configVersionPairs = compatibilityGen
         .suchThat(_.schemaVersion != tsVersionPair.schemaVersion)
         .map(_.copy(reProvisioningNeeded = true))
 
-      judge(configVersionPairs.generateOne).reProvisioningNeeded() shouldBe true.pure[Try]
+      judge(configVersionPairs.generateOne).reProvisioningNeeded().unsafeRunSync() shouldBe true
     }
 
     "return false when TS schema version is the same as the config schema version " +
       "and there's no ongoing re-provisioning" in new TestCase {
         val tsVersionPair = renkuVersionPairs.generateOne
-        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[Try])
+        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[IO])
 
         val configVersion = VersionCompatibilityConfig(tsVersionPair, true)
 
-        (reProvisioningStatus.underReProvisioning _).expects().returning(false.pure[Try])
+        (reProvisioningStatus.underReProvisioning _).expects().returning(false.pure[IO])
 
-        judge(configVersion).reProvisioningNeeded() shouldBe false.pure[Try]
+        judge(configVersion).reProvisioningNeeded().unsafeRunSync() shouldBe false
       }
 
     "return false if schema and CLI version checks resolve to false " +
@@ -89,20 +89,20 @@ class ReProvisionJudgeSpec extends AnyWordSpec with should.Matchers with MockFac
       "and the service is up" in new TestCase {
 
         val tsVersionPair = renkuVersionPairs.generateOne
-        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[Try])
+        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[IO])
 
-        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[Try])
+        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[IO])
 
         val controller = microserviceBaseUrls.generateOne
-        (reProvisioningStatus.findReProvisioningService _).expects().returning(controller.some.pure[Try])
+        (reProvisioningStatus.findReProvisioningService _).expects().returning(controller.some.pure[IO])
 
-        (microserviceUrlFinder.findBaseUrl _).expects().returning(microserviceBaseUrls.generateOne.pure[Try])
+        (microserviceUrlFinder.findBaseUrl _).expects().returning(microserviceBaseUrls.generateOne.pure[IO])
 
-        (serviceHealthChecker.ping _).expects(controller).returning(true.pure[Try])
+        (serviceHealthChecker.ping _).expects(controller).returning(true.pure[IO])
 
         val matrixVersionPairs = VersionCompatibilityConfig(tsVersionPair, false)
 
-        judge(matrixVersionPairs).reProvisioningNeeded() shouldBe false.pure[Try]
+        judge(matrixVersionPairs).reProvisioningNeeded().unsafeRunSync() shouldBe false
       }
 
     "return true if schema and CLI version checks resolve to false " +
@@ -111,20 +111,20 @@ class ReProvisionJudgeSpec extends AnyWordSpec with should.Matchers with MockFac
       "and the service is down" in new TestCase {
 
         val tsVersionPair = renkuVersionPairs.generateOne
-        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[Try])
+        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[IO])
 
-        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[Try])
+        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[IO])
 
         val controller = microserviceBaseUrls.generateOne
-        (reProvisioningStatus.findReProvisioningService _).expects().returning(controller.some.pure[Try])
+        (reProvisioningStatus.findReProvisioningService _).expects().returning(controller.some.pure[IO])
 
-        (microserviceUrlFinder.findBaseUrl _).expects().returning(microserviceBaseUrls.generateOne.pure[Try])
+        (microserviceUrlFinder.findBaseUrl _).expects().returning(microserviceBaseUrls.generateOne.pure[IO])
 
-        (serviceHealthChecker.ping _).expects(controller).returning(false.pure[Try])
+        (serviceHealthChecker.ping _).expects(controller).returning(false.pure[IO])
 
         val configVersion = VersionCompatibilityConfig(tsVersionPair, false)
 
-        judge(configVersion).reProvisioningNeeded() shouldBe true.pure[Try]
+        judge(configVersion).reProvisioningNeeded().unsafeRunSync() shouldBe true
       }
 
     "return true if schema and CLI version checks resolve to false " +
@@ -132,18 +132,18 @@ class ReProvisionJudgeSpec extends AnyWordSpec with should.Matchers with MockFac
       "and the service running the process has the same url as this service" in new TestCase {
 
         val tsVersionPair = renkuVersionPairs.generateOne
-        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[Try])
+        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[IO])
 
-        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[Try])
+        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[IO])
 
         val controller = microserviceBaseUrls.generateOne
-        (reProvisioningStatus.findReProvisioningService _).expects().returning(controller.some.pure[Try])
+        (reProvisioningStatus.findReProvisioningService _).expects().returning(controller.some.pure[IO])
 
-        (microserviceUrlFinder.findBaseUrl _).expects().returning(controller.pure[Try])
+        (microserviceUrlFinder.findBaseUrl _).expects().returning(controller.pure[IO])
 
         val configVersion = VersionCompatibilityConfig(tsVersionPair, false)
 
-        judge(configVersion).reProvisioningNeeded() shouldBe true.pure[Try]
+        judge(configVersion).reProvisioningNeeded().unsafeRunSync() shouldBe true
       }
 
     "return true if schema and CLI version checks resolve to false " +
@@ -151,34 +151,35 @@ class ReProvisionJudgeSpec extends AnyWordSpec with should.Matchers with MockFac
       "and there's no info about service running the process" in new TestCase {
 
         val tsVersionPair = renkuVersionPairs.generateOne
-        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[Try])
+        (versionPairFinder.find _).expects().returning(tsVersionPair.some.pure[IO])
 
-        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[Try])
+        (reProvisioningStatus.underReProvisioning _).expects().returning(true.pure[IO])
 
         (reProvisioningStatus.findReProvisioningService _)
           .expects()
-          .returning(Option.empty[MicroserviceBaseUrl].pure[Try])
+          .returning(Option.empty[MicroserviceBaseUrl].pure[IO])
 
         val configVersion = VersionCompatibilityConfig(tsVersionPair, false)
 
-        judge(configVersion).reProvisioningNeeded() shouldBe true.pure[Try]
+        judge(configVersion).reProvisioningNeeded().unsafeRunSync() shouldBe true
       }
 
     "fail if finding the TS version pair fails" in new TestCase {
       val exception = exceptions.generateOne
-      (versionPairFinder.find _).expects().returning(exception.raiseError[Try, Option[RenkuVersionPair]])
+      (versionPairFinder.find _).expects().returning(exception.raiseError[IO, Option[RenkuVersionPair]])
 
-      judge(compatibilityGen.generateOne).reProvisioningNeeded() shouldBe exception
-        .raiseError[Try, Boolean]
+      intercept[Exception](
+        judge(compatibilityGen.generateOne).reProvisioningNeeded().unsafeRunSync()
+      ) shouldBe exception
     }
   }
 
   private trait TestCase {
-    implicit val logger: TestLogger[Try] = TestLogger[Try]()
-    val versionPairFinder     = mock[RenkuVersionPairFinder[Try]]
-    val reProvisioningStatus  = mock[ReProvisioningStatus[Try]]
-    val microserviceUrlFinder = mock[MicroserviceUrlFinder[Try]]
-    val serviceHealthChecker  = mock[ServiceHealthChecker[Try]]
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val versionPairFinder     = mock[RenkuVersionPairFinder[IO]]
+    val reProvisioningStatus  = mock[ReProvisioningStatus[IO]]
+    val microserviceUrlFinder = mock[MicroserviceUrlFinder[IO]]
+    val serviceHealthChecker  = mock[ServiceHealthChecker[IO]]
     def judge(compatibility: VersionCompatibilityConfig) = new ReProvisionJudgeImpl(versionPairFinder,
                                                                                     reProvisioningStatus,
                                                                                     microserviceUrlFinder,

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigrationSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/QueryBasedMigrationSpec.scala
@@ -22,6 +22,7 @@ package migrations.tooling
 import Generators._
 import QueryBasedMigration.EventData
 import cats.MonadThrow
+import cats.effect.IO
 import cats.syntax.all._
 import io.renku.events.EventRequestContent
 import io.renku.events.Generators._
@@ -31,19 +32,18 @@ import io.renku.generators.Generators.exceptions
 import io.renku.graph.model.GraphModelGenerators.projectPaths
 import io.renku.graph.model.projects
 import io.renku.interpreters.TestLogger
+import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.generators.ErrorGenerators._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.Matchers {
+class QueryBasedMigrationSpec extends AnyWordSpec with IOSpec with MockFactory with should.Matchers {
 
   "QueryBasedMigration" should {
 
     "be the RegisteredMigration" in new TestCase {
-      migration.getClass.getSuperclass shouldBe classOf[RegisteredMigration[Try]]
+      migration.getClass.getSuperclass shouldBe classOf[RegisteredMigration[IO]]
     }
   }
 
@@ -52,7 +52,7 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
     "run find records and send an event for each of the found projects" in new TestCase {
       val records = projectPaths.generateNonEmptyList().toList
 
-      (() => projectsFinder.findProjects).expects().returning(records.pure[Try])
+      (() => projectsFinder.findProjects).expects().returning(records.pure[IO])
 
       records foreach { record =>
         val event = eventRequestContentNoPayloads.generateOne
@@ -66,26 +66,26 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
                                             show"$categoryName: ${migration.name} cannot send event for $record"
                    )
           )
-          .returning(().pure[Try])
+          .returning(().pure[IO])
       }
 
-      migration.migrate().value shouldBe ().asRight.pure[Try]
+      migration.migrate().value.unsafeRunSync() shouldBe ().asRight
     }
 
     "return a Recoverable Error if in case of an exception while finding project " +
       "the given strategy returns one" in new TestCase {
         val exception = exceptions.generateOne
 
-        (() => projectsFinder.findProjects).expects().returning(exception.raiseError[Try, List[projects.Path]])
+        (() => projectsFinder.findProjects).expects().returning(exception.raiseError[IO, List[projects.Path]])
 
-        migration.migrate().value shouldBe recoverableError.asLeft.pure[Try]
+        migration.migrate().value.unsafeRunSync() shouldBe recoverableError.asLeft
       }
 
     "return a Recoverable Error if in case of an exception while sending events " +
       "the given strategy returns one" in new TestCase {
 
         val record = projectPaths.generateOne
-        (() => projectsFinder.findProjects).expects().returning(List(record).pure[Try])
+        (() => projectsFinder.findProjects).expects().returning(List(record).pure[IO])
 
         val event = eventRequestContentNoPayloads.generateOne
         eventProducer.expects(record).returning((record, event, eventCategoryName))
@@ -99,9 +99,9 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
                                      show"$categoryName: ${migration.name} cannot send event for $record"
             )
           )
-          .returning(exception.raiseError[Try, Unit])
+          .returning(exception.raiseError[IO, Unit])
 
-        migration.migrate().value shouldBe recoverableError.asLeft.pure[Try]
+        migration.migrate().value.unsafeRunSync() shouldBe recoverableError.asLeft
       }
   }
 
@@ -109,23 +109,23 @@ class QueryBasedMigrationSpec extends AnyWordSpec with MockFactory with should.M
 
     val eventCategoryName = categoryNames.generateOne
 
-    private implicit val logger: TestLogger[Try] = TestLogger[Try]()
-    val projectsFinder    = mock[ProjectsFinder[Try]]
+    private implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val projectsFinder    = mock[ProjectsFinder[IO]]
     val eventProducer     = mockFunction[projects.Path, EventData]
-    val eventSender       = mock[EventSender[Try]]
-    val executionRegister = mock[MigrationExecutionRegister[Try]]
+    val eventSender       = mock[EventSender[IO]]
+    val executionRegister = mock[MigrationExecutionRegister[IO]]
     val recoverableError  = processingRecoverableErrors.generateOne
     val recoveryStrategy = new RecoverableErrorsRecovery {
       override def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = { _ =>
         recoverableError.asLeft[OUT].pure[F]
       }
     }
-    val migration = new QueryBasedMigration[Try](migrationNames.generateOne,
-                                                 projectsFinder,
-                                                 eventProducer,
-                                                 eventSender,
-                                                 executionRegister,
-                                                 recoveryStrategy
+    val migration = new QueryBasedMigration[IO](migrationNames.generateOne,
+                                                projectsFinder,
+                                                eventProducer,
+                                                eventSender,
+                                                executionRegister,
+                                                recoveryStrategy
     )
   }
 }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -18,6 +18,7 @@
 
 package io.renku.webhookservice.hookvalidation
 
+import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
@@ -28,27 +29,25 @@ import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.AccessToken
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
+import io.renku.testtools.IOSpec
 import io.renku.webhookservice.WebhookServiceGenerators._
 import io.renku.webhookservice.hookvalidation.HookValidator.HookValidationResult.{HookExists, HookMissing}
 import io.renku.webhookservice.model.HookIdentifier
 import io.renku.webhookservice.tokenrepository.{AccessTokenAssociator, AccessTokenRemover}
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.TryValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.util.Try
-
-class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matchers with TryValues {
+class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matchers with IOSpec {
   import AccessTokenFinder.Implicits._
 
   "validateHook - finding access token" should {
 
     "return None if finding stored access token returns None when no access token given" in new TestCase {
 
-      givenAccessTokenFinding(returning = Option.empty[AccessToken].pure[Try])
+      givenAccessTokenFinding(returning = Option.empty[AccessToken].pure[IO])
 
-      validator.validateHook(projectId, maybeAccessToken = None) shouldBe None.pure[Try]
+      validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync() shouldBe None
 
       logger.expectNoLogs()
     }
@@ -56,14 +55,17 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "fail if finding stored access token fails and no access token given" in new TestCase {
 
       val exception = exceptions.generateOne
-      givenAccessTokenFinding(returning = exception.raiseError[Try, Option[AccessToken]])
+      givenAccessTokenFinding(returning = exception.raiseError[IO, Option[AccessToken]])
 
-      val result = validator.validateHook(projectId, maybeAccessToken = None)
+      val result =
+        intercept[Exception] {
+          validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync()
+        }
 
-      result.failure.exception.getMessage shouldBe show"Finding stored access token for $projectId failed"
-      result.failure.exception.getCause   shouldBe exception
+      result.getMessage shouldBe show"Finding stored access token for $projectId failed"
+      result.getCause   shouldBe exception
 
-      logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", result.failure.exception))
+      logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", result))
     }
   }
 
@@ -71,66 +73,66 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
     "re-associate access token and succeed with HookExists if there's a valid hook" in new TestCase {
 
-      givenTokenAssociation(givenAccessToken, returning = ().pure[Try])
+      givenTokenAssociation(givenAccessToken, returning = ().pure[IO])
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       givenHookVerification(HookIdentifier(projectId, projectHookUrl),
                             storedAccessToken,
-                            returning = true.some.pure[Try]
+                            returning = true.some.pure[IO]
       )
 
-      validator.validateHook(projectId, givenAccessToken.some) shouldBe HookExists.some.pure[Try]
+      validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync() shouldBe HookExists.some
 
       logger.expectNoLogs()
     }
 
     "re-associate access token, delete the access token and succeed with HookMissing if there's no hook" in new TestCase {
 
-      givenTokenAssociation(givenAccessToken, returning = ().pure[Try])
+      givenTokenAssociation(givenAccessToken, returning = ().pure[IO])
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       givenHookVerification(HookIdentifier(projectId, projectHookUrl),
                             storedAccessToken,
-                            returning = false.some.pure[Try]
+                            returning = false.some.pure[IO]
       )
 
-      givenTokenRemoving(givenAccessToken.some, returning = ().pure[Try])
+      givenTokenRemoving(givenAccessToken.some, returning = ().pure[IO])
 
-      validator.validateHook(projectId, givenAccessToken.some) shouldBe HookMissing.some.pure[Try]
+      validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync() shouldBe HookMissing.some
 
       logger.expectNoLogs()
     }
 
     "return None if hook verification cannot determine hook existence" in new TestCase {
 
-      givenTokenAssociation(givenAccessToken, returning = ().pure[Try])
+      givenTokenAssociation(givenAccessToken, returning = ().pure[IO])
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
-      givenHookVerification(HookIdentifier(projectId, projectHookUrl), storedAccessToken, returning = None.pure[Try])
+      givenHookVerification(HookIdentifier(projectId, projectHookUrl), storedAccessToken, returning = None.pure[IO])
 
-      validator.validateHook(projectId, givenAccessToken.some) shouldBe None.pure[Try]
+      validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync() shouldBe None
 
       logger.expectNoLogs()
     }
 
     "fail if hook verification step fails" in new TestCase {
 
-      givenTokenAssociation(givenAccessToken, returning = ().pure[Try])
+      givenTokenAssociation(givenAccessToken, returning = ().pure[IO])
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       val exception = exceptions.generateOne
-      val error     = exception.raiseError[Try, Nothing]
+      val error     = exception.raiseError[IO, Nothing]
       givenHookVerification(HookIdentifier(projectId, projectHookUrl), storedAccessToken, returning = error)
 
-      validator.validateHook(projectId, givenAccessToken.some) shouldBe error
+      intercept[Exception](validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync()) shouldBe exception
 
       logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", exception))
     }
@@ -138,31 +140,31 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "fail if access token re-association fails" in new TestCase {
 
       val exception = exceptions.generateOne
-      val error     = exception.raiseError[Try, Nothing]
+      val error     = exception.raiseError[IO, Nothing]
       givenTokenAssociation(givenAccessToken, returning = error)
 
-      validator.validateHook(projectId, givenAccessToken.some) shouldBe error
+      intercept[Exception](validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync()) shouldBe exception
 
       logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", exception))
     }
 
     "fail if access token removal fails" in new TestCase {
 
-      givenTokenAssociation(givenAccessToken, returning = ().pure[Try])
+      givenTokenAssociation(givenAccessToken, returning = ().pure[IO])
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       givenHookVerification(HookIdentifier(projectId, projectHookUrl),
                             storedAccessToken,
-                            returning = false.some.pure[Try]
+                            returning = false.some.pure[IO]
       )
 
       val exception = exceptions.generateOne
-      val error     = exception.raiseError[Try, Nothing]
+      val error     = exception.raiseError[IO, Nothing]
       givenTokenRemoving(givenAccessToken.some, returning = error)
 
-      validator.validateHook(projectId, givenAccessToken.some) shouldBe error
+      intercept[Exception](validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync()) shouldBe exception
 
       logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", exception))
     }
@@ -173,14 +175,14 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "succeed with HookExists if there's a hook" in new TestCase {
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       givenHookVerification(HookIdentifier(projectId, projectHookUrl),
                             storedAccessToken,
-                            returning = true.some.pure[Try]
+                            returning = true.some.pure[IO]
       )
 
-      validator.validateHook(projectId, maybeAccessToken = None) shouldBe HookExists.some.pure[Try]
+      validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync() shouldBe HookExists.some
 
       logger.expectNoLogs()
     }
@@ -188,16 +190,16 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "succeed with HookMissing and delete the stored access token if there's no hook" in new TestCase {
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       givenHookVerification(HookIdentifier(projectId, projectHookUrl),
                             storedAccessToken,
-                            returning = false.some.pure[Try]
+                            returning = false.some.pure[IO]
       )
 
-      givenTokenRemoving(accessToken = None, returning = ().pure[Try])
+      givenTokenRemoving(accessToken = None, returning = ().pure[IO])
 
-      validator.validateHook(projectId, maybeAccessToken = None) shouldBe HookMissing.some.pure[Try]
+      validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync() shouldBe HookMissing.some
 
       logger.expectNoLogs()
     }
@@ -205,11 +207,11 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "return None if hook verification cannot determine hook existence" in new TestCase {
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
-      givenHookVerification(HookIdentifier(projectId, projectHookUrl), storedAccessToken, returning = None.pure[Try])
+      givenHookVerification(HookIdentifier(projectId, projectHookUrl), storedAccessToken, returning = None.pure[IO])
 
-      validator.validateHook(projectId, maybeAccessToken = None) shouldBe None.pure[Try]
+      validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync() shouldBe None
 
       logger.expectNoLogs()
     }
@@ -217,13 +219,15 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "fail if verifying hook validity fails" in new TestCase {
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       val exception = exceptions.generateOne
-      val error     = exception.raiseError[Try, Nothing]
+      val error     = exception.raiseError[IO, Nothing]
       givenHookVerification(HookIdentifier(projectId, projectHookUrl), storedAccessToken, returning = error)
 
-      validator.validateHook(projectId, maybeAccessToken = None) shouldBe error
+      intercept[Exception](
+        validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync()
+      ) shouldBe exception
 
       logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", exception))
     }
@@ -231,18 +235,20 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     "fail if access token removal fails" in new TestCase {
 
       val storedAccessToken = accessTokens.generateOne
-      givenAccessTokenFinding(returning = storedAccessToken.some.pure[Try])
+      givenAccessTokenFinding(returning = storedAccessToken.some.pure[IO])
 
       givenHookVerification(HookIdentifier(projectId, projectHookUrl),
                             storedAccessToken,
-                            returning = false.some.pure[Try]
+                            returning = false.some.pure[IO]
       )
 
       val exception = exceptions.generateOne
-      val error     = exception.raiseError[Try, Nothing]
+      val error     = exception.raiseError[IO, Nothing]
       givenTokenRemoving(accessToken = None, returning = error)
 
-      validator.validateHook(projectId, maybeAccessToken = None) shouldBe error
+      intercept[Exception](
+        validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync()
+      ) shouldBe exception
 
       logger.loggedOnly(Error(s"Hook validation failed for projectId $projectId", exception))
     }
@@ -253,12 +259,12 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
     val projectHookUrl   = projectHookUrls.generateOne
     val projectId        = projectIds.generateOne
 
-    private val projectHookVerifier   = mock[ProjectHookVerifier[Try]]
-    private val accessTokenFinder     = mock[AccessTokenFinder[Try]]
-    private val accessTokenAssociator = mock[AccessTokenAssociator[Try]]
-    private val accessTokenRemover    = mock[AccessTokenRemover[Try]]
-    implicit val logger: TestLogger[Try] = TestLogger[Try]()
-    val validator = new HookValidatorImpl[Try](
+    private val projectHookVerifier   = mock[ProjectHookVerifier[IO]]
+    private val accessTokenFinder     = mock[AccessTokenFinder[IO]]
+    private val accessTokenAssociator = mock[AccessTokenAssociator[IO]]
+    private val accessTokenRemover    = mock[AccessTokenRemover[IO]]
+    implicit val logger: TestLogger[IO] = TestLogger[IO]()
+    val validator = new HookValidatorImpl[IO](
       projectHookUrl,
       projectHookVerifier,
       accessTokenFinder,
@@ -266,25 +272,25 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
       accessTokenRemover
     )
 
-    def givenAccessTokenFinding(returning: Try[Option[AccessToken]]) =
+    def givenAccessTokenFinding(returning: IO[Option[AccessToken]]) =
       (accessTokenFinder
         .findAccessToken(_: GitLabId)(_: GitLabId => String))
         .expects(projectId, projectIdToPath)
         .returning(returning)
 
-    def givenHookVerification(identifier: HookIdentifier, accessToken: AccessToken, returning: Try[Option[Boolean]]) =
+    def givenHookVerification(identifier: HookIdentifier, accessToken: AccessToken, returning: IO[Option[Boolean]]) =
       (projectHookVerifier
         .checkHookPresence(_: HookIdentifier, _: AccessToken))
         .expects(identifier, accessToken)
         .returning(returning)
 
-    def givenTokenAssociation(accessToken: AccessToken, returning: Try[Unit]) =
+    def givenTokenAssociation(accessToken: AccessToken, returning: IO[Unit]) =
       (accessTokenAssociator
         .associate(_: GitLabId, _: AccessToken))
         .expects(projectId, accessToken)
         .returning(returning)
 
-    def givenTokenRemoving(accessToken: Option[AccessToken], returning: Try[Unit]) =
+    def givenTokenRemoving(accessToken: Option[AccessToken], returning: IO[Unit]) =
       (accessTokenRemover.removeAccessToken _)
         .expects(projectId, accessToken)
         .returning(returning)


### PR DESCRIPTION
Makes the `TestLogger` log in the effect and not as a side effect. Same for measuring and logging execution times.

Closes: #1534 