### PR TITLE
chore: TS_MIGRATION_REQUEST to be resent more frequently when not done

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/EventFinder.scala
@@ -46,8 +46,8 @@ private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTime
     with EventFinder[F]
     with TSMigtationTypeSerializers {
 
-  private val SentStatusTimeout        = Duration ofHours 1
-  private val RecoverableStatusTimeout = Duration ofMinutes 2
+  private val SentStatusTimeout        = Duration ofMinutes 1
+  private val RecoverableStatusTimeout = Duration ofSeconds 30
 
   override def popEvent(): F[Option[MigrationRequestEvent]] =
     SessionResource[F].useWithTransactionK[Option[MigrationRequestEvent]] {

--- a/event-log/src/test/scala/io/renku/eventlog/InMemoryEventLogDb.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/InMemoryEventLogDb.scala
@@ -34,8 +34,11 @@ trait InMemoryEventLogDb extends ContainerEventLogDb with TypeSerializers {
 
   implicit val ioRuntime: IORuntime
 
+  def executeIO[O](query: Kleisli[IO, Session[IO], O]): IO[O] =
+    sessionResource.useK(query)
+
   def execute[O](query: Kleisli[IO, Session[IO], O]): O =
-    sessionResource.useK(query).unsafeRunSync()
+    executeIO(query).unsafeRunSync()
 
   def executeCommand(sql: Command[Void]): Unit =
     execute[Unit](Kleisli(session => session.execute(sql).void))


### PR DESCRIPTION
This PR increases the retry/resend frequency of the `TS_MIGRATION_REQUEST` events in case there's no `DONE` status for the latest TG version.

closes #1596 