### PR TITLE
fix: SYNC_REPO_METADATA to use GL project's name not payload's

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/NewValuesCalculator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/NewValuesCalculator.scala
@@ -34,7 +34,7 @@ private object NewValuesCalculator extends NewValuesCalculator {
                              glData:           DataExtract.GL,
                              maybePayloadData: Option[DataExtract.Payload]
   ): NewValues = NewValues(
-    maybeNewName(tsData, glData, maybePayloadData),
+    maybeNewName(tsData, glData),
     Option.when(tsData.visibility != glData.visibility)(glData.visibility),
     maybeNewDateModified(tsData, glData),
     maybeNewDesc(tsData, glData, maybePayloadData),
@@ -42,13 +42,8 @@ private object NewValuesCalculator extends NewValuesCalculator {
     maybeNewImages(tsData, glData, maybePayloadData)
   )
 
-  private def maybeNewName(tsData:           DataExtract.TS,
-                           glData:           DataExtract.GL,
-                           maybePayloadData: Option[DataExtract.Payload]
-  ) = {
-    val potentiallyNewName = maybePayloadData.getOrElse(glData).name
-    Option.when(tsData.name != potentiallyNewName)(potentiallyNewName)
-  }
+  private def maybeNewName(tsData: DataExtract.TS, glData: DataExtract.GL) =
+    Option.when(tsData.name != glData.name)(glData.name)
 
   private def maybeNewDateModified(tsData: DataExtract.TS, glData: DataExtract.GL) =
     tsData.maybeDateModified -> glData.maybeDateModified match {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/model.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/model.scala
@@ -26,8 +26,6 @@ import io.renku.triplesstore.SparqlQuery
 import java.time.Instant
 
 private sealed trait DataExtract {
-  val slug:              projects.Slug
-  val name:              projects.Name
   val maybeDateModified: Option[projects.DateModified]
   val maybeDesc:         Option[projects.Description]
   val keywords:          Set[projects.Keyword]
@@ -55,9 +53,7 @@ private object DataExtract {
     override val maybeDateModified: Option[projects.DateModified] =
       List(updatedAt, lastActivityAt).max.map(projects.DateModified.apply)
   }
-  final case class Payload(slug:      projects.Slug,
-                           name:      projects.Name,
-                           maybeDesc: Option[projects.Description],
+  final case class Payload(maybeDesc: Option[projects.Description],
                            keywords:  Set[projects.Keyword],
                            images:    List[ImageUri]
   ) extends DataExtract {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/EventProcessorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/EventProcessorSpec.scala
@@ -102,7 +102,7 @@ class EventProcessorSpec extends AsyncFlatSpec with AsyncIOSpec with should.Matc
       eventPayloads[IO].map(_.generateOne) >>= { payload =>
         givenPayloadFinding(event.slug, returning = payload.some.pure[IO])
 
-        val maybePayloadData = payloadDataExtracts(having = event.slug).generateOption
+        val maybePayloadData = payloadDataExtracts.generateOption
         givenPayloadDataExtraction(event.slug, payload, returning = maybePayloadData.pure[IO])
 
         val updates = updateCommands.generateList()

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/Generators.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/Generators.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 import io.renku.eventlog.api.events.Generators.redoProjectTransformationEvents
 import io.renku.generators.CommonGraphGenerators.sparqlQueries
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.RenkuTinyTypeGenerators.{imageUris, projectDescriptions, projectKeywords, projectModifiedDates, projectNames, projectSlugs, projectResourceIds, projectVisibilities}
+import io.renku.graph.model.RenkuTinyTypeGenerators.{imageUris, projectDescriptions, projectKeywords, projectModifiedDates, projectNames, projectResourceIds, projectSlugs, projectVisibilities}
 import io.renku.graph.model.{entities, projects}
 import org.scalacheck.Gen
 
@@ -48,12 +48,11 @@ private object Generators {
     maybeImage     <- imageUris.toGeneratorOfOptions
   } yield DataExtract.GL(having, name, visibility, updatedAt, lastActivityAt, maybeDesc, keywords, maybeImage)
 
-  def payloadDataExtracts(having: projects.Slug = projectSlugs.generateOne): Gen[DataExtract.Payload] = for {
-    name      <- projectNames
+  lazy val payloadDataExtracts: Gen[DataExtract.Payload] = for {
     maybeDesc <- projectDescriptions.toGeneratorOfOptions
     keywords  <- projectKeywords.toGeneratorOfSet(min = 0)
     imageUris <- imageUris.toGeneratorOfList()
-  } yield DataExtract.Payload(having, name, maybeDesc, keywords, imageUris)
+  } yield DataExtract.Payload(maybeDesc, keywords, imageUris)
 
   def tsDataFrom(project: entities.Project): DataExtract.TS =
     DataExtract.TS(
@@ -84,7 +83,7 @@ private object Generators {
   }
 
   def payloadDataFrom(data: DataExtract.TS): DataExtract.Payload =
-    DataExtract.Payload(data.slug, data.name, data.maybeDesc, data.keywords, data.images)
+    DataExtract.Payload(data.maybeDesc, data.keywords, data.images)
 
   val sparqlUpdateCommands: Gen[UpdateCommand.Sparql] = sparqlQueries.map(UpdateCommand.Sparql)
   val eventUpdateCommands:  Gen[UpdateCommand.Event]  = redoProjectTransformationEvents.map(UpdateCommand.Event)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/NewValuesCalculatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/NewValuesCalculatorSpec.scala
@@ -34,7 +34,7 @@ class NewValuesCalculatorSpec extends AnyWordSpec with should.Matchers with Opti
 
   "new name" should {
 
-    "be None if ts and gl names are the same - no payload case" in {
+    "be None if ts and gl names are the same" in {
 
       val tsData = tsDataExtracts().generateOne
       val glData = glDataFrom(tsData)
@@ -42,32 +42,13 @@ class NewValuesCalculatorSpec extends AnyWordSpec with should.Matchers with Opti
       NewValuesCalculator.findNewValues(tsData, glData, maybePayloadData = None) shouldBe NewValues.empty
     }
 
-    "be None if ts and payload names are the same" in {
-
-      val tsData      = tsDataExtracts().generateOne
-      val glData      = glDataFrom(tsData).copy(name = projectNames.generateOne)
-      val payloadData = payloadDataFrom(tsData)
-
-      NewValuesCalculator.findNewValues(tsData, glData, payloadData.some) shouldBe NewValues.empty
-    }
-
-    "be gl name if ts and gl contains different names - no payload case" in {
+    "be gl name if ts and gl contains different names" in {
 
       val tsData = tsDataExtracts().generateOne
       val glData = glDataFrom(tsData).copy(name = projectNames.generateOne)
 
       NewValuesCalculator.findNewValues(tsData, glData, maybePayloadData = None) shouldBe
         NewValues.empty.copy(maybeName = glData.name.some)
-    }
-
-    "be payload name if all ts, gl and payload contains different names" in {
-
-      val tsData      = tsDataExtracts().generateOne
-      val glData      = glDataFrom(tsData).copy(name = projectNames.generateOne)
-      val payloadData = payloadDataFrom(tsData).copy(name = projectNames.generateOne)
-
-      NewValuesCalculator.findNewValues(tsData, glData, payloadData.some) shouldBe
-        NewValues.empty.copy(maybeName = payloadData.name.some)
     }
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/PayloadDataExtractorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/PayloadDataExtractorSpec.scala
@@ -53,12 +53,7 @@ class PayloadDataExtractorSpec
       (ioPayload >>=
         (extractor.extractPayloadData(testProject.slug, _)))
         .asserting(
-          _.value shouldBe DataExtract.Payload(testProject.slug,
-                                               testProject.name,
-                                               testProject.maybeDescription,
-                                               testProject.keywords,
-                                               testProject.images
-          )
+          _.value shouldBe DataExtract.Payload(testProject.maybeDescription, testProject.keywords, testProject.images)
         )
     }
   }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/UpdateCommandsCalculatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/syncrepometadata/processor/UpdateCommandsCalculatorSpec.scala
@@ -59,7 +59,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = projectNames.generateOne
     givenNewValuesFinding(tsData, glData, maybePayloadData, returning = NewValues.empty.copy(maybeName = newValue.some))
@@ -84,7 +84,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = projectVisibilities.generateOne
     givenNewValuesFinding(tsData,
@@ -114,7 +114,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = projectModifiedDates(project.dateModified.value).generateSome
     givenNewValuesFinding(tsData,
@@ -143,7 +143,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = projectDescriptions.generateSome
     givenNewValuesFinding(tsData, glData, maybePayloadData, returning = NewValues.empty.copy(maybeDesc = newValue.some))
@@ -171,7 +171,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     givenNewValuesFinding(tsData, glData, maybePayloadData, returning = NewValues.empty.copy(maybeDesc = Some(None)))
     val updatedTsData = tsData.copy(maybeDesc = None)
@@ -198,7 +198,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = projectKeywords.generateSet(min = 1)
     givenNewValuesFinding(tsData,
@@ -230,7 +230,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = Set.empty[projects.Keyword]
     givenNewValuesFinding(tsData,
@@ -259,7 +259,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = imageUris.generateList(min = 1)
     givenNewValuesFinding(tsData,
@@ -291,7 +291,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = List.empty[Image]
     givenNewValuesFinding(tsData,
@@ -320,7 +320,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     val newValue = projectKeywords.generateSet(min = 1)
     givenNewValuesFinding(tsData,
@@ -349,7 +349,7 @@ class UpdateCommandsCalculatorSpec
 
     val tsData           = tsDataFrom(project)
     val glData           = glDataExtracts(project.slug).generateOne
-    val maybePayloadData = payloadDataExtracts(project.slug).generateOption
+    val maybePayloadData = payloadDataExtracts.generateOption
 
     givenNewValuesFinding(tsData, glData, maybePayloadData, returning = NewValues.empty)
 


### PR DESCRIPTION
This PR modifies the logic of the `SYNC_REPO_METADATA` process for calculating the Project's name. Before, the name found in the CLI payload had precedence over the GL name. This was causing issues for projects that were forked as in such cases the name in the payload was the name of the parent Project.