### PR TITLE
chore: Add query time measurements to sparql client

### DIFF
--- a/graph-commons/src/main/scala/io/renku/triplesstore/ProjectSparqlClient.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/ProjectSparqlClient.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package io.renku.triplesgenerator.events.consumers
+package io.renku.triplesstore
 
 import cats.Monad
 import cats.effect._
@@ -26,7 +26,6 @@ import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.auto._
 import fs2.io.net.Network
 import io.renku.jsonld.JsonLD
-import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
 import io.renku.triplesstore.client.http.{Retry, SparqlClient, SparqlQuery, SparqlUpdate}
 import org.typelevel.log4cats.Logger
 

--- a/graph-commons/src/main/scala/io/renku/triplesstore/SparqlQuery.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/SparqlQuery.scala
@@ -27,16 +27,21 @@ import io.renku.jsonld.Schema
 import io.renku.tinytypes.StringTinyType
 import io.renku.triplesstore.SparqlQuery.Prefix
 import io.renku.triplesstore.client.sparql.Fragment
+import io.renku.triplesstore.client.http.{SparqlQuery => ClientSparqlQuery, SparqlUpdate => ClientSparqlUpdate}
 
 final case class SparqlQuery(name:               String Refined NonEmpty,
                              prefixes:           Set[Prefix],
                              body:               String,
                              maybePagingRequest: Option[PagingRequest]
-) {
+) extends ClientSparqlQuery
+    with ClientSparqlUpdate {
+
   override lazy val toString: String =
     s"""|${prefixes.mkString("", "\n", "")}
         |$body
         |$pagingRequest""".stripMargin.trim
+
+  override lazy val render: String = toString
 
   private lazy val pagingRequest =
     maybePagingRequest

--- a/graph-commons/src/main/scala/io/renku/triplesstore/SparqlQueryTimeRecorder.scala
+++ b/graph-commons/src/main/scala/io/renku/triplesstore/SparqlQueryTimeRecorder.scala
@@ -33,7 +33,7 @@ object SparqlQueryTimeRecorder {
 
   import io.renku.metrics.MetricsRegistry
 
-  def apply[F[_]: Sync: Logger: MetricsRegistry](): F[SparqlQueryTimeRecorder[F]] = MetricsRegistry[F]
+  def create[F[_]: Sync: Logger: MetricsRegistry](): F[SparqlQueryTimeRecorder[F]] = MetricsRegistry[F]
     .register {
       new LabeledHistogramImpl[F](
         name = "sparql_execution_times",

--- a/graph-commons/src/test/scala/io/renku/logging/TestSparqlQueryTimeRecorder.scala
+++ b/graph-commons/src/test/scala/io/renku/logging/TestSparqlQueryTimeRecorder.scala
@@ -26,6 +26,6 @@ import org.typelevel.log4cats.Logger
 object TestSparqlQueryTimeRecorder {
   def apply[F[_]: Sync: Logger]: F[SparqlQueryTimeRecorder[F]] = {
     implicit val metricsRegistry: MetricsRegistry[F] = TestMetricsRegistry[F]
-    SparqlQueryTimeRecorder[F]()
+    SparqlQueryTimeRecorder.create[F]()
   }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/Microservice.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/Microservice.scala
@@ -38,7 +38,7 @@ object Microservice extends IOMicroservice {
 
   override def run(args: List[String]): IO[ExitCode] = for {
     implicit0(mr: MetricsRegistry[IO])           <- MetricsRegistry[IO]()
-    implicit0(sqtr: SparqlQueryTimeRecorder[IO]) <- SparqlQueryTimeRecorder[IO]()
+    implicit0(sqtr: SparqlQueryTimeRecorder[IO]) <- SparqlQueryTimeRecorder.create[IO]()
     projectConnConfig                            <- ProjectsConnectionConfig[IO]()
     certificateLoader                            <- CertificateLoader[IO]
     sentryInitializer                            <- SentryInitializer[IO]

--- a/project-auth/src/test/scala/io/renku/projectauth/ProjectAuthServiceSpec.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/ProjectAuthServiceSpec.scala
@@ -27,13 +27,13 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.persons.GitLabId
 import io.renku.graph.model.projects.{Role, Visibility}
-import io.renku.triplesstore.client.util.JenaContainerSpec
+import io.renku.triplesstore.client.util.JenaContainerSupport
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-class ProjectAuthServiceSpec extends AsyncFlatSpec with AsyncIOSpec with JenaContainerSpec with should.Matchers {
+class ProjectAuthServiceSpec extends AsyncFlatSpec with AsyncIOSpec with JenaContainerSupport with should.Matchers {
   implicit val logger:   Logger[IO] = Slf4jLogger.getLogger[IO]
   implicit val renkuUrl: RenkuUrl   = RenkuUrl("http://localhost/renku")
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -42,7 +42,7 @@ import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.
 import io.renku.triplesgenerator.events.consumers.tsprovisioning.{minprojectinfo, triplesgenerated}
 import io.renku.triplesgenerator.init.{CliVersionCompatibilityChecker, CliVersionCompatibilityVerifier}
 import io.renku.triplesgenerator.metrics.MetricsService
-import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
+import io.renku.triplesstore.{ProjectSparqlClient, ProjectsConnectionConfig, SparqlQueryTimeRecorder}
 import natchez.Trace.Implicits.noop
 import org.http4s.server.Server
 import org.typelevel.log4cats.Logger

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -68,12 +68,15 @@ object Microservice extends IOMicroservice {
       dbSessionPool <- Resource
                          .eval(new TgLockDbConfigProvider[IO].map(SessionPoolResource[IO, TgLockDB]))
                          .flatMap(identity)
+      implicit0(mr: MetricsRegistry[IO])           <- Resource.eval(MetricsRegistry[IO]())
+      implicit0(sqtr: SparqlQueryTimeRecorder[IO]) <- Resource.eval(SparqlQueryTimeRecorder.create[IO]())
+
       projectConnConfig <- Resource.eval(ProjectsConnectionConfig[IO](config))
       projectsSparql    <- ProjectSparqlClient[IO](projectConnConfig)
-    } yield (config, dbSessionPool, projectsSparql)
+    } yield (config, dbSessionPool, projectsSparql, mr, sqtr)
 
-    resources.use { case (config, dbSessionPool, projectSparqlClient) =>
-      doRun(config, dbSessionPool, projectSparqlClient)
+    resources.use { case (config, dbSessionPool, projectSparqlClient, mr, sqtr) =>
+      doRun(config, dbSessionPool, projectSparqlClient)(mr, sqtr)
     }
   }
 
@@ -81,12 +84,11 @@ object Microservice extends IOMicroservice {
       config:              Config,
       dbSessionPool:       SessionResource[IO, TgLockDB],
       projectSparqlClient: ProjectSparqlClient[IO]
-  ): IO[ExitCode] = for {
-    implicit0(mr: MetricsRegistry[IO])           <- MetricsRegistry[IO]()
-    implicit0(sqtr: SparqlQueryTimeRecorder[IO]) <- SparqlQueryTimeRecorder[IO]()
-    implicit0(gc: GitLabClient[IO])              <- GitLabClient[IO]()
-    implicit0(acf: AccessTokenFinder[IO])        <- AccessTokenFinder[IO]()
-    implicit0(rp: ReProvisioningStatus[IO])      <- ReProvisioningStatus[IO]()
+  )(implicit mr: MetricsRegistry[IO], sqtr: SparqlQueryTimeRecorder[IO]): IO[ExitCode] = for {
+
+    implicit0(gc: GitLabClient[IO])         <- GitLabClient[IO]()
+    implicit0(acf: AccessTokenFinder[IO])   <- AccessTokenFinder[IO]()
+    implicit0(rp: ReProvisioningStatus[IO]) <- ReProvisioningStatus[IO]()
 
     _ <- TgLockDB.migrate[IO](dbSessionPool, 20.seconds)
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/ProjectAuthSync.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/ProjectAuthSync.scala
@@ -25,7 +25,7 @@ import fs2.io.net.Network
 import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.projects.{Slug, Visibility}
 import io.renku.projectauth.{ProjectAuthData, ProjectAuthService, ProjectMember}
-import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
+import io.renku.triplesstore.{ProjectSparqlClient, ProjectsConnectionConfig, SparqlQueryTimeRecorder}
 import io.renku.triplesstore.client.http.{RowDecoder, SparqlClient}
 import io.renku.triplesstore.client.syntax._
 import org.typelevel.log4cats.Logger

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/ProjectAuthSync.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/ProjectAuthSync.scala
@@ -25,7 +25,7 @@ import fs2.io.net.Network
 import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.projects.{Slug, Visibility}
 import io.renku.projectauth.{ProjectAuthData, ProjectAuthService, ProjectMember}
-import io.renku.triplesstore.ProjectsConnectionConfig
+import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
 import io.renku.triplesstore.client.http.{RowDecoder, SparqlClient}
 import io.renku.triplesstore.client.syntax._
 import org.typelevel.log4cats.Logger
@@ -37,7 +37,9 @@ trait ProjectAuthSync[F[_]] {
 
 object ProjectAuthSync {
 
-  def resource[F[_]: Async: Logger: Network](cc: ProjectsConnectionConfig)(implicit renkuUrl: RenkuUrl) =
+  def resource[F[_]: Async: Logger: Network: SparqlQueryTimeRecorder](cc: ProjectsConnectionConfig)(implicit
+      renkuUrl: RenkuUrl
+  ) =
     ProjectSparqlClient[F](cc).map(apply[F])
 
   def apply[F[_]: Sync](

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/EventHandler.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/EventHandler.scala
@@ -31,7 +31,7 @@ import io.renku.lock.syntax._
 import io.renku.http.client.GitLabClient
 import io.renku.lock.Lock
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
-import io.renku.triplesstore.SparqlQueryTimeRecorder
+import io.renku.triplesstore.{ProjectSparqlClient, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 import tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/MembersSynchronizer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/MembersSynchronizer.scala
@@ -26,7 +26,6 @@ import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.logging.ExecutionTimeRecorder
 import io.renku.logging.ExecutionTimeRecorder.ElapsedTime
-import io.renku.triplesgenerator.events.consumers.ProjectSparqlClient
 import io.renku.triplesgenerator.gitlab.GitLabProjectMembersFinder
 import io.renku.triplesstore._
 import org.typelevel.log4cats.Logger

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/SubscriptionFactory.scala
@@ -28,7 +28,7 @@ import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
 import io.renku.triplesgenerator.Microservice
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
-import io.renku.triplesgenerator.events.consumers.ProjectSparqlClient
+import io.renku.triplesstore.ProjectSparqlClient
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.typelevel.log4cats.Logger

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGSynchronizer.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/namedgraphs/KGSynchronizer.scala
@@ -24,7 +24,7 @@ import cats.effect._
 import cats.syntax.all._
 import io.renku.graph.config.RenkuUrlLoader
 import io.renku.graph.model.{RenkuUrl, projects}
-import io.renku.triplesgenerator.events.consumers.{ProjectAuthSync, ProjectSparqlClient}
+import io.renku.triplesgenerator.events.consumers.ProjectAuthSync
 import io.renku.triplesgenerator.gitlab.GitLabProjectMember
 import io.renku.triplesstore._
 import org.typelevel.log4cats.Logger

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/DatasetProvision.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/DatasetProvision.scala
@@ -25,8 +25,8 @@ import io.renku.graph.model.projects.Role
 import io.renku.graph.model.{RenkuUrl, entities}
 import io.renku.logging.{ExecutionTimeRecorder, TestExecutionTimeRecorder}
 import io.renku.projectauth.ProjectMember
-import io.renku.triplesgenerator.events.consumers.{ProjectAuthSync, ProjectSparqlClient}
-import io.renku.triplesstore.{GraphsProducer, InMemoryJena, ProjectsDataset, SparqlQueryTimeRecorder}
+import io.renku.triplesgenerator.events.consumers.ProjectAuthSync
+import io.renku.triplesstore._
 
 trait DatasetProvision extends SearchInfoDatasets { self: ProjectsDataset with InMemoryJena =>
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/ProjectSparqlClientSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/ProjectSparqlClientSpec.scala
@@ -1,0 +1,89 @@
+package io.renku.triplesgenerator.events.consumers
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.auto._
+import io.prometheus.client.Histogram
+import io.renku.graph.model.Schemas
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestExecutionTimeRecorder
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.client.util.JenaContainerSupport
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+
+class ProjectSparqlClientSpec extends AsyncFlatSpec with AsyncIOSpec with JenaContainerSupport with should.Matchers {
+  implicit val logger: Logger[IO] = TestLogger()
+
+  val makeHistogram = IO(
+    new Histogram.Builder().name("test").help("test").labelNames("update").buckets(0.5, 0.8).create()
+  )
+
+  def makeSparqlQueryTimeRecorder(h: Histogram): SparqlQueryTimeRecorder[IO] =
+    new SparqlQueryTimeRecorder[IO](TestExecutionTimeRecorder[IO](Some(h)))
+
+  def withProjectClient(implicit sqr: SparqlQueryTimeRecorder[IO]) =
+    withDataset("projects").map(ProjectSparqlClient.apply(_))
+
+  it should "measure execution time for named queries" in {
+    val histogram = makeHistogram.unsafeRunSync()
+    implicit val sr: SparqlQueryTimeRecorder[IO] = makeSparqlQueryTimeRecorder(histogram)
+    withProjectClient.use { c =>
+      for {
+        a <- IO(histogram.collect())
+        _ = a.get(0).samples.size() shouldBe 0
+
+        q = SparqlQuery.apply(
+              name = "test-update",
+              prefixes = Prefixes
+                .of(Schemas.prov -> "prov", Schemas.renku -> "renku", Schemas.schema -> "schema", Schemas.xsd -> "xsd")
+                .map(p => Refined.unsafeApply(p.value)),
+              body = sparql"""
+                             |PREFIX p: <http://bedrock/>
+                             |INSERT DATA {
+                             |    p:fred p:hasSpouse p:wilma .
+                             |    p:fred p:hasChild p:pebbles .
+                             |    p:wilma p:hasChild p:pebbles .
+                             |    p:pebbles p:hasSpouse p:bamm-bamm ;
+                             |        p:hasChild p:roxy, p:chip.
+                             |}""".stripMargin
+            )
+        _ <- c.update(q)
+
+        x = histogram.collect()
+        _ = x.get(0).samples.size() should be > 0
+      } yield ()
+    }
+  }
+
+  it should "not measure execution time for un-named queries" in {
+    val histogram = makeHistogram.unsafeRunSync()
+    implicit val sr: SparqlQueryTimeRecorder[IO] = makeSparqlQueryTimeRecorder(histogram)
+
+    withProjectClient.use { c =>
+      for {
+        a <- IO(histogram.collect())
+        _ = a.get(0).samples.size() shouldBe 0
+        q = sparql"""
+                    |PREFIX p: <http://bedrock/>
+                    |INSERT DATA {
+                    |    p:fred p:hasSpouse p:wilma .
+                    |    p:fred p:hasChild p:pebbles .
+                    |    p:wilma p:hasChild p:pebbles .
+                    |    p:pebbles p:hasSpouse p:bamm-bamm ;
+                    |        p:hasChild p:roxy, p:chip.
+                    |}""".stripMargin
+
+        _ <- c.update(q)
+
+        x = histogram.collect()
+        _ = x.get(0).samples.size() shouldBe 0
+      } yield ()
+    }
+  }
+
+}

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/SparqlClient.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/SparqlClient.scala
@@ -39,7 +39,7 @@ trait SparqlClient[F[_]] {
   /** The sparql query operation, returning results as JSON. */
   def query(request: SparqlQuery): F[Json]
 
-  def queryDecode[A](request: SparqlQuery)(implicit d: RowDecoder[A], F: MonadThrow[F]): F[List[A]] = {
+  final def queryDecode[A](request: SparqlQuery)(implicit d: RowDecoder[A], F: MonadThrow[F]): F[List[A]] = {
     val decoder = Decoder
       .instance(c => c.downField("results").downField("bindings").as[List[A]])
       .withErrorMessage(s"Decoding Sparql result failed for request: $request")

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/http/SparqlClientSpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/http/SparqlClientSpec.scala
@@ -27,11 +27,11 @@ import org.scalatest.matchers.should
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import io.renku.triplesstore.client.syntax._
-import io.renku.triplesstore.client.util.JenaContainerSpec
+import io.renku.triplesstore.client.util.JenaContainerSupport
 
 import java.time.Instant
 
-class SparqlClientSpec extends AsyncFlatSpec with AsyncIOSpec with JenaContainerSpec with should.Matchers {
+class SparqlClientSpec extends AsyncFlatSpec with AsyncIOSpec with JenaContainerSupport with should.Matchers {
   implicit val logger: Logger[IO] = Slf4jLogger.getLogger[IO]
   val dataset = "projects"
 

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/util/JenaContainerDirectSupport.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/util/JenaContainerDirectSupport.scala
@@ -25,7 +25,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 import org.typelevel.log4cats.Logger
 
 /** Trait for having a client directly accessible using "unsafe" effects. */
-trait JenaContainerDirectSpec extends JenaContainerSpec with BeforeAndAfterAll { self: Suite =>
+trait JenaContainerDirectSupport extends JenaContainerSupport with BeforeAndAfterAll { self: Suite =>
   implicit def logger: Logger[IO]
 
   implicit val ioRuntime: IORuntime

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/util/JenaContainerSupport.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/util/JenaContainerSupport.scala
@@ -29,7 +29,7 @@ import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
 
-trait JenaContainerSpec extends ForAllTestContainer { self: Suite =>
+trait JenaContainerSupport extends ForAllTestContainer { self: Suite =>
 
   protected val runMode: JenaRunMode = JenaRunMode.GenericContainer
   protected val timeout: Duration    = 2.minutes


### PR DESCRIPTION
The newly created sparql client working on the `projects` dataset now can measure execution times and send them to grafana (+ logging).