### PR TITLE
feat: TG project update API to use DB locking

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -36,6 +36,7 @@ import io.renku.http.server.HttpServer
 import io.renku.logging.ApplicationLogger
 import io.renku.metrics.MetricsRegistry
 import io.renku.microservices.{IOMicroservice, ResourceUse, ServiceReadinessChecker}
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.config.certificates.GitCertificateInstaller
 import io.renku.triplesgenerator.events.consumers._
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
@@ -126,7 +127,7 @@ object Microservice extends IOMicroservice {
                                 viewingDeletionSubscription
                               )
     serviceReadinessChecker <- ServiceReadinessChecker[IO](ServicePort)
-    microserviceRoutes      <- MicroserviceRoutes[IO](eventConsumersRegistry, config).map(_.routes)
+    microserviceRoutes      <- MicroserviceRoutes[IO](eventConsumersRegistry, tsWriteLock, config).map(_.routes)
     termSignal              <- SignallingRef.of[IO, Boolean](false)
     exitCode <- microserviceRoutes.use { routes =>
                   new MicroserviceRunner[IO](

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -36,7 +36,6 @@ import io.renku.http.server.HttpServer
 import io.renku.logging.ApplicationLogger
 import io.renku.metrics.MetricsRegistry
 import io.renku.microservices.{IOMicroservice, ResourceUse, ServiceReadinessChecker}
-import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.config.certificates.GitCertificateInstaller
 import io.renku.triplesgenerator.events.consumers._
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/MicroserviceRoutes.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/MicroserviceRoutes.scala
@@ -26,6 +26,7 @@ import io.renku.events.consumers.EventConsumersRegistry
 import io.renku.graph.http.server.binders.ProjectSlug
 import io.renku.http.server.version
 import io.renku.metrics.{MetricsRegistry, RoutesMetrics}
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.events.EventEndpoint
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.http4s.dsl.Http4sDsl
@@ -64,10 +65,11 @@ private class MicroserviceRoutes[F[_]: MonadThrow](
 
 private object MicroserviceRoutes {
   def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder](consumersRegistry: EventConsumersRegistry[F],
+                                                                           tsWriteLock:       TsWriteLock[F],
                                                                            config:            Config
   ): F[MicroserviceRoutes[F]] = for {
     eventEndpoint         <- EventEndpoint(consumersRegistry)
-    projectUpdateEndpoint <- projects.update.Endpoint[F]
+    projectUpdateEndpoint <- projects.update.Endpoint[F](tsWriteLock)
     versionRoutes         <- version.Routes[F]
   } yield new MicroserviceRoutes(eventEndpoint, projectUpdateEndpoint, new RoutesMetrics[F], versionRoutes, config)
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/Endpoint.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/Endpoint.scala
@@ -24,6 +24,7 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.data.Message
 import io.renku.graph.model.projects
+import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.api.ProjectUpdates
 import io.renku.triplesstore.SparqlQueryTimeRecorder
 import org.http4s.circe._
@@ -36,8 +37,8 @@ trait Endpoint[F[_]] {
 }
 
 object Endpoint {
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[Endpoint[F]] = for {
-    projectUpdater <- ProjectUpdater[F]
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](tsWriteLock: TsWriteLock[F]): F[Endpoint[F]] = for {
+    projectUpdater <- ProjectUpdater[F](tsWriteLock)
   } yield new EndpointImpl[F](projectUpdater)
 }
 


### PR DESCRIPTION
The KG's Project Update API introduced updates on the TS for a given Project. This requires locking on the Project to prevent concurrent updates on a single project in the TS. 