### PR TITLE
feat: better 400 reporting for Project Update API

### DIFF
--- a/commit-event-service/src/main/scala/io/renku/commiteventservice/events/EventEndpoint.scala
+++ b/commit-event-service/src/main/scala/io/renku/commiteventservice/events/EventEndpoint.scala
@@ -26,6 +26,7 @@ import cats.syntax.all._
 import io.circe.Json
 import io.renku.events.EventRequestContent
 import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.{ErrorMessage, InfoMessage}
 import org.http4s.dsl.Http4sDsl

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/events/EventEndpointSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/events/EventEndpointSpec.scala
@@ -23,24 +23,24 @@ import cats.syntax.all._
 import io.circe.Json
 import io.renku.events.EventRequestContent
 import io.renku.events.Generators.eventRequestContents
-import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.events.consumers.ConsumersModelGenerators.badRequests
-import io.renku.generators.Generators.{exceptions, jsons, nonEmptyStrings}
+import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.generators.Generators.Implicits._
-import io.renku.http.{ErrorMessage, InfoMessage}
-import io.renku.http.ErrorMessage.ErrorMessage
+import io.renku.generators.Generators.{exceptions, jsons, nonEmptyStrings}
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.client.RestClient.PartEncoder
 import io.renku.http.server.EndpointTester._
+import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.testtools.IOSpec
 import io.renku.tinytypes.ByteArrayTinyType
 import io.renku.tinytypes.contenttypes.ZippedContent
-import org.http4s.{Method, Request}
 import org.http4s.MediaType._
 import org.http4s.Status.{Accepted, BadRequest, InternalServerError, ServiceUnavailable, TooManyRequests}
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.multipart.Part
+import org.http4s.{Method, Request}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/commit-event-service/src/test/scala/io/renku/commiteventservice/events/EventEndpointSpec.scala
+++ b/commit-event-service/src/test/scala/io/renku/commiteventservice/events/EventEndpointSpec.scala
@@ -61,7 +61,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Not multipart request")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Not multipart request")
     }
 
     s"return $BadRequest if there is no event part in the request" in new TestCase {
@@ -73,7 +73,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Missing event part")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Missing event part")
     }
 
     s"return $BadRequest if the event part in the request is malformed" in new TestCase {
@@ -84,7 +84,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Malformed event body")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Malformed event body")
     }
 
     forAll(
@@ -148,7 +148,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe TooManyRequests
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Too many events to handle")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Too many events to handle")
     }
 
     s"return $InternalServerError if handler returns ${EventSchedulingResult.SchedulingError}" in new TestCase {

--- a/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsEndpoint.scala
@@ -26,6 +26,7 @@ import io.circe.syntax.EncoderOps
 import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.{CompoundEventId, EventDetails}
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.{ErrorMessage, InfoMessage}
 import org.http4s.Response
@@ -52,7 +53,7 @@ class EventDetailsEndpointImpl[F[_]: Concurrent: Logger](eventDetailsFinder: Eve
 
   private lazy val internalServerError: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage("Finding event details failed")
-    Logger[F].error(exception)(errorMessage.value) *> InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) *> InternalServerError(errorMessage)
   }
 
   private implicit lazy val encoder: Encoder[EventDetails] = Encoder.instance[EventDetails] { eventDetails =>

--- a/event-log/src/main/scala/io/renku/eventlog/events/EventEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/EventEndpoint.scala
@@ -28,8 +28,9 @@ import io.renku.events.EventRequestContent
 import io.renku.events.EventRequestContent.WithPayload
 import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.graph.model.events.ZippedEventPayload
-import io.renku.http.{ErrorMessage, InfoMessage}
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
+import io.renku.http.{ErrorMessage, InfoMessage}
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.`Content-Type`

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/SubscriptionsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/SubscriptionsEndpoint.scala
@@ -24,6 +24,7 @@ import cats.effect.kernel.Concurrent
 import io.circe.Json
 import io.renku.events.Subscription
 import io.renku.http.ErrorMessage
+import io.renku.http.ErrorMessage._
 import org.http4s.{Request, Response}
 import org.http4s.dsl.Http4sDsl
 import org.typelevel.log4cats.Logger
@@ -73,7 +74,7 @@ class SubscriptionsEndpointImpl[F[_]: Concurrent: Logger](
       }
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage("Registering subscriber failed")
-      Logger[F].error(exception)(errorMessage.value) *> InternalServerError(errorMessage)
+      Logger[F].error(exception)(errorMessage.show) *> InternalServerError(errorMessage)
   }
 }
 

--- a/event-log/src/main/scala/io/renku/eventlog/status/StatusEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/status/StatusEndpoint.scala
@@ -20,8 +20,8 @@ package io.renku.eventlog.status
 
 import cats.MonadThrow
 import cats.syntax.all._
-import io.renku.eventlog.events.producers.{EventProducerStatus, EventProducersRegistry}
 import io.renku.eventlog.events.producers.EventProducerStatus.Capacity
+import io.renku.eventlog.events.producers.{EventProducerStatus, EventProducersRegistry}
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
 import org.typelevel.log4cats.Logger
