### PR TITLE
fix: slug finding in token creation flow to work when project removed

### DIFF
--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
@@ -31,7 +31,7 @@ import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
-import io.renku.tokenrepository.repository.deletion.{TokenRemover, TokensRevoker}
+import io.renku.tokenrepository.repository.deletion.{DeletionResult, TokenRemover, TokensRevoker}
 import io.renku.tokenrepository.repository.fetching.PersistedTokensFinder
 import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
 import org.typelevel.log4cats.Logger
@@ -83,10 +83,18 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
     case None => Option.empty[AccessToken].pure[F]
     case Some(token) =>
       checkValid(projectId, token) >>= {
-        case true  => token.some.pure[F]
-        case false => tokenRemover.delete(projectId, userToken.some).as(Option.empty)
+        case true => token.some.pure[F]
+        case false =>
+          deleteAndLogSuccess(projectId, userToken, show"Token for $projectId removed as got invalidated in GL")
+            .as(Option.empty)
       }
   }
+
+  private def deleteAndLogSuccess(projectId: projects.GitLabId, mat: AccessToken, message: String) =
+    tokenRemover.delete(projectId, mat.some) >>= {
+      case DeletionResult.Deleted    => Logger[F].info(message)
+      case DeletionResult.NotExisted => ().pure[F]
+    }
 
   private def replaceSlugIfChangedOrRemove(
       projectId: projects.GitLabId,
@@ -96,16 +104,19 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
     case Some(token) =>
       projectSlugFinder
         .findProjectSlug(projectId, token)
-        .semiflatMap(actualSlug =>
-          findPersistedProjectSlug(projectId).flatMap {
-            case `actualSlug` => ().pure[F]
-            case _            => updateSlug(Project(projectId, actualSlug))
-          }
-        )
-        .cataF(
-          default = tokenRemover.delete(projectId, userToken.some).as(Option.empty),
-          _ => token.some.pure[F]
-        )
+        .flatMap {
+          case None =>
+            deleteAndLogSuccess(projectId,
+                                userToken,
+                                show"Token for $projectId removed as project does not exist in GL"
+            ).as(Option.empty)
+          case Some(actualGLSlug) =>
+            findPersistedProjectSlug(projectId) >>= {
+              case Some(`actualGLSlug`) => token.some.pure[F]
+              case Some(_)              => updateSlug(Project(projectId, actualGLSlug)).as(token.some)
+              case _                    => Option.empty[AccessToken].pure[F]
+            }
+        }
   }
 
   private def checkIfDue(projectId: projects.GitLabId): Option[AccessToken] => F[Option[AccessToken]] = {
@@ -123,7 +134,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
     }
 
   private def findProjectSlug(projectId: projects.GitLabId, userToken: AccessToken): OptionT[F, Project] =
-    projectSlugFinder.findProjectSlug(projectId, userToken).map(Project(projectId, _))
+    OptionT(projectSlugFinder.findProjectSlug(projectId, userToken)).map(Project(projectId, _))
 
   private def createNewToken(userToken: AccessToken)(project: Project): OptionT[F, (Project, TokenCreationInfo)] =
     createProjectAccessToken(project.id, userToken).map(project -> _)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
@@ -85,7 +85,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
       checkValid(projectId, token) >>= {
         case true => token.some.pure[F]
         case false =>
-          deleteAndLogSuccess(projectId, userToken, show"Token for $projectId removed as got invalidated in GL")
+          deleteAndLogSuccess(projectId, userToken, show"Token removed for $projectId as got invalidated in GL")
             .as(Option.empty)
       }
   }
