### PR TITLE
refactor: project_path to project_slug DB column renames

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ZombieEventDetectionSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ZombieEventDetectionSpec.scala
@@ -100,7 +100,7 @@ class ZombieEventDetectionSpec
 
   private def insertProjectToDB(project: data.Project, eventDate: EventDate): Int = EventLog.execute { session =>
     val query: Command[GitLabId *: Slug *: EventDate *: EmptyTuple] =
-      sql"""INSERT INTO project (project_id, project_path, latest_event_date)
+      sql"""INSERT INTO project (project_id, project_slug, latest_event_date)
             VALUES ($projectIdEncoder, $projectSlugEncoder, $eventDateEncoder)
             ON CONFLICT (project_id)
             DO UPDATE SET latest_event_date = excluded.latest_event_date WHERE excluded.latest_event_date > project.latest_event_date

--- a/event-log/README.md
+++ b/event-log/README.md
@@ -898,7 +898,7 @@ Event-log uses relational database as an internal storage. The DB has the follow
 | project                                   |
 |-------------------------------------------|
 | project_id        INT4        PK NOT NULL |
-| project_path      VARCHAR        NOT NULL |
+| project_slug      VARCHAR        NOT NULL |
 | latest_event_date TIMESTAMPTZ    NOT NULL |
 
 | event_payload                     |
@@ -945,7 +945,7 @@ Event-log uses relational database as an internal storage. The DB has the follow
 | id           SERIAL      PK NOT NULL |
 | date         TIMESTAMPTZ    NOT NULL |
 | project_id   INT4           NOT NULL |
-| project_path VARCHAR        NOT NULL |
+| project_slug VARCHAR        NOT NULL |
 
 | ts_migration                                |
 |---------------------------------------------|

--- a/event-log/src/main/scala/io/renku/eventlog/eventpayload/EventPayloadFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventpayload/EventPayloadFinder.scala
@@ -56,11 +56,10 @@ object EventPayloadFinder {
           .build(_.option)
 
       def selectPayload: Query[EventId *: ProjectSlug *: EmptyTuple, PayloadData] =
-        sql"""
-              SELECT ep.payload
+        sql"""SELECT ep.payload
               FROM event_payload ep
               INNER JOIN project p USING (project_id)
-              WHERE ep.event_id = $eventIdEncoder AND p.project_path = $projectSlugEncoder
+              WHERE ep.event_id = $eventIdEncoder AND p.project_slug = $projectSlugEncoder
              """
           .query(byteVectorDecoder)
           .map(PayloadData)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/cleanuprequest/CleanUpEventsQueue.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/cleanuprequest/CleanUpEventsQueue.scala
@@ -54,7 +54,7 @@ private class CleanUpEventsQueueImpl[F[_]: Async: SessionResource: QueriesExecut
     measureExecutionTime {
       SqlStatement[F](name = "clean_up_events_queue - offer")
         .command[OffsetDateTime *: projects.GitLabId *: projects.Slug *: EmptyTuple](
-          sql"""INSERT INTO clean_up_events_queue (date, project_id, project_path)
+          sql"""INSERT INTO clean_up_events_queue (date, project_id, project_slug)
                 VALUES ($timestamptz, $projectIdEncoder, $projectSlugEncoder)
                 ON CONFLICT DO NOTHING
           """.command

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/cleanuprequest/ProjectIdFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/cleanuprequest/ProjectIdFinder.scala
@@ -48,7 +48,7 @@ private class ProjectIdFinderImpl[F[_]: MonadCancelThrow: SessionResource: Queri
         .select[projects.Slug, projects.GitLabId](sql"""
           SELECT project_id
           FROM project
-          WHERE project_path = $projectSlugEncoder
+          WHERE project_slug = $projectSlugEncoder
         """.query(projectIdDecoder))
         .arguments(projectSlug)
         .build(_.option)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/CommitSyncForcer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/CommitSyncForcer.scala
@@ -73,10 +73,9 @@ private class CommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource: Quer
     SqlStatement
       .named(s"${categoryName.value.toLowerCase} - insert project")
       .command[projects.GitLabId *: projects.Slug *: EventDate *: EmptyTuple](sql"""
-        INSERT INTO project (project_id, project_path, latest_event_date)
+        INSERT INTO project (project_id, project_slug, latest_event_date)
         VALUES ($projectIdEncoder, $projectSlugEncoder, $eventDateEncoder)
-        ON CONFLICT (project_id)
-        DO NOTHING
+        ON CONFLICT (project_id) DO NOTHING
         """.command)
       .arguments(projectId *: projectSlug *: EventDate(Instant.EPOCH) *: EmptyTuple)
       .build

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/creation/EventPersister.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/creation/EventPersister.scala
@@ -178,11 +178,11 @@ private class EventPersisterImpl[F[_]: MonadCancelThrow: SessionResource: Querie
     SqlStatement(name = "new - upsert project")
       .command[projects.GitLabId *: projects.Slug *: EventDate *: EmptyTuple](
         sql"""
-            INSERT INTO project (project_id, project_path, latest_event_date)
+            INSERT INTO project (project_id, project_slug, latest_event_date)
             VALUES ($projectIdEncoder, $projectSlugEncoder, $eventDateEncoder)
             ON CONFLICT (project_id)
             DO 
-              UPDATE SET latest_event_date = EXCLUDED.latest_event_date, project_path = EXCLUDED.project_path 
+              UPDATE SET latest_event_date = EXCLUDED.latest_event_date, project_slug = EXCLUDED.project_slug
               WHERE EXCLUDED.latest_event_date > project.latest_event_date
           """.command
       )

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/GlobalCommitSyncForcer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/GlobalCommitSyncForcer.scala
@@ -76,10 +76,9 @@ private class GlobalCommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource
     SqlStatement
       .named(s"${categoryName.value.toLowerCase} - insert project")
       .command[projects.GitLabId *: projects.Slug *: EventDate *: EmptyTuple](sql"""
-        INSERT INTO project (project_id, project_path, latest_event_date)
+        INSERT INTO project (project_id, project_slug, latest_event_date)
         VALUES ($projectIdEncoder, $projectSlugEncoder, $eventDateEncoder)
-        ON CONFLICT (project_id)
-        DO NOTHING
+        ON CONFLICT (project_id) DO NOTHING
         """.command)
       .arguments(projectId *: projectSlug *: EventDate(Instant.EPOCH) *: EmptyTuple)
       .build

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/DbUpdater.scala
@@ -60,7 +60,7 @@ private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
     SqlStatement
       .named("all_to_new - find projects")
       .select[Void, ProjectEventsToNew](
-        sql"""SELECT proj.project_id, proj.project_path
+        sql"""SELECT proj.project_id, proj.project_slug
               FROM project proj
               ORDER BY proj.latest_event_date ASC"""
           .query(projectIdDecoder ~ projectSlugDecoder)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandler.scala
@@ -102,7 +102,7 @@ object DequeuedEventHandler {
             FROM event e
             JOIN project p ON e.project_id = p.project_id
               AND p.project_id = $projectIdEncoder
-              AND p.project_path = $projectSlugEncoder
+              AND p.project_slug = $projectSlugEncoder
             WHERE #${`status IN`(EventStatus.all diff Set(Skipped, GeneratingTriples, AwaitingDeletion, Deleting))}
             FOR UPDATE
           ) old_evt
@@ -125,7 +125,7 @@ object DequeuedEventHandler {
             FROM status_processing_time t
             JOIN project p ON t.project_id = p.project_id
               AND p.project_id = $projectIdEncoder
-              AND p.project_path = $projectSlugEncoder
+              AND p.project_slug = $projectSlugEncoder
           )""".command)
         .arguments(project.id *: project.slug *: EmptyTuple)
         .build
@@ -141,7 +141,7 @@ object DequeuedEventHandler {
             FROM event_payload ep
             JOIN project p ON ep.project_id = p.project_id
               AND p.project_id = $projectIdEncoder
-              AND p.project_path = $projectSlugEncoder
+              AND p.project_slug = $projectSlugEncoder
           )""".command)
         .arguments(project.id *: project.slug *: EmptyTuple)
         .build
@@ -158,7 +158,7 @@ object DequeuedEventHandler {
             FROM event e
             JOIN project p ON e.project_id = p.project_id
               AND p.project_id = $projectIdEncoder
-              AND p.project_path = $projectSlugEncoder
+              AND p.project_slug = $projectSlugEncoder
           )
           """.command)
         .arguments(status *: project.id *: project.slug *: EmptyTuple)
@@ -179,7 +179,7 @@ object DequeuedEventHandler {
               FROM event e
               JOIN project p ON e.project_id = p.project_id
                 AND p.project_id = $projectIdEncoder
-                AND p.project_path = $projectSlugEncoder
+                AND p.project_slug = $projectSlugEncoder
               WHERE e.status = '#${GeneratingTriples.value}'
             )""".command)
         .arguments(project.id *: project.id *: project.slug *: EmptyTuple)
@@ -197,7 +197,7 @@ object DequeuedEventHandler {
             FROM subscription_category_sync_time st
             JOIN project p ON st.project_id = p.project_id
               AND p.project_id = $projectIdEncoder
-              AND p.project_path = $projectSlugEncoder
+              AND p.project_slug = $projectSlugEncoder
           )
           """.command)
         .arguments(project.id *: project.slug *: EmptyTuple)
@@ -212,7 +212,7 @@ object DequeuedEventHandler {
           FROM event e
           JOIN project p ON e.project_id = p.project_id
             AND p.project_id = $projectIdEncoder
-            AND p.project_path = $projectSlugEncoder
+            AND p.project_slug = $projectSlugEncoder
           ORDER BY event_date DESC
           LIMIT 1""".query(eventDateDecoder))
         .arguments(project.id *: project.slug *: EmptyTuple)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/cleaning/ProjectCleaner.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/cleaning/ProjectCleaner.scala
@@ -87,7 +87,7 @@ private[statuschange] class ProjectCleanerImpl[F[_]: Async: Logger: QueriesExecu
     SqlStatement(name = "project_to_new - clean_up_events_queue removal")
       .command[projects.GitLabId *: projects.Slug *: EmptyTuple](sql"""
         DELETE FROM clean_up_events_queue 
-        WHERE project_id = $projectIdEncoder AND project_path = $projectSlugEncoder""".command)
+        WHERE project_id = $projectIdEncoder AND project_slug = $projectSlugEncoder""".command)
       .arguments(project.id *: project.slug *: EmptyTuple)
       .build
       .void
@@ -102,7 +102,7 @@ private[statuschange] class ProjectCleanerImpl[F[_]: Async: Logger: QueriesExecu
           FROM subscription_category_sync_time st
           JOIN project p ON st.project_id = p.project_id 
             AND p.project_id = $projectIdEncoder
-            AND p.project_path = $projectSlugEncoder
+            AND p.project_slug = $projectSlugEncoder
         )""".command)
       .arguments(project.id *: project.slug *: EmptyTuple)
       .build
@@ -113,7 +113,7 @@ private[statuschange] class ProjectCleanerImpl[F[_]: Async: Logger: QueriesExecu
     SqlStatement(name = "project_to_new - remove project")
       .command[projects.GitLabId *: projects.Slug *: EmptyTuple](sql"""
         DELETE FROM project 
-        WHERE project_id = $projectIdEncoder AND project_path = $projectSlugEncoder""".command)
+        WHERE project_id = $projectIdEncoder AND project_slug = $projectSlugEncoder""".command)
       .arguments(project.id *: project.slug *: EmptyTuple)
       .build
       .mapResult {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DequeuedEventHandler.scala
@@ -66,7 +66,7 @@ private class DequeuedEventHandlerImpl[F[_]: Async: QueriesExecutionTimes](
         FROM (
           SELECT e.event_id, e.project_id
           FROM event e
-          JOIN project p ON e.project_id = p.project_id AND p.project_path = $projectSlugEncoder
+          JOIN project p ON e.project_id = p.project_id AND p.project_slug = $projectSlugEncoder
           WHERE e.status = '#${TriplesStore.value}'
           ORDER BY event_date DESC
           LIMIT 1
@@ -119,7 +119,7 @@ private class DequeuedEventHandlerImpl[F[_]: Async: QueriesExecutionTimes](
                 AND project_id = (
                   SELECT project_id
                   FROM project
-                  WHERE project_path = $projectSlugEncoder
+                  WHERE project_slug = $projectSlugEncoder
                 )
                """.command
       )

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/awaitinggeneration/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/awaitinggeneration/EventFinder.scala
@@ -83,7 +83,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: QueriesExe
       .named(s"${SubscriptionCategory.categoryName.value.toLowerCase} - find projects")
       .select[ExecutionDate *: ExecutionDate *: Int *: EmptyTuple, ProjectInfo](
         sql"""
-          SELECT p.project_id, p.project_path, p.latest_event_date,
+          SELECT p.project_id, p.project_slug, p.latest_event_date,
 	        (SELECT count(event_id) FROM event evt_int WHERE evt_int.project_id = p.project_id AND evt_int.status = '#${GeneratingTriples.value}') AS current_occupancy
           FROM (
             SELECT DISTINCT project_id, MAX(event_date) AS max_event_date
@@ -140,7 +140,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: QueriesExe
       .select[projects.Slug *: projects.GitLabId *: ExecutionDate *: ExecutionDate *: EmptyTuple,
               AwaitingGenerationEvent
       ](sql"""
-        SELECT evt.event_id, evt.project_id, $projectSlugEncoder AS project_path, evt.event_body
+        SELECT evt.event_id, evt.project_id, $projectSlugEncoder AS project_slug, evt.event_body
         FROM (
           SELECT project_id, max(event_date) AS max_event_date
           FROM event

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/cleanup/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/cleanup/EventFinder.scala
@@ -72,7 +72,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: Logger: Qu
     SqlStatement
       .named(s"${categoryName.show.toLowerCase} - find event in queue")
       .select[Void, Project](sql"""
-        SELECT queue.project_id, queue.project_path
+        SELECT queue.project_id, queue.project_slug
         FROM clean_up_events_queue queue
         ORDER BY queue.date ASC
         LIMIT 1
@@ -85,7 +85,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: Logger: Qu
     SqlStatement
       .named(s"${categoryName.show.toLowerCase} - find event")
       .select[ExecutionDate, Project](sql"""
-        SELECT evt.project_id, prj.project_path
+        SELECT evt.project_id, prj.project_slug
         FROM event evt
         JOIN  project prj ON prj.project_id = evt.project_id 
         WHERE evt.status = '#${AwaitingDeletion.value}'
@@ -104,7 +104,7 @@ private class EventFinderImpl[F[_]: Async: Parallel: SessionResource: Logger: Qu
           .named(s"${categoryName.show.toLowerCase} - delete clean-up event")
           .command[projects.Slug](sql"""
             DELETE FROM clean_up_events_queue
-            WHERE project_path = $projectSlugEncoder
+            WHERE project_slug = $projectSlugEncoder
             """.command)
           .arguments(projectSlug)
           .build

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/commitsync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/commitsync/EventFinder.scala
@@ -77,7 +77,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
               LIMIT 1
             ) event_status,
             proj.project_id,
-            proj.project_path,
+            proj.project_slug,
             sync_time.last_synced,
             proj.latest_event_date
           FROM project proj

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/globalcommitsync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/globalcommitsync/EventFinder.scala
@@ -71,7 +71,7 @@ private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTime
       .select[CategoryName *: LastSyncedDate *: EmptyTuple, (Project, Option[LastSyncedDate])](
         sql"""SELECT
                 proj.project_id,
-                proj.project_path,
+                proj.project_slug,
                 sync_time.last_synced
               FROM project proj
               LEFT JOIN subscription_category_sync_time sync_time

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/membersync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/membersync/EventFinder.scala
@@ -60,7 +60,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
         CategoryName *: EventDate *: LastSyncedDate *: EventDate *: LastSyncedDate *: EventDate *: LastSyncedDate *: EmptyTuple,
         (projects.GitLabId, Option[LastSyncedDate], MemberSyncEvent)
       ](
-        sql"""SELECT proj.project_id, sync_time.last_synced, proj.project_path
+        sql"""SELECT proj.project_id, sync_time.last_synced, proj.project_slug
               FROM project proj
               LEFT JOIN subscription_category_sync_time sync_time
                 ON sync_time.project_id = proj.project_id AND sync_time.category_name = $categoryNameEncoder

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/EventFinder.scala
@@ -54,7 +54,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
     SqlStatement
       .named(s"${categoryName.show.toLowerCase} - find event")
       .select[Void, MinProjectInfoEvent](
-        sql"""SELECT p.project_id, p.project_path
+        sql"""SELECT p.project_id, p.project_slug
               FROM project p
               WHERE NOT EXISTS (
                 SELECT project_id 

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/EventFinder.scala
@@ -52,10 +52,10 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
     SqlStatement
       .named(s"${categoryName.value.toLowerCase} - find event")
       .select[LastSyncedDate, (projects.GitLabId, Option[LastSyncedDate], ProjectSyncEvent)](
-        sql"""SELECT candidate.project_id, candidate.real_sync, candidate.project_path
+        sql"""SELECT candidate.project_id, candidate.real_sync, candidate.project_slug
               FROM (
                 SELECT proj.project_id, 
-                  proj.project_path,
+                  proj.project_slug,
                   sync_time.last_synced,
                   sync_time.last_synced AS real_sync
                 FROM project proj
@@ -64,7 +64,7 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
                 WHERE ($lastSyncedDateEncoder - sync_time.last_synced) > INTERVAL '1 day' 
                 UNION
                 SELECT proj.project_id, 
-                  proj.project_path,
+                  proj.project_slug,
                   TIMESTAMP WITH TIME ZONE 'epoch' AS last_synced,
                   NULL AS real_sync
                 FROM project proj

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/triplesgenerated/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/triplesgenerated/EventFinder.scala
@@ -81,7 +81,7 @@ private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTime
       .named(s"${SubscriptionCategory.categoryName.value.toLowerCase} - find projects")
       .select[ExecutionDate *: ExecutionDate *: Int *: EmptyTuple, ProjectInfo](
         sql"""
-        SELECT p.project_id, p.project_path, p.latest_event_date,
+        SELECT p.project_id, p.project_slug, p.latest_event_date,
           (SELECT count(event_id) FROM event evt_int WHERE evt_int.project_id = p.project_id AND evt_int.status = '#${TransformingTriples.value}') AS current_occupancy
         FROM (
           SELECT DISTINCT evt.project_id, MAX(evt.event_date) AS max_event_date
@@ -140,7 +140,7 @@ private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTime
               TriplesGeneratedEvent
       ](
         sql"""
-         SELECT evt.event_id, evt.project_id, $projectSlugEncoder AS project_path, evt_payload.payload
+         SELECT evt.event_id, evt.project_id, $projectSlugEncoder AS project_slug, evt_payload.payload
          FROM (
            SELECT evt_int.project_id, max(event_date) AS max_event_date
            FROM event evt_int

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LongProcessingEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LongProcessingEventFinder.scala
@@ -90,7 +90,7 @@ private class LongProcessingEventFinder[F[_]: Async: SessionResource: QueriesExe
         projects.GitLabId *: EventStatus *: String *: ExecutionDate *: EventProcessingTime *: ExecutionDate *: EventProcessingTime *: EmptyTuple,
         ZombieEvent
       ](
-        sql"""SELECT evt.event_id, evt.project_id, proj.project_path, evt.status
+        sql"""SELECT evt.event_id, evt.project_id, proj.project_slug, evt.status
               FROM event evt
               JOIN project proj ON proj.project_id = evt.project_id
               LEFT JOIN event_delivery ed ON ed.project_id = evt.project_id AND ed.event_id = evt.event_id

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostSubscriberEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostSubscriberEventFinder.scala
@@ -55,7 +55,7 @@ private class LostSubscriberEventFinder[F[_]: MonadCancelThrow: SessionResource:
       .named(s"${categoryName.value.toLowerCase} - lse - find events")
       .select[Void, ZombieEvent](
         sql"""
-        SELECT DISTINCT evt.event_id, evt.project_id, proj.project_path, evt.status
+        SELECT DISTINCT evt.event_id, evt.project_id, proj.project_slug, evt.status
         FROM event_delivery delivery
         JOIN event evt ON evt.event_id = delivery.event_id
           AND evt.project_id = delivery.project_id

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostZombieEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostZombieEventFinder.scala
@@ -55,11 +55,11 @@ private class LostZombieEventFinder[F[_]: MonadCancelThrow: SessionResource: Que
     SqlStatement
       .named(s"${categoryName.value.toLowerCase} - lze - find event")
       .select[ExecutionDate *: EventProcessingTime *: EmptyTuple, ZombieEvent](
-        sql"""SELECT evt.event_id, evt.project_id, proj.project_path, evt.status
+        sql"""SELECT evt.event_id, evt.project_id, proj.project_slug, evt.status
               FROM event evt
               JOIN project proj ON evt.project_id = proj.project_id
               WHERE 
-                evt.status IN (#${ProcessingStatus.all.map(s => show"'$s'").mkString(", ")})
+                evt.status IN (#${ProcessingStatus.all.map(s => s"'${s.value}'").mkString(", ")})
                 AND evt.message = '#$zombieMessage'
                 AND  (($executionDateEncoder - evt.execution_date) > $eventProcessingTimeEncoder)
               LIMIT 1

--- a/event-log/src/main/scala/io/renku/eventlog/init/DbInitializer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/DbInitializer.scala
@@ -82,6 +82,7 @@ object DbInitializer {
     TSMigrationTableCreator[F],
     CleanUpEventsTableCreator[F],
     ProjectIdOnCleanUpTable[F],
+    ProjectPathToSlug[F],
     FailedEventsRestorer[F](
       "%Error: The repository is dirty. Please use the \"git\" command to clean it.%",
       currentStatus = GenerationNonRecoverableFailure,
@@ -171,8 +172,7 @@ object DbInitializer {
       currentStatus = TransformationNonRecoverableFailure,
       destinationStatus = TriplesGenerated,
       discardingStatuses = TriplesStore :: Nil
-    ),
-    ProjectPathToSlug[F]
+    )
   )
 
   def apply[F[_]: Temporal: Logger: SessionResource](isMigrating: Ref[F, Boolean]): F[DbInitializer[F]] =

--- a/event-log/src/main/scala/io/renku/eventlog/init/DbInitializer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/DbInitializer.scala
@@ -171,7 +171,8 @@ object DbInitializer {
       currentStatus = TransformationNonRecoverableFailure,
       destinationStatus = TriplesGenerated,
       discardingStatuses = TriplesStore :: Nil
-    )
+    ),
+    ProjectPathToSlug[F]
   )
 
   def apply[F[_]: Temporal: Logger: SessionResource](isMigrating: Ref[F, Boolean]): F[DbInitializer[F]] =

--- a/event-log/src/main/scala/io/renku/eventlog/init/MigratorTools.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/MigratorTools.scala
@@ -51,6 +51,26 @@ private object MigratorTools {
     Kleisli(_.unique(query).recover { case _ => false })
   }
 
+  def checkIndexExists[F[_]: MonadCancelThrow](index: String): Kleisli[F, Session[F], Boolean] = {
+    val query: Query[Void, Boolean] = sql"""
+      SELECT EXISTS (
+        SELECT *
+        FROM pg_indexes
+        WHERE indexname = '#$index'
+      )""".query(bool)
+    Kleisli(_.unique(query).recover { case _ => false })
+  }
+
+  def checkIndexExists[F[_]: MonadCancelThrow](table: String, index: String): Kleisli[F, Session[F], Boolean] = {
+    val query: Query[Void, Boolean] = sql"""
+      SELECT EXISTS (
+        SELECT *
+        FROM pg_indexes
+        WHERE tablename = '#$table' AND indexname = '#$index'
+      )""".query(bool)
+    Kleisli(_.unique(query).recover { case _ => false })
+  }
+
   def execute[F[_]: MonadCancelThrow](sql: Command[Void]): Kleisli[F, Session[F], Unit] =
     Kleisli(_.execute(sql).void)
 }

--- a/event-log/src/main/scala/io/renku/eventlog/init/ProjectPathToSlug.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/init/ProjectPathToSlug.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.eventlog.init
+
+import cats.data.Kleisli
+import cats.effect.MonadCancelThrow
+import cats.syntax.all._
+import io.renku.eventlog.EventLogDB.SessionResource
+import org.typelevel.log4cats.Logger
+import skunk._
+import skunk.implicits._
+
+private trait ProjectPathToSlug[F[_]] extends DbMigrator[F]
+
+private object ProjectPathToSlug {
+  def apply[F[_]: MonadCancelThrow: Logger: SessionResource]: ProjectPathToSlug[F] = new ProjectPathToSlugImpl[F]
+}
+
+private class ProjectPathToSlugImpl[F[_]: MonadCancelThrow: Logger: SessionResource] extends ProjectPathToSlug[F] {
+  import MigratorTools._
+
+  override def run: F[Unit] = SessionResource[F].useK {
+    checkAndRenameColumnIfNeeded(table = "project") >>
+      checkAndRenameColumnIfNeeded(table = "clean_up_events_queue") >>
+      removePathIndex() >>
+      checkAndCreateSlugIndexIfAbsent(table = "project") >>
+      checkAndCreateSlugIndexIfAbsent(table = "clean_up_events_queue")
+  }
+
+  private def checkAndRenameColumnIfNeeded(table: String) =
+    checkColumnExists(table, "project_slug") >>= {
+      case true  => Kleisli.liftF(Logger[F].info(s"column '$table.project_slug' existed"))
+      case false => renameColumn(table)
+    }
+
+  private def renameColumn(table: String): Kleisli[F, Session[F], Unit] =
+    execute(sql"ALTER TABLE #$table RENAME COLUMN project_path TO project_slug".command)
+      .flatMapF(_ => Logger[F].info(s"column '$table.project_path' renamed to '$table.project_slug'"))
+
+  private def removePathIndex(): Kleisli[F, Session[F], Unit] = {
+    val idx = "idx_project_path"
+    checkIndexExists(idx) >>= {
+      case false => Kleisli.liftF(Logger[F].info(s"index '$idx' not existed"))
+      case true =>
+        execute(sql"DROP INDEX IF EXISTS #$idx".command)
+          .flatMapF(_ => Logger[F].info(s"index '$idx' removed"))
+    }
+  }
+
+  private def checkAndCreateSlugIndexIfAbsent(table: String) = {
+    val idx = s"idx_${table}_project_slug"
+    checkIndexExists(table, idx) >>= {
+      case true  => Kleisli.liftF(Logger[F].info(s"index '$idx' existed"))
+      case false => createIndex(table, idx)
+    }
+  }
+
+  private def createIndex(table: String, idx: String): Kleisli[F, Session[F], Unit] =
+    execute(sql"CREATE INDEX IF NOT EXISTS #$idx ON #$table(project_slug)".command)
+      .flatMapF(_ => Logger[F].info(s"index '$idx' created"))
+}

--- a/event-log/src/test/scala/io/renku/eventlog/CleanUpEventsProvisioning.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/CleanUpEventsProvisioning.scala
@@ -40,7 +40,7 @@ trait CleanUpEventsProvisioning {
     execute {
       Kleisli { session =>
         val query: Command[OffsetDateTime *: projects.GitLabId *: projects.Slug *: EmptyTuple] = sql"""
-          INSERT INTO clean_up_events_queue (date, project_id, project_path)
+          INSERT INTO clean_up_events_queue (date, project_id, project_slug)
           VALUES ($timestamptz, $projectIdEncoder, $projectSlugEncoder)""".command
         session
           .prepare(query)
@@ -52,7 +52,7 @@ trait CleanUpEventsProvisioning {
   protected def findCleanUpEvents: List[(projects.GitLabId, projects.Slug)] = execute {
     Kleisli { session =>
       val query: Query[Void, projects.GitLabId ~ projects.Slug] = sql"""
-        SELECT project_id, project_path
+        SELECT project_id, project_slug
         FROM clean_up_events_queue
         ORDER BY date DESC"""
         .query(projectIdDecoder ~ projectSlugDecoder)

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/creation/EventPersisterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/creation/EventPersisterSpec.scala
@@ -152,7 +152,7 @@ class EventPersisterSpec
         storedProjects shouldBe List((event1.project.id, event1.project.slug, event2.date))
       }
 
-    "update latest_event_date and project_path for a project " +
+    "update latest_event_date and project_slug for a project " +
       "only if there's an event with more recent Event Date added" in new TestCase {
 
         // storing event 1
@@ -179,7 +179,7 @@ class EventPersisterSpec
         storedProjects shouldBe List((event1.project.id, event2.project.slug, event2.date))
       }
 
-    "do not update latest_event_date and project_path for a project " +
+    "do not update latest_event_date and project_slug for a project " +
       "only if there's an event with less recent Event Date added" in new TestCase {
 
         // storing event 1
@@ -354,7 +354,7 @@ class EventPersisterSpec
   private def storedProjects: List[(projects.GitLabId, projects.Slug, EventDate)] = execute {
     Kleisli { session =>
       val query: Query[Void, (projects.GitLabId, projects.Slug, EventDate)] =
-        sql"""SELECT project_id, project_path, latest_event_date
+        sql"""SELECT project_id, project_slug, latest_event_date
               FROM project"""
           .query(projectIdDecoder ~ projectSlugDecoder ~ eventDateDecoder)
           .map { case projectId ~ projectSlug ~ eventDate => (projectId, projectSlug, eventDate) }

--- a/event-log/src/test/scala/io/renku/eventlog/init/EventStatusRenamerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/EventStatusRenamerSpec.scala
@@ -44,7 +44,6 @@ class EventStatusRenamerSpec
     with IOSpec
     with DbInitSpec
     with should.Matchers
-    with EventLogDataProvisioning
     with EventDataFetching {
 
   protected[init] override lazy val migrationsToRun: List[DbMigrator[IO]] = allMigrations.takeWhile {
@@ -113,24 +112,24 @@ class EventStatusRenamerSpec
   }
 
   private def store(event: Event, withStatus: String): Unit = {
-    upsertProject(event.compoundEventId, event.project.slug, event.date)
+    upsertProject(event.compoundEventId.projectId, event.project.slug, event.date)
     execute[Unit] {
       Kleisli { session =>
         val query: Command[
           EventId *: projects.GitLabId *: String *: CreatedDate *: ExecutionDate *: EventDate *: String *: BatchDate *: EmptyTuple
         ] =
-          sql"""INSERT INTO 
-              event (event_id, project_id, status, created_date, execution_date, event_date, event_body, batch_date) 
-              values (
-              $eventIdEncoder, 
-              $projectIdEncoder, 
-              $varchar, 
-              $createdDateEncoder,
-              $executionDateEncoder, 
-              $eventDateEncoder, 
-              $text,
-              $batchDateEncoder)
-      """.command
+          sql"""INSERT INTO event (event_id, project_id, status, created_date, execution_date, event_date, event_body, batch_date)
+                VALUES (
+                  $eventIdEncoder,
+                  $projectIdEncoder,
+                  $varchar,
+                  $createdDateEncoder,
+                  $executionDateEncoder,
+                  $eventDateEncoder,
+                  $text,
+                  $batchDateEncoder
+                )
+                """.command
         session
           .prepare(query)
           .flatMap(
@@ -151,8 +150,20 @@ class EventStatusRenamerSpec
     }
   }
 
-  private def toJsonBody(event: Event): String =
-    json"""{
+  private def upsertProject(projectId: projects.GitLabId, projectSlug: projects.Slug, eventDate: EventDate): Unit =
+    execute[Unit] {
+      Kleisli { session =>
+        val query: Command[projects.GitLabId *: projects.Slug *: EventDate *: EmptyTuple] =
+          sql"""INSERT INTO project (project_id, project_path, latest_event_date)
+                VALUES ($projectIdEncoder, $projectSlugEncoder, $eventDateEncoder)
+                ON CONFLICT (project_id)
+                DO UPDATE SET latest_event_date = excluded.latest_event_date WHERE excluded.latest_event_date > project.latest_event_date
+          """.command
+        session.prepare(query).flatMap(_.execute(projectId *: projectSlug *: eventDate *: EmptyTuple)).void
+      }
+    }
+
+  private def toJsonBody(event: Event): String = json"""{
     "project": {
       "id":   ${event.project.id},
       "slug": ${event.project.slug}

--- a/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathAdderSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathAdderSpec.scala
@@ -39,7 +39,7 @@ import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 
-class ProjectSlugAdderSpec
+class ProjectPathAdderSpec
     extends AnyWordSpec
     with IOSpec
     with DbInitSpec

--- a/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathToSlugSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/init/ProjectPathToSlugSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.eventlog.init
+
+import cats.effect.IO
+import io.renku.interpreters.TestLogger
+import io.renku.interpreters.TestLogger.Level.Info
+import io.renku.testtools.IOSpec
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class ProjectPathToSlugSpec
+    extends AnyFlatSpec
+    with should.Matchers
+    with IOSpec
+    with DbInitSpec
+    with Eventually
+    with IntegrationPatience {
+
+  protected[init] override lazy val migrationsToRun: List[DbMigrator[IO]] = allMigrations.takeWhile {
+    case _: ProjectPathToSlugImpl[IO] => false
+    case _ => true
+  }
+
+  it should "rename the 'project_path' column to 'project_slug' on the project and clean_up_events_queue tables, " +
+    "remove the old 'idx_project_path' index and " +
+    "create new 'idx_project_project_slug' and 'idx_clean_up_events_queue_project_slug' indices" in {
+
+      verifyColumnExists("project", "project_path")                                        shouldBe true
+      verifyColumnExists("project", "project_slug")                                        shouldBe false
+      verifyColumnExists("clean_up_events_queue", "project_path")                          shouldBe true
+      verifyColumnExists("clean_up_events_queue", "project_slug")                          shouldBe false
+      verifyIndexExists("project", "idx_project_path")                                     shouldBe false
+      verifyIndexExists("project", "idx_project_project_slug")                             shouldBe false
+      verifyIndexExists("clean_up_events_queue", "idx_project_path")                       shouldBe true
+      verifyIndexExists("clean_up_events_queue", "idx_clean_up_events_queue_project_slug") shouldBe false
+
+      projectPathToSlug.run.unsafeRunSync()
+
+      logger.loggedOnly(
+        Info("column 'project.project_path' renamed to 'project.project_slug'"),
+        Info("column 'clean_up_events_queue.project_path' renamed to 'clean_up_events_queue.project_slug'"),
+        Info("index 'idx_project_path' removed"),
+        Info("index 'idx_project_project_slug' created"),
+        Info("index 'idx_clean_up_events_queue_project_slug' created")
+      )
+      logger.reset()
+
+      verifyColumnExists("project", "project_path")                                        shouldBe false
+      verifyColumnExists("project", "project_slug")                                        shouldBe true
+      verifyColumnExists("clean_up_events_queue", "project_path")                          shouldBe false
+      verifyColumnExists("clean_up_events_queue", "project_slug")                          shouldBe true
+      verifyIndexExists("project", "idx_project_path")                                     shouldBe false
+      verifyIndexExists("project", "idx_project_project_slug")                             shouldBe true
+      verifyIndexExists("clean_up_events_queue", "idx_project_path")                       shouldBe false
+      verifyIndexExists("clean_up_events_queue", "idx_clean_up_events_queue_project_slug") shouldBe true
+
+      projectPathToSlug.run.unsafeRunSync()
+
+      logger.loggedOnly(
+        Info("column 'project.project_slug' existed"),
+        Info("column 'clean_up_events_queue.project_slug' existed"),
+        Info("index 'idx_project_path' not existed"),
+        Info("index 'idx_project_project_slug' existed"),
+        Info("index 'idx_clean_up_events_queue_project_slug' existed")
+      )
+    }
+
+  private implicit lazy val logger: TestLogger[IO] = TestLogger[IO]()
+  private lazy val projectPathToSlug = new ProjectPathToSlugImpl[IO]
+}

--- a/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJenaForSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJenaForSpec.scala
@@ -35,8 +35,6 @@ trait InMemoryJenaForSpec extends ForAllTestContainer with InMemoryJena with Bef
   def clearDatasetsBefore: Boolean = true
 
   before {
-    if (clearDatasetsBefore) {
-      clearAllDatasets()
-    }
+    if (clearDatasetsBefore) clearAllDatasets()
   }
 }

--- a/token-repository/README.md
+++ b/token-repository/README.md
@@ -133,7 +133,7 @@ token-repository uses relational database as an internal storage. The DB has the
 | column       | type        | constraints |
 |--------------|-------------|-------------|
 | project_id   | INT4        | PK NOT NULL |
-| project_path | VARCHAR     | NOT NULL    |
+| project_slug | VARCHAR     | NOT NULL    |
 | token        | VARCHAR     | NOT NULL    |
 | created_at   | TIMESTAMPTZ | NOT NULL    |
 | expiry_date  | DATE        | NOT NULL    |

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/TokenRepositoryTypeSerializers.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/TokenRepositoryTypeSerializers.scala
@@ -30,8 +30,7 @@ trait TokenRepositoryTypeSerializers {
   val projectIdEncoder: Encoder[projects.GitLabId] = int4.values.contramap(_.value)
 
   val projectSlugDecoder: Decoder[projects.Slug] = varchar.map(projects.Slug.apply)
-  val projectSlugEncoder: Encoder[projects.Slug] =
-    varchar.values.contramap((b: projects.Slug) => b.value)
+  val projectSlugEncoder: Encoder[projects.Slug] = varchar.values.contramap((b: projects.Slug) => b.value)
 
   private[repository] val encryptedAccessTokenDecoder: Decoder[EncryptedAccessToken] =
     varchar.emap(s => EncryptedAccessToken.from(s).leftMap(_.getMessage))

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/PersistedSlugFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/PersistedSlugFinder.scala
@@ -50,7 +50,7 @@ private class PersistedSlugFinderImpl[F[_]: MonadCancelThrow: SessionResource: Q
     SqlStatement
       .named("find slug for token")
       .select[projects.GitLabId, projects.Slug](
-        sql"""SELECT project_path
+        sql"""SELECT project_slug
               FROM projects_tokens
               WHERE project_id = $projectIdEncoder"""
           .query(projectSlugDecoder)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensPersister.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensPersister.scala
@@ -28,7 +28,6 @@ import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.graph.model.projects.{GitLabId, Slug}
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
-import org.typelevel.twiddles.syntax._
 import skunk._
 import skunk.data.Completion
 import skunk.data.Completion.Delete
@@ -64,7 +63,7 @@ private class TokensPersisterImpl[F[_]: MonadCancelThrow: SessionResource: Queri
       .named("associate token - delete")
       .command[GitLabId *: Slug *: EmptyTuple](sql"""
         DELETE FROM projects_tokens 
-        WHERE project_id = $projectIdEncoder OR project_path = $projectSlugEncoder
+        WHERE project_id = $projectIdEncoder OR project_slug = $projectSlugEncoder
       """.command)
       .arguments(project.id, project.slug)
       .build
@@ -81,7 +80,7 @@ private class TokensPersisterImpl[F[_]: MonadCancelThrow: SessionResource: Queri
     SqlStatement
       .named("associate token - insert")
       .command[GitLabId *: Slug *: EncryptedAccessToken *: CreatedAt *: ExpiryDate *: EmptyTuple](sql"""
-        INSERT INTO projects_tokens (project_id, project_path, token, created_at, expiry_date)
+        INSERT INTO projects_tokens (project_id, project_slug, token, created_at, expiry_date)
         VALUES ($projectIdEncoder, $projectSlugEncoder, $encryptedAccessTokenEncoder, $createdAtEncoder, $expiryDateEncoder)
       """.command)
       .arguments(
@@ -101,7 +100,7 @@ private class TokensPersisterImpl[F[_]: MonadCancelThrow: SessionResource: Queri
       .named("associate token - update slug")
       .command[Slug *: GitLabId *: EmptyTuple](sql"""
         UPDATE projects_tokens
-        SET project_path = $projectSlugEncoder
+        SET project_slug = $projectSlugEncoder
         WHERE project_id = $projectIdEncoder
     """.command)
       .arguments(project.slug -> project.id)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/package.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/package.scala
@@ -27,12 +27,12 @@ package object creation {
 
   import io.renku.tokenrepository.repository.creation.TokenDates._
 
-  private[creation] val createdAtDecoder: Decoder[CreatedAt] =
+  private[repository] val createdAtDecoder: Decoder[CreatedAt] =
     timestamptz.map(timestamp => CreatedAt(timestamp.toInstant))
-  private[creation] val createdAtEncoder: Encoder[CreatedAt] = timestamptz.values.contramap((b: CreatedAt) =>
+  private[repository] val createdAtEncoder: Encoder[CreatedAt] = timestamptz.values.contramap((b: CreatedAt) =>
     OffsetDateTime.ofInstant(b.value, b.value.atOffset(ZoneOffset.UTC).toZonedDateTime.getZone)
   )
 
-  private[creation] val expiryDateDecoder: Decoder[ExpiryDate] = date.map(date => ExpiryDate(date))
-  private[creation] val expiryDateEncoder: Encoder[ExpiryDate] = date.values.contramap((b: ExpiryDate) => b.value)
+  private[repository] val expiryDateDecoder: Decoder[ExpiryDate] = date.map(date => ExpiryDate(date))
+  private[repository] val expiryDateEncoder: Encoder[ExpiryDate] = date.values.contramap((b: ExpiryDate) => b.value)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
@@ -58,7 +58,7 @@ private class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: SessionResource:
   override def findStoredToken(projectSlug: Slug): OptionT[F, EncryptedAccessToken] = run {
     SqlStatement(name = "find token - slug")
       .select[Slug, EncryptedAccessToken](
-        sql"select token from projects_tokens where project_path = $projectSlugEncoder"
+        sql"select token from projects_tokens where project_slug = $projectSlugEncoder"
           .query(encryptedAccessTokenDecoder)
       )
       .arguments(projectSlug)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/MigrationTools.scala
@@ -22,7 +22,6 @@ import cats.MonadThrow
 import cats.data.Kleisli
 import cats.effect.MonadCancelThrow
 import cats.syntax.all._
-import org.typelevel.twiddles.syntax._
 import skunk._
 import skunk.codec.all._
 import skunk.implicits._

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathAdder.scala
@@ -58,7 +58,7 @@ private class ProjectPathAdder[F[_]: Spawn: Logger: SessionResource]
   }
 
   private lazy val logging: PartialFunction[Throwable, F[Unit]] = { case NonFatal(exception) =>
-    Logger[F].error(exception)("'project_path' column adding failure")
-    exception.raiseError[F, Unit]
+    Logger[F].error(exception)("'project_path' column adding failure") >>
+      exception.raiseError[F, Unit]
   }
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathToSlug.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/ProjectPathToSlug.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.init
+
+import MigrationTools._
+import cats.data.Kleisli
+import cats.effect.{Async, Spawn}
+import cats.syntax.all._
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
+import io.renku.tokenrepository.repository.TokenRepositoryTypeSerializers
+import org.typelevel.log4cats.Logger
+import skunk._
+import skunk.implicits._
+
+private object ProjectPathToSlug {
+  def apply[F[_]: Async: Logger: SessionResource]: DBMigration[F] = new ProjectPathToSlug[F]
+}
+
+private class ProjectPathToSlug[F[_]: Spawn: Logger: SessionResource]
+    extends DBMigration[F]
+    with TokenRepositoryTypeSerializers {
+
+  override def run: F[Unit] = SessionResource[F].useK {
+    checkColumnExists("projects_tokens", "project_slug") >>= {
+      case true  => Kleisli.liftF(Logger[F].info("'project_slug' column existed"))
+      case false => renameColumn()
+    }
+  }
+
+  private def renameColumn(): Kleisli[F, Session[F], Unit] = Kleisli { implicit session =>
+    {
+      for {
+        _ <- execute(sql"ALTER TABLE projects_tokens RENAME COLUMN project_path TO project_slug".command)
+        _ <- execute(sql"ALTER INDEX IF EXISTS idx_project_path RENAME TO idx_project_slug".command)
+        _ <- Logger[F].info("column 'project_path' renamed to 'project_slug'")
+      } yield ()
+    } onError log
+  }
+
+  private lazy val log: PartialFunction[Throwable, F[Unit]] =
+    Logger[F].error(_)("renaming column 'project_path' to 'project_slug' failed")
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/init/TokensMigrator.scala
@@ -21,8 +21,10 @@ package init
 
 import AccessTokenCrypto.EncryptedAccessToken
 import ProjectsTokensDB.SessionResource
+import cats.data.Kleisli
 import cats.effect.{Async, Temporal}
 import cats.syntax.all._
+import creation.TokenDates.{CreatedAt, ExpiryDate}
 import creation._
 import deletion.PersistedTokenRemover
 import io.renku.db.DbClient
@@ -30,34 +32,32 @@ import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
 import org.typelevel.log4cats.Logger
-import skunk.~
+import skunk._
+import skunk.data.Completion.Delete
 
 import scala.concurrent.duration._
 
 private object TokensMigrator {
   def apply[F[_]: Async: GitLabClient: SessionResource: Logger: QueriesExecutionTimes]: F[DBMigration[F]] = for {
-    accessTokenCrypto    <- AccessTokenCrypto[F]()
-    tokenValidator       <- TokenValidator[F]
-    tokenRemover         <- PersistedTokenRemover[F].pure[F]
-    tokensCreator        <- NewTokensCreator[F]()
-    associationPersister <- TokensPersister[F].pure[F]
-  } yield new TokensMigrator[F](accessTokenCrypto, tokenValidator, tokenRemover, tokensCreator, associationPersister)
+    accessTokenCrypto <- AccessTokenCrypto[F]()
+    tokenValidator    <- TokenValidator[F]
+    tokenRemover      <- PersistedTokenRemover[F].pure[F]
+    tokensCreator     <- NewTokensCreator[F]()
+  } yield new TokensMigrator[F](accessTokenCrypto, tokenValidator, tokenRemover, tokensCreator)
 }
 
 private class TokensMigrator[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes](
-    tokenCrypto:          AccessTokenCrypto[F],
-    tokenValidator:       TokenValidator[F],
-    tokenRemover:         PersistedTokenRemover[F],
-    tokensCreator:        NewTokensCreator[F],
-    associationPersister: TokensPersister[F],
-    retryInterval:        Duration = 5 seconds
+    tokenCrypto:    AccessTokenCrypto[F],
+    tokenValidator: TokenValidator[F],
+    tokenRemover:   PersistedTokenRemover[F],
+    tokensCreator:  NewTokensCreator[F],
+    retryInterval:  Duration = 5 seconds
 ) extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with DBMigration[F]
     with TokenRepositoryTypeSerializers {
 
   private val logPrefix = "token migration:"
 
-  import associationPersister._
   import fs2.Stream
   import io.renku.db.SqlStatement
   import skunk.Void
@@ -128,11 +128,49 @@ private class TokensMigrator[F[_]: Async: SessionResource: Logger: QueriesExecut
   private def persistWithRetry(project:        Project,
                                newTokenInfo:   TokenCreationInfo,
                                encryptedToken: EncryptedAccessToken
-  ): F[Unit] =
-    persistToken(TokenStoringInfo(project, encryptedToken, newTokenInfo.dates))
-      .recoverWith(retry(persistWithRetry(project, newTokenInfo, encryptedToken))(project))
+  ): F[Unit] = SessionResource[F].useK {
+    Kleisli { session =>
+      (deleteToken(project) >> persistToken(project, encryptedToken, newTokenInfo.dates))
+        .run(session)
+        .recoverWith(retry(persistWithRetry(project, newTokenInfo, encryptedToken))(project))
+    }
+  }
 
-  private def retry[O](thunk: => F[O])(project: Project): PartialFunction[Throwable, F[O]] = { case ex: Exception =>
+  private def deleteToken(project: Project) = measureExecutionTime {
+    SqlStatement
+      .named(s"$logPrefix: delete token")
+      .command[projects.GitLabId *: projects.Slug *: EmptyTuple](sql"""
+        DELETE FROM projects_tokens
+        WHERE project_id = $projectIdEncoder OR project_path = $projectSlugEncoder
+      """.command)
+      .arguments(project.id, project.slug)
+      .build
+      .flatMapResult {
+        case Delete(_) => ().pure[F]
+        case completion =>
+          new Exception(
+            show"$logPrefix $project deleting token for projectId = ${project.id}, projectSlug = ${project.slug} failed: $completion"
+          ).raiseError[F, Unit]
+      }
+  }
+
+  private def persistToken(project: Project, encryptedToken: EncryptedAccessToken, newTokenDates: TokenDates) =
+    measureExecutionTime {
+      SqlStatement
+        .named[F](s"$logPrefix: persist new token")
+        .command[projects.GitLabId *: projects.Slug *: EncryptedAccessToken *: CreatedAt *: ExpiryDate *: EmptyTuple](
+          sql"""INSERT INTO projects_tokens (project_id, project_path, token, created_at, expiry_date)
+                VALUES ($projectIdEncoder, $projectSlugEncoder, $encryptedAccessTokenEncoder, $createdAtEncoder, $expiryDateEncoder)
+                ON CONFLICT DO NOTHING""".command
+        )
+        .arguments(
+          project.id *: project.slug *: encryptedToken *: newTokenDates.createdAt *: newTokenDates.expiryDate *: EmptyTuple
+        )
+        .build
+        .void
+    }
+
+  private def retry[O](thunk: => F[O])(project: Project): PartialFunction[Throwable, F[O]] = { case ex =>
     Logger[F].error(ex)(show"$logPrefix $project failure; retrying") >>
       Temporal[F].delayBy(thunk, retryInterval)
   }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDbSpec.scala
@@ -58,7 +58,7 @@ trait InMemoryProjectsTokensDbSpec extends DbSpec with InMemoryProjectsTokensDb 
   ): Unit = execute {
     Kleisli[IO, Session[IO], Unit] { session =>
       val query: Command[Int *: String *: String *: OffsetDateTime *: LocalDate *: EmptyTuple] =
-        sql"""insert into projects_tokens (project_id, project_path, token, created_at, expiry_date)
+        sql"""insert into projects_tokens (project_id, project_slug, token, created_at, expiry_date)
               values ($int4, $varchar, $varchar, $timestamptz, $date)
          """.command
       session
@@ -102,7 +102,7 @@ trait InMemoryProjectsTokensDbSpec extends DbSpec with InMemoryProjectsTokensDb 
 
   protected def findToken(projectSlug: Slug): Option[String] = sessionResource
     .useK {
-      val query: Query[String, String] = sql"select token from projects_tokens where project_path = $varchar"
+      val query: Query[String, String] = sql"select token from projects_tokens where project_slug = $varchar"
         .query(varchar)
       Kleisli(_.prepare(query).flatMap(_.option(projectSlug.value)))
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensPersisterSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensPersisterSpec.scala
@@ -146,7 +146,7 @@ class TokensPersisterSpec
   private def findTokenInfo(projectId: projects.GitLabId): Option[TokenStoringInfo] = sessionResource
     .useK {
       val query: Query[projects.GitLabId, TokenStoringInfo] = sql"""
-      SELECT project_id, project_path, token, created_at, expiry_date
+      SELECT project_id, project_slug, token, created_at, expiry_date
       FROM projects_tokens
       WHERE project_id = $projectIdEncoder"""
         .query(

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbInitSpec.scala
@@ -42,6 +42,7 @@ trait DbInitSpec extends InMemoryProjectsTokensDb with DbMigrations with BeforeA
   before {
     findAllTables() foreach dropTable
     migrationsToRun.map(_.run).sequence.unsafeRunSync()
+    logger.reset()
   }
 
   private def findAllTables(): List[String] = execute {

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
@@ -31,7 +31,7 @@ trait DbMigrations {
   self: InMemoryProjectsTokensDb with IOSpec with MockFactory =>
 
   implicit lazy val logger:             TestLogger[IO]            = TestLogger[IO]()
-  private implicit lazy val glClient:   GitLabClient[IO]          = mock[GitLabClient[IO]]
+  implicit lazy val glClient:           GitLabClient[IO]          = mock[GitLabClient[IO]]
   private implicit val metricsRegistry: TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
   implicit val queriesExecTimes:        QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathAdderSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
-class ProjectSlugAdderSpec
+class ProjectPathAdderSpec
     extends AnyWordSpec
     with IOSpec
     with DbInitSpec
@@ -60,8 +60,6 @@ class ProjectSlugAdderSpec
   }
 
   private trait TestCase {
-    logger.reset()
-
     val projectPathAdder = new ProjectPathAdder[IO]
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathToSlugSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathToSlugSpec.scala
@@ -40,26 +40,27 @@ class ProjectPathToSlugSpec
     case _ => true
   }
 
-  it should "rename the 'project_path' column to 'project_slug'" in {
+  it should "rename the 'project_path' column to 'project_slug' " +
+    "as well as rename the 'idx_project_path' index" in {
 
-    verifyColumnExists("projects_tokens", "project_path") shouldBe true
-    verifyColumnExists("projects_tokens", "project_slug") shouldBe false
+      verifyColumnExists("projects_tokens", "project_path") shouldBe true
+      verifyColumnExists("projects_tokens", "project_slug") shouldBe false
 
-    projectPathToSlug.run.unsafeRunSync()
+      projectPathToSlug.run.unsafeRunSync()
 
-    logger.loggedOnly(Info("column 'project_path' renamed to 'project_slug'"))
-    logger.reset()
+      logger.loggedOnly(Info("column 'project_path' renamed to 'project_slug'"))
+      logger.reset()
 
-    verifyColumnExists("projects_tokens", "project_path") shouldBe false
-    verifyColumnExists("projects_tokens", "project_slug") shouldBe true
+      verifyColumnExists("projects_tokens", "project_path") shouldBe false
+      verifyColumnExists("projects_tokens", "project_slug") shouldBe true
 
-    projectPathToSlug.run.unsafeRunSync()
+      projectPathToSlug.run.unsafeRunSync()
 
-    logger.loggedOnly(Info("'project_slug' column existed"))
+      logger.loggedOnly(Info("'project_slug' column existed"))
 
-    verifyIndexExists("projects_tokens", "idx_project_path") shouldBe false
-    verifyIndexExists("projects_tokens", "idx_project_slug") shouldBe true
-  }
+      verifyIndexExists("projects_tokens", "idx_project_path") shouldBe false
+      verifyIndexExists("projects_tokens", "idx_project_slug") shouldBe true
+    }
 
   private lazy val projectPathToSlug = new ProjectPathToSlug[IO]
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathToSlugSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/ProjectPathToSlugSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.init
+
+import cats.effect.IO
+import io.renku.interpreters.TestLogger.Level.Info
+import io.renku.testtools.IOSpec
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class ProjectPathToSlugSpec
+    extends AnyFlatSpec
+    with IOSpec
+    with DbInitSpec
+    with Eventually
+    with IntegrationPatience
+    with should.Matchers
+    with MockFactory {
+
+  protected override lazy val migrationsToRun: List[DBMigration[IO]] = allMigrations.takeWhile {
+    case _: ProjectPathToSlug[IO] => false
+    case _ => true
+  }
+
+  it should "rename the 'project_path' column to 'project_slug'" in {
+
+    verifyColumnExists("projects_tokens", "project_path") shouldBe true
+    verifyColumnExists("projects_tokens", "project_slug") shouldBe false
+
+    projectPathToSlug.run.unsafeRunSync()
+
+    logger.loggedOnly(Info("column 'project_path' renamed to 'project_slug'"))
+    logger.reset()
+
+    verifyColumnExists("projects_tokens", "project_path") shouldBe false
+    verifyColumnExists("projects_tokens", "project_slug") shouldBe true
+
+    projectPathToSlug.run.unsafeRunSync()
+
+    logger.loggedOnly(Info("'project_slug' column existed"))
+
+    verifyIndexExists("projects_tokens", "idx_project_path") shouldBe false
+    verifyIndexExists("projects_tokens", "idx_project_slug") shouldBe true
+  }
+
+  private lazy val projectPathToSlug = new ProjectPathToSlug[IO]
+}


### PR DESCRIPTION
This PR adds Postgres DB migrations that renames `project_path` columns `project_slug` in token-repository and event-log. It adapts all the relevant queries as well.