### PR TITLE
feat: Add `slug` as a copy of `name` to remaining dataset api responses

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsApiEncoders.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsApiEncoders.scala
@@ -51,6 +51,7 @@ trait DatasetsApiEncoders extends ImageApiEncoders {
       },
       "title":  ${dataset.identification.title.value},
       "name":   ${dataset.identification.name.value},
+      "slug":   ${dataset.identification.name.value},
       "images": ${dataset.additionalInfo.images -> projectPath}
     }"""
       .deepMerge(
@@ -89,6 +90,7 @@ trait DatasetsApiEncoders extends ImageApiEncoders {
       "identifier":    ${actualIdentifier.value},
       "title":         ${dataset.identification.title.value},
       "name":          ${dataset.identification.name.value},
+      "slug":          ${dataset.identification.name.value},
       "published":     ${dataset.provenance.creators -> dataset.provenance.date},
       "date":          ${dataset.provenance.date.instant},
       "projectsCount": $projectsCount,

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -78,6 +78,7 @@ Response body example:
       "identifier": "9f94add6-6d68-4cf4-91d9-4ba9e6b7dc4c",
       "title":"rmDaYfpehl",
       "name": "mniouUnmal",
+      "slug": "mniouUnmal",      
       "description": "vbnqyyjmbiBQpubavGpxlconuqj",  // optional property
       "published": {
         "datePublished": "2012-10-14", // optional property
@@ -189,6 +190,7 @@ Response body example:
   },
   "title":       "dataset title",
   "name":        "dataset-name",
+  "slug":        "dataset-name",
   "url":         "http://host/url1",             // optional property
   "sameAs":      "http://host/url2",             // optional property when no "derivedFrom" exists
   "derivedFrom": "http://host/url1",             // optional property when no "sameAs" exists
@@ -378,7 +380,7 @@ Response body example:
           }
         ]
       }
-    ]    
+    ]
   },
   {
     "type":          "dataset",
@@ -690,12 +692,12 @@ Response body example for `Accept: application/json`:
     "jobArtifactsSize": 0
   },
   "version": "9",  // optional
-  "_links":[  
-    {  
+  "_links":[
+    {
       "rel": "self",
       "href":"http://t:5511/projects/namespace/project-name"
     },
-    {  
+    {
       "rel": "datasets",
       "href":"http://t:5511/projects/namespace/project-name/datasets"
     }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetSearchResult.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/DatasetSearchResult.scala
@@ -67,6 +67,7 @@ object DatasetSearchResult {
         "identifier":    $id,
         "title":         $title,
         "name":          $name,
+        "slug":          $name,
         "published":     ${creators -> date},
         "date":          ${date.instant},
         "projectsCount": $projectsCount,

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
@@ -103,6 +103,7 @@ private object Dataset {
       List(
         ("identifier" -> dataset.id.asJson).some,
         ("name" -> dataset.name.asJson).some,
+        ("slug" -> dataset.name.asJson).some,
         ("title" -> dataset.title.asJson).some,
         ("url" -> dataset.resourceId.asJson).some,
         dataset match {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetEncoder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/ProjectDatasetEncoder.scala
@@ -47,8 +47,9 @@ private object ProjectDatasetEncoder extends ImagesEncoder {
         "versions": {
           "initial": ${originalId.toString}
         },
-        "title":  ${title.toString},
-        "name":   ${name.toString},
+        "title":  ${title},
+        "name":   ${name},
+        "slug":   ${name},
         "images": ${images -> projectPath}
       }"""
         .deepMerge(sameAsOrDerived.asJson)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
@@ -160,6 +160,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
           "identifier":    $id,
           "title":         $title,
           "name":          $name,
+          "slug":          $name,
           "published":     ${creators -> date},
           "date":          ${date.instant},
           "projectsCount": ${projectsCount.value},

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/EndpointSpec.scala
@@ -130,6 +130,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
           },
           "title": $title,
           "name": $name,
+          "slug": $name,
           "sameAs": $sameAs,
           "images": $images,
           "_links": [{
@@ -151,6 +152,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
           },
           "title": $title,
           "name": $name,
+          "slug": $name,
           "derivedFrom": $derivedFrom,
           "images": $images,
           "_links": [{


### PR DESCRIPTION
Add a slug property as an intermediate step to change the value of `name` in dataset responses.

Closes #1544 