@@ -108,7 +108,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
           case None =>
             deleteAndLogSuccess(projectId,
                                 userToken,
-                                show"Token for $projectId removed as project does not exist in GL"
+                                show"Token removed for $projectId as project does not exist in GL"
             ).as(Option.empty)
           case Some(actualGLSlug) =>
             findPersistedProjectSlug(projectId) >>= {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -44,7 +44,7 @@ class DeleteTokenEndpointImpl[F[_]: Async: Logger](tokenRemover: TokenRemover[F]
       .recoverWith(errorHttpResult(projectId))
 
   private def logSuccess(projectId: GitLabId): DeletionResult => F[Unit] = {
-    case DeletionResult.Deleted    => Logger[F].info(show"Token for project $projectId deleted")
+    case DeletionResult.Deleted    => Logger[F].info(show"Token removed for $projectId")
     case DeletionResult.NotExisted => ().pure[F]
   }
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -40,10 +40,15 @@ class DeleteTokenEndpointImpl[F[_]: Async: Logger](tokenRemover: TokenRemover[F]
     with DeleteTokenEndpoint[F] {
 
   override def deleteToken(projectId: GitLabId, maybeAccessToken: Option[AccessToken]): F[Response[F]] =
-    (tokenRemover.delete(projectId, maybeAccessToken) >> NoContent())
-      .recoverWith(httpResult(projectId))
+    (tokenRemover.delete(projectId, maybeAccessToken).flatMap(logSuccess(projectId)) >> NoContent())
+      .recoverWith(errorHttpResult(projectId))
 
-  private def httpResult(projectId: GitLabId): PartialFunction[Throwable, F[Response[F]]] = {
+  private def logSuccess(projectId: GitLabId): DeletionResult => F[Unit] = {
+    case DeletionResult.Deleted    => Logger[F].info(show"Token for project $projectId deleted")
+    case DeletionResult.NotExisted => ().pure[F]
+  }
+
+  private def errorHttpResult(projectId: GitLabId): PartialFunction[Throwable, F[Response[F]]] = {
     case NonFatal(exception) =>
       val message = Message.Error.unsafeApply(s"Deleting token for projectId: $projectId failed")
       Logger[F].error(exception)(message.show) >> InternalServerError(message)

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeletionResult.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeletionResult.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.deletion
+
+sealed trait DeletionResult {
+  lazy val widen: DeletionResult = this
+}
+
+object DeletionResult {
+  case object Deleted    extends DeletionResult
+  case object NotExisted extends DeletionResult
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
@@ -20,9 +20,9 @@ package io.renku.tokenrepository.repository
 
 import cats.data.Kleisli
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import com.dimafeng.testcontainers._
 import io.renku.db.PostgresContainer
-import io.renku.testtools.IOSpec
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
 import natchez.Trace.Implicits.noop
 import org.scalatest.Suite
@@ -31,7 +31,9 @@ import skunk.codec.all._
 import skunk.implicits._
 
 trait InMemoryProjectsTokensDb extends ForAllTestContainer with TokenRepositoryTypeSerializers {
-  self: Suite with IOSpec =>
+  self: Suite =>
+
+  implicit val ioRuntime: IORuntime
 
   private val dbConfig = new ProjectsTokensDbConfigProvider[IO].get().unsafeRunSync()
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/RepositoryGenerators.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/RepositoryGenerators.scala
@@ -19,6 +19,7 @@
 package io.renku.tokenrepository.repository
 
 import AccessTokenCrypto.EncryptedAccessToken
+import deletion.DeletionResult
 import eu.timepit.refined.api.RefType
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
@@ -38,4 +39,7 @@ private object RepositoryGenerators {
 
   val accessTokenIds: Gen[AccessTokenId] =
     positiveInts().toGeneratorOf(v => AccessTokenId(v.value))
+
+  val deletionResults: Gen[DeletionResult] =
+    Gen.oneOf(DeletionResult.Deleted, DeletionResult.NotExisted)
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -34,395 +34,412 @@ import io.renku.graph.model.projects.GitLabId
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.{AccessToken, UserAccessToken}
 import io.renku.interpreters.TestLogger
-import io.renku.testtools.IOSpec
+import io.renku.testtools.CustomAsyncIOSpec
 import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 import io.renku.tokenrepository.repository.RepositoryGenerators._
 import io.renku.tokenrepository.repository.creation.Generators._
-import io.renku.tokenrepository.repository.deletion.{TokenRemover, TokensRevoker}
+import io.renku.tokenrepository.repository.deletion.{DeletionResult, TokenRemover, TokensRevoker}
 import io.renku.tokenrepository.repository.fetching.PersistedTokensFinder
-import org.scalamock.scalatest.MockFactory
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
 
-class TokensCreatorSpec extends AnyWordSpec with IOSpec with MockFactory with should.Matchers {
+class TokensCreatorSpec extends AsyncFlatSpec with CustomAsyncIOSpec with AsyncMockFactory with should.Matchers {
 
-  "create" should {
-
-    "do nothing if the stored Access Token is valid, is not due for refresh " +
-      "and the project slug has not changed" in new TestCase {
-
-        val encryptedToken = encryptedAccessTokens.generateOne
-        givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
-
-        val storedAccessToken = accessTokens.generateOne
-        givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
-
-        givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
-
-        givenSlugHasNotChanged(projectId, storedAccessToken)
-
-        givenTokenDueCheck(projectId, returning = false.pure[IO])
-
-        tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-      }
-
-    "replace the stored token when it's invalid" in new TestCase {
+  it should "do nothing if the stored Access Token is valid, is not due for refresh " +
+    "and the project slug has not changed" in {
 
       val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
+      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
+
+      val storedAccessToken = accessTokens.generateOne
+      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
+
+      givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
+
+      givenSlugHasNotChanged(projectId, storedAccessToken)
+
+      givenTokenDueCheck(projectId, returning = false.pure[IO])
+
+      tokensCreator.create(projectId, userAccessToken).assertNoException
+    }
+
+  it should "replace the stored token when it's invalid" in {
+
+    val encryptedToken = encryptedAccessTokens.generateOne
+    givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
+
+    val projectAccessToken = projectAccessTokens.generateOne
+    givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[IO])
+
+    givenTokenValidation(of = projectAccessToken, returning = false.pure[IO])
+    givenTokenRemoval(projectId, userAccessToken, returning = deletionResults.generateOne.pure[IO])
+
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+    val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
+    givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
+
+    tokensCreator.create(projectId, userAccessToken).assertNoException
+  }
+
+  it should "leave the stored Access Token untouched but update the slug if " +
+    "the token is valid, it's not due for refresh " +
+    "but the slug has changed" in {
+
+      val encryptedToken = encryptedAccessTokens.generateOne
+      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
 
       val projectAccessToken = projectAccessTokens.generateOne
       givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[IO])
 
-      givenTokenValidation(of = projectAccessToken, returning = false.pure[IO])
-      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[IO])
+      givenTokenValidation(of = projectAccessToken, returning = true.pure[IO])
 
-      givenTokenValidation(userAccessToken, returning = true.pure[IO])
-      val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(projectSlug))
-      val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
-      givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
-
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-    }
-
-    "leave the stored Access Token untouched but update the slug if " +
-      "the token is valid, it's not due for refresh " +
-      "but the slug has changed" in new TestCase {
-
-        val encryptedToken = encryptedAccessTokens.generateOne
-        givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
-
-        val projectAccessToken = projectAccessTokens.generateOne
-        givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[IO])
-
-        givenTokenValidation(of = projectAccessToken, returning = true.pure[IO])
-
-        val newProjectSlug = projectSlugs.generateOne
-        givenSlugFinder(projectId, projectAccessToken, OptionT.some[IO](newProjectSlug))
-        givenStoredSlugFinder(projectId, returning = projectSlugs.generateOne.pure[IO])
-
-        givenSlugUpdate(Project(projectId, newProjectSlug), returning = ().pure[IO])
-
-        givenTokenDueCheck(projectId, returning = false.pure[IO])
-
-        tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-      }
-
-    "replace the stored token if it's due for refresh" in new TestCase {
-
-      val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
-
-      val storedAccessToken = projectAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
-
-      givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
-
-      givenSlugHasNotChanged(projectId, storedAccessToken)
-
-      givenTokenDueCheck(projectId, returning = true.pure[IO])
-
-      givenTokenValidation(userAccessToken, returning = true.pure[IO])
-      val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(projectSlug))
-      val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
-      givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
-
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-    }
-
-    "store a new Project Access Token if there's none stored" in new TestCase {
-
-      givenStoredTokenFinder(projectId, returning = OptionT.none)
-
-      givenTokenValidation(userAccessToken, returning = true.pure[IO])
-      val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(projectSlug))
-      val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
-      givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
-
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-    }
-
-    "remove the stored token if project with the given id does not exist" in new TestCase {
-
-      val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
-
-      val storedToken = userAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[IO])
-      givenTokenValidation(storedToken, returning = false.pure[IO])
-      givenTokenRemoval(projectId, userAccessToken, returning = ().pure[IO])
-
-      givenTokenValidation(userAccessToken, returning = false.pure[IO])
-
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-    }
-
-    "do nothing if new token creation failed with NotFound or Forbidden" in new TestCase {
-
-      val encryptedToken = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
-
-      val storedAccessToken = projectAccessTokens.generateOne
-      givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
-
-      givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
-
-      givenSlugHasNotChanged(projectId, storedAccessToken)
-
-      givenTokenDueCheck(projectId, returning = true.pure[IO])
-
-      givenTokenValidation(userAccessToken, returning = true.pure[IO])
       val newProjectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(newProjectSlug))
+      givenSlugFinder(projectId, projectAccessToken, newProjectSlug.some.pure[IO])
+      givenStoredSlugFinder(projectId, returning = projectSlugs.generateOne.some.pure[IO])
 
-      givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.none)
+      givenSlugUpdate(Project(projectId, newProjectSlug), returning = ().pure[IO])
 
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
+      givenTokenDueCheck(projectId, returning = false.pure[IO])
+
+      tokensCreator.create(projectId, userAccessToken).assertNoException
     }
 
-    "retry if the token couldn't be decrypted after storing (token sanity check failed)" in new TestCase {
+  it should "create a new Access Token if " +
+    "the token found in the DB is valid, it's not due for refresh " +
+    "but got removed in the meanwhile" in {
 
-      givenStoredTokenFinder(projectId, returning = OptionT.none)
+      val encryptedToken = encryptedAccessTokens.generateOne
+      givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
 
-      givenTokenValidation(userAccessToken, returning = true.pure[IO])
+      val projectAccessToken = projectAccessTokens.generateOne
+      givenTokenDecryption(of = encryptedToken, returning = projectAccessToken.pure[IO])
+
+      givenTokenValidation(of = projectAccessToken, returning = true.pure[IO])
 
       val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(projectSlug))
-
-      val tokenCreationInfo = tokenCreationInfos.generateOne
-      givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
-
-      val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
-
-      givenTokenStoring(Project(projectId, projectSlug),
-                        newTokenEncrypted,
-                        tokenCreationInfo.dates,
-                        returning = ().pure[IO]
-      ).twice()
-
-      val invalidEncryptedAfterStoring = encryptedAccessTokens.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.some(invalidEncryptedAfterStoring))
-      val exception = exceptions.generateOne
-      givenTokenDecryption(of = invalidEncryptedAfterStoring, returning = exception.raiseError[IO, AccessToken])
-
-      givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
-
-      givenSuccessfulTokensRevoking(projectId, tokenCreationInfo, userAccessToken)
-
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
-    }
-
-    "retry if the token after storing couldn't be found" in new TestCase {
-
-      givenStoredTokenFinder(projectId, returning = OptionT.none)
+      givenSlugFinder(projectId, projectAccessToken, projectSlug.some.pure[IO])
+      givenStoredSlugFinder(projectId, returning = None.pure[IO])
 
       givenTokenValidation(userAccessToken, returning = true.pure[IO])
+      givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+      val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
+      givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
 
-      val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(projectSlug))
-
-      val tokenCreationInfo = tokenCreationInfos.generateOne
-      givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
-
-      val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
-
-      givenTokenStoring(Project(projectId, projectSlug),
-                        newTokenEncrypted,
-                        tokenCreationInfo.dates,
-                        returning = ().pure[IO]
-      ).twice()
-
-      givenStoredTokenFinder(projectId, returning = OptionT.none)
-
-      givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
-
-      givenSuccessfulTokensRevoking(projectId, tokenCreationInfo, userAccessToken)
-
-      tokensCreator.create(projectId, userAccessToken).unsafeRunSync() shouldBe ()
+      tokensCreator.create(projectId, userAccessToken).assertNoException
     }
 
-    "fail if finding stored token fails" in new TestCase {
+  it should "replace the stored token if it's due for refresh" in {
 
-      val exception = exceptions.generateOne
-      givenStoredTokenFinder(projectId, returning = OptionT.liftF(exception.raiseError[IO, EncryptedAccessToken]))
+    val encryptedToken = encryptedAccessTokens.generateOne
+    givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedToken))
 
-      val ex =
-        intercept[Exception] {
-          tokensCreator.create(projectId, userAccessToken).unsafeRunSync()
-        }
+    val storedAccessToken = projectAccessTokens.generateOne
+    givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
 
-      ex shouldBe exception
-    }
+    givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
 