@@ -41,9 +41,9 @@ private class StatusEndpointImpl[F[_]: MonadThrow: Logger](eventProducersRegistr
     extends Http4sDsl[F]
     with StatusEndpoint[F] {
 
+  import io.circe.Encoder
   import io.circe.literal._
   import io.circe.syntax._
-  import io.circe.Encoder
   import io.renku.http.ErrorMessage
   import io.renku.http.ErrorMessage._
   import org.http4s.circe.CirceEntityEncoder._
@@ -61,7 +61,7 @@ private class StatusEndpointImpl[F[_]: MonadThrow: Logger](eventProducersRegistr
 
   private lazy val httpResult: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val message = ErrorMessage("Finding EL status failed")
-    Logger[F].error(exception)(message.value) >> InternalServerError(message.asJson)
+    Logger[F].error(exception)(message.show) >> InternalServerError(message.asJson)
   }
 
   private implicit lazy val producerStatusDecoder: Encoder[EventProducerStatus] = Encoder.instance {

--- a/event-log/src/main/scala/io/renku/eventlog/tsMigrationModel.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/tsMigrationModel.scala
@@ -83,7 +83,7 @@ object MigrationMessage
     extends TinyTypeFactory[MigrationMessage](new MigrationMessage(_))
     with NonBlank[MigrationMessage] {
 
-  def apply(exception: Throwable): MigrationMessage = MigrationMessage(ErrorMessage.withStackTrace(exception).value)
+  def apply(exception: Throwable): MigrationMessage = MigrationMessage(ErrorMessage.withStackTrace(exception).show)
 
   import io.renku.tinytypes.json.TinyTypeDecoders.stringDecoder
   implicit val decoder: Decoder[MigrationMessage] = stringDecoder(MigrationMessage)

--- a/event-log/src/test/scala/io/renku/eventlog/TSMigrationModelSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/TSMigrationModelSpec.scala
@@ -109,7 +109,7 @@ class MigrationMessageSpec extends AnyWordSpec with ScalaCheckPropertyChecks wit
 
     "be instantiatable from an exception and contain the stack trace" in {
       forAll(nestedExceptions) { exception =>
-        MigrationMessage(exception).value shouldBe ErrorMessage.withStackTrace(exception).value
+        MigrationMessage(exception).value shouldBe ErrorMessage.withStackTrace(exception).show
       }
     }
   }

--- a/event-log/src/test/scala/io/renku/eventlog/events/EventEndpointSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/EventEndpointSpec.scala
@@ -23,23 +23,23 @@ import cats.syntax.all._
 import io.circe.Json
 import io.renku.events.EventRequestContent
 import io.renku.events.Generators.eventRequestContents
-import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.events.consumers.ConsumersModelGenerators.badRequests
 import io.renku.events.consumers.EventSchedulingResult.SchedulingError
-import io.renku.generators.Generators._
+import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators._
 import io.renku.graph.model.EventsGenerators.zippedEventPayloads
-import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.http.ErrorMessage.ErrorMessage
 import io.renku.http.InfoMessage._
 import io.renku.http.client.RestClient._
 import io.renku.http.server.EndpointTester._
+import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.testtools.IOSpec
 import io.renku.tinytypes.ByteArrayTinyType
 import io.renku.tinytypes.contenttypes.ZippedContent
-import org.http4s._
 import org.http4s.MediaType._
 import org.http4s.Status._
+import org.http4s._
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.multipart.Part
@@ -63,7 +63,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Not multipart request")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Not multipart request")
     }
 
     s"$BadRequest if there is no event part in the request" in new TestCase {
@@ -75,7 +75,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Missing event part")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Missing event part")
     }
 
     s"$BadRequest if there the event part in the request is malformed" in new TestCase {
@@ -86,7 +86,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Malformed event body")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Malformed event body")
     }
 
     val scenarios = Table(
@@ -152,7 +152,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe TooManyRequests
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Too many events to handle")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Too many events to handle")
     }
 
     s"$ServiceUnavailable if the handler returns EventSchedulingResult.ServiceUnavailable" in new TestCase {

--- a/event-log/src/test/scala/io/renku/eventlog/modelSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/modelSpec.scala
@@ -93,7 +93,7 @@ class EventMessageSpec extends AnyWordSpec with ScalaCheckPropertyChecks with sh
 
     "be instantiatable from an exception and contain the stack trace" in {
       forAll(nestedExceptions) { exception =>
-        EventMessage(exception).value shouldBe ErrorMessage.withStackTrace(exception).value
+        EventMessage(exception).value shouldBe ErrorMessage.withStackTrace(exception).show
       }
     }
   }

