### PR TITLE
feat: TS migration adding dateModified where missing

### DIFF
--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
@@ -45,11 +45,14 @@ trait SearchInfoDatasets {
       renkuUrl:        RenkuUrl,
       entityFunctions: EntityFunctions[entities.Project],
       graphsProducer:  GraphsProducer[entities.Project]
-  ) = provisionProject(p.to[entities.Project])
+  ): IO[Unit] = provisionProject(p.to[entities.Project])
 
   def provisionProject(
       project: entities.Project
-  )(implicit entityFunctions: EntityFunctions[entities.Project], graphsProducer: GraphsProducer[entities.Project]) =
+  )(implicit
+      entityFunctions: EntityFunctions[entities.Project],
+      graphsProducer:  GraphsProducer[entities.Project]
+  ): IO[Unit] =
     uploadIO(projectsDataset, graphsProducer(project): _*) >> insertSearchInfo(project)
 
   def insertSearchInfo(project: entities.Project): IO[Unit] =

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
@@ -37,7 +37,7 @@ trait SearchInfoDatasets {
       renkuUrl:        RenkuUrl,
       entityFunctions: EntityFunctions[entities.Project],
       graphsProducer:  GraphsProducer[entities.Project]
-  ) = projects.traverse_(provisionTestProject)
+  ): IO[Unit] = projects.traverse_(provisionTestProject)
 
   def provisionTestProject(
       p: testentities.Project

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -45,6 +45,7 @@ private[tsmigrationrequest] object Migrations {
     projectDateViewedDeduplicator  <- ProjectDateViewedDeduplicator[F]
     personViewedEntityDeduplicator <- PersonViewedEntityDeduplicator[F]
     provisionProjectsGraph         <- projectsgraph.ProvisionProjectsGraph[F]
+    addProjectDateModified         <- datemodified.AddProjectDateModified[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -57,7 +58,8 @@ private[tsmigrationrequest] object Migrations {
                     projectsDateViewedCreator,
                     projectDateViewedDeduplicator,
                     personViewedEntityDeduplicator,
-                    provisionProjectsGraph
+                    provisionProjectsGraph,
+                    addProjectDateModified
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/AddProjectDateModified.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/AddProjectDateModified.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
+
+private[migrations] object AddProjectDateModified {
+  val name: Migration.Name = Migration.Name("Add Project dateModified")
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/AddProjectDateModified.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/AddProjectDateModified.scala
@@ -16,10 +16,98 @@
  * limitations under the License.
  */
 
-package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+package datemodified
 
-import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
+import cats.data.EitherT
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.events.consumers.ProcessingRecoverableError
+import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
+import org.typelevel.log4cats.Logger
+import tooling.{MigrationExecutionRegister, RecoverableErrorsRecovery}
+
+private class AddProjectDateModified[F[_]: Async: Logger](
+    migrationNeedChecker: MigrationNeedChecker[F],
+    backlogCreator:       BacklogCreator[F],
+    projectsFinder:       ProjectsPageFinder[F],
+    progressFinder:       ProgressFinder[F],
+    projectFetcher:       ProjectFetcher[F],
+    datePersister:        DatePersister[F],
+    projectDonePersister: ProjectDonePersister[F],
+    executionRegister:    MigrationExecutionRegister[F],
+    recoveryStrategy:     RecoverableErrorsRecovery = RecoverableErrorsRecovery
+) extends ConditionedMigration[F] {
+
+  import datePersister.persistDateModified
+  import executionRegister._
+  import fs2._
+  import progressFinder._
+  import projectDonePersister._
+  import projectFetcher.fetchProject
+  import projectsFinder._
+  import recoveryStrategy._
+
+  override val name: Migration.Name = AddProjectDateModified.name
+
+  protected[datemodified] override def required
+      : EitherT[F, ProcessingRecoverableError, ConditionedMigration.MigrationRequired] = EitherT {
+    migrationNeedChecker.checkMigrationNeeded
+      .map(_.asRight[ProcessingRecoverableError])
+      .recoverWith(maybeRecoverableError[F, ConditionedMigration.MigrationRequired])
+  }
+
+  protected[datemodified] override def migrate(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
+    backlogCreator.createBacklog() >>
+      Logger[F].info(show"$categoryName: $name backlog created") >>
+      Stream
+        .iterate(1)(_ + 1)
+        .evalMap(_ => nextProjectsPage())
+        .takeThrough(_.nonEmpty)
+        .flatMap(Stream.emits(_))
+        .evalMap(path => findProgressInfo.map(path -> _))
+        .evalTap { case (path, info) => logInfo(show"provisioning '$path'", info) }
+        .evalMap { case (path, info) => fetchProject(path).map(p => (path, p, info)) }
+        .evalTap { case (_, maybeProj, _) => maybeProj.map(persistDateModified).getOrElse(().pure[F]) }
+        .evalTap { case (path, _, _) => noteDone(path) }
+        .evalTap { case (path, _, info) => logInfo(show"'$path' provisioned", info) }
+        .compile
+        .drain
+        .map(_.asRight[ProcessingRecoverableError])
+        .recoverWith(maybeRecoverableError[F, Unit])
+  }
+
+  private def logInfo(message: String, progressInfo: String): F[Unit] =
+    Logger[F].info(show"${AddProjectDateModified.name} - $progressInfo - $message")
+
+  protected[datemodified] override def postMigration(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
+    registerExecution(name)
+      .map(_.asRight[ProcessingRecoverableError])
+      .recoverWith(maybeRecoverableError[F, Unit])
+  }
+}
 
 private[migrations] object AddProjectDateModified {
   val name: Migration.Name = Migration.Name("Add Project dateModified")
+
+  def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder]: F[Migration[F]] = for {
+    checkMigrationNeeded <- MigrationNeedChecker[F]
+    backlogCreator       <- BacklogCreator[F]
+    projectsFinder       <- ProjectsPageFinder[F]
+    progressFinder       <- ProgressFinder[F]
+    projectFetcher       <- ProjectFetcher[F]
+    datePersister        <- ProjectsConnectionConfig[F]().map(DatePersister[F](_))
+    projectDonePersister <- ProjectDonePersister[F]
+    executionRegister    <- MigrationExecutionRegister[F]
+  } yield new AddProjectDateModified(checkMigrationNeeded,
+                                     backlogCreator,
+                                     projectsFinder,
+                                     progressFinder,
+                                     projectFetcher,
+                                     datePersister,
+                                     projectDonePersister,
+                                     executionRegister
+  )
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/BacklogCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/BacklogCreator.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package datemodified
+
+import cats.effect.{Async, Ref}
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.Schemas._
+import io.renku.graph.model.{GraphClass, RenkuUrl, projects}
+import io.renku.jsonld.syntax._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.model.Triple
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+import tooling.RecordsFinder
+
+private trait BacklogCreator[F[_]] {
+  def createBacklog(): F[Unit]
+}
+
+private object BacklogCreator {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[BacklogCreator[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    recordsFinder           <- ProjectsConnectionConfig[F]().map(RecordsFinder[F](_))
+    migrationsDSClient      <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new BacklogCreatorImpl[F](recordsFinder, migrationsDSClient)
+
+  def asToBeMigratedInserts(implicit ru: RenkuUrl): List[projects.Path] => Option[SparqlQuery] =
+    toTriples andThen toInsertQuery
+
+  private def toTriples(implicit ru: RenkuUrl): List[projects.Path] => List[Triple] =
+    _.map(path => Triple(AddProjectDateModified.name.asEntityId, renku / "toBeMigrated", path.asObject))
+
+  private lazy val toInsertQuery: List[Triple] => Option[SparqlQuery] = {
+    case Nil => None
+    case triples =>
+      SparqlQuery
+        .ofUnsafe(
+          show"${AddProjectDateModified.name} - store to backlog",
+          sparql"INSERT DATA {\n${triples.map(_.asSparql).combineAll}\n}"
+        )
+        .some
+  }
+}
+
+private class BacklogCreatorImpl[F[_]: Async](recordsFinder: RecordsFinder[F], migrationsDSClient: TSClient[F])(implicit
+    ru: RenkuUrl
+) extends BacklogCreator[F] {
+
+  import BacklogCreator._
+  import io.renku.tinytypes.json.TinyTypeDecoders._
+  import io.renku.triplesstore.ResultsDecoder._
+  import recordsFinder._
+
+  private val pageSize: Int = 50
+
+  override def createBacklog(): F[Unit] = addPageToBacklog(Ref.unsafe(1))
+
+  private def addPageToBacklog(currentPage: Ref[F, Int]): F[Unit] =
+    currentPage
+      .getAndUpdate(_ + 1)
+      .map(query)
+      .flatMap(findRecords[projects.Path])
+      .map(asToBeMigratedInserts)
+      .flatMap(storeInBacklog(currentPage))
+
+  private def query(page: Int) = SparqlQuery.ofUnsafe(
+    show"${AddProjectDateModified.name} - projects to migrate",
+    Prefixes of (schema -> "schema", renku -> "renku"),
+    sparql"""|SELECT DISTINCT ?path
+             |WHERE {
+             |  GRAPH ?id {
+             |    ?id a schema:Project.
+             |  }
+             |  {
+             |    GRAPH ${GraphClass.Projects.id} {
+             |      ?id renku:projectPath ?path
+             |      FILTER NOT EXISTS {
+             |        ?id schema:dateModified ?dm
+             |      }
+             |    }
+             |  } UNION {
+             |    GRAPH ?id {
+             |      ?id renku:projectPath ?path
+             |      FILTER NOT EXISTS {
+             |        ?id schema:dateModified ?dm
+             |      }
+             |    }
+             |  }
+             |}
+             |ORDER BY ?path
+             |LIMIT $pageSize
+             |OFFSET ${(page - 1) * pageSize}
+             |""".stripMargin
+  )
+
+  private implicit lazy val decoder: Decoder[List[projects.Path]] = ResultsDecoder[List, projects.Path] {
+    implicit cur => extract[projects.Path]("path")
+  }
+
+  private def storeInBacklog(currentPage: Ref[F, Int]): Option[SparqlQuery] => F[Unit] = {
+    case None        => ().pure[F]
+    case Some(query) => migrationsDSClient.updateWithNoResult(query) >> addPageToBacklog(currentPage)
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/BacklogCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/BacklogCreator.scala
@@ -86,7 +86,7 @@ private class BacklogCreatorImpl[F[_]: Async](recordsFinder: RecordsFinder[F], m
 
   private def query(page: Int) = SparqlQuery.ofUnsafe(
     show"${AddProjectDateModified.name} - projects to migrate",
-    Prefixes of (schema -> "schema", renku -> "renku"),
+    Prefixes of (renku -> "renku", schema -> "schema"),
     sparql"""|SELECT DISTINCT ?path
              |WHERE {
              |  GRAPH ?id {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/DatePersister.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/DatePersister.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.MonadThrow
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder, TSClient}
+import org.typelevel.log4cats.Logger
+
+private trait DatePersister[F[_]] {
+  def persistDateModified(projectInfo: ProjectInfo): F[Unit]
+}
+
+private object DatePersister {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      connectionConfig: ProjectsConnectionConfig
+  ): DatePersister[F] = new DatePersisterImpl[F](TSClient[F](connectionConfig))
+}
+
+private class DatePersisterImpl[F[_]: MonadThrow](tsClient: TSClient[F]) extends DatePersister[F] {
+
+  override def persistDateModified(projectInfo: ProjectInfo): F[Unit] = println(tsClient).pure[F]
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/MigrationNeedChecker.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/MigrationNeedChecker.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations.datemodified
+
+import cats.MonadThrow
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+
+private trait MigrationNeedChecker[F[_]] {
+  def checkMigrationNeeded: F[ConditionedMigration.MigrationRequired]
+}
+
+private object MigrationNeedChecker {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[MigrationNeedChecker[F]] =
+    ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(new MigrationNeedCheckerImpl[F](_))
+}
+
+private class MigrationNeedCheckerImpl[F[_]: MonadThrow](tsClient: TSClient[F]) extends MigrationNeedChecker[F] {
+
+  override def checkMigrationNeeded: F[ConditionedMigration.MigrationRequired] =
+    tsClient.queryExpecting[Int](query).map {
+      case 0       => ConditionedMigration.MigrationRequired.No("all projects present in the Projects graph")
+      case nonZero => ConditionedMigration.MigrationRequired.Yes(s"$nonZero projects not present in the Projects graph")
+    }
+
+  private lazy val query = SparqlQuery.ofUnsafe(
+    show"${AddProjectDateModified.name} - check migration needed",
+    Prefixes of (renku -> "renku", schema -> "schema"),
+    sparql"""|SELECT (COUNT(DISTINCT ?id) AS ?cnt)
+             |WHERE {
+             |  GRAPH ?id {
+             |    ?id a schema:Project
+             |  }
+             |  {
+             |    GRAPH ${GraphClass.Projects.id} {
+             |      ?id renku:projectPath ?path
+             |      FILTER NOT EXISTS {
+             |        ?id schema:dateModified ?dm
+             |      }
+             |    }
+             |  } UNION {
+             |    GRAPH ?id {
+             |      ?id renku:projectPath ?path
+             |      FILTER NOT EXISTS {
+             |        ?id schema:dateModified ?dm
+             |      }
+             |    }
+             |  }
+             |}
+             |LIMIT 1
+             |""".stripMargin
+  )
+
+  import io.renku.triplesstore.ResultsDecoder._
+
+  private implicit lazy val decoder: Decoder[Int] = ResultsDecoder.single[Int] { implicit cur =>
+    extract[String]("cnt").map(_.toInt)
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProgressFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProgressFinder.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.effect.{Async, Ref, Sync}
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
+import io.renku.graph.model.Schemas.renku
+import io.renku.jsonld.syntax._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+
+private trait ProgressFinder[F[_]] {
+  def findProgressInfo: F[String]
+}
+
+private object ProgressFinder {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProgressFinder[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    migrationsDSClient      <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new ProgressFinderImpl[F](migrationsDSClient)
+}
+
+private class ProgressFinderImpl[F[_]: Sync](migrationsDSClient: TSClient[F])(implicit ru: RenkuUrl)
+    extends ProgressFinder[F] {
+
+  import io.renku.triplesstore.ResultsDecoder._
+
+  private val total: Ref[F, Int] = Ref.unsafe[F, Int](0)
+
+  override def findProgressInfo: F[String] = for {
+    left  <- findLeftCount
+    total <- findTotal
+  } yield s"$left left from $total"
+
+  private def findLeftCount =
+    migrationsDSClient.queryExpecting[Int](
+      SparqlQuery.ofUnsafe(
+        show"${AddProjectDateModified.name} - find left",
+        Prefixes of renku -> "renku",
+        sparql"""|SELECT (COUNT(?path) AS ?count)
+                 |WHERE {
+                 |  ${AddProjectDateModified.name.asEntityId} renku:toBeMigrated ?path
+                 |}
+                 |""".stripMargin
+      )
+    )
+
+  private def findTotal: F[Int] =
+    total.get >>= {
+      case 0       => findLeftCount >>= (v => total.updateAndGet(_ => v))
+      case nonZero => nonZero.pure[F]
+    }
+
+  private implicit lazy val countDecoder: Decoder[Int] =
+    ResultsDecoder.single[Int](implicit cur => extract[String]("count").map(_.toInt))
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectDonePersister.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectDonePersister.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.{RenkuUrl, projects}
+import io.renku.triplesstore.{MigrationsConnectionConfig, SparqlQueryTimeRecorder, TSClient}
+import org.typelevel.log4cats.Logger
+
+private trait ProjectDonePersister[F[_]] {
+  def noteDone(path: projects.Path): F[Unit]
+}
+
+private object ProjectDonePersister {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectDonePersister[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    tsClient                <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new ProjectDonePersisterImpl[F](tsClient)
+}
+
+private class ProjectDonePersisterImpl[F[_]](tsClient: TSClient[F])(implicit ru: RenkuUrl)
+    extends ProjectDonePersister[F] {
+
+  import io.renku.graph.model.Schemas.renku
+  import io.renku.jsonld.syntax._
+  import io.renku.triplesstore.SparqlQuery
+  import io.renku.triplesstore.client.model.Triple
+  import io.renku.triplesstore.client.syntax._
+
+  override def noteDone(path: projects.Path): F[Unit] =
+    tsClient.updateWithNoResult(v10MigratedTriple(path))
+
+  private def v10MigratedTriple(path: projects.Path) = {
+    val triple = Triple(AddProjectDateModified.name.asEntityId, renku / "toBeMigrated", path.asObject)
+    SparqlQuery.ofUnsafe(
+      show"${AddProjectDateModified.name} - remove migrated",
+      sparql"DELETE DATA {$triple}"
+    )
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectFetcher.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectFetcher.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.model.Schemas._
+import io.renku.graph.model.projects
+import io.renku.triplesstore.ResultsDecoder._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+
+private trait ProjectFetcher[F[_]] {
+  def fetchProject(path: projects.Path): F[Option[ProjectInfo]]
+}
+
+private object ProjectFetcher {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectFetcher[F]] =
+    ProjectsConnectionConfig[F]().map(TSClient[F](_)).map(new ProjectFetcherImpl[F](_))
+}
+
+private class ProjectFetcherImpl[F[_]: Async](tsClient: TSClient[F]) extends ProjectFetcher[F] {
+
+  override def fetchProject(path: projects.Path): F[Option[ProjectInfo]] = tsClient.queryExpecting[Option[ProjectInfo]](
+    SparqlQuery.ofUnsafe(
+      show"${AddProjectDateModified.name} - find projects",
+      Prefixes of (renku -> "renku", schema -> "schema"),
+      sparql"""|SELECT DISTINCT ?id ?path ?dateCreated
+               |WHERE {
+               |  BIND (${path.asObject} AS ?path)
+               |  GRAPH ?id {
+               |    ?id a schema:Project;
+               |        renku:projectPath ?path;
+               |        schema:dateCreated ?dateCreated.
+               |  }
+               |}
+               |GROUP BY ?id ?path ?dateCreated
+               |LIMIT 1
+               |""".stripMargin
+    )
+  )
+
+  private implicit lazy val decoder: Decoder[Option[ProjectInfo]] = ResultsDecoder[Option, ProjectInfo] {
+    implicit cur =>
+      import io.renku.tinytypes.json.TinyTypeDecoders._
+      (
+        extract[projects.ResourceId]("id"),
+        extract[projects.Path]("path"),
+        extract[projects.DateCreated]("dateCreated")
+      ).mapN(ProjectInfo)
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectInfo.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectInfo.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import io.renku.graph.model.projects
+
+private final case class ProjectInfo(id: projects.ResourceId, path: projects.Path, dateCreated: projects.DateCreated)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectsPageFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectsPageFinder.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package datemodified
+
+import cats.Monad
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.{RenkuUrl, Schemas, projects}
+import io.renku.jsonld.syntax._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+import tooling._
+
+private trait ProjectsPageFinder[F[_]] {
+  def nextProjectsPage(): F[List[projects.Path]]
+}
+
+private object ProjectsPageFinder {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectsPageFinder[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    recordsFinder           <- MigrationsConnectionConfig[F]().map(RecordsFinder[F](_))
+  } yield new ProjectsPageFinderImpl(recordsFinder)
+}
+
+private class ProjectsPageFinderImpl[F[_]: Monad](recordsFinder: RecordsFinder[F])(implicit
+    ru: RenkuUrl
+) extends ProjectsPageFinder[F]
+    with Schemas {
+
+  import ResultsDecoder._
+  import io.renku.tinytypes.json.TinyTypeDecoders._
+  import recordsFinder._
+
+  private val pageSize: Int = 50
+
+  override def nextProjectsPage(): F[List[projects.Path]] =
+    findRecords[projects.Path](query)
+
+  private lazy val query = SparqlQuery.ofUnsafe(
+    show"${AddProjectDateModified.name} - find projects",
+    Prefixes of renku -> "renku",
+    sparql"""|SELECT DISTINCT ?path
+             |WHERE {
+             |  ${AddProjectDateModified.name.asEntityId} renku:toBeMigrated ?path
+             |}
+             |ORDER BY ?path
+             |LIMIT $pageSize
+             |""".stripMargin
+  )
+
+  private implicit lazy val decoder: Decoder[List[projects.Path]] = ResultsDecoder[List, projects.Path] {
+    implicit cur => extract[projects.Path]("path")
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/AddProjectDateModifiedSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/AddProjectDateModifiedSpec.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+package datemodified
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import GraphModelGenerators.{projectCreatedDates, projectPaths, projectResourceIds}
+import cats.MonadThrow
+import io.renku.generators.Generators.{exceptions, nonEmptyStrings, positiveInts}
+import io.renku.interpreters.TestLogger
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesgenerator.generators.ErrorGenerators.processingRecoverableErrors
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AsyncWordSpec
+import tooling.{MigrationExecutionRegister, RecoverableErrorsRecovery}
+
+class AddProjectDateModifiedSpec
+    extends AsyncWordSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with AsyncMockFactory
+    with EitherValues {
+
+  "AddProjectDateModified" should {
+
+    "be the ConditionedMigration" in {
+      migration.getClass.getSuperclass shouldBe classOf[ConditionedMigration[IO]]
+    }
+  }
+
+  "required" should {
+
+    Set(
+      ConditionedMigration.MigrationRequired.No(nonEmptyStrings().generateOne),
+      ConditionedMigration.MigrationRequired.Yes(nonEmptyStrings().generateOne)
+    ) foreach { answer =>
+      s"return $answer if there are no projects to migrate" in {
+
+        (() => migrationNeedChecker.checkMigrationNeeded)
+          .expects()
+          .returning(answer.pure[IO])
+
+        migration.required.value.unsafeRunSync().value shouldBe answer
+      }
+    }
+  }
+
+  "migrate" should {
+
+    "prepare backlog of projects requiring provisioning " +
+      "and start the process that " +
+      "goes through all the prepared projects, " +
+      "fetch the project data from a relevant project graph," +
+      "pass the project to the ProjectGraphProvisioner " +
+      "and keep a note of the project once an event for it is sent" in {
+
+        givenBacklogCreated()
+
+        val allProjectPaths = projectPaths.generateList(min = pageSize, max = pageSize * 2)
+
+        val projectPathsPages = allProjectPaths
+          .sliding(pageSize, pageSize)
+          .toList
+        givenProjectsPagesReturned(projectPathsPages :+ List.empty[projects.Path])
+
+        givenProgressInfoFinding(returning = nonEmptyStrings().generateOne.pure[IO], times = allProjectPaths.size)
+
+        allProjectPaths foreach { path =>
+          val projectInfo = ProjectInfo(projectResourceIds.generateOne, path, projectCreatedDates().generateOne)
+          givenProjectDataFetching(path, returning = projectInfo.some.pure[IO])
+          givenDatePersisting(projectInfo, returning = ().pure[IO])
+          verifyProjectNotedDone(path)
+        }
+
+        migration.migrate().value.asserting(_.value shouldBe ())
+      }
+
+    "skip projects which cannot be found in the TS" in {
+
+      givenBacklogCreated()
+
+      val projectPath1 = projectPaths.generateOne
+      val projectPath2 = projectPaths.generateOne
+      val projectPath3 = projectPaths.generateOne
+
+      val projectPathsPage = List(projectPath1, projectPath2, projectPath3)
+
+      givenProjectsPagesReturned(List(projectPathsPage) :+ List.empty[projects.Path])
+
+      givenProgressInfoFinding(returning = nonEmptyStrings().generateOne.pure[IO], times = projectPathsPage.size)
+
+      List(projectPath1, projectPath3) foreach { path =>
+        val projectInfo = ProjectInfo(projectResourceIds.generateOne, path, projectCreatedDates().generateOne)
+        givenProjectDataFetching(path, returning = projectInfo.some.pure[IO])
+        givenDatePersisting(projectInfo, returning = ().pure[IO])
+        verifyProjectNotedDone(path)
+      }
+
+      givenProjectDataFetching(projectPath2, returning = None.pure[IO])
+      verifyProjectNotedDone(projectPath2)
+
+      migration.migrate().value.unsafeRunSync().value shouldBe ()
+    }
+
+    "return a Recoverable Error in case the recovery strategy returns one while finding projects" in {
+
+      givenBacklogCreated()
+
+      val exception = exceptions.generateOne
+      (() => projectsFinder.nextProjectsPage())
+        .expects()
+        .returning(exception.raiseError[IO, List[projects.Path]])
+
+      migration.migrate().value.unsafeRunSync().left.value shouldBe recoverableError
+    }
+  }
+
+  "postMigration" should {
+
+    "register migration execution" in {
+
+      verifyMigrationExecutionRegistered
+
+      migration.postMigration().value.asserting(_.value shouldBe ())
+    }
+  }
+
+  private lazy val pageSize = positiveInts(max = 100).generateOne.value
+
+  private implicit lazy val logger: TestLogger[IO] = TestLogger[IO]()
+  private val migrationNeedChecker  = mock[MigrationNeedChecker[IO]]
+  private val backlogCreator        = mock[BacklogCreator[IO]]
+  private val projectsFinder        = mock[ProjectsPageFinder[IO]]
+  private val progressFinder        = mock[ProgressFinder[IO]]
+  private val projectFetcher        = mock[ProjectFetcher[IO]]
+  private val datePersister         = mock[DatePersister[IO]]
+  private val projectDonePersister  = mock[ProjectDonePersister[IO]]
+  private val executionRegister     = mock[MigrationExecutionRegister[IO]]
+  private lazy val recoverableError = processingRecoverableErrors.generateOne
+  private val recoveryStrategy = new RecoverableErrorsRecovery {
+    override def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = { _ =>
+      recoverableError.asLeft[OUT].pure[F]
+    }
+  }
+  private lazy val migration = new AddProjectDateModified[IO](
+    migrationNeedChecker,
+    backlogCreator,
+    projectsFinder,
+    progressFinder,
+    projectFetcher,
+    datePersister,
+    projectDonePersister,
+    executionRegister,
+    recoveryStrategy
+  )
+
+  private def givenBacklogCreated() =
+    (backlogCreator.createBacklog _)
+      .expects()
+      .returning(().pure[IO])
+
+  private def givenProjectsPagesReturned(pages: List[List[projects.Path]]): Unit =
+    pages foreach { page =>
+      (projectsFinder.nextProjectsPage _)
+        .expects()
+        .returning(page.pure[IO])
+    }
+
+  private def givenProgressInfoFinding(returning: IO[String], times: Int) =
+    (() => progressFinder.findProgressInfo)
+      .expects()
+      .returning(returning)
+      .repeat(times)
+
+  private def givenProjectDataFetching(path: projects.Path, returning: IO[Option[ProjectInfo]]) =
+    (projectFetcher.fetchProject _)
+      .expects(path)
+      .returning(returning)
+
+  private def givenDatePersisting(projectInfo: ProjectInfo, returning: IO[Unit]) =
+    (datePersister.persistDateModified _)
+      .expects(projectInfo)
+      .returning(returning)
+
+  private def verifyProjectNotedDone(path: projects.Path) =
+    (projectDonePersister.noteDone _)
+      .expects(path)
+      .returning(().pure[IO])
+
+  private def verifyMigrationExecutionRegistered =
+    (executionRegister.registerExecution _)
+      .expects(AddProjectDateModified.name)
+      .returning(().pure[IO])
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/BacklogCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/BacklogCreatorSpec.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package datemodified
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.entities.searchgraphs.SearchInfoDatasets
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import io.renku.graph.model.entities.EntityFunctions
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.scalacheck.Gen
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+import tooling.RecordsFinder
+
+class BacklogCreatorSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with MigrationsDataset
+    with SearchInfoDatasets
+    with AsyncMockFactory {
+
+  private val pageSize = 50
+
+  it should "find all projects that have no dateModified, either DiscoverableProject or Project entities " +
+    "and copy their paths into the migrations DS" in {
+
+      val projects = anyProjectEntities
+        .generateList(min = pageSize + 1, max = Gen.choose(pageSize + 1, (2 * pageSize) - 1).generateOne)
+
+      fetchBacklogProjects.asserting(_ shouldBe Nil) >>
+        provision(projects).assertNoException >>
+        deleteModifiedDates(projects).assertNoException >>
+        backlogCreator.createBacklog().assertNoException >>
+        fetchBacklogProjects.asserting(_.toSet shouldBe projects.map(_.path).toSet)
+    }
+
+  it should "skip projects that already have dateModified" in {
+
+    val projectToSkip    = anyProjectEntities.generateOne
+    val projectNotToSkip = anyProjectEntities.generateOne
+
+    provision(projectToSkip).assertNoException >>
+      provision(projectNotToSkip).assertNoException >>
+      fetchBacklogProjects.asserting(_ shouldBe Nil) >>
+      deleteModifiedDates(projectNotToSkip.resourceId).assertNoException >>
+      backlogCreator.createBacklog().assertNoException >>
+      fetchBacklogProjects.asserting(_.toSet shouldBe Set(projectNotToSkip.path))
+  }
+
+  it should "find project that does not have dateModified only in the Project graph" in {
+
+    val project = anyProjectEntities.generateOne
+
+    provision(project).assertNoException >>
+      fetchBacklogProjects.asserting(_ shouldBe Nil) >>
+      deleteProjectDateModified(project.resourceId).assertNoException >>
+      backlogCreator.createBacklog().assertNoException >>
+      fetchBacklogProjects.asserting(_.toSet shouldBe Set(project.path))
+  }
+
+  it should "find project that does not have dateModified only in the Projects graph" in {
+
+    val project = anyProjectEntities.generateOne
+
+    provision(project).assertNoException >>
+      fetchBacklogProjects.asserting(_ shouldBe Nil) >>
+      deleteProjectsDateModified(project.resourceId).assertNoException >>
+      backlogCreator.createBacklog().assertNoException >>
+      fetchBacklogProjects.asserting(_.toSet shouldBe Set(project.path))
+  }
+
+  private implicit lazy val logger:    TestLogger[IO] = TestLogger[IO]()
+  implicit override lazy val ioLogger: Logger[IO]     = logger
+
+  private implicit lazy val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val backlogCreator =
+    new BacklogCreatorImpl[IO](RecordsFinder[IO](projectsDSConnectionInfo), TSClient[IO](migrationsDSConnectionInfo))
+
+  private def fetchBacklogProjects: IO[List[projects.Path]] =
+    runSelect(
+      on = migrationsDataset,
+      SparqlQuery.ofUnsafe(
+        "test Projects dateModified",
+        Prefixes of renku -> "renku",
+        sparql"""|SELECT ?path
+                 |WHERE {
+                 |  ${AddProjectDateModified.name.asEntityId} renku:toBeMigrated ?path
+                 |}
+                 |""".stripMargin
+      )
+    ).map(_.flatMap(_.get("path").map(projects.Path)))
+
+  private def deleteModifiedDates(projects: List[Project]): IO[Unit] =
+    projects.traverse_(p => deleteModifiedDates(p.resourceId))
+
+  private def deleteModifiedDates(id: projects.ResourceId): IO[Unit] =
+    deleteProjectDateModified(id) >> deleteProjectsDateModified(id)
+
+  private def deleteProjectDateModified(id: projects.ResourceId): IO[Unit] =
+    runUpdate(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test dateModified delete from Project",
+        Prefixes of schema -> "schema",
+        sparql"""|DELETE {
+                 |  GRAPH ?id { ?id schema:dateModified ?dm }
+                 |}
+                 |WHERE {
+                 |  BIND (${id.asEntityId} AS ?id)
+                 |  GRAPH ?id { ?id schema:dateModified ?dm }
+                 |}
+                 |""".stripMargin
+      )
+    )
+
+  private def deleteProjectsDateModified(id: projects.ResourceId): IO[Unit] =
+    runUpdate(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test dateModified delete from Project",
+        Prefixes of schema -> "schema",
+        sparql"""|DELETE {
+                 |  GRAPH ?gid { ?id schema:dateModified ?dm }
+                 |}
+                 |WHERE {
+                 |  BIND (${id.asEntityId} AS ?id)
+                 |  BIND (${GraphClass.Projects.id} AS ?gid)
+                 |  GRAPH ?gid { ?id schema:dateModified ?dm }
+                 |}
+                 |""".stripMargin
+      )
+    )
+
+  private def provision(project: Project): IO[Unit] =
+    provision(List(project))
+
+  private def provision(projects: List[Project]): IO[Unit] =
+    provisionTestProjects(projects: _*)(implicitly[RenkuUrl],
+                                        implicitly[EntityFunctions[entities.Project]],
+                                        projectsDSGraphsProducer[entities.Project]
+    )
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/DatePersisterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/DatePersisterSpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package datemodified
+
+import cats.effect.IO
+import eu.timepit.refined.auto._
+import io.renku.entities.searchgraphs.SearchInfoDatasets
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.{GraphClass, entities, projects}
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.ConditionedMigration
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+
+import java.time.Instant
+
+class DatePersisterSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with OptionValues
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with SearchInfoDatasets
+    with TSTooling {
+
+  it should "persist given dateCreated as dateModified" in {
+
+    val project      = anyProjectEntities.generateOne.to[entities.Project]
+    val expectedDate = projects.DateModified(project.dateCreated.value)
+
+    provisionProject(project).assertNoException >>
+      deleteModifiedDates(project.resourceId).assertNoException >>
+      findProjectDateModified(project.resourceId).asserting(_ shouldBe None) >>
+      findProjectsDateModified(project.resourceId).asserting(_ shouldBe None) >>
+      persister
+        .persistDateModified(ProjectInfo(project.resourceId, project.path, project.dateCreated))
+        .assertNoException >>
+      findProjectDateModified(project.resourceId).asserting(_.value shouldBe expectedDate) >>
+      findProjectsDateModified(project.resourceId).asserting(_.value shouldBe expectedDate) >>
+      migrationNeedChecker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.No])
+  }
+
+  it should "leave the old dateModified if exists" in {
+
+    val project = anyProjectEntities.generateOne.to[entities.Project]
+
+    provisionProject(project).assertNoException >>
+      findProjectDateModified(project.resourceId).asserting(_.value shouldBe project.dateModified) >>
+      findProjectsDateModified(project.resourceId).asserting(_.value shouldBe project.dateModified) >>
+      persister
+        .persistDateModified(ProjectInfo(project.resourceId, project.path, project.dateCreated))
+        .assertNoException >>
+      findProjectDateModified(project.resourceId).asserting(_.value shouldBe project.dateModified) >>
+      findProjectsDateModified(project.resourceId).asserting(_.value shouldBe project.dateModified) >>
+      migrationNeedChecker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.No])
+  }
+
+  implicit override lazy val ioLogger: Logger[IO]                  = TestLogger[IO]()
+  private implicit val timeRecorder:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val tsClient             = TSClient[IO](projectsDSConnectionInfo)
+  private lazy val persister            = new DatePersisterImpl[IO](tsClient)
+  private lazy val migrationNeedChecker = new MigrationNeedCheckerImpl[IO](tsClient)
+
+  private def findProjectDateModified(id: projects.ResourceId): IO[Option[projects.DateModified]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test find dateModified",
+        Prefixes of schema -> "schema",
+        sparql"""|SELECT ?date
+                 |WHERE {
+                 |  BIND (${id.asEntityId} AS ?id)
+                 |  GRAPH ?id { ?id schema:dateModified ?date }
+                 |}
+                 |LIMIT 1
+                 |""".stripMargin
+      )
+    ).map(_.map(_.get("date").map(Instant.parse).map(projects.DateModified(_))).headOption.flatten)
+
+  private def findProjectsDateModified(id: projects.ResourceId): IO[Option[projects.DateModified]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test find dateModified",
+        Prefixes of schema -> "schema",
+        sparql"""|SELECT ?date
+                 |WHERE {
+                 |  BIND (${id.asEntityId} AS ?id)
+                 |  GRAPH ${GraphClass.Projects.id} { ?id schema:dateModified ?date }
+                 |}
+                 |LIMIT 1
+                 |""".stripMargin
+      )
+    ).map(_.map(_.get("date").map(Instant.parse).map(projects.DateModified(_))).headOption.flatten)
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/MigrationNeedCheckerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/MigrationNeedCheckerSpec.scala
@@ -77,8 +77,7 @@ class MigrationNeedCheckerSpec
       checker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.No])
   }
 
-  private implicit lazy val logger:    TestLogger[IO]              = TestLogger[IO]()
-  implicit override lazy val ioLogger: Logger[IO]                  = logger
+  implicit override lazy val ioLogger: Logger[IO]                  = TestLogger[IO]()
   private implicit val timeRecorder:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
   private lazy val checker = new MigrationNeedCheckerImpl[IO](TSClient[IO](projectsDSConnectionInfo))
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/MigrationNeedCheckerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/MigrationNeedCheckerSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations.datemodified
+
+import cats.effect.IO
+import io.renku.entities.searchgraphs.SearchInfoDatasets
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore._
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+
+class MigrationNeedCheckerSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with SearchInfoDatasets
+    with AsyncMockFactory
+    with TSTooling {
+
+  it should "return Yes if there are projects without dateModified in the Projects or Project graph" in {
+
+    val project = anyProjectEntities.generateOne
+
+    provisionTestProject(project).assertNoException >>
+      deleteModifiedDates(project.resourceId).assertNoException >>
+      checker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.Yes])
+  }
+
+  it should "return Yes if there are projects without dateModified in the Project graph" in {
+
+    val project = anyProjectEntities.generateOne
+
+    provisionTestProject(project).assertNoException >>
+      deleteProjectDateModified(project.resourceId).assertNoException >>
+      checker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.Yes])
+  }
+
+  it should "return Yes if there are projects without dateModified in the Projects graph" in {
+
+    val project = anyProjectEntities.generateOne
+
+    provisionTestProject(project).assertNoException >>
+      deleteProjectsDateModified(project.resourceId).assertNoException >>
+      checker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.Yes])
+  }
+
+  it should "return No if there are no projects without dateModified" in {
+
+    val project = anyProjectEntities.generateOne
+
+    provisionTestProject(project).assertNoException >>
+      checker.checkMigrationNeeded.asserting(_ shouldBe a[ConditionedMigration.MigrationRequired.No])
+  }
+
+  private implicit lazy val logger:    TestLogger[IO]              = TestLogger[IO]()
+  implicit override lazy val ioLogger: Logger[IO]                  = logger
+  private implicit val timeRecorder:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val checker = new MigrationNeedCheckerImpl[IO](TSClient[IO](projectsDSConnectionInfo))
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectDonePersisterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectDonePersisterSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.effect.IO
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators.renkuUrls
+import io.renku.graph.model.RenkuTinyTypeGenerators.projectPaths
+import io.renku.graph.model.RenkuUrl
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore._
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+
+import scala.util.Random
+
+class ProjectDonePersisterSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with MigrationsDataset
+    with OptionValues {
+
+  it should "remove the (ProvisionProjectsGraph, renku:toBeMigrated, path) triple" in {
+
+    val paths       = projectPaths.generateList(min = 2)
+    val insertQuery = BacklogCreator.asToBeMigratedInserts.apply(paths).value
+
+    runUpdate(on = migrationsDataset, insertQuery).assertNoException >>
+      progressFinder.findProgressInfo.asserting(_ shouldBe s"${paths.size} left from ${paths.size}") >>
+      donePersister.noteDone(Random.shuffle(paths).head).assertNoException >>
+      progressFinder.findProgressInfo.asserting(_ shouldBe s"${paths.size - 1} left from ${paths.size}")
+  }
+
+  private implicit lazy val renkuUrl: RenkuUrl                    = renkuUrls.generateOne
+  private implicit val logger:        TestLogger[IO]              = TestLogger[IO]()
+  private implicit lazy val tr:       SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val tsClient       = TSClient[IO](migrationsDSConnectionInfo)
+  private lazy val progressFinder = new ProgressFinderImpl[IO](tsClient)
+  private lazy val donePersister  = new ProjectDonePersisterImpl[IO](tsClient)
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectFetcherSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectFetcherSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.effect.IO
+import io.renku.entities.searchgraphs.SearchInfoDatasets
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQueryTimeRecorder, TSClient}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+
+class ProjectFetcherSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with SearchInfoDatasets
+    with OptionValues {
+
+  it should "fetch info about the project" in {
+
+    val project = anyProjectEntities.generateOne.to[entities.Project]
+
+    provisionProject(project).assertNoException >>
+      fetcher
+        .fetchProject(project.path)
+        .asserting(_.value shouldBe ProjectInfo(project.resourceId, project.path, project.dateCreated))
+  }
+
+  it should "return no project if one does not exists" in {
+    fetcher.fetchProject(projectPaths.generateOne).asserting(_ shouldBe None)
+  }
+
+  implicit override lazy val ioLogger: Logger[IO]                  = TestLogger[IO]()
+  private implicit val timeRecorder:   SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val fetcher = new ProjectFetcherImpl[IO](TSClient[IO](projectsDSConnectionInfo))
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectsPageFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/ProjectsPageFinderSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package datemodified
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators.renkuUrls
+import io.renku.graph.model.RenkuTinyTypeGenerators.projectPaths
+import io.renku.graph.model._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore._
+import org.scalacheck.Gen
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import tooling._
+
+class ProjectsPageFinderSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with MigrationsDataset
+    with AsyncMockFactory
+    with OptionValues {
+
+  private val pageSize = 50
+
+  it should "return next page of projects for migration each time the method is called" in {
+
+    val paths = projectPaths
+      .generateList(min = pageSize + 1, max = Gen.choose(pageSize + 1, (2 * pageSize) - 1).generateOne)
+      .sorted
+
+    val (page1, page2) = paths splitAt pageSize
+
+    runUpdate(on = migrationsDataset, BacklogCreator.asToBeMigratedInserts.apply(paths).value).assertNoException >>
+      finder.nextProjectsPage().asserting(_ shouldBe page1) >>
+      page1.traverse_(donePersister.noteDone).assertNoException >>
+      finder.nextProjectsPage().asserting(_ shouldBe page2) >>
+      page2.traverse_(donePersister.noteDone).assertNoException >>
+      finder.nextProjectsPage().asserting(_ shouldBe Nil)
+  }
+
+  private implicit lazy val renkuUrl:     RenkuUrl                    = renkuUrls.generateOne
+  private implicit lazy val logger:       TestLogger[IO]              = TestLogger[IO]()
+  private implicit lazy val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+  private lazy val finder        = new ProjectsPageFinderImpl[IO](RecordsFinder[IO](migrationsDSConnectionInfo))
+  private lazy val donePersister = new ProjectDonePersisterImpl[IO](TSClient[IO](migrationsDSConnectionInfo))
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/TSTooling.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/datemodified/TSTooling.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.datemodified
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.Schemas.schema
+import io.renku.graph.model.testentities.{Project, ProjectOps}
+import io.renku.graph.model.{GraphClass, RenkuUrl, projects}
+import io.renku.jsonld.syntax._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQuery}
+
+trait TSTooling {
+  self: InMemoryJenaForSpec with ProjectsDataset =>
+
+  protected def deleteModifiedDates(projects: List[Project])(implicit ru: RenkuUrl): IO[Unit] =
+    projects.traverse_(p => deleteModifiedDates(p.resourceId))
+
+  protected def deleteModifiedDates(id: projects.ResourceId): IO[Unit] =
+    deleteProjectDateModified(id) >> deleteProjectsDateModified(id)
+
+  protected def deleteProjectDateModified(id: projects.ResourceId): IO[Unit] =
+    runUpdate(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test dateModified delete from Project",
+        Prefixes of schema -> "schema",
+        sparql"""|DELETE {
+                 |  GRAPH ?id { ?id schema:dateModified ?dm }
+                 |}
+                 |WHERE {
+                 |  BIND (${id.asEntityId} AS ?id)
+                 |  GRAPH ?id { ?id schema:dateModified ?dm }
+                 |}
+                 |""".stripMargin
+      )
+    )
+
+  protected def deleteProjectsDateModified(id: projects.ResourceId): IO[Unit] =
+    runUpdate(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test dateModified delete from Project",
+        Prefixes of schema -> "schema",
+        sparql"""|DELETE {
+                 |  GRAPH ?gid { ?id schema:dateModified ?dm }
+                 |}
+                 |WHERE {
+                 |  BIND (${id.asEntityId} AS ?id)
+                 |  BIND (${GraphClass.Projects.id} AS ?gid)
+                 |  GRAPH ?gid { ?id schema:dateModified ?dm }
+                 |}
+                 |""".stripMargin
+      )
+    )
+}


### PR DESCRIPTION
This PR introduces a new TS migration that adds `dateModified` when missing in the `Project` or the `Projects` graph.