### PR TITLE
fix: StatusChanger to retry the rollback procedure on known failures

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/PostgresDB.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/db/PostgresDB.scala
@@ -103,7 +103,7 @@ object PostgresDB {
       )
 
   def sessionPoolResource[A](dbCfg: DBConfig[_]): Resource[IO, SessionResource[IO, A]] =
-    sessionPool(dbCfg).map(new SessionResource[IO, A](_))
+    sessionPool(dbCfg).map(SessionResource[IO, A](_))
 
   def initializeDatabase(cfg: DBConfig[_]): IO[Unit] = {
     val session = Session.single[IO](

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/EventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/EventHandler.scala
@@ -35,7 +35,7 @@ import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.metrics.MetricsRegistry
 import org.typelevel.log4cats.Logger
 
-final class EventHandler[F[_]: Async: Logger: MetricsRegistry: QueriesExecutionTimes](
+final class EventHandler[F[_]: Async: SessionResource: Logger: MetricsRegistry: QueriesExecutionTimes](
     processExecutor:     ProcessExecutor[F],
     statusChanger:       StatusChanger[F],
     eventSender:         EventSender[F],
@@ -71,7 +71,7 @@ final class EventHandler[F[_]: Async: Logger: MetricsRegistry: QueriesExecutionT
       override def updateDB(event: StatusChangeEvent): UpdateOp[F] =
         dbUpdaterFor(event)._1
 
-      override def onRollback(event: StatusChangeEvent): RollbackOp[F] =
+      override def onRollback(event: StatusChangeEvent)(implicit sr: SessionResource[F]): RollbackOp[F] =
         dbUpdaterFor(event)._2
     }
 

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChanger.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/StatusChanger.scala
@@ -64,17 +64,12 @@ private[statuschange] class StatusChangerImpl[F[_]: MonadCancelThrow: SessionRes
   private def rollback[E <: StatusChangeEvent](transaction: Transaction[F])(savepoint: transaction.Savepoint)(event: E)(
       dbUpdater: DBUpdater[F, E]
   ): Throwable => UpdateOp[F] = { err =>
-    def executeRollback: Throwable => F[DBUpdateResults] = { failure =>
-      if ((dbUpdater onRollback event).isDefinedAt(failure))
-        SessionResource[F]
-          .useK((dbUpdater onRollback event).apply(failure))
-          .handleErrorWith(executeRollback)
-      else
-        failure.raiseError[F, DBUpdateResults]
-    }
+    val throwAll: PartialFunction[Throwable, F[DBUpdateResults]] =
+      _.raiseError[F, DBUpdateResults]
 
     Kleisli.liftF {
-      transaction.rollback(savepoint) >> executeRollback(err)
+      transaction.rollback(savepoint) >>
+        (dbUpdater onRollback event).applyOrElse(err, throwAll)
     }
   }
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/alleventstonew/DbUpdater.scala
@@ -27,6 +27,7 @@ import io.circe.Encoder
 import io.circe.literal._
 import io.circe.syntax._
 import io.renku.db.{DbClient, SqlStatement}
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.TypeSerializers
 import io.renku.eventlog.api.events.StatusChangeEvent.{AllEventsToNew, ProjectEventsToNew}
 import io.renku.eventlog.events.consumers.statuschange
@@ -52,7 +53,8 @@ private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
     createEventsResource(sendEventIfFound(_))
       .as(DBUpdateResults.ForProjects.empty)
 
-  override def onRollback(event: AllEventsToNew.type): RollbackOp[F] = RollbackOp.empty[F]
+  override def onRollback(event: AllEventsToNew.type)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty[F]
 
   private def createEventsResource(
       f: Cursor[F, ProjectEventsToNew] => F[Unit]

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DbUpdater.scala
@@ -20,6 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange.projecteventstonew
 
 import cats.MonadThrow
 import io.circe.Encoder
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.api.events.StatusChangeEvent.ProjectEventsToNew
 import io.renku.eventlog.events.consumers.statuschange
@@ -35,5 +36,6 @@ private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChang
   override def updateDB(event: ProjectEventsToNew): UpdateOp[F] =
     eventsQueue.offer[ProjectEventsToNew](event).map(_ => DBUpdateResults.ForProjects.empty)
 
-  override def onRollback(event: ProjectEventsToNew): RollbackOp[F] = RollbackOp.empty[F]
+  override def onRollback(event: ProjectEventsToNew)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty[F]
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdater.scala
@@ -21,6 +21,7 @@ package io.renku.eventlog.events.consumers.statuschange.redoprojecttransformatio
 import cats.MonadThrow
 import cats.syntax.all._
 import io.circe.Encoder
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange
@@ -36,5 +37,6 @@ private[statuschange] class DbUpdater[F[_]: MonadThrow](eventsQueue: StatusChang
   override def updateDB(event: RedoProjectTransformation): UpdateOp[F] =
     eventsQueue.offer[RedoProjectTransformation](event).as(DBUpdateResults.ForProjects.empty)
 
-  override def onRollback(event: RedoProjectTransformation): RollbackOp[F] = RollbackOp.empty
+  override def onRollback(event: RedoProjectTransformation)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
@@ -22,6 +22,7 @@ import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToAwaitingDeletion
 import io.renku.eventlog.events.consumers.statuschange
@@ -65,5 +66,6 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: RollbackToAwaitingDeletion): RollbackOp[F] = RollbackOp.empty
+  override def onRollback(event: RollbackToAwaitingDeletion)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
@@ -22,6 +22,7 @@ import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToNew
 import io.renku.eventlog.events.consumers.statuschange.DBUpdater.{RollbackOp, UpdateOp}
@@ -66,5 +67,6 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: RollbackToNew): RollbackOp[F] = RollbackOp.empty
+  override def onRollback(event: RollbackToNew)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
@@ -22,6 +22,7 @@ import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.api.events.StatusChangeEvent.RollbackToTriplesGenerated
 import io.renku.eventlog.events.consumers.statuschange
@@ -67,5 +68,6 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: RollbackToTriplesGenerated): RollbackOp[F] = RollbackOp.empty
+  override def onRollback(event: RollbackToTriplesGenerated)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
@@ -23,6 +23,7 @@ import cats.kernel.Monoid
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.api.events.StatusChangeEvent.ToAwaitingDeletion
 import io.renku.eventlog.events.consumers.statuschange
@@ -70,5 +71,6 @@ private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTi
       }
   }
 
-  override def onRollback(event: ToAwaitingDeletion): RollbackOp[F] = RollbackOp.empty
+  override def onRollback(event: ToAwaitingDeletion)(implicit sr: SessionResource[F]): RollbackOp[F] =
+    RollbackOp.empty
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdater.scala
@@ -25,6 +25,7 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.implicits._
 import io.renku.db.{DbClient, SqlStatement}
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.TypeSerializers._
 import io.renku.eventlog.api.events.StatusChangeEvent.ToTriplesGenerated
 import io.renku.eventlog.events.consumers.statuschange
@@ -34,13 +35,16 @@ import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.graph.model.events.EventStatus._
 import io.renku.graph.model.events.{EventId, EventProcessingTime, EventStatus, ExecutionDate}
 import io.renku.graph.model.projects
+import org.typelevel.log4cats.Logger
+import skunk.SqlState.DeadlockDetected
 import skunk._
 import skunk.data.Completion
 import skunk.implicits._
 
 import java.time.Instant
+import scala.concurrent.duration._
 
-private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
+private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes](
     deliveryInfoRemover: DeliveryInfoRemover[F],
     now:                 () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
@@ -50,8 +54,13 @@ private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
 
   import deliveryInfoRemover._
 
-  override def onRollback(event: ToTriplesGenerated): RollbackOp[F] = { _ =>
-    deleteDelivery(event.eventId).as(DBUpdateResults.ForProjects.empty)
+  override def onRollback(event: ToTriplesGenerated)(implicit sr: SessionResource[F]): RollbackOp[F] = {
+    case DeadlockDetected(_) =>
+      Logger[F].warn(show"Deadlock while updating event ${event.eventId} to $TriplesGenerated") >>
+        Async[F].sleep(1 second) >>
+        sr.useK(updateDB(event).map(_.widen)).handleErrorWith(onRollback(event))
+    case ex =>
+      sr.useK(deleteDelivery(event.eventId)) >> ex.raiseError[F, DBUpdateResults]
   }
 
   override def updateDB(event: ToTriplesGenerated): UpdateOp[F] =

--- a/event-log/src/test/scala/io/renku/eventlog/ContainerEventLogDb.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/ContainerEventLogDb.scala
@@ -48,7 +48,7 @@ trait ContainerEventLogDb extends ForAllTestContainer { self: Suite =>
       1
     )
 
-  implicit lazy val sessionResource: SessionResource[IO] = new io.renku.db.SessionResource[IO, EventLogDB](
+  implicit lazy val sessionResource: SessionResource[IO] = io.renku.db.SessionResource[IO, EventLogDB](
     Session.single(
       host = dbConfig.host,
       port = dbConfig.port,

--- a/event-log/src/test/scala/io/renku/eventlog/ExternalEventLogDb.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/ExternalEventLogDb.scala
@@ -38,7 +38,7 @@ trait ExternalEventLogDb { self: IOSpec =>
       1
     )
 
-  implicit lazy val sessionResource: SessionResource[IO] = new io.renku.db.SessionResource[IO, EventLogDB](
+  implicit lazy val sessionResource: SessionResource[IO] = io.renku.db.SessionResource[IO, EventLogDB](
     Session.single(
       host = dbConfig.host,
       port = dbConfig.port,

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/DBUpdaterSpec.scala
@@ -27,7 +27,7 @@ class DBUpdaterSpec extends AnyWordSpec with should.Matchers {
 
   "RollbackOp.empty" should {
     "be an empty PartialFunction" in {
-      DBUpdater.RollbackOp.empty[Try] shouldBe PartialFunction.empty[Throwable, DBUpdater.UpdateOp[Try]]
+      DBUpdater.RollbackOp.empty[Try] shouldBe PartialFunction.empty[Throwable, Try[DBUpdateResults]]
     }
   }
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/EventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/EventHandlerSpec.scala
@@ -22,16 +22,17 @@ package statuschange
 import cats.effect.IO
 import cats.syntax.all._
 import io.circe.syntax._
-import io.renku.eventlog.api.events.{StatusChangeEvent, StatusChangeGenerators}
+import io.renku.eventlog.InMemoryEventLogDbSpec
 import io.renku.eventlog.api.events.StatusChangeEvent._
+import io.renku.eventlog.api.events.{StatusChangeEvent, StatusChangeGenerators}
 import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.EventRequestContent
 import io.renku.events.consumers.{EventSchedulingResult, ProcessExecutor}
 import io.renku.events.producers.EventSender
+import io.renku.generators.Generators.Implicits._
 import io.renku.interpreters.TestLogger
 import io.renku.metrics.{MetricsRegistry, TestMetricsRegistry}
 import io.renku.testtools.IOSpec
-import io.renku.generators.Generators.Implicits._
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should
@@ -41,6 +42,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class EventHandlerSpec
     extends AnyWordSpec
     with IOSpec
+    with InMemoryEventLogDbSpec
     with MockFactory
     with EitherValues
     with should.Matchers

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/SkunkExceptionsGenerators.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/SkunkExceptionsGenerators.scala
@@ -26,14 +26,16 @@ import skunk.exception.PostgresErrorException
 object SkunkExceptionsGenerators {
 
   def postgresErrors(sqlState: SqlState): Gen[PostgresErrorException] =
-    nonEmptyStrings().map(postgresMessage =>
-      new PostgresErrorException(sql = "SELECT 1",
-                                 sqlOrigin = None,
-                                 info = Map(
-                                   'C' -> sqlState.code,
-                                   'M' -> postgresMessage
-                                 ),
-                                 history = Nil
-      )
+    for {
+      postgresMessage <- nonEmptyStrings()
+      severity        <- Gen.oneOf("ERROR", "FATAL", "PANIC", "WARNING", "NOTICE", "DEBUG", "INFO", "LOG")
+    } yield new PostgresErrorException(sql = "SELECT 1",
+                                       sqlOrigin = None,
+                                       info = Map(
+                                         'C' -> sqlState.code,
+                                         'M' -> postgresMessage,
+                                         'S' -> severity
+                                       ),
+                                       history = Nil
     )
 }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueueSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/StatusChangeEventsQueueSpec.scala
@@ -114,7 +114,7 @@ class StatusChangeEventsQueueSpec
     }
 
     "continue if there are general problems with dequeueing" in {
-      implicit val failingSessionResource: SessionResource[IO] = new io.renku.db.SessionResource[IO, EventLogDB](
+      implicit val failingSessionResource: SessionResource[IO] = io.renku.db.SessionResource[IO, EventLogDB](
         Session.single[IO](
           host = dbConfig.host.value,
           port = Generators.positiveInts().generateOne.value,

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
@@ -195,11 +195,8 @@ class DequeuedEventHandlerSpec
 
         (projectCleaner.cleanUp _).expects(project).returns(Kleisli.pure(()))
 
-        sessionResource
-          .useK((dbUpdater onRollback ProjectEventsToNew(project))(failure))
-          .unsafeRunSync() shouldBe DBUpdateResults.ForProjects(project.slug,
-                                                                Map(AwaitingDeletion -> 0, Deleting -> -1)
-        )
+        (dbUpdater onRollback ProjectEventsToNew(project)).apply(failure).unsafeRunSync() shouldBe
+          DBUpdateResults.ForProjects(project.slug, Map(AwaitingDeletion -> 0, Deleting -> -1))
 
         findEvent(event) shouldBe None
       }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/projecteventstonew/DequeuedEventHandlerSpec.scala
@@ -49,7 +49,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.wordspec.AnyWordSpec
-import skunk.SqlState
+import skunk.SqlState.{DeadlockDetected, ForeignKeyViolation}
 
 import java.time.Instant
 import scala.util.Random
@@ -181,8 +181,8 @@ class DequeuedEventHandlerSpec
     forAll(
       Table(
         "failure name"        -> "failure",
-        "Deadlock"            -> postgresErrors(SqlState.DeadlockDetected).generateOne,
-        "ForeignKeyViolation" -> postgresErrors(SqlState.ForeignKeyViolation).generateOne
+        "Deadlock"            -> postgresErrors(DeadlockDetected).generateOne,
+        "ForeignKeyViolation" -> postgresErrors(ForeignKeyViolation).generateOne
       )
     ) { (failureName, failure) =>
       s"run the updateDB on $failureName" in new TestCase {

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/redoprojecttransformation/DbUpdaterSpec.scala
@@ -22,6 +22,8 @@ import cats.Show
 import cats.data.Kleisli
 import cats.syntax.all._
 import io.circe.Encoder
+import io.renku.eventlog.EventLogDB
+import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.api.events.StatusChangeEvent
 import io.renku.eventlog.api.events.StatusChangeEvent.RedoProjectTransformation
 import io.renku.eventlog.events.consumers.statuschange.StatusChangeEventsQueue.EventType
@@ -54,6 +56,7 @@ class DbUpdaterSpec extends AnyWordSpec with should.Matchers with MockFactory {
 
   "onRollback" should {
     "return RollbackOp.empty" in new TestCase {
+      implicit val sr: SessionResource[Try] = mock[io.renku.db.SessionResource[Try, EventLogDB]]
       handler.onRollback(event) shouldBe DBUpdater.RollbackOp.empty[Try]
     }
   }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/tofailure/DbUpdaterSpec.scala
@@ -239,8 +239,8 @@ class DbUpdaterSpec
       givenDeliveryInfoRemoved(statusChangeEvent.eventId)
 
       val deadlockException = postgresErrors(SqlState.DeadlockDetected).generateOne
-      sessionResource
-        .useK((dbUpdater onRollback statusChangeEvent)(deadlockException))
+      (dbUpdater onRollback statusChangeEvent)
+        .apply(deadlockException)
         .unsafeRunSync() shouldBe DBUpdateResults.ForProjects(
         project.slug,
         Map(statusChangeEvent.currentStatus -> -1, statusChangeEvent.newStatus -> 1)
@@ -267,8 +267,8 @@ class DbUpdaterSpec
 
         val exception = exceptions.generateOne
         intercept[Exception] {
-          sessionResource
-            .useK((dbUpdater onRollback event)(exception))
+          (dbUpdater onRollback event)
+            .apply(exception)
             .unsafeRunSync() shouldBe DBUpdateResults.ForProjects.empty
         } shouldBe exception
       }

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesgenerated/DbUpdaterSpec.scala
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
-package io.renku.eventlog.events.consumers.statuschange.totriplesgenerated
+package io.renku.eventlog.events.consumers.statuschange
+package totriplesgenerated
 
+import SkunkExceptionsGenerators.postgresErrors
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.syntax.all._
@@ -32,11 +34,13 @@ import io.renku.graph.model.EventContentGenerators.eventDates
 import io.renku.graph.model.EventsGenerators.{eventIds, eventProcessingTimes, zippedEventPayloads}
 import io.renku.graph.model.events.EventStatus._
 import io.renku.graph.model.events._
+import io.renku.interpreters.TestLogger
 import io.renku.metrics.TestMetricsRegistry
 import io.renku.testtools.IOSpec
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
+import skunk.SqlState.DeadlockDetected
 
 import java.time.Instant
 
@@ -147,6 +151,7 @@ class DbUpdaterSpec
     }
 
     "just clean the delivery info if the event is already in the TRIPLES_GENERATED" in new TestCase {
+
       val eventDate = eventDates.generateOne
       val (olderEventId, olderEventStatus, _, _, _) =
         addEvent(New, timestamps(max = eventDate.value).generateAs(EventDate))
@@ -183,7 +188,27 @@ class DbUpdaterSpec
   }
 
   "onRollback" should {
-    "clean the delivery info for the event" in new TestCase {
+
+    "retry updating DB on a DeadlockDetected" in new TestCase {
+
+      val (eventId, _, _, _, _) = addEvent(GeneratingTriples, eventDates.generateOne)
+
+      val statusChangeEvent =
+        ToTriplesGenerated(eventId, project, eventProcessingTimes.generateOne, zippedEventPayloads.generateOne)
+
+      (deliveryInfoRemover.deleteDelivery _).expects(statusChangeEvent.eventId).returning(Kleisli.pure(()))
+
+      val exception = postgresErrors(DeadlockDetected).generateOne
+
+      (dbUpdater onRollback statusChangeEvent)
+        .apply(exception)
+        .unsafeRunSync() shouldBe DBUpdateResults.ForProjects(project.slug,
+                                                              Map(GeneratingTriples -> -1, TriplesGenerated -> 1)
+      )
+    }
+
+    "clean the delivery info for the event if a random exception thrown" in new TestCase {
+
       val event = ToTriplesGenerated(eventIds.generateOne,
                                      project,
                                      eventProcessingTimes.generateOne,
@@ -192,9 +217,11 @@ class DbUpdaterSpec
 
       (deliveryInfoRemover.deleteDelivery _).expects(event.eventId).returning(Kleisli.pure(()))
 
-      sessionResource
-        .useK((dbUpdater onRollback event)(exceptions.generateOne))
-        .unsafeRunSync() shouldBe DBUpdateResults.ForProjects.empty
+      val exception = exceptions.generateOne
+
+      intercept[Exception] {
+        (dbUpdater onRollback event).apply(exception).unsafeRunSync()
+      } shouldBe exception
     }
   }
 
@@ -202,7 +229,8 @@ class DbUpdaterSpec
 
     val project = ConsumersModelGenerators.consumerProjects.generateOne
 
-    val currentTime         = mockFunction[Instant]
+    private implicit val logger: TestLogger[IO] = TestLogger()
+    private val currentTime = mockFunction[Instant]
     val deliveryInfoRemover = mock[DeliveryInfoRemover[IO]]
     private implicit val metricsRegistry:  TestMetricsRegistry[IO]   = TestMetricsRegistry[IO]
     private implicit val queriesExecTimes: QueriesExecutionTimes[IO] = QueriesExecutionTimes[IO]().unsafeRunSync()

--- a/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdaterSpec.scala
+++ b/event-log/src/test/scala/io/renku/eventlog/events/consumers/statuschange/totriplesstore/DbUpdaterSpec.scala
@@ -180,8 +180,8 @@ class DbUpdaterSpec
       givenDeliveryInfoRemoved(statusChangeEvent.eventId)
 
       val deadlockException = postgresErrors(SqlState.DeadlockDetected).generateOne
-      sessionResource
-        .useK((dbUpdater onRollback statusChangeEvent)(deadlockException))
+      (dbUpdater onRollback statusChangeEvent)
+        .apply(deadlockException)
         .unsafeRunSync() shouldBe DBUpdateResults
         .ForProjects(
           project.slug,
@@ -210,8 +210,8 @@ class DbUpdaterSpec
 
         val exception = exceptions.generateOne
         intercept[Exception] {
-          sessionResource
-            .useK((dbUpdater onRollback event)(exception))
+          (dbUpdater onRollback event)
+            .apply(exception)
             .unsafeRunSync() shouldBe DBUpdateResults.ForProjects.empty
         } shouldBe exception
       }

--- a/graph-commons/src/test/scala/io/renku/interpreters/TestSessionResource.scala
+++ b/graph-commons/src/test/scala/io/renku/interpreters/TestSessionResource.scala
@@ -19,8 +19,8 @@
 package io.renku.interpreters
 
 import cats.effect.{IO, Resource}
-import io.renku.db.SessionResource
+import io.renku.db.SessionResourceImpl
 import skunk.Session
 
 class TestSessionResource[TargetDB](sessionResource: Resource[IO, Session[IO]])
-    extends SessionResource[IO, TargetDB](sessionResource)
+    extends SessionResourceImpl[IO, TargetDB](sessionResource)

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/InMemoryProjectsTokensDb.scala
@@ -37,7 +37,7 @@ trait InMemoryProjectsTokensDb extends ForAllTestContainer with TokenRepositoryT
 
   override val container: PostgreSQLContainer = PostgresContainer.container(dbConfig)
 
-  implicit lazy val sessionResource: SessionResource[IO] = new io.renku.db.SessionResource[IO, ProjectsTokensDB](
+  implicit lazy val sessionResource: SessionResource[IO] = io.renku.db.SessionResource[IO, ProjectsTokensDB](
     Session.single(
       host = container.host,
       database = dbConfig.name.value,


### PR DESCRIPTION
This PR adds a retry procedure in the rollback branch of the `StatusChanger`. The idea is that once a failure is raised from the rollback procedure and the DBUpdate can deal with this specific failure, the StatusChanger retries the rollback procedure again.

closes #1665 