### PR TITLE
feat: avoid concurrent writes to jena

### DIFF
--- a/acceptance-tests/src/test/resources/application.conf
+++ b/acceptance-tests/src/test/resources/application.conf
@@ -47,10 +47,3 @@ services {
     api-url = "http://localhost:9004/knowledge-graph"
   }
 }
-
-projects-tokens {
-  db-port = 49998
-}
-triples-generator-db {
-  db-port = 49997
-}

--- a/acceptance-tests/src/test/resources/application.conf
+++ b/acceptance-tests/src/test/resources/application.conf
@@ -51,3 +51,6 @@ services {
 projects-tokens {
   db-port = 49998
 }
+triples-generator-db {
+  db-port = 49997
+}

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
@@ -86,7 +86,7 @@ class CommitHistoryChangesSpec
 
       sleep((10 seconds).toMillis)
 
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, newCommits.size)
 
       eventually {
         EventLog.findEvents(project.id, events.EventStatus.TriplesStore).toSet shouldBe newCommits.toList.toSet

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
@@ -86,7 +86,7 @@ class CommitHistoryChangesSpec
 
       sleep((10 seconds).toMillis)
 
-      `wait for events to be processed`(project.id, user.accessToken, newCommits.size)
+      `wait for events to be processed`(project.id, user.accessToken, 5)
 
       eventually {
         EventLog.findEvents(project.id, events.EventStatus.TriplesStore).toSet shouldBe newCommits.toList.toSet

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitSyncFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitSyncFlowsSpec.scala
@@ -69,7 +69,7 @@ class CommitSyncFlowsSpec extends AcceptanceSpec with ApplicationServices with T
         .status shouldBe Accepted
 
       And("relevant commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, 0)
 
       Then("the non missed events should be in the Triples Store")
       eventually {
@@ -83,7 +83,7 @@ class CommitSyncFlowsSpec extends AcceptanceSpec with ApplicationServices with T
       EventLog.forceCategoryEventTriggering(CategoryName("COMMIT_SYNC"), project.id)
 
       And("commit events for the missed event are created and processed")
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, 1)
 
       Then("triples for both of the project's commits should be in the Triples Store")
       eventually {

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitSyncFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitSyncFlowsSpec.scala
@@ -83,7 +83,7 @@ class CommitSyncFlowsSpec extends AcceptanceSpec with ApplicationServices with T
       EventLog.forceCategoryEventTriggering(CategoryName("COMMIT_SYNC"), project.id)
 
       And("commit events for the missed event are created and processed")
-      `wait for events to be processed`(project.id, user.accessToken, 1)
+      `wait for events to be processed`(project.id, user.accessToken, 5)
 
       Then("triples for both of the project's commits should be in the Triples Store")
       eventually {

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
@@ -59,7 +59,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
         .status shouldBe Accepted
 
       And("commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, 1)
 
       Then(s"all the events should get the $TriplesStore status in the Event Log")
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(TriplesStore)
@@ -89,7 +89,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
         .status shouldBe Accepted
 
       And("relevant commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, 1)
 
       And(s"all the events should get the $GenerationNonRecoverableFailure status in the Event Log")
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(GenerationNonRecoverableFailure)
@@ -151,7 +151,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
         .status shouldBe Accepted
 
       And("relevant commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, 1)
 
       Then(s"all the events should get the $TransformationNonRecoverableFailure status in the Event Log")
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(TransformationNonRecoverableFailure)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
@@ -59,7 +59,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
         .status shouldBe Accepted
 
       And("commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken, 1)
+      `wait for events to be processed`(project.id, user.accessToken, 5)
 
       Then(s"all the events should get the $TriplesStore status in the Event Log")
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(TriplesStore)
@@ -89,7 +89,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
         .status shouldBe Accepted
 
       And("relevant commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken, 1)
+      `wait for events to be processed`(project.id, user.accessToken, 5)
 
       And(s"all the events should get the $GenerationNonRecoverableFailure status in the Event Log")
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(GenerationNonRecoverableFailure)
@@ -151,7 +151,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
         .status shouldBe Accepted
 
       And("relevant commit events are processed")
-      `wait for events to be processed`(project.id, user.accessToken, 1)
+      `wait for events to be processed`(project.id, user.accessToken, 5)
 
       Then(s"all the events should get the $TransformationNonRecoverableFailure status in the Event Log")
       EventLog.findEvents(project.id).map(_._2).toSet shouldBe Set(TransformationNonRecoverableFailure)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectReProvisioningSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectReProvisioningSpec.scala
@@ -87,7 +87,7 @@ class ProjectReProvisioningSpec extends AcceptanceSpec with ApplicationServices 
 
       Then("the old data in the TS should be replaced with the new")
       sleep((10 seconds).toMillis)
-      `wait for events to be processed`(project.id, user.accessToken, 1)
+      `wait for events to be processed`(project.id, user.accessToken, 5)
 
       eventually {
         knowledgeGraphClient

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectReProvisioningSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectReProvisioningSpec.scala
@@ -87,7 +87,7 @@ class ProjectReProvisioningSpec extends AcceptanceSpec with ApplicationServices 
 
       Then("the old data in the TS should be replaced with the new")
       sleep((10 seconds).toMillis)
-      `wait for events to be processed`(project.id, user.accessToken)
+      `wait for events to be processed`(project.id, user.accessToken, 1)
 
       eventually {
         knowledgeGraphClient

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/PostgresDB.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/PostgresDB.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.acceptancetests.db
+
+import cats.effect._
+import com.dimafeng.testcontainers.FixedHostPortGenericContainer
+import eu.timepit.refined.auto._
+import io.renku.db.DBConfigProvider.DBConfig
+import io.renku.db.{PostgresContainer, SessionResource}
+import skunk.codec.all._
+import skunk.implicits._
+import skunk._
+import natchez.Trace.Implicits.noop
+import org.typelevel.log4cats.Logger
+import scala.concurrent.duration._
+
+object PostgresDB {
+  private[this] val starting: Ref[IO, Boolean] = Ref.unsafe[IO, Boolean](false)
+
+  private val dbConfig = DBConfig[Any](
+    host = "localhost",
+    port = 5432,
+    name = "postgres",
+    user = "at",
+    pass = "at",
+    connectionPool = 8
+  )
+
+  private val postgresContainer = {
+    val cfg = dbConfig
+    FixedHostPortGenericContainer(
+      imageName = PostgresContainer.image,
+      env = Map(
+        "POSTGRES_USER"     -> cfg.user.value,
+        "POSTGRES_PASSWORD" -> cfg.pass.value
+      ),
+      exposedPorts = Seq(cfg.port.value),
+      exposedHostPort = cfg.port.value,
+      exposedContainerPort = cfg.port.value,
+      command = Seq(s"-p ${cfg.port.value}")
+    )
+  }
+
+  def startPostgres(implicit L: Logger[IO]) =
+    starting.getAndUpdate(_ => true).flatMap {
+      case false =>
+        IO.unlessA(postgresContainer.container.isRunning)(
+          IO(postgresContainer.start()) *> waitForPostgres *> L.info(
+            "PostgreSQL database started"
+          )
+        )
+
+      case true =>
+        waitForPostgres
+    }
+
+  private def waitForPostgres =
+    fs2.Stream
+      .awakeDelay[IO](0.5.seconds)
+      .evalMap { _ =>
+        Session
+          .single[IO](
+            host = dbConfig.host,
+            port = dbConfig.port,
+            user = dbConfig.user.value,
+            password = Some(dbConfig.pass.value),
+            database = dbConfig.name.value
+          )
+          .use(_.unique(sql"SELECT 1".query(int4)))
+          .attempt
+      }
+      .map(_.fold(_ => 1, _ => 0))
+      .take(100)
+      .find(_ == 0)
+      .compile
+      .drain
+
+  def sessionPool(dbCfg: DBConfig[_]): Resource[IO, Resource[IO, Session[IO]]] =
+    Session
+      .pooled[IO](
+        host = postgresContainer.host,
+        port = dbConfig.port.value,
+        database = dbCfg.name.value,
+        user = dbCfg.user.value,
+        password = Some(dbCfg.pass.value),
+        max = dbConfig.connectionPool.value
+      )
+
+  def sessionPoolResource[A](dbCfg: DBConfig[_]): Resource[IO, SessionResource[IO, A]] =
+    sessionPool(dbCfg).map(new SessionResource[IO, A](_))
+
+  def initializeDatabase(cfg: DBConfig[_]): IO[Unit] = {
+    val session = Session.single[IO](
+      host = dbConfig.host,
+      port = dbConfig.port,
+      user = dbConfig.user.value,
+      password = Some(dbConfig.pass.value),
+      database = dbConfig.name.value
+    )
+
+    // note: it would be simpler to use the default user that is created with the container, but that requires
+    // to first refactor how the configuration is loaded. Currently services load it from the file every time and so
+    // this creates the users as expected from the given config
+    val createRole: Command[Void] =
+      sql"create role #${cfg.user.value} with password '#${cfg.pass.value}' superuser login".command
+    val createDatabase: Command[Void] = sql"create database  #${cfg.name.value}".command
+    val grants:         Command[Void] = sql"grant all on database #${cfg.name.value} to #${cfg.user.value}".command
+
+    session.use { s =>
+      s.execute(createRole) *>
+        s.execute(createDatabase) *>
+        s.execute(grants)
+    }.void
+  }
+}

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/TriplesStore.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/TriplesStore.scala
@@ -20,15 +20,12 @@ package io.renku.graph.acceptancetests.db
 
 import cats.effect.{IO, Resource, Temporal}
 import cats.{Applicative, Monad}
-import com.dimafeng.testcontainers.FixedHostPortGenericContainer
 import eu.timepit.refined.auto._
-import io.renku.db.{DBConfigProvider, PostgresContainer}
+import io.renku.db.DBConfigProvider
 import io.renku.triplesgenerator.TgLockDB.SessionResource
 import io.renku.triplesgenerator.{TgLockDB, TgLockDbConfigProvider}
 import io.renku.triplesstore._
-import natchez.Trace.Implicits.noop
 import org.typelevel.log4cats.Logger
-import skunk.Session
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -37,37 +34,16 @@ object TriplesStore extends InMemoryJena with ProjectsDataset with MigrationsDat
 
   protected override val jenaRunMode: JenaRunMode = JenaRunMode.FixedPortContainer(3030)
 
-  private lazy val dbConfig: DBConfigProvider.DBConfig[TgLockDB] =
+  private val dbConfig: DBConfigProvider.DBConfig[TgLockDB] =
     new TgLockDbConfigProvider[Try].get().fold(throw _, identity)
 
-  private lazy val postgresContainer = FixedHostPortGenericContainer(
-    imageName = PostgresContainer.image,
-    env = Map(
-      "POSTGRES_USER"     -> dbConfig.user.value,
-      "POSTGRES_PASSWORD" -> dbConfig.pass.value,
-      "POSTGRES_DB"       -> dbConfig.name.value
-    ),
-    exposedPorts = Seq(dbConfig.port.value),
-    exposedHostPort = dbConfig.port.value,
-    exposedContainerPort = dbConfig.port.value,
-    command = Seq(s"-p ${dbConfig.port.value}")
-  )
-
   lazy val sessionResource: Resource[IO, SessionResource[IO]] =
-    Session
-      .pooled[IO](
-        host = postgresContainer.host,
-        port = dbConfig.port.value,
-        database = dbConfig.name.value,
-        user = dbConfig.user.value,
-        password = Some(dbConfig.pass.value),
-        max = dbConfig.connectionPool.value
-      )
-      .map(new SessionResource(_))
+    PostgresDB.sessionPoolResource(dbConfig)
 
   def start()(implicit logger: Logger[IO]): IO[Unit] = for {
     _ <- Applicative[IO].unlessA(isRunning)(IO(container.start()))
-    _ <- Applicative[IO].unlessA(postgresContainer.container.isRunning)(IO(postgresContainer.start()))
+    _ <- PostgresDB.startPostgres
+    _ <- PostgresDB.initializeDatabase(dbConfig)
     _ <- waitForReadiness
     _ <- logger.info("Triples Store started")
   } yield ()

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/flows/TSProvisioning.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/flows/TSProvisioning.scala
@@ -74,15 +74,20 @@ trait TSProvisioning
       sleep((5 seconds).toMillis)
     }
 
-    `wait for events to be processed`(project.id, accessToken)
+    `wait for events to be processed`(project.id, accessToken, commitIds.size)
   }
 
-  def `wait for events to be processed`(projectId: projects.GitLabId, accessToken: AccessToken): Assertion =
+  def `wait for events to be processed`(
+      projectId:    projects.GitLabId,
+      accessToken:  AccessToken,
+      expectedDone: Int
+  ): Assertion =
     eventually {
       val response = webhookServiceClient.`GET projects/:id/events/status`(projectId, accessToken)
       response.status                                                                          shouldBe Ok
       response.jsonBody.hcursor.downField("activated").as[Boolean].value                       shouldBe true
       response.jsonBody.hcursor.downField("progress").downField("percentage").as[Double].value shouldBe 100d
+      response.jsonBody.hcursor.downField("progress").downField("total").as[Int].value         shouldBe expectedDone
     }
 
   def `check hook cannot be found`(projectId: projects.GitLabId, accessToken: AccessToken): Assertion = eventually {

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/flows/TSProvisioning.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/flows/TSProvisioning.scala
@@ -75,22 +75,20 @@ trait TSProvisioning
       sleep((5 seconds).toMillis)
     }
 
-    val items = eventLogClient.getEvents(project.id.asLeft).unsafeRunSync().size
-
-    `wait for events to be processed`(project.id, accessToken, math.min(0, items))
+    `wait for events to be processed`(project.id, accessToken, 5)
   }
 
   def `wait for events to be processed`(
-      projectId:    projects.GitLabId,
-      accessToken:  AccessToken,
-      expectedDone: Int
+      projectId:        projects.GitLabId,
+      accessToken:      AccessToken,
+      expectedMinTotal: Int
   ): Assertion =
     eventually {
       val response = webhookServiceClient.`GET projects/:id/events/status`(projectId, accessToken)
       response.status                                                                          shouldBe Ok
       response.jsonBody.hcursor.downField("activated").as[Boolean].value                       shouldBe true
       response.jsonBody.hcursor.downField("progress").downField("percentage").as[Double].value shouldBe 100d
-      response.jsonBody.hcursor.downField("progress").downField("total").as[Int].value should be >= expectedDone
+      response.jsonBody.hcursor.downField("progress").downField("total").as[Int].value should be >= expectedMinTotal
     }
 
   def `check hook cannot be found`(projectId: projects.GitLabId, accessToken: AccessToken): Assertion = eventually {

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
@@ -492,7 +492,7 @@ class DatasetsResourcesSpec
       gitLabStub.setupProject(project, commitId)
       mockCommitDataOnTripleGenerator(project, toPayloadJsonLD(project), commitId)
       `data in the Triples Store`(project, commitId, creator.accessToken)
-      `wait for events to be processed`(project.id, creator.accessToken, 1)
+      `wait for events to be processed`(project.id, creator.accessToken, 5)
 
       When("an authenticated and authorised user fetches dataset details through GET knowledge-graph/datasets/:id")
       val detailsResponse =

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/DatasetsResourcesSpec.scala
@@ -492,7 +492,7 @@ class DatasetsResourcesSpec
       gitLabStub.setupProject(project, commitId)
       mockCommitDataOnTripleGenerator(project, toPayloadJsonLD(project), commitId)
       `data in the Triples Store`(project, commitId, creator.accessToken)
-      `wait for events to be processed`(project.id, creator.accessToken)
+      `wait for events to be processed`(project.id, creator.accessToken, 1)
 
       When("an authenticated and authorised user fetches dataset details through GET knowledge-graph/datasets/:id")
       val detailsResponse =

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/testing/AcceptanceTestPatience.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/testing/AcceptanceTestPatience.scala
@@ -24,7 +24,7 @@ import org.scalatest.time.{Minutes, Second, Span}
 trait AcceptanceTestPatience extends AbstractPatienceConfiguration {
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(
-    timeout = scaled(Span(4, Minutes)),
+    timeout = scaled(Span(6, Minutes)),
     interval = scaled(Span(1, Second))
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -177,6 +177,13 @@ lazy val triplesGenerator = project
   .in(file("triples-generator"))
   .withId("triples-generator")
   .settings(commonSettings)
+  .settings(
+    reStart / envVars := Map(
+      "JENA_RENKU_PASSWORD" -> "renku",
+      "JENA_ADMIN_PASSWORD" -> "renku",
+      "RENKU_URL"           -> "http://localhost:3000"
+    )
+  )
   .dependsOn(
     triplesGeneratorApi % "compile->compile; test->test",
     entitiesSearch,

--- a/graph-commons/src/main/scala/io/renku/db/SessionResource.scala
+++ b/graph-commons/src/main/scala/io/renku/db/SessionResource.scala
@@ -37,6 +37,8 @@ class SessionResource[F[_]: MonadCancelThrow, TargetDB](resource: Resource[F, Se
   ): F[ResultType] = resource.use { session =>
     session.transaction.use(transaction => query.run((transaction, session)))
   }
+
+  val session: Resource[F, Session[F]] = resource
 }
 
 object SessionPoolResource {

--- a/graph-commons/src/main/scala/io/renku/lock/Lock.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/Lock.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.lock
+
+import cats.Functor
+import cats.data.Kleisli
+import cats.effect._
+import cats.effect.std.Mutex
+import cats.syntax.all._
+import fs2.Stream
+
+import scala.concurrent.duration.FiniteDuration
+
+object Lock {
+
+  def none[F[_], A]: Lock[F, A] =
+    Kleisli(_ => Resource.unit)
+
+  def global[F[_]: Async, A]: F[Lock[F, A]] =
+    Mutex[F].map(mutex => Kleisli(_ => mutex.lock))
+
+  def memory[F[_]: Async, A]: F[Lock[F, A]] =
+    memory0[F, A].map(_._2)
+
+  private[lock] def memory0[F[_]: Async, A]: F[(Ref[F, Map[A, Mutex[F]]], Lock[F, A])] =
+    Ref.of[F, Map[A, Mutex[F]]](Map.empty[A, Mutex[F]]).map { data =>
+      def set(k: A) =
+        Resource.eval(Mutex[F]).flatMap { newMutex =>
+          val next =
+            Resource.eval(
+              data.updateAndGet(m =>
+                m.updatedWith(k) {
+                  case r @ Some(_) => r
+                  case None        => Some(newMutex)
+                }
+              )
+            )
+
+          next.flatMap(_(k).lock.onFinalize(data.update(_.removed(k))))
+        }
+
+      (data, Kleisli(set))
+    }
+
+  def create[F[_]: Temporal, A](acquire: Kleisli[F, A, Boolean], interval: FiniteDuration)(
+      release: Kleisli[F, A, Unit]
+  ): Lock[F, A] = {
+    val acq: Kleisli[F, A, Unit] = Kleisli { key =>
+      (Stream.eval(acquire.run(key)) ++ Stream.sleep(interval).drain).repeat
+        .find(_ == true)
+        .compile
+        .drain
+    }
+
+    from(acq)(release)
+  }
+
+  def from[F[_]: Functor, A](acquire: Kleisli[F, A, Unit])(release: Kleisli[F, A, Unit]): Lock[F, A] =
+    Kleisli(key => Resource.make(acquire.run(key))(_ => release.run(key)))
+}

--- a/graph-commons/src/main/scala/io/renku/lock/LongKey.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/LongKey.scala
@@ -18,9 +18,13 @@
 
 package io.renku.lock
 
-trait LongKey[A] {
+import scala.util.hashing.MurmurHash3
+
+trait LongKey[A] { self =>
   def asLong(a: A): Long
 
+  def contramap[B](f: B => A): LongKey[B] =
+    LongKey.create(b => self.asLong(f(b)))
 }
 
 object LongKey {
@@ -34,4 +38,7 @@ object LongKey {
 
   implicit val forInt: LongKey[Int] =
     create(_.toLong)
+
+  implicit val forString: LongKey[String] =
+    forInt.contramap(MurmurHash3.stringHash)
 }

--- a/graph-commons/src/main/scala/io/renku/lock/LongKey.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/LongKey.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.lock
+
+trait LongKey[A] {
+  def asLong(a: A): Long
+
+}
+
+object LongKey {
+  def apply[A](implicit lk: LongKey[A]): LongKey[A] = lk
+
+  def create[A](f: A => Long): LongKey[A] =
+    (a: A) => f(a)
+
+  implicit val forLong: LongKey[Long] =
+    create(identity)
+
+  implicit val forInt: LongKey[Int] =
+    create(_.toLong)
+}

--- a/graph-commons/src/main/scala/io/renku/lock/LongKey.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/LongKey.scala
@@ -18,6 +18,7 @@
 
 package io.renku.lock
 
+import io.renku.graph.model.entities.Project
 import io.renku.graph.model.projects
 
 import scala.util.hashing.MurmurHash3
@@ -46,4 +47,7 @@ object LongKey {
 
   implicit val forProjectPath: LongKey[projects.Path] =
     forString.contramap(_.value)
+
+  implicit val forProject: LongKey[Project] =
+    forProjectPath.contramap(_.path)
 }

--- a/graph-commons/src/main/scala/io/renku/lock/PostgresLock.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/PostgresLock.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.lock
+
+import cats.Functor
+import cats.data.Kleisli
+import cats.effect._
+import cats.syntax.all._
+import skunk._
+import skunk.codec.all._
+import skunk.implicits._
+
+import scala.concurrent.duration.FiniteDuration
+
+object PostgresLock {
+
+  def apply[F[_]: Temporal, A: LongKey](session: Session[F], interval: FiniteDuration): Lock[F, A] = {
+    def acq(n: Long): F[Boolean] =
+      session.unique(tryAcquireSql)(n)
+
+    def rel(n: Long): F[Unit] =
+      session.unique(releaseSql)(n).void
+
+    val conv = LongKey[A]
+
+    Lock
+      .create(Kleisli(acq), interval)(Kleisli(rel))
+      .local(conv.asLong)
+  }
+
+  def blocking[F[_]: Functor, A: LongKey](session: Session[F]): Lock[F, A] = {
+    def acq(n: Long): F[Unit] =
+      session.unique(acquireSql)(n).void
+
+    def rel(n: Long): F[Unit] =
+      session.unique(releaseSql)(n).void
+
+    val conv = LongKey[A]
+
+    Lock
+      .from(Kleisli(acq))(Kleisli(rel))
+      .local(conv.asLong)
+  }
+
+  // ???
+  implicit val voidDecoder: Decoder[Void] =
+    Codec.simple[Void](_ => "null", _ => Right(Void), skunk.data.Type.void)
+
+  private def tryAcquireSql: Query[Long, Boolean] =
+    sql"SELECT pg_try_advisory_lock($int8)".query(bool)
+
+  private def acquireSql: Query[Long, Void] =
+    sql"SELECT pg_advisory_lock($int8)".query(voidDecoder)
+
+  private def releaseSql: Query[Long, Boolean] =
+    sql"SELECT pg_unlock_advisory_lock($int8)".query(bool)
+}

--- a/graph-commons/src/main/scala/io/renku/lock/PostgresLock.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/PostgresLock.scala
@@ -26,48 +26,81 @@ import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
+/** Uses postgres' per session advisory locks. It requires the key to be of type bigint, so callers must provide
+ * a `LongKey` instance to do the conversion. 
+ */
 object PostgresLock {
 
-  def apply[F[_]: Temporal, A: LongKey](session: Session[F], interval: FiniteDuration): Lock[F, A] = {
+  /** Obtains an exclusive lock, retrying periodically via non-blocking waits */
+  def exclusive[F[_]: Temporal, A: LongKey](session: Session[F], interval: FiniteDuration = 0.5.seconds): Lock[F, A] =
+    createPolling[F, A](session, interval, tryAdvisoryLockSql, advisoryUnlockSql)
+
+  /** Obtains a shared lock, retrying periodically via non-blocking waits. */
+  def shared[F[_]: Temporal, A: LongKey](session: Session[F], interval: FiniteDuration = 0.5.seconds): Lock[F, A] =
+    createPolling(session, interval, tryAdvisoryLockSharedSql, advisoryUnlockSharedSql)
+
+  /** Obtains an exclusive lock, blocking the current thread until it becomes available. */
+  def exclusiveBlocking[F[_]: Functor, A: LongKey](session: Session[F]): Lock[F, A] =
+    createBlocking(session, advisoryLockSql, advisoryUnlockSql)
+
+  /** Obtains a shared lock, blocking the current thread until it becomes available. */
+  def sharedBlocking[F[_]: Functor, A: LongKey](session: Session[F]): Lock[F, A] =
+    createBlocking(session, advisoryLockSharedSql, advisoryUnlockSharedSql)
+
+  private def createPolling[F[_]: Temporal, A: LongKey](
+      session:   Session[F],
+      interval:  FiniteDuration,
+      lockSql:   Query[Long, Boolean],
+      unlockSql: Query[Long, Boolean]
+  ): Lock[F, A] = {
     def acq(n: Long): F[Boolean] =
-      session.unique(tryAcquireSql)(n)
+      session.unique(lockSql)(n)
 
     def rel(n: Long): F[Unit] =
-      session.unique(releaseSql)(n).void
-
-    val conv = LongKey[A]
+      session.unique(unlockSql)(n).void
 
     Lock
       .create(Kleisli(acq), interval)(Kleisli(rel))
-      .local(conv.asLong)
+      .local(LongKey[A].asLong)
   }
 
-  def blocking[F[_]: Functor, A: LongKey](session: Session[F]): Lock[F, A] = {
+  private def createBlocking[F[_]: Functor, A: LongKey](
+      session:   Session[F],
+      lockSql:   Query[Long, Void],
+      unlockSql: Query[Long, Boolean]
+  ): Lock[F, A] = {
     def acq(n: Long): F[Unit] =
-      session.unique(acquireSql)(n).void
+      session.unique(lockSql)(n).void
 
     def rel(n: Long): F[Unit] =
-      session.unique(releaseSql)(n).void
-
-    val conv = LongKey[A]
+      session.unique(unlockSql)(n).void
 
     Lock
       .from(Kleisli(acq))(Kleisli(rel))
-      .local(conv.asLong)
+      .local(LongKey[A].asLong)
   }
 
-  // ???
-  implicit val voidDecoder: Decoder[Void] =
+  // how to avoid that boilerplate???
+  implicit val void: Codec[Void] =
     Codec.simple[Void](_ => "null", _ => Right(Void), skunk.data.Type.void)
 
-  private def tryAcquireSql: Query[Long, Boolean] =
+  private def tryAdvisoryLockSql: Query[Long, Boolean] =
     sql"SELECT pg_try_advisory_lock($int8)".query(bool)
 
-  private def acquireSql: Query[Long, Void] =
-    sql"SELECT pg_advisory_lock($int8)".query(voidDecoder)
+  private def tryAdvisoryLockSharedSql: Query[Long, Boolean] =
+    sql"SELECT pg_try_advisory_lock_shared($int8)".query(bool)
 
-  private def releaseSql: Query[Long, Boolean] =
-    sql"SELECT pg_unlock_advisory_lock($int8)".query(bool)
+  private def advisoryLockSql: Query[Long, Void] =
+    sql"SELECT pg_advisory_lock($int8)".query(void)
+
+  private def advisoryLockSharedSql: Query[Long, Void] =
+    sql"SELECT pg_advisory_lock_shared($int8)".query(void)
+
+  private def advisoryUnlockSql: Query[Long, Boolean] =
+    sql"SELECT  pg_advisory_unlock($int8)".query(bool)
+
+  private def advisoryUnlockSharedSql: Query[Long, Boolean] =
+    sql"SELECT pg_advisory_unlock_shared($int8)".query(bool)
 }

--- a/graph-commons/src/main/scala/io/renku/lock/PostgresLock.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/PostgresLock.scala
@@ -18,67 +18,52 @@
 
 package io.renku.lock
 
-import cats.Functor
 import cats.data.Kleisli
 import cats.effect._
 import cats.syntax.all._
+import org.typelevel.log4cats.Logger
 import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 
 import scala.concurrent.duration._
 
-/** Uses postgres' per session advisory locks. It requires the key to be of type bigint, so callers must provide
- * a `LongKey` instance to do the conversion. 
+/** Uses postgres' per session advisory locks. It requires the key to be of type bigint, so
+ *  callers must provide a `LongKey` instance to do the conversion.
  */
 object PostgresLock {
 
   /** Obtains an exclusive lock, retrying periodically via non-blocking waits */
-  def exclusive[F[_]: Temporal, A: LongKey](session: Session[F], interval: FiniteDuration = 0.5.seconds): Lock[F, A] =
+  def exclusive[F[_]: Temporal: Logger, A: LongKey](
+      session:  Session[F],
+      interval: FiniteDuration = 0.5.seconds
+  ): Lock[F, A] =
     createPolling[F, A](session, interval, tryAdvisoryLockSql, advisoryUnlockSql)
 
   /** Obtains a shared lock, retrying periodically via non-blocking waits. */
-  def shared[F[_]: Temporal, A: LongKey](session: Session[F], interval: FiniteDuration = 0.5.seconds): Lock[F, A] =
+  def shared[F[_]: Temporal: Logger, A: LongKey](
+      session:  Session[F],
+      interval: FiniteDuration = 0.5.seconds
+  ): Lock[F, A] =
     createPolling(session, interval, tryAdvisoryLockSharedSql, advisoryUnlockSharedSql)
 
-  /** Obtains an exclusive lock, blocking the current thread until it becomes available. */
-  def exclusiveBlocking[F[_]: Functor, A: LongKey](session: Session[F]): Lock[F, A] =
-    createBlocking(session, advisoryLockSql, advisoryUnlockSql)
-
-  /** Obtains a shared lock, blocking the current thread until it becomes available. */
-  def sharedBlocking[F[_]: Functor, A: LongKey](session: Session[F]): Lock[F, A] =
-    createBlocking(session, advisoryLockSharedSql, advisoryUnlockSharedSql)
-
-  private def createPolling[F[_]: Temporal, A: LongKey](
+  private def createPolling[F[_]: Temporal: Logger, A: LongKey](
       session:   Session[F],
       interval:  FiniteDuration,
       lockSql:   Query[Long, Boolean],
       unlockSql: Query[Long, Boolean]
   ): Lock[F, A] = {
     def acq(n: Long): F[Boolean] =
-      session.unique(lockSql)(n)
+      session.unique(lockSql)(n).attempt.flatMap {
+        case Right(v) => v.pure[F]
+        case Left(ex) => Logger[F].warn(ex)(s"Acquiring postgres advisory lock failed! Retry in $interval.").as(false)
+      }
 
     def rel(n: Long): F[Unit] =
       session.unique(unlockSql)(n).void
 
     Lock
       .create(Kleisli(acq), interval)(Kleisli(rel))
-      .local(LongKey[A].asLong)
-  }
-
-  private def createBlocking[F[_]: Functor, A: LongKey](
-      session:   Session[F],
-      lockSql:   Query[Long, Void],
-      unlockSql: Query[Long, Boolean]
-  ): Lock[F, A] = {
-    def acq(n: Long): F[Unit] =
-      session.unique(lockSql)(n).void
-
-    def rel(n: Long): F[Unit] =
-      session.unique(unlockSql)(n).void
-
-    Lock
-      .from(Kleisli(acq))(Kleisli(rel))
       .local(LongKey[A].asLong)
   }
 
@@ -91,12 +76,6 @@ object PostgresLock {
 
   private def tryAdvisoryLockSharedSql: Query[Long, Boolean] =
     sql"SELECT pg_try_advisory_lock_shared($int8)".query(bool)
-
-  private def advisoryLockSql: Query[Long, Void] =
-    sql"SELECT pg_advisory_lock($int8)".query(void)
-
-  private def advisoryLockSharedSql: Query[Long, Void] =
-    sql"SELECT pg_advisory_lock_shared($int8)".query(void)
 
   private def advisoryUnlockSql: Query[Long, Boolean] =
     sql"SELECT  pg_advisory_unlock($int8)".query(bool)

--- a/graph-commons/src/main/scala/io/renku/lock/PostgresLockStats.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/PostgresLockStats.scala
@@ -51,10 +51,10 @@ object PostgresLockStats {
     session.execute(createTable).void
 
   def recordWaiting[F[_]: MonadCancelThrow](session: Session[F])(key: Long): F[Unit] =
-    session.transaction.use(_ => session.execute(upsertWaiting)(key).void)
+    session.execute(upsertWaiting)(key).void
 
   def removeWaiting[F[_]: MonadCancelThrow](session: Session[F])(key: Long): F[Unit] =
-    session.transaction.use(_ => session.execute(deleteWaiting)(key).void)
+    session.execute(deleteWaiting)(key).void
 
   private val countCurrentLocks: Query[Void, Long] =
     sql"""
@@ -90,5 +90,5 @@ object PostgresLockStats {
          """.command
 
   private val deleteWaiting: Command[Long] =
-    sql"""DELETE FROM kg_lock_stats WHERE obj_id = $int8""".command
+    sql"""DELETE FROM kg_lock_stats WHERE obj_id = $int8 AND sess_id = pg_backend_pid()""".command
 }

--- a/graph-commons/src/main/scala/io/renku/lock/package.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku
+
+import cats.data.Kleisli
+import cats.effect._
+
+package object lock {
+
+  type Lock[F[_], A] = Kleisli[Resource[F, *], A, Unit]
+
+}

--- a/graph-commons/src/main/scala/io/renku/lock/package.scala
+++ b/graph-commons/src/main/scala/io/renku/lock/package.scala
@@ -25,4 +25,13 @@ package object lock {
 
   type Lock[F[_], A] = Kleisli[Resource[F, *], A, Unit]
 
+  object syntax {
+    final implicit class LockSyntax[F[_], A](self: Lock[F, A]) {
+      def surround[B](fa: A => F[B])(implicit F: MonadCancelThrow[F]): A => F[B] =
+        a => self(a).surround(fa(a))
+
+      def surround[B](k: Kleisli[F, A, B])(implicit F: MonadCancelThrow[F]): Kleisli[F, A, B] =
+        Kleisli(surround(k.run))
+    }
+  }
 }

--- a/graph-commons/src/main/scala/io/renku/metrics/Histogram.scala
+++ b/graph-commons/src/main/scala/io/renku/metrics/Histogram.scala
@@ -67,6 +67,7 @@ class SingleValueHistogramImpl[F[_]: MonadThrow](val name: String Refined NonEmp
 
 trait LabeledHistogram[F[_]] extends Histogram[F] {
   def startTimer(labelValue: String): F[Histogram.Timer[F]]
+  def observe(labelValue:    String, amt: Double): F[Unit]
 }
 
 object LabeledHistogram {
@@ -116,6 +117,11 @@ class LabeledHistogramImpl[F[_]: MonadThrow](val name: String Refined NonEmpty,
       .create()
 
   private val maybeThresholdMillis = maybeThreshold.map(_.toMillis.toDouble)
+
+  def observe(labelValue: String, amt: Double): F[Unit] =
+    MonadThrow[F].catchNonFatal {
+      wrappedCollector.labels(labelValue).observe(amt)
+    }
 
   override def startTimer(labelValue: String): F[Histogram.Timer[F]] = MonadThrow[F].catchNonFatal {
     maybeThresholdMillis match {

--- a/graph-commons/src/test/scala/io/renku/lock/MemoryLockSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/MemoryLockSpec.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.lock
 
 import cats.effect._
@@ -21,12 +39,12 @@ class MemoryLockSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers
         result <- Ref.of[IO, List[FiniteDuration]](Nil)
         update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
 
-        lock  <- Lock.memory[IO]
+        lock  <- Lock.memory[IO, Int]
         latch <- CountDownLatch[IO](1)
 
-        f1 <- Async[IO].start(latch.await *> lock(Key.global).use(_ => update))
-        f2 <- Async[IO].start(latch.await *> lock(Key.global).use(_ => update))
-        f3 <- Async[IO].start(latch.await *> lock(Key.global).use(_ => update))
+        f1 <- Async[IO].start(latch.await *> lock(1).use(_ => update))
+        f2 <- Async[IO].start(latch.await *> lock(1).use(_ => update))
+        f3 <- Async[IO].start(latch.await *> lock(1).use(_ => update))
 
         _ <- latch.release
         _ <- List(f1, f2, f3).traverse_(_.join)
@@ -41,12 +59,12 @@ class MemoryLockSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers
         result <- Ref.of[IO, List[FiniteDuration]](Nil)
         update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
 
-        lock  <- Lock.memory[IO]
+        lock  <- Lock.memory[IO, Int]
         latch <- CountDownLatch[IO](1)
 
-        f1 <- Async[IO].start(latch.await *> lock(new Key {}).use(_ => update))
-        f2 <- Async[IO].start(latch.await *> lock(new Key {}).use(_ => update))
-        f3 <- Async[IO].start(latch.await *> lock(new Key {}).use(_ => update))
+        f1 <- Async[IO].start(latch.await *> lock(1).use(_ => update))
+        f2 <- Async[IO].start(latch.await *> lock(2).use(_ => update))
+        f3 <- Async[IO].start(latch.await *> lock(3).use(_ => update))
         _  <- latch.release
         _  <- List(f1, f2, f3).traverse_(_.join)
 
@@ -58,14 +76,14 @@ class MemoryLockSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers
 
   "remove mutexes on release" in {
     for {
-      (state, lock) <- Lock.memory0[IO]
+      (state, lock) <- Lock.memory0[IO, Int]
       latch         <- CountDownLatch[IO](1)
 
       // initial state is empty
       _ <- state.get.asserting(_ shouldBe empty)
 
       // one mutex if active
-      _ <- Async[IO].start(lock(Key.global).use(_ => latch.await))
+      _ <- Async[IO].start(lock(1).use(_ => latch.await))
       _ <- state.get.asserting(_.size shouldBe 1)
 
       // once released, mutex must be removed from map

--- a/graph-commons/src/test/scala/io/renku/lock/MemoryLockSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/MemoryLockSpec.scala
@@ -1,0 +1,76 @@
+package io.renku.lock
+
+import cats.effect._
+import cats.effect.std.CountDownLatch
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AsyncWordSpec
+
+import scala.concurrent.duration._
+
+class MemoryLockSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers {
+
+  def debug(m: String): IO[Unit] =
+    IO.realTimeInstant.map(t => s"$t : $m").flatMap(IO.println)
+
+  "memory lock" should {
+
+    "sequentially on same key" in {
+      for {
+        result <- Ref.of[IO, List[FiniteDuration]](Nil)
+        update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+
+        lock  <- Lock.memory[IO]
+        latch <- CountDownLatch[IO](1)
+
+        f1 <- Async[IO].start(latch.await *> lock(Key.global).use(_ => update))
+        f2 <- Async[IO].start(latch.await *> lock(Key.global).use(_ => update))
+        f3 <- Async[IO].start(latch.await *> lock(Key.global).use(_ => update))
+
+        _ <- latch.release
+        _ <- List(f1, f2, f3).traverse_(_.join)
+
+        diff <- result.get.map(list => list.max - list.min)
+        _ = diff should be >= 400.millis
+      } yield ()
+    }
+
+    "parallel on different key" in {
+      for {
+        result <- Ref.of[IO, List[FiniteDuration]](Nil)
+        update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+
+        lock  <- Lock.memory[IO]
+        latch <- CountDownLatch[IO](1)
+
+        f1 <- Async[IO].start(latch.await *> lock(new Key {}).use(_ => update))
+        f2 <- Async[IO].start(latch.await *> lock(new Key {}).use(_ => update))
+        f3 <- Async[IO].start(latch.await *> lock(new Key {}).use(_ => update))
+        _  <- latch.release
+        _  <- List(f1, f2, f3).traverse_(_.join)
+
+        diff <- result.get.map(list => list.max - list.min)
+        _ = diff should be < 300.millis
+      } yield ()
+    }
+  }
+
+  "remove mutexes on release" in {
+    for {
+      (state, lock) <- Lock.memory0[IO]
+      latch         <- CountDownLatch[IO](1)
+
+      // initial state is empty
+      _ <- state.get.asserting(_ shouldBe empty)
+
+      // one mutex if active
+      _ <- Async[IO].start(lock(Key.global).use(_ => latch.await))
+      _ <- state.get.asserting(_.size shouldBe 1)
+
+      // once released, mutex must be removed from map
+      _ <- latch.release
+      _ <- state.get.asserting(_ shouldBe empty)
+    } yield ()
+  }
+}

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockSpec.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.lock
+
+import cats.effect._
+import cats.effect.std.CountDownLatch
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import io.renku.db.PostgresContainer
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AsyncWordSpec
+import skunk.Session
+import natchez.Trace.Implicits.noop
+
+import scala.concurrent.duration._
+
+class PostgresLockSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers with TestContainerForAll {
+
+  override val containerDef = PostgreSQLContainer.Def(
+    dockerImageName = PostgresContainer.imageName,
+    databaseName = "locktest",
+    username = "pg",
+    password = "pg"
+  )
+
+  def session(c: Containers): Resource[IO, Session[IO]] =
+    Session.single[IO](
+      host = c.host,
+      port = c.underlyingUnsafeContainer.getFirstMappedPort,
+      user = c.username,
+      database = c.databaseName,
+      password = Some(c.password)
+    )
+
+  "PostgresLock.exclusiveBlocking" should {
+
+    "sequentially on same key" in withContainers { cnt =>
+      def makeLock = session(cnt).map(PostgresLock.exclusiveBlocking[IO, String])
+
+      (makeLock, makeLock, makeLock).tupled.use { case (l1, l2, l3) =>
+        for {
+          result <- Ref.of[IO, List[FiniteDuration]](Nil)
+          update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+          latch <- CountDownLatch[IO](1)
+
+          f1 <- Async[IO].start(latch.await *> l1("p1").use(_ => update))
+          f2 <- Async[IO].start(latch.await *> l2("p1").use(_ => update))
+          f3 <- Async[IO].start(latch.await *> l3("p1").use(_ => update))
+
+          _ <- latch.release
+          _ <- List(f1, f2, f3).traverse_(_.join)
+
+          diff <- result.get.map(list => list.max - list.min)
+          _ = diff should be >= 400.millis
+        } yield ()
+      }
+    }
+
+    "parallel on different key" in withContainers { cnt =>
+      def makeLock = session(cnt).map(PostgresLock.exclusiveBlocking[IO, String])
+
+      (makeLock, makeLock, makeLock).tupled.use { case (l1, l2, l3) =>
+        for {
+          result <- Ref.of[IO, List[FiniteDuration]](Nil)
+          update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+          latch <- CountDownLatch[IO](1)
+
+          f1 <- Async[IO].start(latch.await *> l1("p1").use(_ => update))
+          f2 <- Async[IO].start(latch.await *> l2("p2").use(_ => update))
+          f3 <- Async[IO].start(latch.await *> l3("p3").use(_ => update))
+
+          _ <- latch.release
+          _ <- List(f1, f2, f3).traverse_(_.join)
+
+          diff <- result.get.map(list => list.max - list.min)
+          _ = diff should be < 300.millis
+        } yield ()
+      }
+    }
+  }
+
+  "PostgresLock.exclusivePolling" should {
+    val pollInterval = 100.millis
+
+    "sequentially on same key" in withContainers { cnt =>
+      def makeLock = session(cnt).map(PostgresLock.exclusive[IO, String](_, pollInterval))
+
+      (makeLock, makeLock, makeLock).tupled.use { case (l1, l2, l3) =>
+        for {
+          result <- Ref.of[IO, List[FiniteDuration]](Nil)
+          update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+          latch <- CountDownLatch[IO](1)
+
+          f1 <- Async[IO].start(latch.await *> l1("p1").use(_ => update))
+          f2 <- Async[IO].start(latch.await *> l2("p1").use(_ => update))
+          f3 <- Async[IO].start(latch.await *> l3("p1").use(_ => update))
+
+          _ <- latch.release
+          _ <- List(f1, f2, f3).traverse_(_.join)
+
+          diff <- result.get.map(list => list.max - list.min)
+          _ = diff should be >= 400.millis
+        } yield ()
+      }
+    }
+
+    "parallel on different key" in withContainers { cnt =>
+      def makeLock = session(cnt).map(PostgresLock.exclusive[IO, String](_))
+
+      (makeLock, makeLock, makeLock).tupled.use { case (l1, l2, l3) =>
+        for {
+          result <- Ref.of[IO, List[FiniteDuration]](Nil)
+          update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+          latch <- CountDownLatch[IO](1)
+
+          f1 <- Async[IO].start(latch.await *> l1("p1").use(_ => update))
+          f2 <- Async[IO].start(latch.await *> l2("p2").use(_ => update))
+          f3 <- Async[IO].start(latch.await *> l3("p3").use(_ => update))
+
+          _ <- latch.release
+          _ <- List(f1, f2, f3).traverse_(_.join)
+
+          diff <- result.get.map(list => list.max - list.min)
+          _ = diff should be < 300.millis
+        } yield ()
+      }
+    }
+  }
+
+  "PostgresLock.shared" should {
+    "allow multiple shared locks" in withContainers { cnt =>
+      def makeLock = session(cnt).map(PostgresLock.shared[IO, String](_))
+
+      (makeLock, makeLock, makeLock).tupled.use { case (l1, l2, l3) =>
+        for {
+          result <- Ref.of[IO, List[FiniteDuration]](Nil)
+          update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+          latch <- CountDownLatch[IO](1)
+
+          f1 <- Async[IO].start(latch.await *> l1("p1").use(_ => update))
+          f2 <- Async[IO].start(latch.await *> l2("p1").use(_ => update))
+          f3 <- Async[IO].start(latch.await *> l3("p1").use(_ => update))
+
+          _ <- latch.release
+          _ <- List(f1, f2, f3).traverse_(_.join)
+
+          diff <- result.get.map(list => list.max - list.min)
+          _ = diff should be < 300.millis
+        } yield ()
+      }
+    }
+  }
+  "PostgresLock.sharedBlocking" should {
+    "allow multiple shared locks" in withContainers { cnt =>
+      def makeLock = session(cnt).map(PostgresLock.sharedBlocking[IO, String])
+
+      (makeLock, makeLock, makeLock).tupled.use { case (l1, l2, l3) =>
+        for {
+          result <- Ref.of[IO, List[FiniteDuration]](Nil)
+          update = IO.sleep(200.millis) *> IO.realTime.flatMap(time => result.update(time :: _))
+          latch <- CountDownLatch[IO](1)
+
+          f1 <- Async[IO].start(latch.await *> l1("p1").use(_ => update))
+          f2 <- Async[IO].start(latch.await *> l2("p1").use(_ => update))
+          f3 <- Async[IO].start(latch.await *> l3("p1").use(_ => update))
+
+          _ <- latch.release
+          _ <- List(f1, f2, f3).traverse_(_.join)
+
+          diff <- result.get.map(list => list.max - list.min)
+          _ = diff should be < 300.millis
+        } yield ()
+      }
+    }
+  }
+}

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockStatsSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockStatsSpec.scala
@@ -1,23 +1,107 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.lock
 
 import cats.effect._
 import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import io.renku.interpreters.TestLogger
+import io.renku.lock.PostgresLockStats.{Stats, Waiting}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AsyncWordSpec
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
+import java.time.{Duration, OffsetDateTime}
 
 class PostgresLockStatsSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers with PostgresLockTest {
+  implicit val logger: Logger[IO] = TestLogger[IO]()
 
   "PostgresLockStats" should {
     "obtain empty statistics" in withContainers { cnt =>
-      session(cnt).use(PostgresLockStats.getStats[IO]).asserting(_ shouldBe Nil)
+      session(cnt).use { s =>
+        for {
+          _     <- PostgresLockStats.ensureStatsTable(s)
+          stats <- PostgresLockStats.getStats[IO](s)
+          _ = stats shouldBe Stats(0, Nil)
+        } yield ()
+      }
     }
 
     "show when a lock is held" in withContainers { cnt =>
-      IO.unit
+      session(cnt).use { s =>
+        for {
+          _            <- PostgresLockStats.ensureStatsTable(s)
+          (_, release) <- PostgresLock.exclusive[IO, Int](s).run(1).allocated
+          stats        <- PostgresLockStats.getStats(s)
+          _            <- release
+          _ = stats shouldBe Stats(1, Nil)
+        } yield ()
+      }
+    }
+
+    "insert waiting info" in withContainers { cnt =>
+      session(cnt).use { s =>
+        for {
+          _     <- PostgresLockStats.ensureStatsTable(s)
+          _     <- PostgresLockStats.recordWaiting(s)(5L)
+          stats <- PostgresLockStats.getStats(s)
+          _ = stats.currentLocks shouldBe 0
+          _ = stats.waiting.size shouldBe 1
+
+          _      <- PostgresLockStats.recordWaiting(s)(5L)
+          stats2 <- PostgresLockStats.getStats(s)
+          _ = stats shouldBe stats2.copy(waiting =
+                stats2.waiting.map(_.copy(waitDuration = stats.waiting.head.waitDuration))
+              )
+        } yield ()
+      }
+    }
+
+    "remove waiting info" in withContainers { cnt =>
+      session(cnt).use { s =>
+        for {
+          _     <- PostgresLockStats.ensureStatsTable(s)
+          _     <- PostgresLockStats.recordWaiting(s)(5L)
+          _     <- PostgresLockStats.removeWaiting(s)(5L)
+          stats <- PostgresLockStats.getStats(s)
+          _ = stats shouldBe Stats(0, Nil)
+        } yield ()
+      }
     }
 
     "show when a session is waiting for a lock" in withContainers { cnt =>
-      IO.unit
+      (session(cnt), session(cnt)).tupled.use { case (s1, _) =>
+        for { // ???
+          _            <- IO.print("***** TEST START")
+          _            <- PostgresLockStats.ensureStatsTable(s1)
+          (_, release) <- PostgresLock.exclusive[IO, Int](s1).run(1).allocated
+          // fiber        <- Async[IO].start(PostgresLock.exclusive[IO, Int](s2).run(1).allocated)
+          _     <- IO.sleep(10.millis)
+          _     <- IO.println("GET STATS")
+          stats <- PostgresLockStats.getStats(s1)
+          _     <- release
+          // _            <- fiber.join
+          _ <- IO.print("***** TEST END")
+          _ = stats shouldBe Stats(1, List(Waiting(1, 2, OffsetDateTime.now(), Duration.ZERO)))
+        } yield ()
+      }
     }
   }
 }

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockStatsSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockStatsSpec.scala
@@ -1,0 +1,23 @@
+package io.renku.lock
+
+import cats.effect._
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AsyncWordSpec
+
+class PostgresLockStatsSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers with PostgresLockTest {
+
+  "PostgresLockStats" should {
+    "obtain empty statistics" in withContainers { cnt =>
+      session(cnt).use(PostgresLockStats.getStats[IO]).asserting(_ shouldBe Nil)
+    }
+
+    "show when a lock is held" in withContainers { cnt =>
+      IO.unit
+    }
+
+    "show when a session is waiting for a lock" in withContainers { cnt =>
+      IO.unit
+    }
+  }
+}

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockStatsSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockStatsSpec.scala
@@ -45,7 +45,7 @@ class PostgresLockStatsSpec extends AsyncWordSpec with AsyncIOSpec with should.M
       session(cnt).use { s =>
         for {
           _            <- resetLockTable(s)
-          (_, release) <- PostgresLock.exclusive[IO, Int](s).run(1).allocated
+          (_, release) <- PostgresLock.exclusive_[IO, Int](s).run(1).allocated
           stats        <- PostgresLockStats.getStats(s)
           _            <- release
           _ = stats shouldBe Stats(1, Nil)

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockTest.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockTest.scala
@@ -49,13 +49,13 @@ trait PostgresLockTest extends TestContainerForAll { self: Suite =>
     )
 
   def makeExclusiveLock(s: Session[IO], interval: FiniteDuration = 100.millis)(implicit L: Logger[IO]) =
-    PostgresLock.exclusive[IO, String](s, interval)
+    PostgresLock.exclusive_[IO, String](s, interval)
 
   def exclusiveLock(cnt: Containers, interval: FiniteDuration = 100.millis)(implicit L: Logger[IO]) =
-    session(cnt).map(makeExclusiveLock(_, interval))
+    PostgresLock.exclusive[IO, String](session(cnt), interval)
 
   def sharedLock(cnt: Containers, interval: FiniteDuration = 100.millis)(implicit L: Logger[IO]) =
-    session(cnt).map(PostgresLock.shared[IO, String](_, interval))
+    PostgresLock.shared[IO, String](session(cnt), interval)
 
   def resetLockTable(s: Session[IO]) =
     PostgresLockStats.ensureStatsTable[IO](s) *>

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockTest.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockTest.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.lock
 
 import cats.effect._

--- a/graph-commons/src/test/scala/io/renku/lock/PostgresLockTest.scala
+++ b/graph-commons/src/test/scala/io/renku/lock/PostgresLockTest.scala
@@ -1,0 +1,37 @@
+package io.renku.lock
+
+import cats.effect._
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import io.renku.db.PostgresContainer
+import org.scalatest.Suite
+import skunk.Session
+import natchez.Trace.Implicits.noop
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
+
+trait PostgresLockTest extends TestContainerForAll { self: Suite =>
+
+  override val containerDef = PostgreSQLContainer.Def(
+    dockerImageName = PostgresContainer.imageName,
+    databaseName = "locktest",
+    username = "pg",
+    password = "pg"
+  )
+
+  def session(c: Containers): Resource[IO, Session[IO]] =
+    Session.single[IO](
+      host = c.host,
+      port = c.underlyingUnsafeContainer.getFirstMappedPort,
+      user = c.username,
+      database = c.databaseName,
+      password = Some(c.password)
+    )
+
+  def exclusiveLock(cnt: Containers, interval: FiniteDuration = 100.millis)(implicit L: Logger[IO]) =
+    session(cnt).map(PostgresLock.exclusive[IO, String](_, interval))
+
+  def sharedLock(cnt: Containers, interval: FiniteDuration = 100.millis)(implicit L: Logger[IO]) =
+    session(cnt).map(PostgresLock.shared[IO, String](_, interval))
+}

--- a/graph-commons/src/test/scala/io/renku/logging/ExecutionTimeRecorderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/logging/ExecutionTimeRecorderSpec.scala
@@ -122,6 +122,7 @@ class ExecutionTimeRecorderSpec
           labelValue shouldBe "label"
           mock[Histogram.Timer[IO]].pure[IO]
         }
+        override def observe(labelValue: String, amt: Double): IO[Unit] = ???
       }
 
       override val executionTimeRecorder = new ExecutionTimeRecorderImpl(loggingThreshold, Some(histogram))

--- a/graph-commons/src/test/scala/io/renku/metrics/HistogramSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/HistogramSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.metrics
 
 import cats.syntax.all._
+import eu.timepit.refined.auto._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.metrics.MetricsTools._
@@ -64,6 +65,14 @@ class SingleValueHistogramSpec extends AnyWordSpec with MockFactory with should.
 
       (observedDuration * 1000)              should be > simulatedDuration.toMillis.toDouble
       underlying.collectAllSamples.last._3 shouldBe 1d
+    }
+  }
+
+  "observe" should {
+    "call the underlying impl" in new TestCase {
+      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1))
+      histogram.observe("label", 101d)
+      histogram.wrappedCollector.labels("label").get().sum shouldBe 101d
     }
   }
 

--- a/graph-commons/src/test/scala/io/renku/metrics/TestLabeledHistogram.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/TestLabeledHistogram.scala
@@ -64,6 +64,11 @@ class TestLabeledHistogram(labelName: String) extends LabeledHistogram[IO] with 
   override def startTimer(labelValue: String): IO[Histogram.Timer[IO]] = IO {
     new LabeledHistogram.NoThresholdTimerImpl[IO](wrappedCollector.labels(labelValue).startTimer())
   }
+
+  override def observe(labelValue: String, amt: Double): IO[Unit] =
+    IO {
+      wrappedCollector.labels(labelValue).observe(amt)
+    }
 }
 
 object TestLabeledHistogram {

--- a/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-deployment.yaml
@@ -64,6 +64,23 @@ spec:
                 secretKeyRef:
                   name: {{ template "jena.fullname" . }}
                   key: jena-users-renku-password
+            - name: TRIPLES_GENERATOR_POSTGRES_HOST
+              value: "{{ template "postgresql.fullname" . }}"
+            - name: TRIPLES_GENERATOR_POSTGRES_PORT
+              value: "5432"
+            - name: TRIPLES_GENERATOR_POSTGRES_USER
+              value: {{ .Values.global.graph.triplesGenerator.postgresUser }}
+            - name: TRIPLES_GENERATOR_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+{{- if .Values.global.graph.triplesGenerator.existingSecret }}
+                  name: {{ tpl .Values.global.graph.triplesGenerator.existingSecret . }}
+{{- else }}
+                  name: {{ template "triplesGenerator.fullname" . }}-postgres
+{{- end }}
+                  key: graph-triplesGenerator-postgresPassword
+            - name: TRIPLES_GENERATOR_POSTGRES_CONNECTION_POOL
+              value: "{{ .Values.triplesGenerator.connectionPool }}"
             - name: RENKU_DISABLE_VERSION_CHECK
               value: "true"
             - name: SENTRY_ENABLED

--- a/helm-chart/renku-graph/templates/triples-generator-postgres-secret.yaml
+++ b/helm-chart/renku-graph/templates/triples-generator-postgres-secret.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.global.graph.triplesGenerator.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "triplesGenerator.fullname" . }}-postgres
+  labels:
+    app: {{ template "triplesGenerator.name" . }}
+    chart: {{ template "graph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{ if or .Values.global.graph.triplesGenerator.postgresPassword.value .Values.global.graph.triplesGenerator.postgresPassword.overwriteOnHelmUpgrade -}}
+    "helm.sh/hook": "pre-install,pre-upgrade,pre-rollback"
+    {{- else -}}
+    "helm.sh/hook": "pre-install,pre-rollback"
+    {{- end }}
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  triplesGenerator-postgresPassword: {{ default (randAlphaNum 64) .Values.global.graph.triplesGenerator.postgresPassword.value | b64enc | quote }}
+{{- end }}

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -20,16 +20,16 @@ global:
         # Password for the `eventlog` user
         # Generate one using: `openssl rand -hex 16`
         value:
-  tokenRepository:
-    postgresPassword:
-      # Password for the `tokenstorage` user
-      # Generate one using: `openssl rand -hex 16`
-      value:
-  triplesGenerator:
-    postgresPassword:
-      # Password for the `triplesgenerator` user
-      # Generate one using: `openssl rand -hex 16`
-      value:
+    tokenRepository:
+      postgresPassword:
+        # Password for the `tokenstorage` user
+        # Generate one using: `openssl rand -hex 16`
+        value:
+    triplesGenerator:
+      postgresPassword:
+        # Password for the `triplesgenerator` user
+        # Generate one using: `openssl rand -hex 16`
+        value:
   ## to enable debug mode
   debug: false
 

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -25,6 +25,11 @@ global:
       # Password for the `tokenstorage` user
       # Generate one using: `openssl rand -hex 16`
       value:
+  triplesGenerator:
+    postgresPassword:
+      # Password for the `triplesgenerator` user
+      # Generate one using: `openssl rand -hex 16`
+      value:
   ## to enable debug mode
   debug: false
 
@@ -130,6 +135,7 @@ triplesGenerator:
   ## a demanded number of concurrent triples generation processes
   generationProcessesNumber: 2
   transformationProcessesNumber: 2
+  connectionPool: 2
   # set this to a pip-installable renku-python version which will be installed on startup
   renkuPythonDevVersion:
 

--- a/helm-chart/renku-graph/values.yaml
+++ b/helm-chart/renku-graph/values.yaml
@@ -135,7 +135,7 @@ triplesGenerator:
   ## a demanded number of concurrent triples generation processes
   generationProcessesNumber: 2
   transformationProcessesNumber: 2
-  connectionPool: 2
+  connectionPool: 10
   # set this to a pip-installable renku-python version which will be installed on startup
   renkuPythonDevVersion:
 

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -31,7 +31,7 @@ compatibility {
 
 renku-python-dev-version = ${?RENKU_PYTHON_DEV_VERSION}
 
-tg-lock {
+triples-generator-db {
   db-host = "localhost"
   db-host = ${?TRIPLES_GENERATOR_POSTGRES_HOST}
   db-port = 5432
@@ -44,6 +44,8 @@ tg-lock {
   connection-pool = 8
   connection-pool = ${?TRIPLES_GENERATOR_POSTGRES_CONNECTION_POOL}
 }
+
+metrics-interval = "30 seconds"
 
 services {
 

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -36,7 +36,7 @@ tg-lock {
   db-host = ${?TRIPLES_GENERATOR_POSTGRES_HOST}
   db-port = 5432
   db-port = ${?TRIPLES_GENERATOR_POSTGRES_PORT}
-  db-user = "kg_lock_stats"
+  db-user = "triplesgenerator"
   db-user = ${?TRIPLES_GENERATOR_POSTGRES_USER}
   db-pass = "triplesgeneratorpass"
   db-pass = ${?TRIPLES_GENERATOR_POSTGRES_PASSWORD}

--- a/triples-generator/src/main/resources/application.conf
+++ b/triples-generator/src/main/resources/application.conf
@@ -31,6 +31,20 @@ compatibility {
 
 renku-python-dev-version = ${?RENKU_PYTHON_DEV_VERSION}
 
+tg-lock {
+  db-host = "localhost"
+  db-host = ${?TRIPLES_GENERATOR_POSTGRES_HOST}
+  db-port = 5432
+  db-port = ${?TRIPLES_GENERATOR_POSTGRES_PORT}
+  db-user = "kg_lock_stats"
+  db-user = ${?TRIPLES_GENERATOR_POSTGRES_USER}
+  db-pass = "triplesgeneratorpass"
+  db-pass = ${?TRIPLES_GENERATOR_POSTGRES_PASSWORD}
+  db-url-template = "jdbc:postgresql://$host/$dbName"
+  connection-pool = 8
+  connection-pool = ${?TRIPLES_GENERATOR_POSTGRES_CONNECTION_POOL}
+}
+
 services {
 
   triples-generator {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -86,7 +86,7 @@ object Microservice extends IOMicroservice {
     _ <- dbSessionPool.session.use(PostgresLockStats.ensureStatsTable[IO])
 
     metricsService <- MetricsService[IO](dbSessionPool)
-    _              <- metricsService.collectEvery(5.minutes).start
+    _ <- metricsService.collectEvery(Duration.fromNanos(config.getDuration("metrics-interval").toNanos)).start
 
     tsWriteLock = TgLockDB.createLock[IO, projects.Path](dbSessionPool, 0.5.seconds)
     projectConnConfig              <- ProjectsConnectionConfig[IO](config)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -33,7 +33,6 @@ import io.renku.graph.model.projects
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
 import io.renku.http.server.HttpServer
-import io.renku.lock.PostgresLockStats
 import io.renku.logging.ApplicationLogger
 import io.renku.metrics.MetricsRegistry
 import io.renku.microservices.{IOMicroservice, ResourceUse, ServiceReadinessChecker}
@@ -83,7 +82,7 @@ object Microservice extends IOMicroservice {
     implicit0(acf: AccessTokenFinder[IO])        <- AccessTokenFinder[IO]()
     implicit0(rp: ReProvisioningStatus[IO])      <- ReProvisioningStatus[IO]()
 
-    _ <- dbSessionPool.session.use(PostgresLockStats.ensureStatsTable[IO])
+    _ <- TgLockDB.migrate[IO](dbSessionPool, 20.seconds)
 
     metricsService <- MetricsService[IO](dbSessionPool)
     _ <- metricsService.collectEvery(Duration.fromNanos(config.getDuration("metrics-interval").toNanos)).start

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -156,6 +156,7 @@ private class MicroserviceRunner[F[_]: Async: Logger](
       _      <- Resource.eval(cliVersionCompatibilityVerifier.run)
       _      <- Spawn[F].background(serviceReadinessChecker.waitIfNotUp >> eventConsumersRegistry.run)
       server <- httpServer.createServer
+      _      <- Resource.eval(Logger[F].info(s"Triples-Generator service started"))
     } yield server
   } recoverWith logAndThrow
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/TgLockDB.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/TgLockDB.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator
+
+import cats._
+import cats.effect.std.Console
+import cats.effect.{Resource, Temporal}
+import eu.timepit.refined.auto._
+import fs2.io.net.Network
+import io.renku.db.{DBConfigProvider, SessionPoolResource}
+import io.renku.graph.model.projects
+import io.renku.lock.{Lock, LongKey, PostgresLock}
+import natchez.Trace
+
+import scala.concurrent.duration.FiniteDuration
+
+sealed trait TgLockDB
+
+object TgLockDB {
+  type TsWriteLock[F[_]] = Lock[F, projects.Path]
+
+  type SessionResource[F[_]] = io.renku.db.SessionResource[F, TgLockDB]
+
+  object SessionResource {
+    def apply[F[_]](implicit sr: SessionResource[F]): SessionResource[F] = sr
+  }
+
+  def createLock[F[_]: MonadThrow: Trace: Network: Console: Temporal, A: LongKey](
+      interval: FiniteDuration
+  ): Resource[F, Lock[F, A]] =
+    Resource
+      .eval(new TgLockDbConfigProvider[F].map(SessionPoolResource[F, TgLockDB]))
+      .flatMap(identity)
+      .flatMap(_.session.map(PostgresLock.exclusive[F, A](_, interval)))
+}
+
+class TgLockDbConfigProvider[F[_]: MonadThrow]()
+    extends DBConfigProvider[F, TgLockDB](
+      namespace = "tg-lock",
+      dbName = "tg_lock"
+    )

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/TgLockDB.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/TgLockDB.scala
@@ -48,6 +48,6 @@ object TgLockDB {
 
 class TgLockDbConfigProvider[F[_]: MonadThrow]()
     extends DBConfigProvider[F, TgLockDB](
-      namespace = "tg-lock",
+      namespace = "triples-generator-db",
       dbName = "triples_generator"
     )

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/TSReadinessForEventsChecker.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/TSReadinessForEventsChecker.scala
@@ -28,7 +28,7 @@ import TSStateChecker.TSState.{MissingDatasets, ReProvisioning, Ready}
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
 
-private trait TSReadinessForEventsChecker[F[_]] {
+private[consumers] trait TSReadinessForEventsChecker[F[_]] {
   def verifyTSReady: F[Option[EventSchedulingResult]]
 }
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/SubscriptionFactory.scala
@@ -28,7 +28,6 @@ import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.Microservice
-import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
@@ -36,9 +35,8 @@ import org.typelevel.log4cats.Logger
 object SubscriptionFactory {
   def apply[F[
       _
-  ]: Async: ReProvisioningStatus: GitLabClient: AccessTokenFinder: Logger: MetricsRegistry: SparqlQueryTimeRecorder](
-      tsWriteLock: TsWriteLock[F]
-  ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
+  ]: Async: ReProvisioningStatus: GitLabClient: AccessTokenFinder: Logger: MetricsRegistry: SparqlQueryTimeRecorder]
+      : F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     generationProcessesNumber <- GenerationProcessesNumber[F]()
     subscriptionMechanism <-
       SubscriptionMechanism(
@@ -49,6 +47,6 @@ object SubscriptionFactory {
         )
       )
     _       <- ReProvisioningStatus[F].registerForNotification(subscriptionMechanism)
-    handler <- EventHandler(subscriptionMechanism, generationProcessesNumber, tsWriteLock)
+    handler <- EventHandler(subscriptionMechanism, generationProcessesNumber)
   } yield handler -> subscriptionMechanism
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/SubscriptionFactory.scala
@@ -20,23 +20,25 @@ package io.renku.triplesgenerator.events.consumers.awaitinggeneration
 
 import cats.effect.Async
 import cats.syntax.all._
-import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.events.Subscription.SubscriberCapacity
 import io.renku.events.consumers
+import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.events.consumers.subscriptions.SubscriptionPayloadComposer.defaultSubscriptionPayloadComposerFactory
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
 import io.renku.metrics.MetricsRegistry
-import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 import io.renku.triplesgenerator.Microservice
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
 
 object SubscriptionFactory {
   def apply[F[
       _
-  ]: Async: ReProvisioningStatus: GitLabClient: AccessTokenFinder: Logger: MetricsRegistry: SparqlQueryTimeRecorder]
-      : F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
+  ]: Async: ReProvisioningStatus: GitLabClient: AccessTokenFinder: Logger: MetricsRegistry: SparqlQueryTimeRecorder](
+      tsWriteLock: TsWriteLock[F]
+  ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     generationProcessesNumber <- GenerationProcessesNumber[F]()
     subscriptionMechanism <-
       SubscriptionMechanism(
@@ -47,6 +49,6 @@ object SubscriptionFactory {
         )
       )
     _       <- ReProvisioningStatus[F].registerForNotification(subscriptionMechanism)
-    handler <- EventHandler(subscriptionMechanism, generationProcessesNumber)
+    handler <- EventHandler(subscriptionMechanism, generationProcessesNumber, tsWriteLock)
   } yield handler -> subscriptionMechanism
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/SubscriptionFactory.scala
@@ -25,19 +25,21 @@ import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.events.consumers.subscriptions.SubscriptionPayloadComposer.defaultSubscriptionPayloadComposerFactory
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.Microservice
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
 
 object SubscriptionFactory {
-  def apply[F[_]: Async: ReProvisioningStatus: Logger: MetricsRegistry: SparqlQueryTimeRecorder]
-      : F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
+  def apply[F[_]: Async: ReProvisioningStatus: Logger: MetricsRegistry: SparqlQueryTimeRecorder](
+      tsWriteLock: TsWriteLock[F]
+  ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     subscriptionMechanism <-
       SubscriptionMechanism(
         categoryName,
         defaultSubscriptionPayloadComposerFactory(Microservice.ServicePort, Microservice.Identifier)
       )
     _       <- ReProvisioningStatus[F].registerForNotification(subscriptionMechanism)
-    handler <- EventHandler(subscriptionMechanism)
+    handler <- EventHandler(subscriptionMechanism, tsWriteLock)
   } yield handler -> subscriptionMechanism
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/EventHandler.scala
@@ -28,6 +28,7 @@ import io.renku.events.{CategoryName, consumers}
 import io.renku.lock.syntax._
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
+import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.api.events.SyncRepoMetadata
 import io.renku.triplesgenerator.events.consumers.TSReadinessForEventsChecker
@@ -59,7 +60,7 @@ private object EventHandler {
   def apply[F[
       _
   ]: Async: NonEmptyParallel: GitLabClient: AccessTokenFinder: Logger: ReProvisioningStatus: SparqlQueryTimeRecorder: MetricsRegistry](
-      config: Config,
+      config:      Config,
       tsWriteLock: TsWriteLock[F]
   ): F[consumers.EventHandler[F]] = for {
     tsReadinessChecker <- TSReadinessForEventsChecker[F]

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/EventHandler.scala
@@ -36,7 +36,7 @@ import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
 import processor.EventProcessor
 
-private class EventHandler[F[_]: MonadCancelThrow: Logger](
+private[syncrepometadata] class EventHandler[F[_]: MonadCancelThrow: Logger](
     override val categoryName: CategoryName,
     tsReadinessChecker:        TSReadinessForEventsChecker[F],
     eventDecoder:              EventDecoder,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/SubscriptionFactory.scala
@@ -27,6 +27,7 @@ import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
 import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger
@@ -36,7 +37,8 @@ object SubscriptionFactory {
   def apply[F[
       _
   ]: Async: NonEmptyParallel: GitLabClient: AccessTokenFinder: Logger: ReProvisioningStatus: SparqlQueryTimeRecorder: MetricsRegistry](
-      config: Config
+      config: Config,
+      tsWriteLock: TsWriteLock[F]
   ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] =
-    EventHandler[F](config).map(_ -> SubscriptionMechanism.noOpSubscriptionMechanism(categoryName))
+    EventHandler[F](config, tsWriteLock).map(_ -> SubscriptionMechanism.noOpSubscriptionMechanism(categoryName))
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/SubscriptionFactory.scala
@@ -37,7 +37,7 @@ object SubscriptionFactory {
   def apply[F[
       _
   ]: Async: NonEmptyParallel: GitLabClient: AccessTokenFinder: Logger: ReProvisioningStatus: SparqlQueryTimeRecorder: MetricsRegistry](
-      config: Config,
+      config:      Config,
       tsWriteLock: TsWriteLock[F]
   ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] =
     EventHandler[F](config, tsWriteLock).map(_ -> SubscriptionMechanism.noOpSubscriptionMechanism(categoryName))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/MetricsService.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/MetricsService.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.metrics
+
+import cats.Traverse
+import cats.data.Kleisli
+import cats.effect._
+import cats.syntax.all._
+import fs2.{Compiler, Stream}
+import eu.timepit.refined.auto._
+import io.renku.lock.PostgresLockStats
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.TgLockDB
+
+import scala.concurrent.duration.FiniteDuration
+
+trait MetricsService[F[_]] {
+
+  def collect: F[Unit]
+
+  def collectEvery(interval: FiniteDuration)(implicit C: Compiler[F, F], T: Temporal[F]) =
+    Stream.repeatEval(collect *> T.sleep(interval)).compile.drain
+}
+
+object MetricsService {
+
+  def apply[F[_]: Async: MetricsRegistry](dbPool: TgLockDB.SessionResource[F]): F[MetricsService[F]] = {
+    val pgGauge  = PostgresLockGauge[F]("triples_generator")
+    val pgHg     = PostgresLockHistogram[F]
+    val getStats = dbPool.useK(Kleisli(PostgresLockStats.getStats[F]))
+
+    (pgGauge, pgHg).mapN { (gauge, hg) =>
+      new MetricsService[F] {
+        override def collect: F[Unit] =
+          getStats.flatMap { stats =>
+            Traverse[List].sequence_(
+              gauge.set(PostgresLockGauge.Label.CurrentLocks -> stats.currentLocks.toDouble) ::
+                gauge.set(PostgresLockGauge.Label.Waiting -> stats.waiting.size.toDouble) ::
+                stats.waiting.map(w => hg.observe(w.objectId.toString, w.waitDuration.toMillis.toDouble))
+            )
+          }
+      }
+    }
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/MetricsService.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/MetricsService.scala
@@ -35,7 +35,7 @@ trait MetricsService[F[_]] {
   def collect: F[Unit]
 
   def collectEvery(interval: FiniteDuration)(implicit C: Compiler[F, F], T: Temporal[F]) =
-    Stream.repeatEval(collect *> T.sleep(interval)).compile.drain
+    Stream.awakeEvery(interval).evalMap(_ => collect).compile.drain
 }
 
 object MetricsService {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockGauge.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockGauge.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.metrics
+
+import cats.effect._
+import cats.syntax.all._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.auto._
+import io.renku.metrics.{LabeledGauge, MetricsRegistry, PositiveValuesLabeledGauge}
+
+trait PostgresLockGauge[F[_]] extends LabeledGauge[F, PostgresLockGauge.Label]
+
+object PostgresLockGauge {
+
+  sealed trait Label
+  object Label {
+    case object CurrentLocks extends Label {
+      override def toString = "current_lock_count"
+    }
+    case object Waiting extends Label {
+      override def toString = "waiting_count"
+    }
+  }
+
+  def apply[F[_]: Async: MetricsRegistry](dbId: String Refined NonEmpty): F[PostgresLockGauge[F]] =
+    MetricsRegistry[F]
+      .register(
+        new PositiveValuesLabeledGauge[F, Label](
+          name = dbId,
+          help = s"Statistics for postgres locks",
+          labelName = "postgres_lock_stats",
+          resetDataFetch = () => Async[F].pure(Map.empty)
+        ) with PostgresLockGauge[F]
+      )
+      .widen
+
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockHistogram.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockHistogram.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.metrics
+
+import cats.MonadThrow
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.metrics.{LabeledHistogram, LabeledHistogramImpl, MetricsRegistry}
+
+import scala.concurrent.duration._
+
+trait PostgresLockHistogram[F[_]] extends LabeledHistogram[F] {}
+
+object PostgresLockHistogram {
+  def apply[F[_]: MonadThrow: MetricsRegistry]: F[PostgresLockHistogram[F]] = MetricsRegistry[F].register {
+    new LabeledHistogramImpl[F](
+      name = "postgres_lock_wait_times",
+      help = "PostgresLock wait times",
+      labelName = "object_id",
+      buckets = Seq(.05, .1, .5, 1, 2.5, 5, 10, 50),
+      maybeThreshold = 750.millis.some
+    ) with PostgresLockHistogram[F]
+  }.widen
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockHistogram.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockHistogram.scala
@@ -25,7 +25,7 @@ import io.renku.metrics.{LabeledHistogram, LabeledHistogramImpl, MetricsRegistry
 
 import scala.concurrent.duration._
 
-trait PostgresLockHistogram[F[_]] extends LabeledHistogram[F] {}
+trait PostgresLockHistogram[F[_]] extends LabeledHistogram[F]
 
 object PostgresLockHistogram {
   def apply[F[_]: MonadThrow: MetricsRegistry]: F[PostgresLockHistogram[F]] = MetricsRegistry[F].register {
@@ -34,7 +34,7 @@ object PostgresLockHistogram {
       help = "PostgresLock wait times",
       labelName = "object_id",
       buckets = Seq(.05, .1, .5, 1, 2.5, 5, 10, 50),
-      maybeThreshold = 750.millis.some
+      maybeThreshold = 200.millis.some
     ) with PostgresLockHistogram[F]
   }.widen
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/cleanup/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/cleanup/EventHandlerSpec.scala
@@ -18,6 +18,7 @@
 
 package io.renku.triplesgenerator.events.consumers.cleanup
 
+import cats.data.Kleisli
 import cats.effect.{IO, Ref}
 import cats.syntax.all._
 import io.circe.syntax._
@@ -26,8 +27,11 @@ import io.renku.events.consumers.ConsumersModelGenerators.{consumerProjects, eve
 import io.renku.events.consumers.ProcessExecutor
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.projects
 import io.renku.interpreters.TestLogger
+import io.renku.lock.Lock
 import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.api.events.CleanUpEvent
 import io.renku.triplesgenerator.events.consumers.TSReadinessForEventsChecker
 import org.scalamock.scalatest.MockFactory
@@ -59,6 +63,19 @@ class EventHandlerSpec extends AnyWordSpec with MockFactory with IOSpec with sho
       (eventProcessor.process _).expects(event.project).returns(().pure[IO])
 
       handler.createHandlingDefinition().process(event).unsafeRunSync() shouldBe ()
+    }
+
+    "lock while executing" in new TestCase {
+      val test = Ref.unsafe[IO, Int](0)
+      override val tsWriteLock: TsWriteLock[IO] =
+        Lock.from[IO, projects.Path](Kleisli(_ => test.update(_ + 1)))(Kleisli(_ => test.update(_ + 1)))
+
+      val event = consumerProjects.map(CleanUpEvent(_)).generateOne
+
+      (eventProcessor.process _).expects(event.project).returns(().pure[IO])
+
+      handler.createHandlingDefinition().process(event).unsafeRunSync() shouldBe ()
+      test.get.unsafeRunSync()                                          shouldBe 2
     }
   }
 
@@ -93,11 +110,14 @@ class EventHandlerSpec extends AnyWordSpec with MockFactory with IOSpec with sho
     val renewSubscriptionCalled       = Ref.unsafe[IO, Boolean](false)
     (subscriptionMechanism.renewSubscription _).expects().returns(renewSubscriptionCalled.set(true))
 
-    val handler = new EventHandler[IO](categoryName,
-                                       tsReadinessChecker,
-                                       eventProcessor,
-                                       subscriptionMechanism,
-                                       mock[ProcessExecutor[IO]]
+    def tsWriteLock: TsWriteLock[IO] = Lock.none[IO, projects.Path]
+    lazy val handler = new EventHandler[IO](
+      categoryName,
+      tsReadinessChecker,
+      eventProcessor,
+      subscriptionMechanism,
+      mock[ProcessExecutor[IO]],
+      tsWriteLock
     )
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/EventHandlerSpec.scala
@@ -24,7 +24,9 @@ import cats.syntax.all._
 import io.renku.events.consumers.ConsumersModelGenerators.eventSchedulingResults
 import io.renku.events.consumers.ProcessExecutor
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.projects
 import io.renku.interpreters.TestLogger
+import io.renku.lock.Lock
 import io.renku.triplesgenerator.api.events.Generators.syncRepoMetadataEvents
 import io.renku.triplesgenerator.events.consumers.TSReadinessForEventsChecker
 import io.renku.triplesgenerator.events.consumers.syncrepometadata.processor.EventProcessor
@@ -32,6 +34,7 @@ import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AsyncWordSpec
 
+//TODO
 class EventHandlerSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers with AsyncMockFactory {
 
   "handlingDefinition.decode" should {
@@ -89,5 +92,12 @@ class EventHandlerSpec extends AsyncWordSpec with AsyncIOSpec with should.Matche
   private lazy val eventProcessor = mock[EventProcessor[IO]]
 
   private lazy val handler =
-    new EventHandler[IO](categoryName, tsReadinessChecker, EventDecoder, eventProcessor, mock[ProcessExecutor[IO]])
+    new EventHandler[IO](
+      categoryName,
+      tsReadinessChecker,
+      EventDecoder,
+      eventProcessor,
+      mock[ProcessExecutor[IO]],
+      Lock.none[IO, projects.Path]
+    )
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsprovisioning/minprojectinfo/EventHandlerSpec.scala
@@ -30,7 +30,9 @@ import io.renku.events.consumers.ProcessExecutor
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.events.consumers.ConsumersModelGenerators.eventSchedulingResults
 import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.projects
 import io.renku.interpreters.TestLogger
+import io.renku.lock.Lock
 import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
@@ -94,12 +96,14 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
     (subscriptionMechanism.renewSubscription _).expects().returns(renewSubscriptionCalled.set(true))
 
     val eventProcessor = mock[EventProcessor[IO]]
-
-    val handler = new EventHandler[IO](categoryName,
-                                       tsReadinessChecker,
-                                       subscriptionMechanism,
-                                       eventProcessor,
-                                       mock[ProcessExecutor[IO]]
+    def tsWriteLock    = Lock.none[IO, projects.Path]
+    lazy val handler = new EventHandler[IO](
+      categoryName,
+      tsReadinessChecker,
+      subscriptionMechanism,
+      eventProcessor,
+      mock[ProcessExecutor[IO]],
+      tsWriteLock
     )
   }
 


### PR DESCRIPTION
This PR makes the event handlers writing to TS sequentially to avoid concurrent writes that lead to duplicates.

/deploy #persist extra-values=core.sentry.dsn=https://0cc02f3a02d3474d9f7e90915873ab4d@sentry.dev.renku.ch/2,core.sentry.environment=renku-dev,core.sentry.enabled=true 