-    "fail if retry process hit the max number of attempts" in new TestCase {
+    givenSlugHasNotChanged(projectId, storedAccessToken)
 
-      givenStoredTokenFinder(projectId, returning = OptionT.none)
+    givenTokenDueCheck(projectId, returning = true.pure[IO])
 
-      givenTokenValidation(userAccessToken, returning = true.pure[IO])
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+    val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
+    givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
 
-      val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, userAccessToken, returning = OptionT.some(projectSlug))
-
-      val tokenCreationInfo = tokenCreationInfos.generateOne
-      givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
-
-      val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
-
-      givenTokenStoring(Project(projectId, projectSlug),
-                        newTokenEncrypted,
-                        tokenCreationInfo.dates,
-                        returning = ().pure[IO]
-      ).repeated(3)
-
-      givenStoredTokenFinder(projectId, returning = OptionT.none).repeated(3)
-
-      val exception = intercept[Exception] {
-        tokensCreator
-          .create(projectId, userAccessToken)
-          .unsafeRunSync()
-      }
-
-      exception.getMessage shouldBe show"Token associator - just saved token cannot be found for project: $projectId"
-    }
+    tokensCreator.create(projectId, userAccessToken).assertNoException
   }
 
-  private trait TestCase {
-    val projectId       = projectIds.generateOne
-    val userAccessToken = userAccessTokens.generateOne
+  it should "store a new Project Access Token if there's none stored" in {
 
-    implicit val logger:    TestLogger[IO]          = TestLogger[IO]()
-    private val maxRetries: Int Refined NonNegative = 2
-    private val projectSlugFinder   = mock[ProjectSlugFinder[IO]]
-    private val accessTokenCrypto   = mock[AccessTokenCrypto[IO]]
-    private val tokenValidator      = mock[TokenValidator[IO]]
-    private val tokenDueChecker     = mock[TokenDueChecker[IO]]
-    private val newTokensCreator    = mock[NewTokensCreator[IO]]
-    private val tokensPersister     = mock[TokensPersister[IO]]
-    private val persistedSlugFinder = mock[PersistedSlugFinder[IO]]
-    private val tokenRemover        = mock[TokenRemover[IO]]
-    private val tokensFinder        = mock[PersistedTokensFinder[IO]]
-    private val tokensRevoker       = mock[TokensRevoker[IO]]
-    val tokensCreator = new TokensCreatorImpl[IO](
-      projectSlugFinder,
-      accessTokenCrypto,
-      tokenValidator,
-      tokenDueChecker,
-      newTokensCreator,
-      tokensPersister,
-      persistedSlugFinder,
-      tokenRemover,
-      tokensFinder,
-      tokensRevoker,
-      maxRetries
+    givenStoredTokenFinder(projectId, returning = OptionT.none)
+
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+    val tokenInfo = givenSuccessfulTokenCreation(projectSlug)
+    givenSuccessfulTokensRevoking(projectId, tokenInfo, userAccessToken)
+
+    tokensCreator.create(projectId, userAccessToken).assertNoException
+  }
+
+  it should "remove the stored token if project with the given id does not exist" in {
+
+    val encryptedToken = encryptedAccessTokens.generateOne
+    givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
+
+    val storedToken = userAccessTokens.generateOne
+    givenTokenDecryption(of = encryptedToken, returning = storedToken.pure[IO])
+    givenTokenValidation(storedToken, returning = false.pure[IO])
+    givenTokenRemoval(projectId, userAccessToken, returning = deletionResults.generateOne.pure[IO])
+
+    givenTokenValidation(userAccessToken, returning = false.pure[IO])
+
+    tokensCreator.create(projectId, userAccessToken).assertNoException
+  }
+
+  it should "do nothing if new token creation failed with NotFound or Forbidden" in {
+
+    val encryptedToken = encryptedAccessTokens.generateOne
+    givenStoredTokenFinder(projectId, returning = OptionT.some[IO](encryptedToken))
+
+    val storedAccessToken = projectAccessTokens.generateOne
+    givenTokenDecryption(of = encryptedToken, returning = storedAccessToken.pure[IO])
+
+    givenTokenValidation(of = storedAccessToken, returning = true.pure[IO])
+
+    givenSlugHasNotChanged(projectId, storedAccessToken)
+
+    givenTokenDueCheck(projectId, returning = true.pure[IO])
+
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+    val newProjectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = newProjectSlug.some.pure[IO])
+
+    givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.none)
+
+    tokensCreator.create(projectId, userAccessToken).assertNoException
+  }
+
+  it should "retry if the token couldn't be decrypted after storing (token sanity check failed)" in {
+
+    givenStoredTokenFinder(projectId, returning = OptionT.none)
+
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+
+    val tokenCreationInfo = tokenCreationInfos.generateOne
+    givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
+
+    val newTokenEncrypted = encryptedAccessTokens.generateOne
+    givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
+
+    givenTokenStoring(Project(projectId, projectSlug),
+                      newTokenEncrypted,
+                      tokenCreationInfo.dates,
+                      returning = ().pure[IO]
+    ).twice()
+
+    val invalidEncryptedAfterStoring = encryptedAccessTokens.generateOne
+    givenStoredTokenFinder(projectId, returning = OptionT.some(invalidEncryptedAfterStoring))
+    val exception = exceptions.generateOne
+    givenTokenDecryption(of = invalidEncryptedAfterStoring, returning = exception.raiseError[IO, AccessToken])
+
+    givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
+
+    givenSuccessfulTokensRevoking(projectId, tokenCreationInfo, userAccessToken)
+
+    tokensCreator.create(projectId, userAccessToken).assertNoException
+  }
+
+  it should "retry if the token after storing couldn't be found" in {
+
+    givenStoredTokenFinder(projectId, returning = OptionT.none)
+
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+
+    val tokenCreationInfo = tokenCreationInfos.generateOne
+    givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
+
+    val newTokenEncrypted = encryptedAccessTokens.generateOne
+    givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
+
+    givenTokenStoring(Project(projectId, projectSlug),
+                      newTokenEncrypted,
+                      tokenCreationInfo.dates,
+                      returning = ().pure[IO]
+    ).twice()
+
+    givenStoredTokenFinder(projectId, returning = OptionT.none)
+
+    givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
+
+    givenSuccessfulTokensRevoking(projectId, tokenCreationInfo, userAccessToken)
+
+    tokensCreator.create(projectId, userAccessToken).assertNoException
+  }
+
+  it should "fail if finding stored token fails" in {
+
+    val exception = exceptions.generateOne
+    givenStoredTokenFinder(projectId, returning = OptionT.liftF(exception.raiseError[IO, EncryptedAccessToken]))
+
+    tokensCreator.create(projectId, userAccessToken).assertThrowsError[Exception](_ shouldBe exception)
+  }
+
+  it should "fail if retry process hit the max number of attempts" in {
+
+    givenStoredTokenFinder(projectId, returning = OptionT.none)
+
+    givenTokenValidation(userAccessToken, returning = true.pure[IO])
+
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, userAccessToken, returning = projectSlug.some.pure[IO])
+
+    val tokenCreationInfo = tokenCreationInfos.generateOne
+    givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
+
+    val newTokenEncrypted = encryptedAccessTokens.generateOne
+    givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
+
+    givenTokenStoring(Project(projectId, projectSlug),
+                      newTokenEncrypted,
+                      tokenCreationInfo.dates,
+                      returning = ().pure[IO]
+    ).repeated(3)
+
+    givenStoredTokenFinder(projectId, returning = OptionT.none).repeated(3)
+
+    tokensCreator
+      .create(projectId, userAccessToken)
+      .assertThrowsWithMessage[Exception](
+        show"Token associator - just saved token cannot be found for project: $projectId"
+      )
+  }
+
+  private lazy val projectId       = projectIds.generateOne
+  private lazy val userAccessToken = userAccessTokens.generateOne
+
+  private implicit lazy val logger: TestLogger[IO]          = TestLogger[IO]()
+  private val maxRetries:           Int Refined NonNegative = 2
+  private val projectSlugFinder   = mock[ProjectSlugFinder[IO]]
+  private val accessTokenCrypto   = mock[AccessTokenCrypto[IO]]
+  private val tokenValidator      = mock[TokenValidator[IO]]
+  private val tokenDueChecker     = mock[TokenDueChecker[IO]]
+  private val newTokensCreator    = mock[NewTokensCreator[IO]]
+  private val tokensPersister     = mock[TokensPersister[IO]]
+  private val persistedSlugFinder = mock[PersistedSlugFinder[IO]]
+  private val tokenRemover        = mock[TokenRemover[IO]]
+  private val tokensFinder        = mock[PersistedTokensFinder[IO]]
+  private val tokensRevoker       = mock[TokensRevoker[IO]]
+  private lazy val tokensCreator = new TokensCreatorImpl[IO](
+    projectSlugFinder,
+    accessTokenCrypto,
+    tokenValidator,
+    tokenDueChecker,
+    newTokensCreator,
+    tokensPersister,
+    persistedSlugFinder,
+    tokenRemover,
+    tokensFinder,
+    tokensRevoker,
+    maxRetries
+  )
+
+  private def givenStoredTokenFinder(projectId: projects.GitLabId, returning: OptionT[IO, EncryptedAccessToken]) =
+    (tokensFinder
+      .findStoredToken(_: GitLabId))
+      .expects(projectId)
+      .returning(returning)
+      .noMoreThanOnce()
+
+  private def givenTokenDecryption(of: EncryptedAccessToken, returning: IO[AccessToken]) =
+    (accessTokenCrypto
+      .decrypt(_: EncryptedAccessToken))
+      .expects(of)
+      .returning(returning)
+
+  private def givenTokenEncryption(projectAccessToken: ProjectAccessToken, returning: IO[EncryptedAccessToken]) =
+    (accessTokenCrypto.encrypt _)
+      .expects(projectAccessToken)
+      .returning(returning)
+
+  private def givenTokenValidation(of: AccessToken, returning: IO[Boolean]) =
+    (tokenValidator.checkValid _)
+      .expects(projectId, of)
+      .returning(returning)
+
+  private def givenTokenDueCheck(projectId: projects.GitLabId, returning: IO[Boolean]) =
+    (tokenDueChecker.checkTokenDue _)
+      .expects(projectId)
+      .returning(returning)
+
+  private def givenStoredSlugFinder(projectId: projects.GitLabId, returning: IO[Option[projects.Slug]]) =
+    (persistedSlugFinder.findPersistedProjectSlug _)
+      .expects(projectId)
+      .returning(returning)
+
+  private def givenSlugFinder(projectId:   projects.GitLabId,
+                              accessToken: AccessToken,
+                              returning:   IO[Option[projects.Slug]]
+  ) =
+    (projectSlugFinder.findProjectSlug _)
+      .expects(projectId, accessToken)
+      .returning(returning)
+
+  private def givenSlugHasNotChanged(projectId: projects.GitLabId, accessToken: AccessToken) = {
+    val projectSlug = projectSlugs.generateOne
+    givenSlugFinder(projectId, accessToken, projectSlug.some.pure[IO])
+    givenStoredSlugFinder(projectId, returning = projectSlug.some.pure[IO])
+  }
+
+  private def givenProjectTokenCreator(projectId:       projects.GitLabId,
+                                       userAccessToken: UserAccessToken,
+                                       returning:       OptionT[IO, TokenCreationInfo]
+  ) = (newTokensCreator.createProjectAccessToken _)
+    .expects(projectId, userAccessToken)
+    .returning(returning)
+
+  private def givenTokenStoring(project:        Project,
+                                encryptedToken: EncryptedAccessToken,
+                                dates:          TokenDates,
+                                returning:      IO[Unit]
+  ) = (tokensPersister.persistToken _)
+    .expects(TokenStoringInfo(project, encryptedToken, dates))
+    .returning(returning)
+
+  private def givenSlugUpdate(project: Project, returning: IO[Unit]) =
+    (tokensPersister.updateSlug _)
+      .expects(project)
+      .returning(returning)
+
+  private def givenTokenRemoval(projectId:       projects.GitLabId,
+                                userAccessToken: UserAccessToken,
+                                returning:       IO[DeletionResult]
+  ) = (tokenRemover.delete _)
+    .expects(projectId, userAccessToken.some)
+    .returning(returning)
+
+  private def givenIntegrityCheckPasses(projectId:            projects.GitLabId,
+                                        token:                ProjectAccessToken,
+                                        encryptedAccessToken: EncryptedAccessToken
+  ) = {
+    givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedAccessToken))
+    givenTokenDecryption(of = encryptedAccessToken, returning = token.pure[IO])
+  }
+
+  private def givenSuccessfulTokenCreation(projectSlug: projects.Slug): TokenCreationInfo = {
+
+    val tokenCreationInfo = tokenCreationInfos.generateOne
+    givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
+
+    val newTokenEncrypted = encryptedAccessTokens.generateOne
+    givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
+
+    givenTokenStoring(Project(projectId, projectSlug),
+                      newTokenEncrypted,
+                      tokenCreationInfo.dates,
+                      returning = ().pure[IO]
     )
 
-    def givenStoredTokenFinder(projectId: projects.GitLabId, returning: OptionT[IO, EncryptedAccessToken]) =
-      (tokensFinder
-        .findStoredToken(_: GitLabId))
-        .expects(projectId)
-        .returning(returning)
-        .noMoreThanOnce()
+    givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
 
-    def givenTokenDecryption(of: EncryptedAccessToken, returning: IO[AccessToken]) =
-      (accessTokenCrypto
-        .decrypt(_: EncryptedAccessToken))
-        .expects(of)
-        .returning(returning)
-
-    def givenTokenEncryption(projectAccessToken: ProjectAccessToken, returning: IO[EncryptedAccessToken]) =
-      (accessTokenCrypto.encrypt _)
-        .expects(projectAccessToken)
-        .returning(returning)
-
-    def givenTokenValidation(of: AccessToken, returning: IO[Boolean]) =
-      (tokenValidator.checkValid _)
-        .expects(projectId, of)
-        .returning(returning)
-
-    def givenTokenDueCheck(projectId: projects.GitLabId, returning: IO[Boolean]) =
-      (tokenDueChecker.checkTokenDue _)
-        .expects(projectId)
-        .returning(returning)
-
-    def givenStoredSlugFinder(projectId: projects.GitLabId, returning: IO[projects.Slug]) =
-      (persistedSlugFinder.findPersistedProjectSlug _)
-        .expects(projectId)
-        .returning(returning)
-
-    def givenSlugFinder(projectId: projects.GitLabId, accessToken: AccessToken, returning: OptionT[IO, projects.Slug]) =
-      (projectSlugFinder.findProjectSlug _)
-        .expects(projectId, accessToken)
-        .returning(returning)
-
-    def givenSlugHasNotChanged(projectId: projects.GitLabId, accessToken: AccessToken) = {
-      val projectSlug = projectSlugs.generateOne
-      givenSlugFinder(projectId, accessToken, OptionT.some[IO](projectSlug))
-      givenStoredSlugFinder(projectId, returning = projectSlug.pure[IO])
-    }
-
-    def givenProjectTokenCreator(projectId:       projects.GitLabId,
-                                 userAccessToken: UserAccessToken,
-                                 returning:       OptionT[IO, TokenCreationInfo]
-    ) = (newTokensCreator.createProjectAccessToken _)
-      .expects(projectId, userAccessToken)
-      .returning(returning)
-
-    def givenTokenStoring(project:        Project,
-                          encryptedToken: EncryptedAccessToken,
-                          dates:          TokenDates,
-                          returning:      IO[Unit]
-    ) = (tokensPersister.persistToken _)
-      .expects(TokenStoringInfo(project, encryptedToken, dates))
-      .returning(returning)
-
-    def givenSlugUpdate(project: Project, returning: IO[Unit]) =
-      (tokensPersister.updateSlug _)
-        .expects(project)
-        .returning(returning)
-
-    def givenTokenRemoval(projectId: projects.GitLabId, userAccessToken: UserAccessToken, returning: IO[Unit]) =
-      (tokenRemover.delete _)
-        .expects(projectId, userAccessToken.some)
-        .returning(returning)
-
-    def givenIntegrityCheckPasses(projectId:            projects.GitLabId,
-                                  token:                ProjectAccessToken,
-                                  encryptedAccessToken: EncryptedAccessToken
-    ) = {
-      givenStoredTokenFinder(projectId, returning = OptionT.some(encryptedAccessToken))
-      givenTokenDecryption(of = encryptedAccessToken, returning = token.pure[IO])
-    }
-
-    def givenSuccessfulTokenCreation(projectSlug: projects.Slug): TokenCreationInfo = {
-
-      val tokenCreationInfo = tokenCreationInfos.generateOne
-      givenProjectTokenCreator(projectId, userAccessToken, returning = OptionT.some(tokenCreationInfo))
-
-      val newTokenEncrypted = encryptedAccessTokens.generateOne
-      givenTokenEncryption(tokenCreationInfo.token, returning = newTokenEncrypted.pure[IO])
-
-      givenTokenStoring(Project(projectId, projectSlug),
-                        newTokenEncrypted,
-                        tokenCreationInfo.dates,
-                        returning = ().pure[IO]
-      )
-
-      givenIntegrityCheckPasses(projectId, tokenCreationInfo.token, newTokenEncrypted)
-
-      tokenCreationInfo
-    }
-
-    def givenSuccessfulTokensRevoking(projectId:   projects.GitLabId,
-                                      tokenInfo:   TokenCreationInfo,
-                                      accessToken: AccessToken
-    ) = (tokensRevoker.revokeAllTokens _)
-      .expects(projectId, tokenInfo.tokenId.some, accessToken)
-      .returning(().pure[IO])
+    tokenCreationInfo
   }
