### PR TITLE
feat: KG APIs to return project slug along the path

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
@@ -47,27 +47,28 @@ package object knowledgegraph {
     ).max
 
     json"""{
-    "identifier":   ${project.id.value},
-    "path":         ${project.slug.value},
-    "name":         ${project.name.value},
-    "visibility":   ${project.entitiesProject.visibility.value},
-    "created":      ${(project.entitiesProject.dateCreated, project.entitiesProject.maybeCreator)},
-    "dateModified": ${modified.value},
-    "urls":         ${project.urls.toJson},
-    "forking":      ${project.entitiesProject.forksCount -> project.entitiesProject},
-    "keywords":     ${project.entitiesProject.keywords.map(_.value).toList.sorted},
-    "starsCount":   ${project.starsCount.value},
-    "permissions":  ${toJson(project.permissions)},
-    "images":       ${project.entitiesProject.images -> project.slug},
-    "statistics": {
-      "commitsCount":     ${project.statistics.commitsCount.value},
-      "storageSize":      ${project.statistics.storageSize.value},
-      "repositorySize":   ${project.statistics.repositorySize.value},
-      "lfsObjectsSize":   ${project.statistics.lsfObjectsSize.value},
-      "jobArtifactsSize": ${project.statistics.jobArtifactsSize.value}
-    },
-    "version": ${project.entitiesProject.version.value}
-  }"""
+      "identifier":   ${project.id.value},
+      "slug":         ${project.slug.value},
+      "path":         ${project.slug.value},
+      "name":         ${project.name.value},
+      "visibility":   ${project.entitiesProject.visibility.value},
+      "created":      ${(project.entitiesProject.dateCreated, project.entitiesProject.maybeCreator)},
+      "dateModified": ${modified.value},
+      "urls":         ${project.urls.toJson},
+      "forking":      ${project.entitiesProject.forksCount -> project.entitiesProject},
+      "keywords":     ${project.entitiesProject.keywords.map(_.value).toList.sorted},
+      "starsCount":   ${project.starsCount.value},
+      "permissions":  ${toJson(project.permissions)},
+      "images":       ${project.entitiesProject.images -> project.slug},
+      "statistics": {
+        "commitsCount":     ${project.statistics.commitsCount.value},
+        "storageSize":      ${project.statistics.storageSize.value},
+        "repositorySize":   ${project.statistics.repositorySize.value},
+        "lfsObjectsSize":   ${project.statistics.lsfObjectsSize.value},
+        "jobArtifactsSize": ${project.statistics.jobArtifactsSize.value}
+      },
+      "version": ${project.entitiesProject.version.value}
+    }"""
       .deepMerge {
         _links(
           Link(Rel.Self        -> Href(renkuApiUrl / "projects" / project.slug)),
@@ -92,6 +93,7 @@ package object knowledgegraph {
         "forksCount": $forksCount,
         "parent": {
           "path":    ${project.parent.slug},
+          "slug":    ${project.parent.slug},
           "name":    ${project.parent.name},
           "created": ${(project.parent.dateCreated, project.parent.maybeCreator)}
         }

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -16,7 +16,7 @@ The following routes may be slightly different when accessed via the main Renku 
 | DELETE | ```/knowledge-graph/projects/:namespace/:name```                         | Deletes the project with the given `namespace/name` from knowledge-graph and GitLab  |
 | GET    | ```/knowledge-graph/projects/:namespace/:name```                         | Returns details of the project with the given `namespace/name`                       |
 | PUT    | ```/knowledge-graph/projects/:namespace/:name```                         | Updates selected properties of the project with the given `namespace/name`           |
-| GET    | ```/knowledge-graph/projects/:namespace/:name/datasets```                | Returns datasets of the project with the given `path`                                |
+| GET    | ```/knowledge-graph/projects/:namespace/:name/datasets```                | Returns datasets of the project with the given `slug`                                |
 | GET    | ```/knowledge-graph/projects/:namespace/:name/datasets/:dsName/tags```   | Returns tags of the dataset with the given `dsName` on project with the given `slug` |
 | GET    | ```/knowledge-graph/projects/:namespace/:name/files/:location/lineage``` | Returns the lineage for a the path (location) of a file on a project                 |
 | GET    | ```/knowledge-graph/spec.json```                                         | Returns OpenAPI specification of the service's resources                             |
@@ -102,7 +102,7 @@ Response body example:
           "_links":[  
              {  
                 "rel":  "view",
-                "href": "https://renkulab.io/gitlab/project_path/raw/master/data/mniouUnmal/image.png"
+                "href": "https://renkulab.io/gitlab/project_slug/raw/master/data/mniouUnmal/image.png"
              }
           ]
         }
@@ -230,6 +230,7 @@ Response body example:
       "identifier": "22222222-2222-2222-2222-222222222222"
     },
     "path":       "namespace1/project1-name",
+    "slug":       "namespace1/project1-name",
     "name":       "project1 name",
     "visibility": "public"
   },
@@ -245,6 +246,7 @@ Response body example:
         "identifier": "33333333333"
       },
       "path":       "namespace1/project1-name",
+      "slug":       "namespace1/project1-name",
       "name":       "project1 name",
       "visibility": "public"
     },
@@ -259,6 +261,7 @@ Response body example:
         "identifier": "4444444444"
       },
       "path":       "namespace2/project2-name",
+      "slug":       "namespace2/project2-name",
       "name":       "project2 name",
       "visibility": "public"
     }

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -1101,6 +1101,7 @@ Response body example:
 [
   {
     "name":        "name",
+    "slug":        "group/subgroup/name",
     "path":        "group/subgroup/name",
     "visibility":  "public",
     "date":        "2012-11-15T10:00:00.000Z",
@@ -1120,6 +1121,7 @@ Response body example:
   {
     "id":          123,
     "name":        "name",
+    "slug":        "group/subgroup/name",
     "path":        "group/subgroup/name",
     "visibility":  "public",
     "date":        "2012-11-15T10:00:00.000Z",

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -664,6 +664,7 @@ Response body example for `Accept: application/json`:
 {
   "identifier":  123,
   "path":        "namespace/project-name", 
+  "slug":        "namespace/project-name", 
   "name":        "Some project name",
   "description": "This is a longer text describing the project", // optional
   "visibility":  "public|private|internal",
@@ -686,6 +687,7 @@ Response body example for `Accept: application/json`:
     "forksCount": 1,
     "parent": { // optional
       "path":       "namespace/parent-project",
+      "slug":       "namespace/parent-project",
       "name":       "Parent project name",
       "created": {
         "dateCreated": "2001-09-04T10:48:29.457Z",
@@ -749,6 +751,9 @@ Response body example for `Accept: application/ld+json`:
     "http://schema.org/Project"
   ],
   "https://swissdatasciencecenter.github.io/renku-ontology#projectPath": {
+    "@value": "d_llli5Zo/2nTaozqw/llosas_/__-6h3a"
+  },
+  "https://swissdatasciencecenter.github.io/renku-ontology#slug": {
     "@value": "d_llli5Zo/2nTaozqw/llosas_/__-6h3a"
   },
   "http://schema.org/description": {

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -362,6 +362,7 @@ Response body example:
     "type":          "project",
     "matchingScore": 1.0055376,
     "name":          "name",
+    "slug":          "group/subgroup/name",
     "path":          "group/subgroup/name",
     "namespace":     "group/subgroup",
     "namespaces": [
@@ -491,6 +492,7 @@ Response body example:
     "creator":       "Jan Kowalski",
     "matchingScore": 1,
     "name":          "name",
+    "slug":          "group/subgroup/name",
     "path":          "group/subgroup/name",
     "namespace":     "group/subgroup",
     "namespaces": [

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/Dataset.scala
@@ -173,6 +173,7 @@ private object Dataset {
     Encoder.instance[DatasetProject] { project =>
       json"""{
         "path":       ${project.slug},
+        "slug":       ${project.slug},
         "name":       ${project.name},
         "visibility": ${project.visibility},
         "dataset": {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/ModelEncoders.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/ModelEncoders.scala
@@ -58,6 +58,7 @@ trait ModelEncoders {
         "type":          ${Criteria.Filters.EntityType.Project.value},
         "matchingScore": ${project.matchingScore},
         "name":          ${project.name},
+        "slug":          ${project.slug},
         "path":          ${project.slug},
         "namespace":     ${project.slug.toNamespaces.mkString("/")},
         "namespaces":    ${toDetailedInfo(project.slug.toNamespaces)},

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/ProjectJsonEncoder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/ProjectJsonEncoder.scala
@@ -48,6 +48,7 @@ private class ProjectJsonEncoderImpl(renkuApiUrl: renku.ApiUrl) extends ProjectJ
     json"""{
       "identifier":   ${project.id},
       "path":         ${project.slug},
+      "slug":         ${project.slug},
       "name":         ${project.name},
       "visibility":   ${project.visibility},
       "created":      ${project.created},
@@ -91,6 +92,7 @@ private class ProjectJsonEncoderImpl(renkuApiUrl: renku.ApiUrl) extends ProjectJ
   private implicit lazy val parentProjectEncoder: Encoder[ParentProject] = Encoder.instance[ParentProject] { parent =>
     json"""{
       "path":    ${parent.slug},
+      "slug":    ${parent.slug},
       "name":    ${parent.name},
       "created": ${parent.created}
     }"""

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/ProjectJsonLDEncoder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/details/ProjectJsonLDEncoder.scala
@@ -38,6 +38,7 @@ private object ProjectJsonLDEncoder extends ProjectJsonLDEncoder {
       entities.Project.entityTypes,
       schema / "identifier"       -> project.id.asJsonLD,
       renku / "projectPath"       -> project.slug.asJsonLD,
+      renku / "slug"              -> project.slug.asJsonLD,
       schema / "name"             -> project.name.asJsonLD,
       schema / "description"      -> project.maybeDescription.asJsonLD,
       renku / "projectVisibility" -> project.visibility.asJsonLD,

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/model.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/model.scala
@@ -56,11 +56,12 @@ private object model {
       implicit def encoder(implicit renkuApiUrl: renku.ApiUrl): Encoder[Activated] =
         Encoder.instance[Activated] { project =>
           json"""{
-            "path":        ${project.slug},
-            "name":        ${project.name},
-            "visibility":  ${project.visibility},
-            "date":        ${project.dateCreated},
-            "keywords":    ${project.keywords.sorted.map(_.value)}
+            "path":       ${project.slug},
+            "slug":       ${project.slug},
+            "name":       ${project.name},
+            "visibility": ${project.visibility},
+            "date":       ${project.dateCreated},
+            "keywords":   ${project.keywords.sorted.map(_.value)}
           }"""
             .addIfDefined("creator" -> project.maybeCreator)
             .addIfDefined("description" -> project.maybeDesc)
@@ -88,12 +89,13 @@ private object model {
       implicit def encoder(implicit renkuUrl: RenkuUrl): Encoder[NotActivated] =
         Encoder.instance[NotActivated] { project =>
           json"""{
-            "id":          ${project.id},
-            "path":        ${project.slug},
-            "name":        ${project.name},
-            "visibility":  ${project.visibility},
-            "date":        ${project.dateCreated},
-            "keywords":    ${project.keywords.sorted.map(_.value)}
+            "id":         ${project.id},
+            "slug":       ${project.slug},
+            "path":       ${project.slug},
+            "name":       ${project.name},
+            "visibility": ${project.visibility},
+            "date":       ${project.dateCreated},
+            "keywords":   ${project.keywords.sorted.map(_.value)}
           }"""
             .addIfDefined("creator" -> project.maybeCreator)
             .addIfDefined("description" -> project.maybeDesc)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/EndpointSpec.scala
@@ -372,7 +372,9 @@ class EndpointSpec
 
   private implicit lazy val projectDecoder: Decoder[DatasetProject] = cursor =>
     for {
-      slug         <- cursor.downField("path").as[projects.Slug]
+      path         <- cursor.downField("path").as[projects.Slug]
+      slug         <- cursor.downField("slug").as[projects.Slug]
+      _            <- Either.cond(path == slug, (), DecodingFailure("path != slug", Nil))
       name         <- cursor.downField("name").as[projects.Name]
       visibility   <- cursor.downField("visibility").as[projects.Visibility]
       dsIdentifier <- cursor.downField("dataset").downField("identifier").as[datasets.Identifier]

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/ModelEncoderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/entities/ModelEncoderSpec.scala
@@ -75,6 +75,7 @@ class ModelEncoderSpec extends AnyFlatSpec with should.Matchers with DiffInstanc
       project.maybeCreator,
       project.matchingScore,
       project.slug,
+      project.slug,
       project.name,
       project.slug.toNamespace,
       makeNamespaces(project.slug),
@@ -91,7 +92,7 @@ class ModelEncoderSpec extends AnyFlatSpec with should.Matchers with DiffInstanc
   it should "encode datasets with topmost-sameas" in {
     val dataset = Entity.Dataset(
       MatchingScore(0.65f),
-      datasets.TopmostSameAs(s"${renkuApiUrl}/datasets/123"),
+      datasets.TopmostSameAs(s"$renkuApiUrl/datasets/123"),
       datasets.Name("my-dataset"),
       Visibility.Public,
       datasets.DateCreated(Instant.parse("2013-03-31T13:03:45Z")),
@@ -180,6 +181,7 @@ object ModelEncoderSpec {
       creator:       Option[persons.Name],
       matchingScore: MatchingScore,
       path:          projects.Slug,
+      slug:          projects.Slug,
       name:          projects.Name,
       namespace:     projects.Namespace,
       namespaces:    List[Ns],

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/ProjectJsonEncoderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/ProjectJsonEncoderSpec.scala
@@ -71,7 +71,9 @@ class ProjectJsonEncoderSpec extends AnyWordSpec with should.Matchers with Scala
   private def decoder(project: Project): Decoder[Project] = cursor =>
     for {
       id               <- cursor.downField("identifier").as[GitLabId]
-      slug             <- cursor.downField("path").as[Slug]
+      path             <- cursor.downField("path").as[Slug]
+      slug             <- cursor.downField("slug").as[Slug]
+      _                <- Either.cond(path == slug, (), DecodingFailure("path != slug", Nil))
       name             <- cursor.downField("name").as[Name]
       maybeDescription <- cursor.downField("description").as[Option[Description]]
       visibility       <- cursor.downField("visibility").as[Visibility]
@@ -126,7 +128,9 @@ class ProjectJsonEncoderSpec extends AnyWordSpec with should.Matchers with Scala
 
   private def parentDecoder(maybeParent: Option[ParentProject]): Decoder[ParentProject] = cursor =>
     for {
-      slug    <- cursor.downField("path").as[Slug]
+      path    <- cursor.downField("path").as[Slug]
+      slug    <- cursor.downField("slug").as[Slug]
+      _       <- Either.cond(path == slug, (), DecodingFailure("parent path != slug", Nil))
       name    <- cursor.downField("name").as[Name]
       parent  <- maybeParent.toRight(DecodingFailure(show"'$slug' parent project expected but found None", Nil))
       created <- cursor.downField("created").as(creationDecoder(parent.created))

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/ProjectJsonLDEncoderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/ProjectJsonLDEncoderSpec.scala
@@ -20,6 +20,7 @@ package io.renku.knowledgegraph.projects.details
 
 import ProjectsGenerators._
 import cats.syntax.all._
+import io.circe.DecodingFailure
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.Schemas._
 import io.renku.graph.model._
@@ -47,7 +48,9 @@ class ProjectJsonLDEncoderSpec extends AnyWordSpec with should.Matchers with Sca
       for {
         resourceId   <- cursor.downEntityId.as[projects.ResourceId]
         identifier   <- cursor.downField(schema / "identifier").as[projects.GitLabId]
-        slug         <- cursor.downField(renku / "projectPath").as[projects.Slug]
+        path         <- cursor.downField(renku / "projectPath").as[projects.Slug]
+        slug         <- cursor.downField(renku / "slug").as[projects.Slug]
+        _            <- Either.cond(path == slug, (), DecodingFailure("path != slug", Nil))
         name         <- cursor.downField(schema / "name").as[Option[projects.Name]].flatMap(projects.Name.failIfNone)
         maybeDesc    <- cursor.downField(schema / "description").as[Option[projects.Description]]
         visibility   <- cursor.downField(renku / "projectVisibility").as[projects.Visibility]

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/EndpointSpec.scala
@@ -118,7 +118,9 @@ class EndpointSpec extends AnyWordSpec with should.Matchers with IOSpec with Moc
     cursor._links >>= {
       case links if links.get(Links.Rel("details")).isDefined =>
         for {
-          slug         <- cursor.downField("path").as[projects.Slug]
+          path         <- cursor.downField("path").as[projects.Slug]
+          slug         <- cursor.downField("slug").as[projects.Slug]
+          _            <- Either.cond(path == slug, (), DecodingFailure("path != slug", Nil))
           name         <- cursor.downField("name").as[projects.Name]
           visibility   <- cursor.downField("visibility").as[projects.Visibility]
           date         <- cursor.downField("date").as[projects.DateCreated]
@@ -137,7 +139,9 @@ class EndpointSpec extends AnyWordSpec with should.Matchers with IOSpec with Moc
       case links if links.get(Links.Rel("activation")).isDefined =>
         for {
           id           <- cursor.downField("id").as[projects.GitLabId]
+          path         <- cursor.downField("path").as[projects.Slug]
           slug         <- cursor.downField("path").as[projects.Slug]
+          _            <- Either.cond(path == slug, (), DecodingFailure("path != slug", Nil))
           name         <- cursor.downField("name").as[projects.Name]
           visibility   <- cursor.downField("visibility").as[projects.Visibility]
           date         <- cursor.downField("date").as[projects.DateCreated]


### PR DESCRIPTION
This PR adds a redundant `project.slug` property to all KG APIs where info about the Project entity is returned. This is a transition phase towards the state where no `project.path` exists in the APIs.