### PR TITLE
fix: webhook-service not to fail when Project not found in GL

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
@@ -114,9 +114,6 @@ class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServi
 
       Then("he should get NOT_FOUND response back")
       afterDeletionResponse.status shouldBe NotFound
-
-      And("the Access Token should be removed from the token repository")
-      tokenRepositoryClient.GET(s"projects/${project.id}/tokens").status shouldBe NotFound
     }
   }
 }

--- a/graph-commons/src/test/scala/io/renku/interpreters/TestLogger.scala
+++ b/graph-commons/src/test/scala/io/renku/interpreters/TestLogger.scala
@@ -43,6 +43,10 @@ class TestLogger[F[_]: Async] extends Logger[F] with should.Matchers {
   def getMessages(severity: Level): List[LogMessage] =
     invocations(of = severity).toList.map(_.message)
 
+  def getMessagesF(severity: Level): F[List[LogMessage]] = F.delay {
+    invocations(of = severity).toList.map(_.message)
+  }
+
   private def invocations(of: Level): Iterable[LogEntry] =
     invocations.asScala.filter(_.level === of)
 
@@ -55,6 +59,10 @@ class TestLogger[F[_]: Async] extends Logger[F] with should.Matchers {
   def loggedOnly(expected: LogEntry*): Assertion =
     loggedOnly(expected.toList)
 
+  def loggedOnlyF(expected: LogEntry*): F[Assertion] = F.delay {
+    loggedOnly(expected.toList)
+  }
+
   def loggedOnly(expected: LogEntry, times: Int): Assertion =
     loggedOnly(List.fill(times)(expected))
 
@@ -64,6 +72,11 @@ class TestLogger[F[_]: Async] extends Logger[F] with should.Matchers {
   def expectNoLogs(): Assertion =
     if (invocations.isEmpty) Succeeded
     else fail(s"No logs expected but got $invocationsPrettyPrint")
+
+  def expectNoLogsF(): F[Assertion] = F.delay {
+    if (invocations.isEmpty) Succeeded
+    else fail(s"No logs expected but got $invocationsPrettyPrint")
+  }
 
   def expectNoLogs(severity: Level): Assertion = invocations(of = severity).toList match {
     case Nil         => Succeeded

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensCreator.scala
@@ -85,7 +85,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
       checkValid(projectId, storedToken) >>= {
         case true => storedToken.some.pure[F]
         case false =>
-          deleteAndLogSuccess(projectId, userToken, show"Token removed for $projectId as got invalidated in GL")
+          deleteAndLogSuccess(projectId, userToken, show"token removed for $projectId as got invalidated in GL")
             .as(Option.empty)
       }
   }
@@ -108,7 +108,7 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
           case None =>
             deleteAndLogSuccess(projectId,
                                 userToken,
-                                show"Token removed for $projectId as project does not exist in GL"
+                                show"token removed for $projectId as project does not exist in GL"
             ).as(Option.empty)
           case Some(actualGLSlug) =>
             findPersistedProjectSlug(projectId) >>= {
@@ -171,12 +171,12 @@ private class TokensCreatorImpl[F[_]: MonadThrow: Logger](
   private def verifyTokenIntegrity(projectId: projects.GitLabId, token: ProjectAccessToken) =
     findStoredToken(projectId)
       .cataF(
-        new Exception(show"Token associator - just saved token cannot be found for project: $projectId")
+        new Exception(show"token for project: $projectId that has been just saved cannot be found")
           .raiseError[F, Unit],
         accessTokenCrypto.decrypt(_) >>= {
           case `token` => ().pure[F]
           case _ =>
-            new Exception(show"Token associator - just saved token integrity check failed for project: $projectId")
+            new Exception(show"token for project: $projectId that has been just saved failed the integrity check")
               .raiseError[F, Unit]
         }
       )

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensPersister.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensPersister.scala
@@ -48,10 +48,8 @@ private class TokensPersisterImpl[F[_]: MonadCancelThrow: SessionResource: Queri
     with TokensPersister[F]
     with TokenRepositoryTypeSerializers {
 
-  override def persistToken(storingInfo: TokenStoringInfo): F[Unit] = SessionResource[F].useWithTransactionK {
-    Kleisli { case (_, session) =>
-      (deleteAssociation(storingInfo.project) >> insert(storingInfo)).run(session)
-    }
+  override def persistToken(storingInfo: TokenStoringInfo): F[Unit] = SessionResource[F].useK {
+    deleteAssociation(storingInfo.project) >> insert(storingInfo)
   }
 
   override def updateSlug(project: Project): F[Unit] = SessionResource[F].useK(

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpoint.scala
@@ -44,7 +44,7 @@ class DeleteTokenEndpointImpl[F[_]: Async: Logger](tokenRemover: TokenRemover[F]
       .recoverWith(errorHttpResult(projectId))
 
   private def logSuccess(projectId: GitLabId): DeletionResult => F[Unit] = {
-    case DeletionResult.Deleted    => Logger[F].info(show"Token removed for $projectId")
+    case DeletionResult.Deleted    => Logger[F].info(show"token removed for $projectId")
     case DeletionResult.NotExisted => ().pure[F]
   }
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/creation/TokensCreatorSpec.scala
@@ -301,9 +301,7 @@ class TokensCreatorSpec extends AsyncFlatSpec with CustomAsyncIOSpec with AsyncM
 
     tokensCreator
       .create(projectId, userAccessToken)
-      .assertThrowsWithMessage[Exception](
-        show"Token associator - just saved token cannot be found for project: $projectId"
-      )
+      .assertThrowsWithMessage[Exception](show"token for project: $projectId that has been just saved cannot be found")
   }
 
   private lazy val projectId       = projectIds.generateOne

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpointSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/deletion/DeleteTokenEndpointSpec.scala
@@ -60,7 +60,7 @@ class DeleteTokenEndpointSpec
           response.body.compile.toVector.asserting(_ shouldBe Vector.empty)
       } >> {
       deletionResult match {
-        case DeletionResult.Deleted    => IO(logger.loggedOnly(Info(show"Token removed for $projectId")))
+        case DeletionResult.Deleted    => IO(logger.loggedOnly(Info(show"token removed for $projectId")))
         case DeletionResult.NotExisted => IO(logger.expectNoLogs())
       }
     }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/GLProjectVisibilityFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/membersync/GLProjectVisibilityFinder.scala
@@ -45,12 +45,12 @@ private class GLProjectVisibilityFinderImpl[F[_]: Async: GitLabClient] extends G
     GitLabClient[F].get(uri"projects" / slug, "single-project")(mapResponse)(mat)
 
   private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Option[projects.Visibility]]] = {
-    case (Ok, _, response)                           => response.as[projects.Visibility].map(Option.apply)
+    case (Ok, _, response)                           => response.as[Option[projects.Visibility]]
     case (Unauthorized | Forbidden | NotFound, _, _) => Option.empty[projects.Visibility].pure[F]
   }
 
-  private implicit lazy val entityDecoder: EntityDecoder[F, projects.Visibility] = {
-    lazy val decoder: Decoder[projects.Visibility] = _.downField("visibility").as[projects.Visibility]
-    jsonOf[F, projects.Visibility](Sync[F], decoder)
+  private implicit lazy val entityDecoder: EntityDecoder[F, Option[projects.Visibility]] = {
+    lazy val decoder: Decoder[Option[projects.Visibility]] = _.downField("visibility").as[Option[projects.Visibility]]
+    jsonOf[F, Option[projects.Visibility]](Sync[F], decoder)
   }
 }

--- a/webhook-service/src/main/scala/io/renku/webhookservice/ProjectInfoFinder.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/ProjectInfoFinder.scala
@@ -26,11 +26,12 @@ import io.renku.events.consumers.Project
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.tinytypes.TinyTypeURIEncoder._
+import org.http4s.Status.NotFound
 import org.http4s.implicits._
 import org.typelevel.log4cats.Logger
 
 private trait ProjectInfoFinder[F[_]] {
-  def findProjectInfo(projectId: projects.GitLabId)(implicit maybeAccessToken: Option[AccessToken]): F[Project]
+  def findProjectInfo(projectId: projects.GitLabId)(implicit maybeAccessToken: Option[AccessToken]): F[Option[Project]]
 }
 
 private class ProjectInfoFinderImpl[F[_]: Async: GitLabClient: Logger] extends ProjectInfoFinder[F] {
@@ -40,23 +41,20 @@ private class ProjectInfoFinderImpl[F[_]: Async: GitLabClient: Logger] extends P
   import io.renku.tinytypes.json.TinyTypeDecoders._
   import org.http4s.Status.{Ok, Unauthorized}
   import org.http4s._
-  import org.http4s.circe._
+  import org.http4s.circe.CirceEntityDecoder._
 
-  def findProjectInfo(projectId: projects.GitLabId)(implicit maybeAccessToken: Option[AccessToken]): F[Project] =
+  def findProjectInfo(projectId: projects.GitLabId)(implicit mat: Option[AccessToken]): F[Option[Project]] =
     GitLabClient[F].get(uri"projects" / projectId, "single-project")(mapResponse)
 
-  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Project]] = {
-    case (Ok, _, response)    => response.as[Project]
+  private lazy val mapResponse: PartialFunction[(Status, Request[F], Response[F]), F[Option[Project]]] = {
+    case (Ok, _, response)    => response.as[Project].map(_.some)
+    case (NotFound, _, _)     => Option.empty[Project].pure[F]
     case (Unauthorized, _, _) => MonadThrow[F].raiseError(UnauthorizedException)
   }
 
-  private implicit lazy val projectEntityDecoder: EntityDecoder[F, Project] = {
-    implicit val projectDecoder: Decoder[Project] = cursor =>
-      (cursor.downField("id").as[projects.GitLabId], cursor.downField("path_with_namespace").as[projects.Slug])
-        .mapN(Project(_, _))
-
-    jsonOf[F, Project]
-  }
+  private implicit lazy val projectDecoder: Decoder[Project] = cursor =>
+    (cursor.downField("id").as[projects.GitLabId], cursor.downField("path_with_namespace").as[projects.Slug])
+      .mapN(Project(_, _))
 }
 
 private object ProjectInfoFinder {

--- a/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/eventstatus/Endpoint.scala
@@ -69,12 +69,12 @@ private class EndpointImpl[F[_]: Async: NonEmptyParallel: Logger: ExecutionTimeR
         .parFlatMapN {
           case (Some(HookMissing), _) =>
             Ok(StatusInfo.NotActivated.asJson)
-          case (Some(HookExists), Some(si)) =>
-            sendProjectViewed(projectId, authUser) >> Ok(si.asJson)
+          case (Some(HookExists), Some(status)) =>
+            sendProjectViewed(projectId, authUser) >> Ok(status.asJson)
           case (Some(HookExists), None) =>
             sendCommitSyncRequest(projectId, authUser) >> Ok(StatusInfo.webhookReady.widen.asJson)
-          case (None, Some(si)) =>
-            sendProjectViewed(projectId, authUser) >> Ok(si.asJson)
+          case (None, Some(status)) =>
+            sendProjectViewed(projectId, authUser) >> Ok(status.asJson)
           case (None, None) =>
             NotFound(Message.Info("Info about project cannot be found"))
         }

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreator.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookcreation/HookCreator.scala
@@ -94,7 +94,7 @@ private class HookCreatorImpl[F[_]: Spawn: Logger](
     findProjectInfo(projectId)(accessToken.some)
       .flatMap {
         case Some(project) => elClient.send(CommitSyncRequest(project))
-        case None => Logger[F].warn(s"Hook creation - COMMIT_SYNC_REQUEST not sent as no project $projectId found")
+        case None => Logger[F].error(s"Hook creation - COMMIT_SYNC_REQUEST not sent as no project $projectId found")
       }
       .handleErrorWith(
         Logger[F].error(_)(s"Hook creation - COMMIT_SYNC_REQUEST not sent as finding project $projectId failed")

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookvalidation/HookValidator.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookvalidation/HookValidator.scala
@@ -103,7 +103,7 @@ private class HookValidatorImpl[F[_]: MonadThrow: Logger](
                                     maybeAccessToken: Option[AccessToken]
   ): F[Option[HookValidationResult]] =
     fetchToken(projectId)
-      .flatMapF(at => checkHookPresence(HookIdentifier(projectId, projectHookUrl), at))
+      .flatMapF(checkHookPresence(HookIdentifier(projectId, projectHookUrl), _))
       .cataF(
         default = Option.empty[HookValidationResult].pure[F],
         hookPresent =>

--- a/webhook-service/src/main/scala/io/renku/webhookservice/hookvalidation/HookValidator.scala
+++ b/webhook-service/src/main/scala/io/renku/webhookservice/hookvalidation/HookValidator.scala
@@ -18,10 +18,10 @@
 
 package io.renku.webhookservice.hookvalidation
 
+import cats.MonadThrow
 import cats.data.OptionT
 import cats.effect.Async
 import cats.syntax.all._
-import cats.{Applicative, MonadThrow}
 import com.typesafe.config.ConfigFactory
 import eu.timepit.refined.auto._
 import io.renku.cache.{Cache, CacheBuilder, CacheConfigLoader}
@@ -51,7 +51,6 @@ object HookValidator {
       tokenRepositoryUrl    <- TokenRepositoryUrl[F]()
       projectHookVerifier   <- ProjectHookVerifier[F]
       accessTokenAssociator <- AccessTokenAssociator[F]
-      accessTokenRemover    <- AccessTokenRemover[F]
       cacheConfig           <- CacheConfigLoader.load[F]("services.self.hook-validation-cache", ConfigFactory.load())
       validationCache <- CacheBuilder
                            .default[F, GitLabId, HookValidationResult]
@@ -63,7 +62,6 @@ object HookValidator {
       projectHookVerifier,
       new AccessTokenFinderImpl(tokenRepositoryUrl),
       accessTokenAssociator,
-      accessTokenRemover,
       validationCache
     )
 }
@@ -73,25 +71,20 @@ private class HookValidatorImpl[F[_]: MonadThrow: Logger](
     projectHookVerifier:   ProjectHookVerifier[F],
     accessTokenFinder:     AccessTokenFinder[F],
     accessTokenAssociator: AccessTokenAssociator[F],
-    accessTokenRemover:    AccessTokenRemover[F],
     validationCache:       Cache[F, GitLabId, HookValidationResult]
 ) extends HookValidator[F] {
-
-  private val applicative = Applicative[F]
 
   import HookValidator.HookValidationResult._
   import HookValidator._
   import accessTokenAssociator._
   import accessTokenFinder._
-  import accessTokenRemover._
-  import applicative._
   import projectHookVerifier._
 
   def validateHook(projectId: GitLabId, maybeAccessToken: Option[AccessToken]): F[Option[HookValidationResult]] =
     validationCache.withCache(pId => validateHook0(pId, maybeAccessToken))(projectId)
 
   private def validateHook0(projectId: GitLabId, mat: Option[AccessToken]): F[Option[HookValidationResult]] = {
-    persistGivenToken(projectId, mat) >> validateHookExistence(projectId, mat)
+    persistGivenToken(projectId, mat) >> validateHookExistence(projectId)
   }.onError(logError(projectId))
 
   private def persistGivenToken(projectId: GitLabId, maybeAccessToken: Option[AccessToken]): F[Unit] =
@@ -99,16 +92,12 @@ private class HookValidatorImpl[F[_]: MonadThrow: Logger](
       .map(associate(projectId, _))
       .getOrElse(().pure[F])
 
-  private def validateHookExistence(projectId: GitLabId, mat: Option[AccessToken]): F[Option[HookValidationResult]] =
+  private def validateHookExistence(projectId: GitLabId): F[Option[HookValidationResult]] =
     fetchToken(projectId)
       .flatMapF(checkHookPresence(HookIdentifier(projectId, projectHookUrl), _))
       .cataF(
         default = Option.empty[HookValidationResult].pure[F],
-        hookPresent =>
-          whenA(!hookPresent)(
-            removeAccessToken(projectId, mat) >>
-              Logger[F].info(show"Token removed for projectId = $projectId as hook doesn't exist")
-          ).as(toValidationResult(hookPresent).some)
+        toValidationResult(_).some.pure[F]
       )
 
   private def fetchToken(projectId: GitLabId): OptionT[F, AccessToken] = OptionT {
@@ -119,8 +108,8 @@ private class HookValidatorImpl[F[_]: MonadThrow: Logger](
   private def storedAccessTokenError(projectId: GitLabId): PartialFunction[Throwable, Throwable] =
     new Exception(s"Finding stored access token for $projectId failed", _)
 
-  private def toValidationResult(projectHookPresent: Boolean): HookValidationResult =
-    if (projectHookPresent) HookExists else HookMissing
+  private def toValidationResult(hookPresent: Boolean): HookValidationResult =
+    if (hookPresent) HookExists else HookMissing
 
   private def logError(projectId: GitLabId): PartialFunction[Throwable, F[Unit]] = { case exception =>
     Logger[F].error(exception)(s"Hook validation failed for projectId $projectId")

--- a/webhook-service/src/test/scala/io/renku/webhookservice/ProjectInfoFinderSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/ProjectInfoFinderSpec.scala
@@ -34,81 +34,77 @@ import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.interpreters.TestLogger
 import io.renku.stubbing.ExternalServiceStubbing
-import io.renku.testtools.{GitLabClientTools, IOSpec}
+import io.renku.testtools.{CustomAsyncIOSpec, GitLabClientTools}
 import org.http4s.circe.jsonEncoder
 import org.http4s.implicits._
 import org.http4s.{Request, Response, Status, Uri}
-import org.scalacheck.Gen
-import org.scalamock.scalatest.MockFactory
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
 
 class ProjectInfoFinderSpec
-    extends AnyWordSpec
-    with MockFactory
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with AsyncMockFactory
     with ExternalServiceStubbing
     with GitLabClientTools[IO]
     with should.Matchers
-    with IOSpec {
+    with OptionValues {
 
-  "findProjectInfo" should {
+  it should "return fetched project info if service responds with 200 and a valid body" in {
 
-    "return fetched project info if service responds with 200 and a valid body" in new TestCase {
+    val mat: Option[AccessToken] = accessTokens.generateSome
 
-      implicit override val maybeAccessToken: Option[AccessToken] = accessTokens.generateSome
+    (gitLabClient
+      .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, Option[Project]])(_: Option[AccessToken]))
+      .expects(uri, endpointName, *, mat)
+      .returning(project.some.pure[IO])
 
-      (gitLabClient
-        .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, Project])(_: Option[AccessToken]))
-        .expects(uri, endpointName, *, maybeAccessToken)
-        .returning(project.pure[IO])
-
-      projectInfoFinder.findProjectInfo(projectId).unsafeRunSync() shouldBe project
-    }
-
-    "return project info if gitLabClient returns Ok" in new TestCase {
-      mapResponse(Status.Ok, Request(), Response().withEntity(projectJson))
-        .unsafeRunSync() shouldBe project
-    }
-
-    "return an UnauthorizedException if remote client responds with UNAUTHORIZED" in new TestCase {
-      intercept[Exception] {
-        mapResponse(Status.Unauthorized, Request(), Response()).unsafeRunSync()
-      } shouldBe UnauthorizedException
-    }
-
-    "return a RuntimeException if remote client responds with status neither OK nor UNAUTHORIZED" in new TestCase {
-      intercept[Exception] {
-        mapResponse(Status.NotFound, Request(), Response()).unsafeRunSync()
-      } shouldBe a[RuntimeException]
-    }
-
-    "return a RuntimeException if remote client responds with unexpected body" in new TestCase {
-      intercept[Exception] {
-        mapResponse(Status.Ok, Request(), Response().withEntity(json"{}")).unsafeRunSync()
-      }.getMessage should startWith("Invalid message body: Could not decode JSON")
-    }
+    projectInfoFinder.findProjectInfo(projectId)(mat).asserting(_.value shouldBe project)
   }
 
-  private trait TestCase {
-    val project   = consumerProjects.generateOne
-    val projectId = project.id
-    val uri:          Uri                     = uri"projects" / projectId
-    val endpointName: String Refined NonEmpty = "single-project"
+  it should "decode project info from a valid OK response" in {
+    mapResponse(Status.Ok, Request(), Response().withEntity(projectJson)).asserting(_.value shouldBe project)
+  }
 
-    implicit val maybeAccessToken: Option[AccessToken] = accessTokens.generateOption
+  it should "decode to none if remote returns NotFound" in {
+    mapResponse(Status.NotFound, Request(), Response()).asserting(_ shouldBe None)
+  }
 
-    implicit val logger:       TestLogger[IO]   = TestLogger[IO]()
-    implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
-    val projectInfoFinder = new ProjectInfoFinderImpl[IO]
+  it should "fail with an UnauthorizedException if remote responds with UNAUTHORIZED" in {
+    mapResponse(Status.Unauthorized, Request(), Response()).assertThrows[UnauthorizedException]
+  }
 
-    lazy val projectJson: String = json"""{
+  it should "do not define a mapping case for status different than OK, NOT_FOUND or UNAUTHORIZED" in {
+    intercept[Exception](
+      mapResponse(Status.InternalServerError, Request(), Response()).assertNoException
+    ) shouldBe a[MatchError]
+  }
+
+  it should "return an Exception if remote client responds with unexpected body" in {
+    mapResponse(Status.Ok, Request(), Response().withEntity(json"{}"))
+      .assertThrowsError[Exception](_.getMessage should startWith("Invalid message body: Could not decode JSON"))
+  }
+
+  private lazy val project   = consumerProjects.generateOne
+  private lazy val projectId = project.id
+  private lazy val uri:          Uri                     = uri"projects" / projectId
+  private lazy val endpointName: String Refined NonEmpty = "single-project"
+
+  private implicit lazy val maybeAccessToken: Option[AccessToken] = accessTokens.generateOption
+
+  private implicit val logger:            TestLogger[IO]   = TestLogger[IO]()
+  private implicit lazy val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
+  private lazy val projectInfoFinder = new ProjectInfoFinderImpl[IO]
+
+  private lazy val projectJson: String = json"""{
       "id":                  $projectId,
       "path_with_namespace": ${project.slug}
     }""".noSpaces
 
-    lazy val mapResponse = captureMapping(gitLabClient)(
-      projectInfoFinder.findProjectInfo(projectId).unsafeRunSync(),
-      Gen.const(project)
-    )
-  }
+  private lazy val mapResponse = captureMapping(gitLabClient)(
+    projectInfoFinder.findProjectInfo(projectId).unsafeRunSync(),
+    consumerProjects.generateSome
+  )
 }

--- a/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/EndpointSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/eventstatus/EndpointSpec.scala
@@ -75,7 +75,7 @@ class EndpointSpec
         givenStatusInfoFinding(projectId, returning = statusInfo.some.pure[IO])
 
         val project = consumerProjects.generateOne.copy(id = projectId)
-        givenProjectInfoFinding(projectId, authUser, returning = project.pure[IO])
+        givenProjectInfoFinding(projectId, authUser, returning = project.some.pure[IO])
         givenProjectViewedEventSent
 
         val response = endpoint.fetchProcessingStatus(projectId, authUser).unsafeRunSync()
@@ -100,7 +100,7 @@ class EndpointSpec
         givenStatusInfoFinding(projectId, returning = None.pure[IO])
 
         val project = consumerProjects.generateOne.copy(id = projectId)
-        givenProjectInfoFinding(projectId, authUser, returning = project.pure[IO])
+        givenProjectInfoFinding(projectId, authUser, returning = project.some.pure[IO])
         givenCommitSyncRequestSent
 
         val response = endpoint.fetchProcessingStatus(projectId, authUser).unsafeRunSync()
@@ -143,7 +143,7 @@ class EndpointSpec
         givenStatusInfoFinding(projectId, returning = statusInfo.some.pure[IO])
 
         val project = consumerProjects.generateOne.copy(id = projectId)
-        givenProjectInfoFinding(projectId, authUser, returning = project.pure[IO])
+        givenProjectInfoFinding(projectId, authUser, returning = project.some.pure[IO])
         givenProjectViewedEventSent
 
         val response = endpoint.fetchProcessingStatus(projectId, authUser).unsafeRunSync()
@@ -235,11 +235,13 @@ class EndpointSpec
         .expects(projectId)
         .returning(returning)
 
-    def givenProjectInfoFinding(projectId: projects.GitLabId, authUser: Option[AuthUser], returning: IO[Project]) =
-      (projectInfoFinder
-        .findProjectInfo(_: projects.GitLabId)(_: Option[AccessToken]))
-        .expects(projectId, authUser.map(_.accessToken))
-        .returning(returning)
+    def givenProjectInfoFinding(projectId: projects.GitLabId,
+                                authUser:  Option[AuthUser],
+                                returning: IO[Option[Project]]
+    ) = (projectInfoFinder
+      .findProjectInfo(_: projects.GitLabId)(_: Option[AccessToken]))
+      .expects(projectId, authUser.map(_.accessToken))
+      .returning(returning)
 
     private val sentEvents: Ref[IO, List[AnyRef]] = Ref.unsafe(Nil)
 

--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidatorSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookvalidation/HookValidatorSpec.scala
@@ -29,7 +29,7 @@ import io.renku.graph.model.projects.GitLabId
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.AccessToken
 import io.renku.interpreters.TestLogger
-import io.renku.interpreters.TestLogger.Level.Error
+import io.renku.interpreters.TestLogger.Level.{Error, Info}
 import io.renku.testtools.IOSpec
 import io.renku.webhookservice.WebhookServiceGenerators._
 import io.renku.webhookservice.hookvalidation.HookValidator.HookValidationResult
@@ -106,7 +106,7 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       validator.validateHook(projectId, givenAccessToken.some).unsafeRunSync() shouldBe HookMissing.some
 
-      logger.expectNoLogs()
+      logger.loggedOnly(Info(show"Token removed for projectId = $projectId as hook doesn't exist"))
     }
 
     "return None if hook verification cannot determine hook existence" in new TestCase {
@@ -203,7 +203,7 @@ class HookValidatorSpec extends AnyWordSpec with MockFactory with should.Matcher
 
       validator.validateHook(projectId, maybeAccessToken = None).unsafeRunSync() shouldBe HookMissing.some
 
-      logger.expectNoLogs()
+      logger.loggedOnly(Info(show"Token removed for projectId = $projectId as hook doesn't exist"))
     }
 
     "return None if hook verification cannot determine hook existence" in new TestCase {


### PR DESCRIPTION
This PR:
* assumes finding project info in GL may return 404s
* ensures the Hook Validation process should not remove the token
* 
/deploy #persist