--- a/graph-commons/src/main/scala/io/renku/data/ErrorMessage.scala
+++ b/graph-commons/src/main/scala/io/renku/data/ErrorMessage.scala
@@ -28,7 +28,8 @@ import java.io.{PrintWriter, StringWriter}
 sealed trait ErrorMessage {
   type T
   val value: T
-  def show: String
+  def show:                   String
+  override lazy val toString: String = show
 }
 
 object ErrorMessage {

--- a/graph-commons/src/main/scala/io/renku/graph/model/events.scala
+++ b/graph-commons/src/main/scala/io/renku/graph/model/events.scala
@@ -134,7 +134,7 @@ object events {
     implicit val decoder: Decoder[EventMessage] = stringDecoder(EventMessage)
     implicit val encoder: Encoder[EventMessage] = Encoder.encodeString.contramap(_.value)
 
-    def apply(exception: Throwable): EventMessage = EventMessage(ErrorMessage.withStackTrace(exception).value)
+    def apply(exception: Throwable): EventMessage = EventMessage(ErrorMessage.withStackTrace(exception).show)
   }
 
   final class ExecutionDate private (val value: Instant) extends AnyVal with InstantTinyType

--- a/graph-commons/src/main/scala/io/renku/http/server/QueryParameterTools.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/QueryParameterTools.scala
@@ -22,6 +22,7 @@ import cats.MonadThrow
 import cats.data.NonEmptyList
 import io.circe.syntax._
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.{ErrorMessage, InfoMessage}
 import org.http4s.circe._
 import org.http4s.{ParseFailure, Response, Status}

--- a/graph-commons/src/main/scala/io/renku/http/server/endpoint/ResponseTools.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/endpoint/ResponseTools.scala
@@ -20,7 +20,10 @@ package io.renku.http.server.endpoint
 
 import cats.syntax.all._
 import cats.{Applicative, Eval}
+import io.circe.syntax._
 import io.renku.http.ErrorMessage
+import io.renku.http.ErrorMessage._
+import org.http4s.circe.CirceEntityEncoder._
 import org.http4s.headers.Accept
 import org.http4s.{MediaRange, MediaType, Request, Response, Status}
 
@@ -38,7 +41,7 @@ trait ResponseTools {
   )(default: => F[Response[F]])(implicit request: Request[F]): F[Response[F]] = {
     def notSupported(accept: Accept) = Response[F](Status.BadRequest)
       .withEntity(
-        ErrorMessage(s"Accept: ${accept.values.map(_.mediaRange.toString()).intercalate(", ")} not supported").value
+        ErrorMessage(s"Accept: ${accept.values.map(_.mediaRange.toString()).intercalate(", ")} not supported").asJson
       )
       .pure[F]
 

--- a/graph-commons/src/main/scala/io/renku/http/server/security/model.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/security/model.scala
@@ -21,6 +21,7 @@ package io.renku.http.server.security
 import cats.Applicative
 import cats.syntax.all._
 import io.renku.graph.model.persons
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage.messageJsonEntityEncoder
 import io.renku.http.client.UserAccessToken
 import io.renku.http.server.security.EndpointSecurityException.AuthenticationFailure

--- a/graph-commons/src/test/scala/io/renku/data/ErrorMessageSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/data/ErrorMessageSpec.scala
@@ -34,64 +34,70 @@ class ErrorMessageSpec extends AnyWordSpec with should.Matchers {
       val line1                 = nonEmptyStrings().generateOne
       val (line2Message, line2) = tabbedLines.generateOne
 
-      ErrorMessage(s"$line1\n$line2").value shouldBe s"$line1; $line2Message"
+      ErrorMessage(s"$line1\n$line2").value.value shouldBe s"$line1; $line2Message"
     }
   }
 
   "ErrorMessage.withExceptionMessage" should {
 
     "be instantiable from an Exception with a non-null, non-blank, single line message" in {
+
       val exception = exceptions.generateOne
 
       val message = ErrorMessage.withExceptionMessage(exception)
 
-      message.value shouldBe exception.getMessage
+      message.value.value shouldBe exception.getMessage
     }
 
     "be instantiable from an Exception with a multi-line message having some tabbing" in {
+
       val line1                 = nonEmptyStrings().generateOne
       val (line2Message, line2) = tabbedLines.generateOne
       val exception             = new Exception(s"$line1\n$line2")
 
       val message = ErrorMessage.withExceptionMessage(exception)
 
-      message.value shouldBe s"$line1; $line2Message"
+      message.value.value shouldBe s"$line1; $line2Message"
     }
 
     "be instantiable from an Exception with a null message" in {
+
       val exception = new Exception()
       assume(exception.getMessage == null)
 
       val message = ErrorMessage.withExceptionMessage(exception)
 
-      message.value shouldBe s"${exception.getClass.getName}"
+      message.value.value shouldBe s"${exception.getClass.getName}"
     }
 
     "be instantiable from an Exception with a blank message" in {
+
       val exception = new Exception(blankStrings().generateOne)
 
       val message = ErrorMessage.withExceptionMessage(exception)
 
-      message.value shouldBe s"${exception.getClass.getName}"
+      message.value.value shouldBe s"${exception.getClass.getName}"
     }
   }
 
   "ErrorMessage.withStackTrace" should {
 
     "be instantiable from an Exception with a non-null, non-blank, single line message" in {
+
       val exception = exceptions.generateOne
 
       val message = ErrorMessage.withStackTrace(exception)
 
       val sw = new StringWriter
       exception.printStackTrace(new PrintWriter(sw))
-      message.value shouldBe sw.toString.split("\n").map(_.trim).mkString("; ")
+      message.value.value shouldBe sw.toString.split("\n").map(_.trim).mkString("; ")
     }
   }
 
   "ErrorMessage.withMessageAndStackTrace" should {
 
     "be instantiable from the given message and Exception with a non-null, non-blank, single line message" in {
+
       val message   = sentences().generateOne.value
       val exception = exceptions.generateOne
 
@@ -99,15 +105,43 @@ class ErrorMessageSpec extends AnyWordSpec with should.Matchers {
 
       val sw = new StringWriter
       exception.printStackTrace(new PrintWriter(sw))
-      actual.value shouldBe s"$message; ${sw.toString.split("\n").map(_.trim).mkString("; ")}"
+      actual.value.value shouldBe s"$message; ${sw.toString.split("\n").map(_.trim).mkString("; ")}"
     }
 
     "return the message only for null exception" in {
+
       val message = sentences().generateOne.value
 
       val actual = ErrorMessage.withMessageAndStackTrace(message, exception = null)
 
-      actual.value shouldBe s"$message"
+      actual.value.value shouldBe s"$message"
+    }
+  }
+
+  "ErrorMessage(Json)" should {
+
+    "return the JsonMessage" in {
+
+      val message = jsons.generateOne
+
+      ErrorMessage(message).value shouldBe message
+    }
+  }
+
+  "ErrorMessage.show" should {
+
+    "return value in case of a StringMessage" in {
+
+      val message = nonBlankStrings().generateOne
+
+      ErrorMessage(message.value).show shouldBe message.value
+    }
+
+    "return value in case of a JsonMessage" in {
+
+      val message = jsons.generateOne
+
+      ErrorMessage(message).show shouldBe message.noSpaces
     }
   }
 

--- a/graph-commons/src/test/scala/io/renku/data/ErrorMessageSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/data/ErrorMessageSpec.scala
@@ -128,13 +128,14 @@ class ErrorMessageSpec extends AnyWordSpec with should.Matchers {
     }
   }
 
-  "ErrorMessage.show" should {
+  "ErrorMessage.show & toString" should {
 
     "return value in case of a StringMessage" in {
 
       val message = nonBlankStrings().generateOne
 
       ErrorMessage(message.value).show shouldBe message.value
+      ErrorMessage(message.value).toString shouldBe message.value
     }
 
     "return value in case of a JsonMessage" in {
@@ -142,6 +143,7 @@ class ErrorMessageSpec extends AnyWordSpec with should.Matchers {
       val message = jsons.generateOne
 
       ErrorMessage(message).show shouldBe message.noSpaces
+      ErrorMessage(message).toString shouldBe message.noSpaces
     }
   }
 

--- a/graph-commons/src/test/scala/io/renku/http/ErrorMessageSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/ErrorMessageSpec.scala
@@ -33,48 +33,46 @@ class ErrorMessageSpec extends AnyWordSpec with should.Matchers {
     import ErrorMessage._
 
     "be instantiatable from a non blank String" in {
+
       val line1                 = nonEmptyStrings().generateOne
       val (line2Message, line2) = tabbedLines.generateOne
 
-      ErrorMessage(s"$line1\n$line2").value shouldBe s"$line1; $line2Message"
+      ErrorMessage(s"$line1\n$line2").value.value shouldBe s"$line1; $line2Message"
     }
 
     "be instantiable from an Exception with a non-null, non-blank, single line message" in {
+
       val exception = exceptions.generateOne
 
-      val message = ErrorMessage(exception)
-
-      message.value shouldBe exception.getMessage
+      ErrorMessage(exception).value.value shouldBe exception.getMessage
     }
 
     "be instantiable from an Exception with a multi-line message having some tabbing" in {
+
       val line1                 = nonEmptyStrings().generateOne
       val (line2Message, line2) = tabbedLines.generateOne
       val exception             = new Exception(s"$line1\n$line2")
 
-      val message = ErrorMessage(exception)
-
-      message.value shouldBe s"$line1; $line2Message"
+      ErrorMessage(exception).value.value shouldBe s"$line1; $line2Message"
     }
 
     "be instantiable from an Exception with a null message" in {
+
       val exception = new Exception()
       assume(exception.getMessage == null)
 
-      val message = ErrorMessage(exception)
-
-      message.value shouldBe s"${exception.getClass.getName}"
+      ErrorMessage(exception).value.value shouldBe s"${exception.getClass.getName}"
     }
 
     "be instantiable from an Exception with a blank message" in {
+
       val exception = new Exception(blankStrings().generateOne)
 
-      val message = ErrorMessage(exception)
-
-      message.value shouldBe s"${exception.getClass.getName}"
+      ErrorMessage(exception).value.value shouldBe s"${exception.getClass.getName}"
     }
 
     "be encodable to JSON-LD" in {
+
       val exception = new Exception(blankStrings().generateOne)
       val message   = ErrorMessage(exception)
 

--- a/graph-commons/src/test/scala/io/renku/http/server/EndpointTester.scala
+++ b/graph-commons/src/test/scala/io/renku/http/server/EndpointTester.scala
@@ -24,7 +24,8 @@ import cats.effect.{Concurrent, IO, Resource}
 import cats.syntax.all._
 import eu.timepit.refined.api.RefType
 import io.circe._
-import io.renku.http.ErrorMessage.ErrorMessage
+import io.renku.data.ErrorMessage
+import io.renku.http.InfoMessage.InfoMessage
 import io.renku.http.rest.Links
 import io.renku.http.rest.Links.{Href, Rel}
 import io.renku.http.server.security.model.{AuthUser, MaybeAuthUser}
@@ -63,14 +64,34 @@ object EndpointTester {
       Kleisli(a => routes.run(a).getOrElse(response))
   }
 
-  implicit val errorMessageDecoder: Decoder[ErrorMessage] = Decoder.instance[ErrorMessage] {
-    _.downField("message")
-      .as[String]
-      .flatMap(RefType.applyRef[ErrorMessage](_))
-      .leftMap(error => DecodingFailure(s"Cannot deserialize 'message' to ErrorMessage: $error", Nil))
+  implicit val errorMessageDecoder: Decoder[ErrorMessage] = Decoder.instance[ErrorMessage] { cur =>
+    def failure(v: Any): Decoder.Result[ErrorMessage] =
+      DecodingFailure(s"Cannot deserialize 'message': $v to ErrorMessage", Nil).asLeft[ErrorMessage]
+
+    cur
+      .downField("message")
+      .as[Json]
+      .flatMap { json =>
+        json.fold[Decoder.Result[ErrorMessage]](failure(Json.Null),
+                                                failure(_),
+                                                failure(_),
+                                                ErrorMessage(_).asRight[DecodingFailure],
+                                                failure(_),
+                                                _ => ErrorMessage(json).asRight[DecodingFailure]
+        )
+      }
   }
 
   implicit def errorMessageEntityDecoder[F[_]: Concurrent]: EntityDecoder[F, ErrorMessage] = jsonOf[F, ErrorMessage]
+
+  implicit val infoMessageDecoder: Decoder[InfoMessage] = Decoder.instance[InfoMessage] {
+    _.downField("message")
+      .as[String]
+      .flatMap(RefType.applyRef[InfoMessage](_))
+      .leftMap(error => DecodingFailure(s"Cannot deserialize 'message' to InfoMessage: $error", Nil))
+  }
+
+  implicit def infoMessageEntityDecoder[F[_]: Concurrent]: EntityDecoder[F, InfoMessage] = jsonOf[F, InfoMessage]
 
   implicit class JsonOps(override val json: Json) extends JsonExt {
     import io.circe.Decoder

--- a/graph-commons/src/test/scala/io/renku/http/server/QueryParameterToolsSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/server/QueryParameterToolsSpec.scala
@@ -20,33 +20,34 @@ package io.renku.http.server
 
 import EndpointTester._
 import cats.effect.IO
+import io.renku.data.ErrorMessage
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
-import io.renku.http.ErrorMessage
-import io.renku.http.ErrorMessage.ErrorMessage
-import io.renku.testtools.IOSpec
+import io.renku.testtools.CustomAsyncIOSpec
 import org.http4s.ParseFailure
 import org.http4s.Status._
 import org.scalacheck.Gen
 import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AsyncWordSpec
 
-class QueryParameterToolsSpec extends AnyWordSpec with IOSpec with should.Matchers {
+class QueryParameterToolsSpec extends AsyncWordSpec with CustomAsyncIOSpec with should.Matchers {
 
   import QueryParameterTools._
 
   "toBadRequest" should {
 
     "return a BAD_REQUEST response containing JSON body with information about the query parameter name and validation errors" in {
+
       val parseFailuresList  = parseFailures.generateNonEmptyList()
       val badRequestResponse = toBadRequest[IO]
 
-      val response = badRequestResponse(parseFailuresList).unsafeRunSync()
-
-      response.status shouldBe BadRequest
-      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage(
-        parseFailuresList.toList.map(_.message).mkString("; ")
-      )
+      for {
+        response <- badRequestResponse(parseFailuresList)
+        _ = response.status shouldBe BadRequest
+        r <- response.as[ErrorMessage].asserting {
+               _ shouldBe ErrorMessage(parseFailuresList.toList.map(_.message).mkString("; "))
+             }
+      } yield r
     }
   }
 

--- a/graph-commons/src/test/scala/io/renku/http/server/endpoint/ResponseToolsSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/server/endpoint/ResponseToolsSpec.scala
@@ -22,7 +22,10 @@ import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
+import io.renku.http.ErrorMessage._
+import io.renku.http.server.EndpointTester.errorMessageEntityDecoder
 import io.renku.testtools.IOSpec
+import org.http4s.EntityEncoder.stringEncoder
 import org.http4s.MediaRange.`*/*`
 import org.http4s.MediaType.application
 import org.http4s.headers.Accept
@@ -43,8 +46,8 @@ class ResponseToolsSpec extends AnyWordSpec with should.Matchers with IOSpec wit
       implicit val request: Request[IO] = Request(headers = Headers(Accept(application.json)))
 
       val response = whenAccept(
-        application.json      --> Response[IO](Status.Ok).withEntity(bodyFactory()).pure[IO],
-        application.`ld+json` --> Response[IO](Status.Ok).withEntity(bodyFactory()).pure[IO]
+        application.json      --> Response[IO](Status.Ok).withEntity(bodyFactory())(stringEncoder[IO]).pure[IO],
+        application.`ld+json` --> Response[IO](Status.Ok).withEntity(bodyFactory())(stringEncoder[IO]).pure[IO]
       )(default = Response[IO](Status.Accepted).pure[IO])
 
       response.map(_.status).unsafeRunSync()         shouldBe Status.Ok
@@ -74,6 +77,7 @@ class ResponseToolsSpec extends AnyWordSpec with should.Matchers with IOSpec wit
     }
 
     "return BadRequest with an error message result when no matching MediaType defined" in new TestCase {
+
       val otherAccept = Accept(application.`ld+json`)
       implicit val request: Request[IO] = Request(headers = Headers(otherAccept))
 
@@ -83,8 +87,9 @@ class ResponseToolsSpec extends AnyWordSpec with should.Matchers with IOSpec wit
 
       response.map(_.status).unsafeRunSync() shouldBe Status.BadRequest
       response
-        .flatMap(_.as[String])
-        .unsafeRunSync() shouldBe s"Accept: ${otherAccept.values.map(_.mediaRange.toString()).intercalate(", ")} not supported"
+        .flatMap(_.as[ErrorMessage])
+        .unsafeRunSync()
+        .show shouldBe s"Accept: ${otherAccept.values.map(_.mediaRange.toString()).intercalate(", ")} not supported"
     }
   }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/Endpoint.scala
@@ -28,7 +28,7 @@ import io.renku.config.renku.ResourceUrl
 import io.renku.graph.config.GitLabUrlLoader
 import io.renku.graph.model.GitLabUrl
 import io.renku.http.ErrorMessage
-import io.renku.http.InfoMessage._
+import io.renku.http.ErrorMessage._
 import io.renku.http.rest.Sorting
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.server.security.model.AuthUser
@@ -93,8 +93,7 @@ class EndpointImpl[F[_]: Parallel: MonadThrow: Logger](
         .map(phrase => s"Finding datasets matching '$phrase' failed")
         .getOrElse("Finding all datasets failed")
     )
-    Logger[F].error(exception)(errorMessage.value) >>
-      InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 
   private def finishedSuccessfully(maybePhrase: Option[Phrase]): PartialFunction[Response[F], String] = {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Endpoint.scala
@@ -27,6 +27,7 @@ import io.renku.config.renku
 import io.renku.graph.config.{GitLabUrlLoader, RenkuUrlLoader}
 import io.renku.graph.http.server.security.Authorizer.AuthContext
 import io.renku.graph.model.{GitLabUrl, RenkuUrl}
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.rest.Links.Href
 import io.renku.http.{ErrorMessage, InfoMessage}
@@ -83,7 +84,7 @@ class EndpointImpl[F[_]: MonadThrow: Logger](
   private def httpResult(identifier: RequestedDataset): PartialFunction[Throwable, F[Response[F]]] = {
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage(show"Finding dataset '$identifier' failed")
-      Logger[F].error(exception)(errorMessage.value) >>
+      Logger[F].error(exception)(errorMessage.show) >>
         InternalServerError(errorMessage)
   }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/docs/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/docs/EndpointDocs.scala
@@ -21,7 +21,7 @@ package io.renku.knowledgegraph.docs
 import cats.MonadThrow
 import cats.implicits._
 import io.renku.http.ErrorMessage
-import io.renku.http.InfoMessage._
+import io.renku.http.ErrorMessage._
 import io.renku.knowledgegraph.docs.model.Operation.GET
 import io.renku.knowledgegraph.docs.model._
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/Endpoint.scala
@@ -76,6 +76,6 @@ private class EndpointImpl[F[_]: Async: Logger](
 
   private lazy val httpResult: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage("Cross-entity search failed")
-    Logger[F].error(exception)(errorMessage.value) >> InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/ontology/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/ontology/EndpointDocs.scala
@@ -22,7 +22,7 @@ import cats.MonadThrow
 import cats.implicits._
 import io.circe.literal._
 import io.renku.http.ErrorMessage
-import io.renku.http.InfoMessage._
+import io.renku.http.ErrorMessage._
 import io.renku.jsonld.parser._
 import io.renku.knowledgegraph.docs
 import io.renku.knowledgegraph.docs.model.Operation.GET

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/Endpoint.scala
@@ -27,7 +27,7 @@ import io.renku.config.renku
 import io.renku.graph.config.{GitLabUrlLoader, RenkuUrlLoader}
 import io.renku.graph.model.{GitLabUrl, RenkuUrl, projects}
 import io.renku.http.ErrorMessage
-import io.renku.http.InfoMessage._
+import io.renku.http.ErrorMessage._
 import io.renku.http.rest.Links._
 import io.renku.logging.ExecutionTimeRecorder
 import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
@@ -69,7 +69,7 @@ class EndpointImpl[F[_]: MonadCancelThrow: Logger](
       projectPath: projects.Path
   ): PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage(s"Finding $projectPath's datasets failed")
-    Logger[F].error(exception)(errorMessage.value) >>
+    Logger[F].error(exception)(errorMessage.show) >>
       InternalServerError(errorMessage)
   }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/tags/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/datasets/tags/Endpoint.scala
@@ -92,6 +92,6 @@ private class EndpointImpl[F[_]: Async: Logger](tagsFinder: TagsFinder[F],
 
   private lazy val httpResult: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage("Project Dataset Tags search failed")
-    Logger[F].error(exception)(errorMessage.value) >> InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/delete/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/delete/Endpoint.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.events.consumers.Project
 import io.renku.graph.model.projects
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.server.security.model.AuthUser

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/Endpoint.scala
@@ -18,18 +18,19 @@
 
 package io.renku.knowledgegraph.projects.details
 
-import cats.{MonadThrow, Parallel}
 import cats.effect._
 import cats.syntax.all._
+import cats.{MonadThrow, Parallel}
 import io.renku.config.renku
 import io.renku.graph.config.GitLabUrlLoader
-import io.renku.graph.model.{projects, GitLabUrl}
+import io.renku.graph.model.{GitLabUrl, projects}
 import io.renku.graph.tokenrepository.AccessTokenFinder
-import io.renku.http.{ErrorMessage, InfoMessage}
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.client.GitLabClient
 import io.renku.http.rest.Links.Href
 import io.renku.http.server.security.model.AuthUser
+import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.jsonld.syntax._
 import io.renku.logging.ExecutionTimeRecorder
 import io.renku.metrics.MetricsRegistry
@@ -37,9 +38,9 @@ import io.renku.triplesgenerator
 import io.renku.triplesgenerator.api.events.ProjectViewedEvent
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import model._
-import org.http4s.{Request, Response}
 import org.http4s.MediaType.application
 import org.http4s.dsl.Http4sDsl
+import org.http4s.{Request, Response}
 import org.typelevel.log4cats.Logger
 
 import java.time.Instant
@@ -106,7 +107,7 @@ class EndpointImpl[F[_]: MonadThrow: Logger](
       request: Request[F]
   ): PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val message = ErrorMessage(s"Finding '$path' project failed")
-    Logger[F].error(exception)(message.value) >> whenAccept(
+    Logger[F].error(exception)(message.show) >> whenAccept(
       application.`ld+json` --> InternalServerError(message.asJsonLD),
       application.json      --> InternalServerError(message.asJson)
     )(default = InternalServerError(message.asJson))

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/Endpoint.scala
@@ -23,6 +23,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.circe.syntax._
 import io.renku.graph.model.projects
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage.messageJsonEntityEncoder
 import io.renku.http.server.security.model.AuthUser
 import io.renku.http.{ErrorMessage, InfoMessage}
@@ -58,7 +59,7 @@ private class EndpointImpl[F[_]: Async: Logger](lineageFinder: LineageFinder[F])
 
   private lazy val httpResult: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage("Lineage generation failed")
-    Logger[F].error(exception)(errorMessage.value) >> InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/EndpointDocs.scala
@@ -22,6 +22,7 @@ package projects.update
 import cats.syntax.all._
 import io.circe.literal._
 import io.renku.graph.model.projects
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.knowledgegraph.docs.model.Operation.PUT

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/Endpoint.scala
@@ -129,6 +129,6 @@ private class EndpointImpl[F[_]: Async: Logger](projectsFinder: ProjectsFinder[F
 
   private lazy val httpResult: PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage("Finding user's projects failed")
-    Logger[F].error(exception)(errorMessage.value) >> InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
@@ -18,39 +18,39 @@
 
 package io.renku.knowledgegraph
 
-import cats.data.{EitherT, Kleisli}
 import cats.data.EitherT.{leftT, rightT}
+import cats.data.{EitherT, Kleisli}
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import io.circe.Json
 import io.renku.generators.CommonGraphGenerators._
-import io.renku.generators.Generators._
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators._
 import io.renku.graph.http.server.security.Authorizer
 import io.renku.graph.http.server.security.Authorizer.AuthContext
 import io.renku.graph.model
 import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.RenkuUrl
-import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.http.ErrorMessage.ErrorMessage
 import io.renku.http.InfoMessage._
 import io.renku.http.client.UrlEncoder.urlEncode
-import io.renku.http.rest.{SortBy, Sorting}
 import io.renku.http.rest.SortBy.Direction
 import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.rest.paging.model.{Page, PerPage}
+import io.renku.http.rest.{SortBy, Sorting}
 import io.renku.http.server.EndpointTester._
 import io.renku.http.server.security.EndpointSecurityException
 import io.renku.http.server.security.EndpointSecurityException.AuthorizationFailure
 import io.renku.http.server.security.model.{AuthUser, MaybeAuthUser}
 import io.renku.http.server.version
+import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.interpreters.TestRoutesMetrics
 import io.renku.knowledgegraph.datasets.details.RequestedDataset
 import io.renku.testtools.IOSpec
-import org.http4s._
 import org.http4s.MediaType.application
 import org.http4s.Method.{DELETE, GET, PUT}
 import org.http4s.Status._
+import org.http4s._
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.server.AuthMiddleware
@@ -73,10 +73,10 @@ class MicroserviceRoutesSpec
 
   "GET /knowledge-graph/datasets?query=<phrase>" should {
 
-    import datasets._
     import datasets.Endpoint.Query._
     import datasets.Endpoint.Sort
     import datasets.Endpoint.Sort._
+    import datasets._
 
     s"return $Ok when a valid 'query' and no 'sort', `page` and `per_page` parameters given" in new TestCase {
 
@@ -260,14 +260,14 @@ class MicroserviceRoutesSpec
 
       response.status             shouldBe NotFound
       response.contentType        shouldBe Some(`Content-Type`(application.json))
-      response.body[ErrorMessage] shouldBe InfoMessage(AuthorizationFailure.getMessage)
+      response.body[ErrorMessage] shouldBe ErrorMessage(AuthorizationFailure.getMessage)
     }
   }
 
   "GET /knowledge-graph/entities" should {
     import io.renku.entities.search.Criteria
-    import io.renku.entities.search.Criteria._
     import io.renku.entities.search.Criteria.Sort._
+    import io.renku.entities.search.Criteria._
     import io.renku.entities.search.Generators._
 
     forAll {
@@ -497,7 +497,7 @@ class MicroserviceRoutesSpec
 
       response.status             shouldBe NotFound
       response.contentType        shouldBe Some(`Content-Type`(application.json))
-      response.body[ErrorMessage] shouldBe InfoMessage(AuthorizationFailure.getMessage)
+      response.body[ErrorMessage] shouldBe ErrorMessage(AuthorizationFailure.getMessage)
     }
   }
 
@@ -560,7 +560,7 @@ class MicroserviceRoutesSpec
 
       response.status             shouldBe NotFound
       response.contentType        shouldBe Some(`Content-Type`(application.json))
-      response.body[ErrorMessage] shouldBe InfoMessage(AuthorizationFailure.getMessage)
+      response.body[ErrorMessage] shouldBe ErrorMessage(AuthorizationFailure.getMessage)
     }
   }
 
@@ -609,7 +609,7 @@ class MicroserviceRoutesSpec
 
       response.status             shouldBe NotFound
       response.contentType        shouldBe Some(`Content-Type`(application.json))
-      response.body[ErrorMessage] shouldBe InfoMessage(AuthorizationFailure.getMessage)
+      response.body[ErrorMessage] shouldBe ErrorMessage(AuthorizationFailure.getMessage)
     }
   }
 
@@ -657,7 +657,7 @@ class MicroserviceRoutesSpec
 
       response.status             shouldBe NotFound
       response.contentType        shouldBe Some(`Content-Type`(application.json))
-      response.body[ErrorMessage] shouldBe InfoMessage(AuthorizationFailure.getMessage)
+      response.body[ErrorMessage] shouldBe ErrorMessage(AuthorizationFailure.getMessage)
     }
   }
 
@@ -845,9 +845,9 @@ class MicroserviceRoutesSpec
   }
 
   "GET /knowledge-graph/users/:id/projects" should {
-    import users.projects._
-    import users.projects.Endpoint._
     import users.projects.Endpoint.Criteria._
+    import users.projects.Endpoint._
+    import users.projects._
 
     val userId = personGitLabIds.generateOne
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/EndpointSpec.scala
@@ -24,7 +24,6 @@ import Endpoint.Sort
 import cats.effect.IO
 import cats.syntax.all._
 import io.circe.literal._
-import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import io.renku.config.renku
 import io.renku.config.renku.ResourceUrl
@@ -33,10 +32,10 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.datasets._
 import io.renku.graph.model.images.ImageUri
-import io.renku.graph.model.{GraphModelGenerators, projects}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
+import io.renku.graph.model.{GraphModelGenerators, projects}
 import io.renku.http.ErrorMessage
-import io.renku.http.InfoMessage._
+import io.renku.http.ErrorMessage.ErrorMessage
 import io.renku.http.rest.paging.PagingRequest.Decoders.{page, perPage}
 import io.renku.http.rest.paging.{PagingHeaders, PagingResponse}
 import io.renku.http.server.EndpointTester._
@@ -109,7 +108,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
         case None         => s"Finding all datasets failed"
       }
 
-      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(errorMessage).asJson
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage(errorMessage)
 
       logger.loggedOnly(Error(errorMessage, exception))
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
@@ -32,12 +32,13 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.http.server.security.Authorizer.AuthContext
 import io.renku.graph.model.GraphModelGenerators._
+import io.renku.graph.model._
 import io.renku.graph.model.datasets._
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.persons.{Affiliation, Email, Name => UserName}
 import io.renku.graph.model.projects.Path
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
-import io.renku.graph.model._
+import io.renku.http.ErrorMessage._
 import io.renku.http.InfoMessage._
 import io.renku.http.rest.Links
 import io.renku.http.rest.Links.Rel.Self
@@ -171,7 +172,7 @@ class EndpointSpec
       response.status      shouldBe InternalServerError
       response.contentType shouldBe `Content-Type`(MediaType.application.json).some
 
-      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(show"Finding dataset '$requestedDataset' failed").asJson
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage(show"Finding dataset '$requestedDataset' failed")
 
       logger.loggedOnly(Error(show"Finding dataset '$requestedDataset' failed", exception))
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/datasets/EndpointSpec.scala
@@ -21,7 +21,6 @@ package io.renku.knowledgegraph.projects.datasets
 import cats.effect.IO
 import cats.syntax.all._
 import io.circe.literal._
-import io.circe.syntax._
 import io.circe.{Encoder, Json}
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
@@ -31,7 +30,7 @@ import io.renku.graph.model.datasets.{Identifier, Name, OriginalIdentifier, Titl
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Path
 import io.renku.http.ErrorMessage
-import io.renku.http.InfoMessage._
+import io.renku.http.ErrorMessage.ErrorMessage
 import io.renku.http.server.EndpointTester._
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.{Error, Warn}
@@ -105,7 +104,7 @@ class EndpointSpec extends AnyWordSpec with MockFactory with ScalaCheckPropertyC
       response.status      shouldBe InternalServerError
       response.contentType shouldBe Some(`Content-Type`(MediaType.application.json))
 
-      response.as[Json].unsafeRunSync() shouldBe ErrorMessage(s"Finding $projectPath's datasets failed").asJson
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage(s"Finding $projectPath's datasets failed")
 
       logger.loggedOnly(Error(s"Finding $projectPath's datasets failed", exception))
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EndpointSpec.scala
@@ -27,8 +27,8 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
 import io.renku.graph.model.GraphModelGenerators._
 import io.renku.http.ErrorMessage.ErrorMessage
-import io.renku.http.InfoMessage.InfoMessage
-import io.renku.http.server.EndpointTester.errorMessageEntityDecoder
+import io.renku.http.InfoMessage._
+import io.renku.http.server.EndpointTester.{errorMessageEntityDecoder, infoMessageEntityDecoder}
 import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.interpreters.TestLogger
 import io.renku.testtools.IOSpec

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/CreateTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/CreateTokenEndpoint.scala
@@ -67,7 +67,7 @@ class CreateTokenEndpointImpl[F[_]: Concurrent: Logger](
       BadRequest(ErrorMessage(exception))
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage(show"Associating token with projectId: $projectId failed")
-      Logger[F].error(exception)(errorMessage.value) >> InternalServerError(errorMessage)
+      Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -47,8 +47,7 @@ class DeleteTokenEndpointImpl[F[_]: Async: Logger](tokenRemover: TokenRemover[F]
   private def httpResult(projectId: GitLabId): PartialFunction[Throwable, F[Response[F]]] = {
     case NonFatal(exception) =>
       val errorMessage = ErrorMessage(s"Deleting token for projectId: $projectId failed")
-      Logger[F].error(exception)(errorMessage.value) >>
-        InternalServerError(errorMessage)
+      Logger[F].error(exception)(errorMessage.show) >> InternalServerError(errorMessage)
   }
 }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
@@ -25,6 +25,7 @@ import cats.syntax.all._
 import io.circe.syntax._
 import io.renku.graph.model.projects
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.client.AccessToken
 import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
@@ -67,7 +68,7 @@ class FetchTokenEndpointImpl[F[_]: MonadThrow: Logger](tokenFinder: TokenFinder[
       projectIdentifier: ID
   ): PartialFunction[Throwable, F[Response[F]]] = { case NonFatal(exception) =>
     val errorMessage = ErrorMessage(s"Finding token for project: $projectIdentifier failed")
-    Logger[F].error(exception)(errorMessage.value) *> InternalServerError(errorMessage)
+    Logger[F].error(exception)(errorMessage.show) *> InternalServerError(errorMessage)
   }
 
   implicit val findById:   projects.GitLabId => OptionT[F, AccessToken] = tokenFinder.findToken

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/EventEndpoint.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/EventEndpoint.scala
@@ -25,15 +25,16 @@ import cats.effect.Async
 import io.circe.Json
 import io.renku.events.EventRequestContent
 import io.renku.events.EventRequestContent.WithPayload
-import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.events.consumers.EventSchedulingResult.SchedulingError
+import io.renku.events.consumers.{EventConsumersRegistry, EventSchedulingResult}
 import io.renku.graph.model.events.ZippedEventPayload
 import io.renku.http.ErrorMessage
-import org.http4s.{Request, Response}
+import io.renku.http.ErrorMessage._
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.`Content-Type`
 import org.http4s.multipart.{Multipart, Part}
+import org.http4s.{Request, Response}
 import org.typelevel.log4cats.Logger
 
 import scala.util.control.NonFatal

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/EventStatusUpdater.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/EventStatusUpdater.scala
@@ -169,7 +169,7 @@ private class EventStatusUpdaterImpl[F[_]: Sync](
       },
       "subCategory": "ToFailure",
       "newStatus": $eventStatus,
-      "message":   ${ErrorMessage.withStackTrace(exception).value}
+      "message":   ${ErrorMessage.withStackTrace(exception).show}
     }""".addIfDefined("executionDelay" -> maybeExecutionDelay)),
     EventSender.EventContext(CategoryName("EVENTS_STATUS_CHANGE"),
                              errorMessage = s"$categoryName: Change event status as $eventStatus failed"

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandler.scala
@@ -19,23 +19,23 @@
 package io.renku.triplesgenerator.events.consumers
 package tsmigrationrequest
 
+import TSStateChecker.TSState.{MissingDatasets, ReProvisioning, Ready}
 import cats.effect.{Async, MonadCancelThrow}
 import cats.syntax.all._
 import com.typesafe.config.Config
 import io.renku.config.ServiceVersion
 import io.renku.data.ErrorMessage
-import io.renku.events.{CategoryName, EventRequestContent, consumers}
+import io.renku.events.Subscription.SubscriberUrl
 import io.renku.events.consumers.EventSchedulingResult.{SchedulingError, ServiceUnavailable}
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
-import io.renku.events.Subscription.SubscriberUrl
 import io.renku.events.consumers.{EventSchedulingResult, ProcessExecutor}
 import io.renku.events.producers.EventSender
+import io.renku.events.{CategoryName, EventRequestContent, consumers}
 import io.renku.graph.config.EventLogUrl
 import io.renku.metrics.MetricsRegistry
 import io.renku.microservices.MicroserviceIdentifier
-import migrations.reprovisioning.ReProvisioningStatus
-import TSStateChecker.TSState.{MissingDatasets, ReProvisioning, Ready}
 import io.renku.triplesstore.SparqlQueryTimeRecorder
+import migrations.reprovisioning.ReProvisioningStatus
 import org.typelevel.log4cats.Logger
 
 import scala.util.control.NonFatal
@@ -97,11 +97,11 @@ private class EventHandler[F[_]: MonadCancelThrow: Logger](
   private def toRecoverableFailure(recoverableFailure: ProcessingRecoverableError) =
     changeMigrationStatus(
       "RECOVERABLE_FAILURE",
-      ErrorMessage.withMessageAndStackTrace(recoverableFailure.message, recoverableFailure.cause).value.some
+      ErrorMessage.withMessageAndStackTrace(recoverableFailure.message, recoverableFailure.cause).show.some
     )
 
   private def nonRecoverableFailure: PartialFunction[Throwable, F[Unit]] = { case NonFatal(e) =>
-    changeMigrationStatus("NON_RECOVERABLE_FAILURE", ErrorMessage.withStackTrace(e).value.some)
+    changeMigrationStatus("NON_RECOVERABLE_FAILURE", ErrorMessage.withStackTrace(e).show.some)
   }
 
   private def verifyTSState: F[Option[EventSchedulingResult]] =

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/EventEndpointSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/EventEndpointSpec.scala
@@ -23,24 +23,24 @@ import cats.syntax.all._
 import io.circe.Json
 import io.renku.events.EventRequestContent
 import io.renku.events.Generators._
-import io.renku.events.consumers._
 import io.renku.events.consumers.ConsumersModelGenerators.badRequests
-import io.renku.generators.Generators._
+import io.renku.events.consumers._
 import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators._
 import io.renku.graph.model.EventsGenerators.zippedEventPayloads
-import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.http.ErrorMessage.ErrorMessage
 import io.renku.http.InfoMessage._
 import io.renku.http.client.RestClient._
 import io.renku.http.server.EndpointTester._
+import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.Error
 import io.renku.testtools.IOSpec
 import io.renku.tinytypes.ByteArrayTinyType
 import io.renku.tinytypes.contenttypes.ZippedContent
-import org.http4s._
 import org.http4s.MediaType._
 import org.http4s.Status._
+import org.http4s._
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.multipart.Part
@@ -64,7 +64,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Not multipart request")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Not multipart request")
     }
 
     s"return $BadRequest if there is no event part in the request" in new TestCase {
@@ -76,7 +76,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Missing event part")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Missing event part")
     }
 
     s"return $BadRequest if the event part in the request is malformed" in new TestCase {
@@ -87,7 +87,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe BadRequest
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Malformed event body")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Malformed event body")
     }
 
     val scenarios = Table(
@@ -153,7 +153,7 @@ class EventEndpointSpec
 
       response.status                          shouldBe TooManyRequests
       response.contentType                     shouldBe Some(`Content-Type`(application.json))
-      response.as[InfoMessage].unsafeRunSync() shouldBe ErrorMessage("Too many events to handle")
+      response.as[ErrorMessage].unsafeRunSync() shouldBe ErrorMessage("Too many events to handle")
     }
 
     s"return $InternalServerError if handler returns ${EventSchedulingResult.SchedulingError}" in new TestCase {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/EventStatusUpdaterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/EventStatusUpdaterSpec.scala
@@ -190,7 +190,7 @@ class EventStatusUpdaterSpec extends AnyWordSpec with IOSpec with MockFactory wi
                     "path": $projectPath
                   },
                   "subCategory": "ToFailure",
-                  "message":   ${ErrorMessage.withStackTrace(exception).value},  
+                  "message":   ${ErrorMessage.withStackTrace(exception).show},
                   "newStatus": $eventStatus 
                 }"""
               ),

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandlerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/EventHandlerSpec.scala
@@ -94,7 +94,7 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
         .expects(
           statusChangePayload(
             status = "RECOVERABLE_FAILURE",
-            ErrorMessage.withMessageAndStackTrace(recoverableFailure.message, recoverableFailure.cause).value.some
+            ErrorMessage.withMessageAndStackTrace(recoverableFailure.message, recoverableFailure.cause).show.some
           ),
           expectedEventContext
         )
@@ -120,9 +120,8 @@ class EventHandlerSpec extends AnyWordSpec with IOSpec with MockFactory with sho
 
       val eventCursor = payloadCaptor.value.event.hcursor
       eventCursor.downField("newStatus").as[String] shouldBe "NON_RECOVERABLE_FAILURE".asRight
-      eventCursor.downField("message").as[String].fold(throw _, identity) should include(
-        ErrorMessage.withStackTrace(exception).value
-      )
+      eventCursor.downField("message").as[String].fold(throw _, identity) should
+        include(ErrorMessage.withStackTrace(exception).show)
     }
   }
 

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
@@ -27,6 +27,7 @@ import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.graph.model.projects
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.client.GitLabClient
 import io.renku.http.server.security.model.AuthUser
 import io.renku.http.{ErrorMessage, InfoMessage}

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreationEndpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreationEndpoint.scala
@@ -23,6 +23,7 @@ import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.client.GitLabClient
 import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.http.server.security.model.AuthUser

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookdeletion/HookDeletionEndpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookdeletion/HookDeletionEndpoint.scala
@@ -23,6 +23,7 @@ import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.client.GitLabClient
 import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.http.server.security.model.AuthUser

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookvalidation/HookValidationEndpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookvalidation/HookValidationEndpoint.scala
@@ -23,6 +23,7 @@ import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.client.GitLabClient
 import io.renku.http.server.security.model.AuthUser
 import io.renku.http.{ErrorMessage, InfoMessage}

--- a/webhook-service/src/main/scala/io/renku/webhookservice/webhookevents/Endpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/webhookevents/Endpoint.scala
@@ -28,6 +28,7 @@ import io.renku.events.consumers.Project
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.projects.{GitLabId, Path}
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage._
 import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.http.{ErrorMessage, InfoMessage}
 import io.renku.metrics.MetricsRegistry

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/EndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/EndpointSpec.scala
@@ -33,6 +33,7 @@ import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.graph.model.projects
 import io.renku.graph.model.projects.GitLabId
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage.InfoMessage
 import io.renku.http.client.AccessToken
 import io.renku.http.server.EndpointTester._
 import io.renku.http.server.security.model.AuthUser
@@ -165,9 +166,9 @@ class EndpointSpec
 
         val response = endpoint.fetchProcessingStatus(projectId, authUser).unsafeRunSync()
 
-        response.status                   shouldBe NotFound
-        response.contentType              shouldBe Some(`Content-Type`(application.json))
-        response.as[Json].unsafeRunSync() shouldBe InfoMessage("Info about project cannot be found").asJson
+        response.status                          shouldBe NotFound
+        response.contentType                     shouldBe Some(`Content-Type`(application.json))
+        response.as[InfoMessage].unsafeRunSync() shouldBe InfoMessage("Info about project cannot be found")
       }
 
     "return INTERNAL_SERVER_ERROR when checking if project webhook exists fails" in new TestCase {

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookcreation/HookCreationEndpointSpec.scala
@@ -92,7 +92,7 @@ class HookCreationEndpointSpec extends AnyWordSpec with MockFactory with should.
     "return INTERNAL_SERVER_ERROR when there was an error during hook creation and log the error" in new TestCase {
 
       val errorMessage = ErrorMessage("some error")
-      val exception    = new Exception(errorMessage.toString())
+      val exception    = new Exception(errorMessage.show)
       (hookCreator
         .createHook(_: GitLabId, _: AuthUser))
         .expects(projectId, authUser)

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookdeletion/HookDeletionEndpointImplSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookdeletion/HookDeletionEndpointImplSpec.scala
@@ -81,7 +81,7 @@ class HookDeletionEndpointImplSpec extends AnyWordSpec with MockFactory with sho
     "return INTERNAL_SERVER_ERROR when there was an error during hook deletion and log the error" in new TestCase {
 
       val errorMessage = ErrorMessage("some error")
-      val exception    = new Exception(errorMessage.toString())
+      val exception    = new Exception(errorMessage.show)
       (hookRemover
         .deleteHook(_: HookIdentifier, _: AccessToken))
         .expects(projectHookId, authUser.accessToken)

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidationEndpointSpec.scala
@@ -91,7 +91,7 @@ class HookValidationEndpointSpec extends AnyWordSpec with MockFactory with shoul
     "return INTERNAL_SERVER_ERROR when there was an error during hook validation and log the error" in new TestCase {
 
       val errorMessage      = ErrorMessage("some error")
-      private val exception = new Exception(errorMessage.toString())
+      private val exception = new Exception(errorMessage.show)
       (hookValidator
         .validateHook(_: projects.GitLabId, _: Option[AccessToken]))
         .expects(projectId, Some(authUser.accessToken))

--- a/webhook-service/src/test/scala/io/renku/webhookservice/webhookevents/EndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/webhookevents/EndpointSpec.scala
@@ -32,6 +32,7 @@ import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.projectIds
 import io.renku.graph.model.events.CommitId
 import io.renku.http.ErrorMessage._
+import io.renku.http.InfoMessage.InfoMessage
 import io.renku.http.client.RestClientError.UnauthorizedException
 import io.renku.http.server.EndpointTester._
 import io.renku.http.{ErrorMessage, InfoMessage}
@@ -68,9 +69,9 @@ class EndpointSpec extends AnyWordSpec with MockFactory with should.Matchers wit
 
       val response = endpoint.processPushEvent(request).unsafeRunSync()
 
-      response.status                   shouldBe Accepted
-      response.contentType              shouldBe Some(`Content-Type`(MediaType.application.json))
-      response.as[Json].unsafeRunSync() shouldBe InfoMessage("Event accepted").asJson
+      response.status                          shouldBe Accepted
+      response.contentType                     shouldBe Some(`Content-Type`(MediaType.application.json))
+      response.as[InfoMessage].unsafeRunSync() shouldBe InfoMessage("Event accepted")
 
       logger.loggedOnly(
         Info(


### PR DESCRIPTION
This PR improves reporting when the Project Update API responds `400 BAD_REQUEST`. Specifically, in case GL returns 400 response and body like:
```json
{
  "message": {
    "visibility_level": [
      "internal is not allowed in a private group.",
      "internal is not allowed since the fork source project has lower visibility."
    ]
  }
}
```
the Project Update API should return the same amount of details back to the caller.