### PR TITLE
feat: Sort by dateModified, as rendundant parameter for `sort=date`

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -88,11 +88,12 @@ object Criteria {
     final case object ByName          extends Property("name") with SortProperty
     final case object ByMatchingScore extends Property("matchingScore") with SortProperty
     final case object ByDate          extends Property("date") with SortProperty
+    final case object ByDateModified  extends Property("dateModified") with SortProperty
 
     val byNameAsc = Sort.By(ByName, Direction.Asc)
 
     val default: Sorting[Sort.type] = Sorting(byNameAsc)
 
-    override lazy val properties: Set[SortProperty] = Set(ByName, ByMatchingScore, ByDate)
+    override lazy val properties: Set[SortProperty] = Set(ByName, ByMatchingScore, ByDate, ByDateModified)
   }
 }

--- a/entities-search/src/main/scala/io/renku/entities/search/EntitiesFinder.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/EntitiesFinder.scala
@@ -77,6 +77,7 @@ private class EntitiesFinderImpl[F[_]: Async: NonEmptyParallel: Logger: SparqlQu
     def mapPropertyName(property: Criteria.Sort.SortProperty) = property match {
       case Criteria.Sort.ByName          => OrderBy.Property("LCASE(?name)")
       case Criteria.Sort.ByDate          => OrderBy.Property("xsd:dateTime(?date)")
+      case Criteria.Sort.ByDateModified  => OrderBy.Property("xsd:dateTime(?date)")
       case Criteria.Sort.ByMatchingScore => OrderBy.Property("?matchingScore")
     }
 

--- a/entities-search/src/test/scala/io/renku/entities/search/FinderSpecOps.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/FinderSpecOps.scala
@@ -67,8 +67,8 @@ trait FinderSpecOps {
 
   protected[search] implicit class EntityOps(entity: model.Entity) {
     lazy val dateAsInstant: Instant = entity match {
-      case proj:     model.Entity.Project  => proj.date.value
-      case ds:       model.Entity.Dataset  => ds.date.instant
+      case proj:     model.Entity.Project  => proj.dateModified.value
+      case ds:       model.Entity.Dataset  => ds.dateModified.map(_.value).getOrElse(ds.date.instant)
       case workflow: model.Entity.Workflow => workflow.date.value
       case person:   model.Entity.Person   => person.date.value
     }


### PR DESCRIPTION
Adds sorting by `dateModified`, which has already been implemented for datasets. Now it's also done for projects, since they now also have the dateModified available.

/deploy #persist