### PR TITLE
feat: Project Status API to send PROJECT_VIEWED_EVENT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,10 @@ lazy val webhookService = project
   .in(file("webhook-service"))
   .withId("webhook-service")
   .settings(commonSettings)
-  .dependsOn(eventLogApi % "compile->compile; test->test")
+  .dependsOn(
+    eventLogApi         % "compile->compile; test->test",
+    triplesGeneratorApi % "compile->compile; test->test"
+  )
   .enablePlugins(
     JavaAppPackaging,
     AutomateHeaderPlugin

--- a/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
+++ b/helm-chart/renku-graph/templates/webhook-service-deployment.yaml
@@ -45,6 +45,8 @@ spec:
                   key: webhookService-hookToken-secret
             - name: EVENT_LOG_BASE_URL
               value: "http://{{ template "eventLog.fullname" . }}:{{ .Values.eventLog.service.port }}"
+            - name: TRIPLES_GENERATOR_BASE_URL
+              value: "http://{{ template "triplesGenerator.fullname" . }}:{{ .Values.triplesGenerator.service.port }}"
             - name: TOKEN_REPOSITORY_BASE_URL
               value: "http://{{ template "tokenRepository.fullname" . }}:{{ .Values.tokenRepository.service.port }}"
             - name: GITLAB_BASE_URL

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -270,7 +270,7 @@ Response body example:
          }
       ]
     }
-  ],
+  ]
 }
 ```
 

--- a/webhook-service/src/main/resources/application.conf
+++ b/webhook-service/src/main/resources/application.conf
@@ -30,6 +30,11 @@ services {
     service = "webhook-service"
   }
 
+  triples-generator {
+    url = "http://localhost:9002"
+    url = ${?TRIPLES_GENERATOR_BASE_URL}
+  }
+
   token-repository {
     url = "http://localhost:9003"
     url = ${?TOKEN_REPOSITORY_BASE_URL}

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
@@ -79,7 +79,8 @@ private class EndpointImpl[F[_]: Async: NonEmptyParallel: Logger: ExecutionTimeR
 
   private def sendEvents(projectId: GitLabId, authUser: Option[AuthUser]): F[Unit] = Spawn[F].start {
     findProjectInfo(projectId)(authUser.map(_.accessToken)) >>= { project =>
-      (elClient send CommitSyncRequest(project)).handleErrorWith(Logger[F].warn(_)("Sending CommitSyncRequest failed")) >>
+      (elClient send CommitSyncRequest(project))
+        .handleErrorWith(Logger[F].warn(_)("Sending CommitSyncRequest failed")) >>
         (tgClient send ProjectViewedEvent.forProjectAndUserId(project.path, authUser.map(_.id)))
           .handleErrorWith(Logger[F].warn(_)("Sending ProjectViewedEvent failed"))
     }


### PR DESCRIPTION
This PR makes the Project Status API send a `PROJECT_VIEWED_EVENT` on top of the already sent `COMMIT_SYNC_REQUEST`. Additionally, the sending will be done in an asynchronous way.

closes #1474 