+
+  private def givenSuccessfulTokensRevoking(projectId:   projects.GitLabId,
+                                            tokenInfo:   TokenCreationInfo,
+                                            accessToken: AccessToken
+  ) = (tokensRevoker.revokeAllTokens _)
+    .expects(projectId, tokenInfo.tokenId.some, accessToken)
+    .returning(().pure[IO])
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpointSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpointSpec.scala
@@ -33,10 +33,16 @@ import io.renku.testtools.CustomAsyncIOSpec
 import org.http4s._
 import org.http4s.headers.`Content-Type`
 import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should
 
-class DeleteTokenEndpointSpec extends AsyncFlatSpec with CustomAsyncIOSpec with AsyncMockFactory with should.Matchers {
+class DeleteTokenEndpointSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with AsyncMockFactory
+    with should.Matchers
+    with BeforeAndAfterEach {
 
   it should "respond with NO_CONTENT if the token removal was successful" in {
 
@@ -81,4 +87,6 @@ class DeleteTokenEndpointSpec extends AsyncFlatSpec with CustomAsyncIOSpec with 
   private implicit lazy val logger: TestLogger[IO] = TestLogger[IO]()
   private lazy val tokenRemover = mock[TokenRemover[IO]]
   private lazy val endpoint     = new DeleteTokenEndpointImpl[IO](tokenRemover)
+
+  protected override def beforeEach() = logger.reset()
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpointSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpointSpec.scala
@@ -54,7 +54,7 @@ class DeleteTokenEndpointSpec extends AsyncFlatSpec with CustomAsyncIOSpec with 
           response.body.compile.toVector.asserting(_ shouldBe Vector.empty)
       } >> {
       deletionResult match {
-        case DeletionResult.Deleted    => IO(logger.loggedOnly(Info(show"Token for project $projectId deleted")))
+        case DeletionResult.Deleted    => IO(logger.loggedOnly(Info(show"Token removed for $projectId")))
         case DeletionResult.NotExisted => IO(logger.expectNoLogs())
       }
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemoverSpec.scala
@@ -40,7 +40,7 @@ class PersistedTokenRemoverSpec
   "delete" should {
 
     "succeed if token does not exist" in new TestCase {
-      remover.delete(projectId).unsafeRunSync() shouldBe ()
+      remover.delete(projectId).unsafeRunSync() shouldBe DeletionResult.NotExisted
     }
 
     "succeed if token exists" in new TestCase {
@@ -49,7 +49,7 @@ class PersistedTokenRemoverSpec
       insert(projectId, projectSlug, encryptedToken)
       findToken(projectId) shouldBe Some(encryptedToken.value)
 
-      remover.delete(projectId).unsafeRunSync() shouldBe ()
+      remover.delete(projectId).unsafeRunSync() shouldBe DeletionResult.Deleted
 
       findToken(projectId) shouldBe None
     }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/init/DbMigrations.scala
@@ -30,10 +30,10 @@ import org.scalamock.scalatest.MockFactory
 trait DbMigrations {
   self: InMemoryProjectsTokensDb with IOSpec with MockFactory =>
 
-  implicit lazy val logger:             TestLogger[IO]            = TestLogger[IO]()
-  implicit lazy val glClient:           GitLabClient[IO]          = mock[GitLabClient[IO]]
-  private implicit val metricsRegistry: TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
-  implicit val queriesExecTimes:        QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()
+  implicit lazy val logger:      TestLogger[IO]            = TestLogger[IO]()
+  implicit lazy val glClient:    GitLabClient[IO]          = mock[GitLabClient[IO]]
+  implicit val metricsRegistry:  TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
+  implicit val queriesExecTimes: QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()
 
   protected lazy val allMigrations: List[DBMigration[IO]] = DbInitializer.migrations[IO].unsafeRunSync()
 }


### PR DESCRIPTION
The Token Creation flow, in some race condition cases, was failing when finding the slug in the DB. This PR makes the process more robust by losing the assumption about the slug existence in the DB.

It also does some cleaning around the logs produced by the flow.

closes #1648 