### PR TITLE
fix: DB operations on failed transaction

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
@@ -55,7 +55,7 @@ private class DequeuedEventHandlerImpl[F[_]: Async: QueriesExecutionTimes](
   override def updateDB(event: RedoProjectTransformation): UpdateOp[F] =
     findLatestSuccessfulEvent(event.project.path) >>= {
       case Some(eventId) => toTriplesGenerated(eventId) flatMapF toDBUpdateResults(eventId, event.project.path)
-      case None          => triggerMinProjectInfoEvent(event.project.path) map (_ => DBUpdateResults.ForProjects.empty)
+      case None          => triggerMinProjectInfoEvent(event.project.path).as(DBUpdateResults.ForProjects.empty)
     }
 
   private def findLatestSuccessfulEvent(path: projects.Path) = measureExecutionTime {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdater.scala
@@ -49,8 +49,14 @@ private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes
 
   import deliveryInfoRemover._
 
-  override def onRollback(event: ToFailure): RollbackOp[F] = { _ =>
-    deleteDelivery(event.eventId).as(DBUpdateResults.ForProjects.empty)
+  override def onRollback(event: ToFailure): RollbackOp[F] = {
+    case DeadlockDetected(_) =>
+      Kleisli.liftF[F, Session[F], Unit] {
+        Logger[F].warn(show"Deadlock while updating event ${event.eventId} to ${event.newStatus}") >>
+          Temporal[F].sleep(1 second)
+      } >> updateDB(event).map(_.widen)
+    case ex =>
+      deleteDelivery(event.eventId).flatMapF(_ => ex.raiseError[F, DBUpdateResults])
   }
 
   override def updateDB(event: ToFailure): UpdateOp[F] = for {
@@ -59,53 +65,42 @@ private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes
     ancestorsUpdateResult <- maybeUpdateAncestors(event, eventUpdateResult)
   } yield ancestorsUpdateResult combine eventUpdateResult
 
-  private def updateEvent(
-      event: ToFailure
-  ): Kleisli[F, Session[F], DBUpdateResults.ForProjects] = measureExecutionTime {
-    SqlStatement
-      .named(s"to_${event.newStatus.value.toLowerCase} - status update")
-      .command[
-        FailureStatus *: ExecutionDate *: EventMessage *: EventId *: projects.GitLabId *: ProcessingStatus *: EmptyTuple
-      ](
-        sql"""UPDATE event
+  private def updateEvent(event: ToFailure): Kleisli[F, Session[F], DBUpdateResults.ForProjects] =
+    measureExecutionTime {
+      SqlStatement
+        .named(s"to_${event.newStatus.value.toLowerCase} - status update")
+        .command[
+          FailureStatus *: ExecutionDate *: EventMessage *: EventId *: projects.GitLabId *: ProcessingStatus *: EmptyTuple
+        ](sql"""UPDATE event
               SET status = $eventFailureStatusEncoder,
                 execution_date = $executionDateEncoder,
                 message = $eventMessageEncoder
               WHERE event_id = $eventIdEncoder 
                 AND project_id = $projectIdEncoder 
                 AND status = $eventProcessingStatusEncoder
-               """.command
-      )
-      .arguments(
-        event.newStatus *:
-          ExecutionDate(now().plusMillis(event.executionDelay.getOrElse(Duration.ofMillis(0)).toMillis)) *:
-          event.message *:
-          event.eventId.id *:
-          event.eventId.projectId *:
-          event.currentStatus *:
-          EmptyTuple
-      )
-      .build
-      .flatMapResult {
-        case Completion.Update(1) =>
-          DBUpdateResults
-            .ForProjects(event.project.path, Map(event.currentStatus -> -1, event.newStatus -> 1))
-            .pure[F]
-        case Completion.Update(0) => DBUpdateResults.ForProjects.empty.pure[F]
-        case completion =>
-          new Exception(s"Could not update event ${event.eventId} to status ${event.newStatus}: $completion")
-            .raiseError[F, DBUpdateResults.ForProjects]
-      }
-  }.recoverWith(retryUpdating(event))
-
-  private def retryUpdating(
-      event: ToFailure
-  ): PartialFunction[Throwable, Kleisli[F, Session[F], DBUpdateResults.ForProjects]] = { case DeadlockDetected(_) =>
-    Kleisli.liftF[F, Session[F], Unit] {
-      Logger[F].warn(show"Deadlock while updating event ${event.eventId} to ${event.newStatus}") >>
-        Temporal[F].sleep(1 second)
-    } >> updateEvent(event)
-  }
+               """.command)
+        .arguments(
+          event.newStatus *:
+            ExecutionDate(now().plusMillis(event.executionDelay.getOrElse(Duration.ofMillis(0)).toMillis)) *:
+            event.message *:
+            event.eventId.id *:
+            event.eventId.projectId *:
+            event.currentStatus *:
+            EmptyTuple
+        )
+        .build
+        .flatMapResult {
+          case Completion.Update(1) =>
+            DBUpdateResults
+              .ForProjects(event.project.path, Map(event.currentStatus -> -1, event.newStatus -> 1))
+              .pure[F]
+          case Completion.Update(0) =>
+            DBUpdateResults.ForProjects.empty.pure[F]
+          case completion =>
+            new Exception(s"Could not update event ${event.eventId} to status ${event.newStatus}: $completion")
+              .raiseError[F, DBUpdateResults.ForProjects]
+        }
+    }
 
   private def maybeUpdateAncestors(event: ToFailure, updateResults: DBUpdateResults.ForProjects) =
     updateResults -> event.newStatus match {
@@ -122,8 +117,7 @@ private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes
         .select[
           EventStatus *: ExecutionDate *: projects.GitLabId *: projects.GitLabId *: EventId *: EventId *: EmptyTuple,
           EventId
-        ](
-          sql"""UPDATE event evt
+        ](sql"""UPDATE event evt
                 SET status = $eventStatusEncoder, 
                     execution_date = $executionDateEncoder, 
                     message = NULL
@@ -143,8 +137,7 @@ private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes
                 ) old_evt
                 WHERE evt.event_id = old_evt.event_id AND evt.project_id = old_evt.project_id 
                 RETURNING evt.event_id
-           """.query(eventIdDecoder)
-        )
+           """.query(eventIdDecoder))
         .arguments(
           newStatus *:
             ExecutionDate(now().plusMillis(event.executionDelay.getOrElse(Duration ofMillis 0).toMillis)) *:
@@ -156,7 +149,8 @@ private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes
         )
         .build(_.toList)
         .mapResult { ids =>
-          DBUpdateResults.ForProjects(event.project.path, Map(newStatus -> ids.size, TriplesGenerated -> -ids.size))
+          DBUpdateResults
+            .ForProjects(event.project.path, Map(newStatus -> ids.size, TriplesGenerated -> -ids.size))
         }
     }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
@@ -47,6 +47,7 @@ import io.renku.testtools.IOSpec
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
 import skunk.SqlState
 
@@ -60,7 +61,8 @@ class DequeuedEventHandlerSpec
     with SubscriptionDataProvisioning
     with TypeSerializers
     with should.Matchers
-    with MockFactory {
+    with MockFactory
+    with TableDrivenPropertyChecks {
 
   "updateDB" should {
 
@@ -102,9 +104,7 @@ class DequeuedEventHandlerSpec
         val counts: Map[EventStatus, Int] = eventsStatuses
           .groupBy(identity)
           .map { case (eventStatus, statuses) => (eventStatus, -1 * statuses.length) }
-          .updatedWith(EventStatus.New) { maybeNewEvents =>
-            maybeNewEvents.map(_ + events.size).orElse(Some(events.size))
-          }
+          .updatedWith(EventStatus.New)(_.map(_ + events.size).orElse(Some(events.size)))
           .updated(AwaitingDeletion, -1)
           .updated(Deleting, -1)
 
@@ -154,50 +154,55 @@ class DequeuedEventHandlerSpec
         findEvent(event2) shouldBe None
       }
 
-    "change the status of all events of a specific project to NEW except SKIPPED events " +
-      "- case when there are no events left in the project and cleaning the project fails" in new TestCase {
+    "fail if the cleaning the project fails" in new TestCase {
 
-        val exception = exceptions.generateOne
-        val project   = consumerProjects.generateOne
+      val project = consumerProjects.generateOne
 
-        val event1 = addEvent(Deleting, project)
-        val event2 = addEvent(Deleting, project)
+      addEvent(Deleting, project)
+      addEvent(Deleting, project)
 
-        (projectCleaner.cleanUp _)
-          .expects(project)
-          .returning(Kleisli.liftF(exception.raiseError[IO, Unit]))
+      val exception = exceptions.generateOne
+      (projectCleaner.cleanUp _)
+        .expects(project)
+        .returning(Kleisli.liftF(exception.raiseError[IO, Unit]))
 
+      intercept[Exception](
         sessionResource
           .useK(dbUpdater.updateDB(ProjectEventsToNew(project)))
-          .unsafeRunSync() shouldBe DBUpdateResults.ForProjects(project.path,
-                                                                Map(AwaitingDeletion -> 0, Deleting -> -2)
-        )
+          .unsafeRunSync()
+      ) shouldBe exception
 
-        findEvent(event1) shouldBe None
-        findEvent(event2) shouldBe None
-
-        logger.loggedOnly(Error(show"$categoryName: project clean up failed: ${project.show}", exception))
-      }
+      logger.loggedOnly(Error(show"$categoryName: project clean up failed: ${project.show}; will retry", exception))
+    }
   }
 
   "onRollback" should {
 
-    "run the updateDB on DeadlockDetected" in new TestCase {
+    forAll(
+      Table(
+        "failure name"        -> "failure",
+        "Deadlock"            -> postgresErrors(SqlState.DeadlockDetected).generateOne,
+        "ForeignKeyViolation" -> postgresErrors(SqlState.ForeignKeyViolation).generateOne
+      )
+    ) { (failureName, failure) =>
+      s"run the updateDB on $failureName" in new TestCase {
 
-      val project = consumerProjects.generateOne
+        val project = consumerProjects.generateOne
 
-      val event = addEvent(Deleting, project)
+        val event = addEvent(Deleting, project)
 
-      upsertCategorySyncTime(project.id, categoryNames.generateOne, lastSyncedDates.generateOne)
+        upsertCategorySyncTime(project.id, categoryNames.generateOne, lastSyncedDates.generateOne)
 
-      (projectCleaner.cleanUp _).expects(project).returns(Kleisli.pure(()))
+        (projectCleaner.cleanUp _).expects(project).returns(Kleisli.pure(()))
 
-      val deadlockException = postgresErrors(SqlState.DeadlockDetected).generateOne
-      sessionResource
-        .useK((dbUpdater onRollback ProjectEventsToNew(project))(deadlockException))
-        .unsafeRunSync() shouldBe DBUpdateResults.ForProjects(project.path, Map(AwaitingDeletion -> 0, Deleting -> -1))
+        sessionResource
+          .useK((dbUpdater onRollback ProjectEventsToNew(project))(failure))
+          .unsafeRunSync() shouldBe DBUpdateResults.ForProjects(project.path,
+                                                                Map(AwaitingDeletion -> 0, Deleting -> -1)
+        )
 
-      findEvent(event) shouldBe None
+        findEvent(event) shouldBe None
+      }
     }
   }
 
@@ -252,9 +257,9 @@ class DequeuedEventHandlerSpec
     private val now         = Instant.now()
     currentTime.expects().returning(now).anyNumberOfTimes()
 
-    val subscriberId  = subscriberIds.generateOne
-    val sourceUrl     = microserviceBaseUrls.generateOne
-    val subscriberUrl = subscriberUrls.generateOne
+    val subscriberId          = subscriberIds.generateOne
+    private val sourceUrl     = microserviceBaseUrls.generateOne
+    private val subscriberUrl = subscriberUrls.generateOne
     upsertSubscriber(subscriberId, subscriberUrl, sourceUrl)
 
     implicit val logger:                   TestLogger[IO]            = TestLogger[IO]()


### PR DESCRIPTION
This PR fixes several `DBUpdater`s that were trying to perform DB updates in exception handling clauses while the transaction was already failed. The mentioned DB updates were moved to the `onRollback` methods so they can be redone on a new transaction after the rollback operation is performed.

closes #1623 