### PR TITLE
feat: Project Update API to wait for call to the Core

### DIFF
--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/DefaultBranch.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/DefaultBranch.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.knowledgegraph.projects.update
+
+import io.renku.core.client.Branch
+
+private sealed trait DefaultBranch {
+  val branch: Branch
+}
+
+private object DefaultBranch {
+  final case class PushProtected(branch: Branch) extends DefaultBranch
+  final case class Unprotected(branch: Branch)   extends DefaultBranch
+}

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Failure.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Failure.scala
@@ -57,10 +57,10 @@ private object Failure {
     Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in GitLab failed"), cause)
 
   def onTGUpdatesFinding(slug: projects.Slug, cause: Throwable): Failure =
-    Failure(InternalServerError, Message.Error.unsafeApply(show"Finding TS updates for $slug failed"), cause)
+    Failure(InternalServerError, Message.Error.unsafeApply(show"Finding Knowledge Graph updates for $slug failed"), cause)
 
   def onTSUpdate(slug: projects.Slug, cause: Throwable): Failure =
-    Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in TS failed"), cause)
+    Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in the Knowledge Graph failed"), cause)
 
   def onCoreUpdate(slug: projects.Slug, cause: Throwable): Failure =
     Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in renku-core failed"), cause)
@@ -74,7 +74,7 @@ private object Failure {
       else show"Only $tgUpdates"
     val defaultBranchInfo = defaultBranch.map(_.branch).fold("")(b => show" '$b'")
     val details =
-      show"""|$updatedValuesInfo got updated in the TS due to branch protection rules on the default branch$defaultBranchInfo. 
+      show"""|$updatedValuesInfo got updated in the Knowledge Graph due to branch protection rules on the default branch$defaultBranchInfo.
              |However, an update commit was pushed to a new branch '$corePushBranch' which has to be merged to the default branch with a PR""".stripMargin
         .filter(_ != '\n')
     val message = json"""{

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Failure.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Failure.scala
@@ -57,10 +57,16 @@ private object Failure {
     Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in GitLab failed"), cause)
 
   def onTGUpdatesFinding(slug: projects.Slug, cause: Throwable): Failure =
-    Failure(InternalServerError, Message.Error.unsafeApply(show"Finding Knowledge Graph updates for $slug failed"), cause)
+    Failure(InternalServerError,
+            Message.Error.unsafeApply(show"Finding Knowledge Graph updates for $slug failed"),
+            cause
+    )
 
   def onTSUpdate(slug: projects.Slug, cause: Throwable): Failure =
-    Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in the Knowledge Graph failed"), cause)
+    Failure(InternalServerError,
+            Message.Error.unsafeApply(show"Updating project $slug in the Knowledge Graph failed"),
+            cause
+    )
 
   def onCoreUpdate(slug: projects.Slug, cause: Throwable): Failure =
     Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in renku-core failed"), cause)

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Failure.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Failure.scala
@@ -21,8 +21,11 @@ package io.renku.knowledgegraph.projects.update
 import ProvisioningStatusFinder.ProvisioningStatus.Unhealthy
 import cats.syntax.all._
 import eu.timepit.refined.auto._
+import io.circe.literal._
+import io.renku.core.client.Branch
 import io.renku.data.Message
 import io.renku.graph.model.{persons, projects}
+import io.renku.triplesgenerator.api.{ProjectUpdates => TGProjectUpdates}
 import org.http4s.Status
 import org.http4s.Status.{BadRequest, Conflict, Forbidden, InternalServerError}
 
@@ -59,8 +62,27 @@ private object Failure {
   def onTSUpdate(slug: projects.Slug, cause: Throwable): Failure =
     Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in TS failed"), cause)
 
-  val cannotPushToBranch: Failure =
-    Failure(Conflict, Message.Error("Updating project not possible; the user cannot push to the default branch"))
+  def onCoreUpdate(slug: projects.Slug, cause: Throwable): Failure =
+    Failure(InternalServerError, Message.Error.unsafeApply(show"Updating project $slug in renku-core failed"), cause)
+
+  def corePushedToNonDefaultBranch(tgUpdates:      TGProjectUpdates,
+                                   defaultBranch:  Option[DefaultBranch],
+                                   corePushBranch: Branch
+  ): Failure = {
+    val updatedValuesInfo =
+      if (tgUpdates == TGProjectUpdates.empty) "No values"
+      else show"Only $tgUpdates"
+    val defaultBranchInfo = defaultBranch.map(_.branch).fold("")(b => show" '$b'")
+    val details =
+      show"""|$updatedValuesInfo got updated in the TS due to branch protection rules on the default branch$defaultBranchInfo. 
+             |However, an update commit was pushed to a new branch '$corePushBranch' which has to be merged to the default branch with a PR""".stripMargin
+        .filter(_ != '\n')
+    val message = json"""{
+      "details": $details,
+      "branch":  $corePushBranch
+    }"""
+    Failure(Conflict, Message.Error.fromJsonUnsafe(message))
+  }
 
   def onProvisioningNotHealthy(slug: projects.Slug, unhealthy: Unhealthy): Failure =
     Failure(

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/EndpointSpec.scala
@@ -96,7 +96,7 @@ class EndpointSpec extends AsyncFlatSpec with CustomAsyncIOSpec with should.Matc
         Failure.badRequestOnGLUpdate(Message.Error(nonBlankStrings().generateOne)),
         Failure.forbiddenOnGLUpdate(Message.Error(nonBlankStrings().generateOne)),
         Failure.onGLUpdate(slug, exceptions.generateOne),
-        Failure.cannotPushToBranch
+        Failure.onFindingCoreUri(exceptions.generateOne)
       )
       .generateOne
     givenUpdatingProject(slug, updates, authUser, returning = failure.raiseError[IO, Nothing])

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/FailureSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/FailureSpec.scala
@@ -47,7 +47,7 @@ class FailureSpec extends AnyWordSpec with should.Matchers with ScalaCheckProper
             else show"Only $tgUpdates"
           val defaultBranchInfo = maybeDefaultBranch.map(_.branch).fold("")(b => show" '$b'")
           val details =
-            show"""|$updatedValuesInfo got updated in the TS due to branch protection rules on the default branch$defaultBranchInfo. 
+            show"""|$updatedValuesInfo got updated in the Knowledge Graph due to branch protection rules on the default branch$defaultBranchInfo.
                    |However, an update commit was pushed to a new branch '$corePushBranch' which has to be merged to the default branch with a PR""".stripMargin
               .filter(_ != '\n')
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/FailureSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/FailureSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.knowledgegraph.projects.update
+
+import Generators.defaultBranchInfos
+import cats.syntax.all._
+import io.circe.literal._
+import io.renku.core.client.Generators.branches
+import io.renku.data.Message
+import io.renku.generators.Generators.Implicits._
+import io.renku.triplesgenerator.api.Generators.{projectUpdatesGen => tgUpdatesGen}
+import io.renku.triplesgenerator.api.{ProjectUpdates => TGProjectUpdates}
+import org.http4s.Status.Conflict
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class FailureSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
+
+  "corePushedToNonDefaultBranch" should {
+
+    "return a Conflict Failure with a JSON message containing the branch Core pushed to" in {
+      forAll(tgUpdatesGen, defaultBranchInfos.toGeneratorOfOptions, branches) {
+        (tgUpdates, maybeDefaultBranch, corePushBranch) =>
+          val failure = Failure.corePushedToNonDefaultBranch(tgUpdates, maybeDefaultBranch, corePushBranch)
+
+          failure.status shouldBe Conflict
+
+          val updatedValuesInfo =
+            if (tgUpdates == TGProjectUpdates.empty) "No values"
+            else show"Only $tgUpdates"
+          val defaultBranchInfo = maybeDefaultBranch.map(_.branch).fold("")(b => show" '$b'")
+          val details =
+            show"""|$updatedValuesInfo got updated in the TS due to branch protection rules on the default branch$defaultBranchInfo. 
+                   |However, an update commit was pushed to a new branch '$corePushBranch' which has to be merged to the default branch with a PR""".stripMargin
+              .filter(_ != '\n')
+
+          println(failure.message)
+          failure.message shouldBe Message.Error.fromJsonUnsafe {
+            json"""{
+              "details": $details,
+              "branch":  $corePushBranch
+            }"""
+          }
+      }
+    }
+  }
+}

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/Generators.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/Generators.scala
@@ -18,6 +18,7 @@
 
 package io.renku.knowledgegraph.projects.update
 
+import io.renku.core.client.Generators.branches
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
 import io.renku.graph.model.RenkuTinyTypeGenerators.{imageUris, projectDescriptions, projectKeywords, projectVisibilities}
@@ -48,4 +49,8 @@ private object Generators {
       maybeNewImage      <- imageUris.toGeneratorOfOptions
       maybeNewVisibility <- projectVisibilities
     } yield GLUpdatedProject(maybeNewImage, maybeNewVisibility)
+
+  val defaultBranchInfos: Gen[DefaultBranch] =
+    branches
+      .flatMap(branch => Gen.oneOf(DefaultBranch.PushProtected(branch), DefaultBranch.Unprotected(branch)))
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/ProjectUpdaterSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/ProjectUpdaterSpec.scala
@@ -22,8 +22,8 @@ import Generators._
 import ProvisioningStatusFinder.ProvisioningStatus
 import cats.effect.IO
 import cats.syntax.all._
-import io.renku.core.client.Generators.{coreUrisVersioned, resultDetailedFailures, resultSuccesses, userInfos}
-import io.renku.core.client.{RenkuCoreClient, RenkuCoreUri, Result, UserInfo, ProjectUpdates => CoreProjectUpdates}
+import io.renku.core.client.Generators.{branches, coreUrisVersioned, resultDetailedFailures, resultSuccesses, userInfos}
+import io.renku.core.client.{Branch, RenkuCoreClient, RenkuCoreUri, Result, UserInfo, ProjectUpdates => CoreProjectUpdates}
 import io.renku.data.Message
 import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
@@ -33,7 +33,6 @@ import io.renku.graph.model.events.EventStatus
 import io.renku.graph.model.projects
 import io.renku.http.client.{AccessToken, UserAccessToken}
 import io.renku.interpreters.TestLogger
-import io.renku.interpreters.TestLogger.Level.Error
 import io.renku.testtools.CustomAsyncIOSpec
 import io.renku.triplesgenerator.api.Generators.{projectUpdatesGen => tgUpdatesGen}
 import io.renku.triplesgenerator.api.{TriplesGeneratorClient, ProjectUpdates => TGProjectUpdates}
@@ -68,9 +67,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
 
       val authUser = authUsers.generateOne
       val slug     = projectSlugs.generateOne
-      val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      val repoBranch    = branches.generateOne
+      val defaultBranch = DefaultBranch.Unprotected(repoBranch).some
+      givenPrerequisitesCheckFine(slug, authUser.accessToken, defaultBranch.pure[IO])
 
       val projectGitUrl = projectGitHttpUrls.generateOne
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitUrl.some.pure[IO])
@@ -79,17 +79,18 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val coreUri = coreUrisVersioned.generateOne
       givenFindingCoreUri(projectGitUrl, authUser.accessToken, returning = Result.success(coreUri))
 
+      val updates = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
       givenUpdatingProjectInCore(
         coreUri,
         CoreProjectUpdates(projectGitUrl, userInfo, updates.newDescription, updates.newKeywords),
         authUser.accessToken,
-        returning = resultSuccesses(()).generateOne
+        returning = resultSuccesses(repoBranch).generateOne
       )
 
       val glUpdated = glUpdatedProjectsGen.generateSome
       givenUpdatingProjectInGL(slug, updates, authUser.accessToken, returning = glUpdated.asRight.pure[IO])
       val tgUpdates = tgUpdatesGen.generateOne
-      givenTGUpdatesCalculation(updates, glUpdated, returning = tgUpdates.pure[IO])
+      givenTGUpdatesCalculation(updates, glUpdated, defaultBranch, repoBranch, returning = tgUpdates.pure[IO])
       givenSendingUpdateToTG(slug, tgUpdates, returning = TriplesGeneratorClient.Result.success(()).pure[IO])
 
       updater.updateProject(slug, updates, authUser).assertNoException
@@ -101,7 +102,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val authUser = authUsers.generateOne
       val slug     = projectSlugs.generateOne
 
-      givenBranchProtectionChecking(slug, authUser.accessToken, returning = true.pure[IO])
+      givenBranchProtectionChecking(slug,
+                                    authUser.accessToken,
+                                    returning = DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       val provisioningStatus = ProvisioningStatus.Unhealthy(EventStatus.GenerationNonRecoverableFailure)
       givenProvisioningStatusFinding(slug, returning = provisioningStatus.pure[IO])
@@ -119,7 +123,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val authUser = authUsers.generateOne
       val slug     = projectSlugs.generateOne
 
-      givenBranchProtectionChecking(slug, authUser.accessToken, returning = true.pure[IO])
+      givenBranchProtectionChecking(slug,
+                                    authUser.accessToken,
+                                    returning = DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       val exception = exceptions.generateOne
       givenProvisioningStatusFinding(slug, returning = exception.raiseError[IO, Nothing])
@@ -132,16 +139,43 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
     }
 
   it should "if core update needed, " +
-    "fail if pushing to the default branch check return false" in {
+    "fail if Core pushed the update to a branch different than the default " +
+    "but still update GL and TS" in {
 
       val authUser = authUsers.generateOne
       val slug     = projectSlugs.generateOne
 
-      givenBranchProtectionChecking(slug, authUser.accessToken, returning = false.pure[IO])
+      val defaultBranch = DefaultBranch.PushProtected(branches.generateOne).some
+      givenBranchProtectionChecking(slug, authUser.accessToken, returning = defaultBranch.pure[IO])
       givenProvisioningStatusFinding(slug, returning = ProvisioningStatus.Healthy.pure[IO])
-      val updates = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      updater.updateProject(slug, updates, authUser).assertThrowsError[Exception](_ shouldBe Failure.cannotPushToBranch)
+      val projectGitUrl = projectGitHttpUrls.generateOne
+      givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitUrl.some.pure[IO])
+      val userInfo = userInfos.generateOne
+      givenUserInfoFinding(authUser.accessToken, returning = userInfo.some.pure[IO])
+      val coreUri = coreUrisVersioned.generateOne
+      givenFindingCoreUri(projectGitUrl, authUser.accessToken, returning = Result.success(coreUri))
+
+      val updates        = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
+      val corePushBranch = branches.generateOne
+      givenUpdatingProjectInCore(
+        coreUri,
+        CoreProjectUpdates(projectGitUrl, userInfo, updates.newDescription, updates.newKeywords),
+        authUser.accessToken,
+        returning = resultSuccesses(corePushBranch).generateOne
+      )
+
+      val glUpdated = glUpdatedProjectsGen.generateSome
+      givenUpdatingProjectInGL(slug, updates, authUser.accessToken, returning = glUpdated.asRight.pure[IO])
+      val tgUpdates = tgUpdatesGen.generateOne
+      givenTGUpdatesCalculation(updates, glUpdated, defaultBranch, corePushBranch, returning = tgUpdates.pure[IO])
+      givenSendingUpdateToTG(slug, tgUpdates, returning = TriplesGeneratorClient.Result.success(()).pure[IO])
+
+      updater
+        .updateProject(slug, updates, authUser)
+        .assertThrowsError[Exception](
+          _ shouldBe Failure.corePushedToNonDefaultBranch(tgUpdates, defaultBranch, corePushBranch)
+        )
     }
 
   it should "if core update needed, " +
@@ -167,7 +201,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val slug     = projectSlugs.generateOne
       val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      givenPrerequisitesCheckFine(slug,
+                                  authUser.accessToken,
+                                  DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       val exception = exceptions.generateOne
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = exception.raiseError[IO, Nothing])
@@ -185,7 +222,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val slug     = projectSlugs.generateOne
       val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      givenPrerequisitesCheckFine(slug,
+                                  authUser.accessToken,
+                                  DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = None.pure[IO])
       givenUserInfoFinding(authUser.accessToken, returning = userInfos.generateSome.pure[IO])
@@ -202,7 +242,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val slug     = projectSlugs.generateOne
       val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      givenPrerequisitesCheckFine(slug,
+                                  authUser.accessToken,
+                                  DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitHttpUrls.generateSome.pure[IO])
       val exception = exceptions.generateOne
@@ -220,7 +263,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val slug     = projectSlugs.generateOne
       val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      givenPrerequisitesCheckFine(slug,
+                                  authUser.accessToken,
+                                  DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitHttpUrls.generateSome.pure[IO])
       givenUserInfoFinding(authUser.accessToken, returning = None.pure[IO])
@@ -237,7 +283,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val slug     = projectSlugs.generateOne
       val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      givenPrerequisitesCheckFine(slug,
+                                  authUser.accessToken,
+                                  DefaultBranch.Unprotected(branches.generateOne).some.pure[IO]
+      )
 
       val projectGitUrl = projectGitHttpUrls.generateOne
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitUrl.some.pure[IO])
@@ -252,13 +301,14 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
     }
 
   it should "if core update needed, " +
-    "log an error and succeed if updating renku core fails" in {
+    "fail if updating renku core fails" in {
 
       val authUser = authUsers.generateOne
       val slug     = projectSlugs.generateOne
       val updates  = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
 
-      givenPrerequisitesCheckFine(slug, authUser.accessToken)
+      val repoBranch = branches.generateOne
+      givenPrerequisitesCheckFine(slug, authUser.accessToken, DefaultBranch.Unprotected(repoBranch).some.pure[IO])
 
       val projectGitUrl = projectGitHttpUrls.generateOne
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitUrl.some.pure[IO])
@@ -274,15 +324,10 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
         authUser.accessToken,
         returning = failedResult
       )
-      val glUpdated = glUpdatedProjectsGen.generateSome
-      givenUpdatingProjectInGL(slug, updates, authUser.accessToken, returning = glUpdated.asRight.pure[IO])
-      val tgUpdates = tgUpdatesGen.generateOne
-      givenTGUpdatesCalculation(updates, glUpdated, returning = tgUpdates.pure[IO])
-      givenSendingUpdateToTG(slug, tgUpdates, returning = TriplesGeneratorClient.Result.success(()).pure[IO])
 
-      updater.updateProject(slug, updates, authUser).assertNoException >> {
-        logger.waitFor(Error(show"Updating project $slug failed", failedResult))
-      }
+      updater
+        .updateProject(slug, updates, authUser)
+        .assertThrowsError[Exception](_ shouldBe Failure.onCoreUpdate(slug, failedResult))
     }
 
   it should "fail if updating GL returns an error" in {
@@ -381,9 +426,12 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
                                                         tgUpdatesFinder
   )
 
-  private def givenPrerequisitesCheckFine(slug: projects.Slug, at: UserAccessToken) = {
+  private def givenPrerequisitesCheckFine(slug:      projects.Slug,
+                                          at:        UserAccessToken,
+                                          returning: IO[Option[DefaultBranch]]
+  ) = {
     givenProvisioningStatusFinding(slug, returning = ProvisioningStatus.Healthy.pure[IO])
-    givenBranchProtectionChecking(slug, at, returning = true.pure[IO])
+    givenBranchProtectionChecking(slug, at, returning = returning)
   }
 
   private def givenProvisioningStatusFinding(slug: projects.Slug, returning: IO[ProvisioningStatus]) =
@@ -391,8 +439,11 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       .expects(slug)
       .returning(returning)
 
-  private def givenBranchProtectionChecking(slug: projects.Slug, at: UserAccessToken, returning: IO[Boolean]) =
-    (branchProtectionCheck.canPushToDefaultBranch _)
+  private def givenBranchProtectionChecking(slug:      projects.Slug,
+                                            at:        UserAccessToken,
+                                            returning: IO[Option[DefaultBranch]]
+  ) =
+    (branchProtectionCheck.findDefaultBranchInfo _)
       .expects(slug, at)
       .returning(returning)
 
@@ -434,7 +485,7 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
   private def givenUpdatingProjectInCore(coreUri:   RenkuCoreUri.Versioned,
                                          updates:   CoreProjectUpdates,
                                          at:        UserAccessToken,
-                                         returning: Result[Unit]
+                                         returning: Result[Branch]
   ) = (renkuCoreClient.updateProject _)
     .expects(coreUri, updates, at)
     .returning(returning.pure[IO])
@@ -442,7 +493,18 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
   private def givenTGUpdatesCalculation(updates:               ProjectUpdates,
                                         maybeGLUpdatedProject: Option[GLUpdatedProject],
                                         returning:             IO[TGProjectUpdates]
-  ) = (tgUpdatesFinder.findTGProjectUpdates _)
+  ) = (tgUpdatesFinder
+    .findTGProjectUpdates(_: ProjectUpdates, _: Option[GLUpdatedProject]))
     .expects(updates, maybeGLUpdatedProject)
+    .returning(returning)
+
+  private def givenTGUpdatesCalculation(updates:               ProjectUpdates,
+                                        maybeGLUpdatedProject: Option[GLUpdatedProject],
+                                        maybeDefaultBranch:    Option[DefaultBranch],
+                                        corePushBranch:        Branch,
+                                        returning:             IO[TGProjectUpdates]
+  ) = (tgUpdatesFinder
+    .findTGProjectUpdates(_: ProjectUpdates, _: Option[GLUpdatedProject], _: Option[DefaultBranch], _: Branch))
+    .expects(updates, maybeGLUpdatedProject, maybeDefaultBranch, corePushBranch)
     .returning(returning)
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/TGUpdatesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/TGUpdatesFinderSpec.scala
@@ -20,75 +20,160 @@ package io.renku.knowledgegraph.projects.update
 
 import Generators._
 import cats.syntax.all._
+import io.renku.core.client.Generators.branches
 import io.renku.generators.Generators.Implicits._
 import io.renku.triplesgenerator.api.{ProjectUpdates => TGProjectUpdates}
 import org.scalatest.TryValues
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.util.Try
 
-class TGUpdatesFinderSpec extends AnyFlatSpec with should.Matchers with TryValues {
+class TGUpdatesFinderSpec extends AnyWordSpec with should.Matchers with TryValues with ScalaCheckPropertyChecks {
 
   private val updatesFinder = TGUpdatesFinder[Try]
   import updatesFinder.findTGProjectUpdates
 
-  it should "map values from the Project updates if no GL updated values given" in {
+  "findTGProjectUpdates - case without the Core update" should {
 
-    val updates = projectUpdatesGen.suchThat(_.newImage.isEmpty).generateOne
+    "fail if no info about GL updated project given" in {
 
-    findTGProjectUpdates(updates, maybeGLUpdatedProject = None).success.value shouldBe TGProjectUpdates(
-      newDescription = updates.newDescription,
-      newImages = None,
-      newKeywords = updates.newKeywords,
-      newVisibility = updates.newVisibility
-    )
+      val updates = projectUpdatesGen.suchThat(u => u.newImage.isEmpty && u.onlyGLUpdateNeeded).generateOne
+
+      findTGProjectUpdates(updates, maybeGLUpdatedProject = None).failure.exception.getMessage shouldBe
+        "No info about values updated in GL"
+    }
+
+    "merge the Project updates with the GL updated project " +
+      "if info about GL updated project given" in {
+
+        val updates   = projectUpdatesGen.suchThat(u => u.newImage.flatten.nonEmpty && u.onlyGLUpdateNeeded).generateOne
+        val glUpdated = glUpdatedProjectsGen.suchThat(_.image.nonEmpty).generateOne
+
+        findTGProjectUpdates(updates, glUpdated.some).success.value shouldBe TGProjectUpdates(
+          newDescription = None,
+          newImages = glUpdated.image.toList.some,
+          newKeywords = None,
+          newVisibility = updates.newVisibility
+        )
+      }
+
+    "fail if there's a new image update but GL updated values without the uri" in {
+
+      val updates   = projectUpdatesGen.suchThat(u => u.newImage.flatten.nonEmpty && u.onlyGLUpdateNeeded).generateOne
+      val glUpdated = glUpdatedProjectsGen.suchThat(_.image.isEmpty).generateSome
+
+      findTGProjectUpdates(updates, glUpdated).failure.exception.getMessage shouldBe
+        "Image not updated in GL"
+    }
+
+    "fail if there's an image deletion but GL updated project contains some uri" in {
+
+      val updates   = projectUpdatesGen.generateOne.copy(newImage = Some(None))
+      val glUpdated = glUpdatedProjectsGen.suchThat(_.image.nonEmpty).generateSome
+
+      findTGProjectUpdates(updates, glUpdated).failure.exception.getMessage shouldBe
+        "Image not deleted in GL"
+    }
   }
 
-  it should "map values from the Project updates taking the image uri from GL update" in {
+  "findTGProjectUpdates - case with the Core update" should {
 
-    val updates   = projectUpdatesGen.suchThat(_.newImage.flatten.nonEmpty).generateOne
-    val glUpdated = glUpdatedProjectsGen.suchThat(_.image.nonEmpty).generateOne
+    "fail there are GL updatable values " +
+      "but no info about GL updated project given" in {
 
-    findTGProjectUpdates(updates, glUpdated.some).success.value shouldBe TGProjectUpdates(
-      newDescription = updates.newDescription,
-      newImages = glUpdated.image.toList.some,
-      newKeywords = updates.newKeywords,
-      newVisibility = updates.newVisibility
-    )
-  }
+        val updates = projectUpdatesGen.suchThat(u => u.glUpdateNeeded && u.coreUpdateNeeded).generateOne
+        val branch  = branches.generateOne
 
-  it should "fail if there's a new image update but no GL updated values" in {
+        findTGProjectUpdates(updates,
+                             maybeGLUpdatedProject = None,
+                             maybeDefaultBranch = DefaultBranch.Unprotected(branch).some,
+                             corePushBranch = branch
+        ).failure.exception.getMessage shouldBe "No info about values updated in GL"
+      }
 
-    val updates = projectUpdatesGen.suchThat(_.newImage.flatten.nonEmpty).generateOne
+    "map the Core updatable values from the Project updates " +
+      "if there are only Core updatable values and " +
+      "it's confirmed Core pushed to the default branch" in {
 
-    findTGProjectUpdates(updates, maybeGLUpdatedProject = None).failure.exception.getMessage shouldBe
-      "No info about updated values in GL"
-  }
+        forAll(projectUpdatesGen.suchThat(_.coreUpdateNeeded).map(_.copy(newImage = None, newVisibility = None))) {
+          updates =>
+            val branch = branches.generateOne
 
-  it should "fail if there's a new image update but GL updated values without the uri" in {
+            findTGProjectUpdates(updates,
+                                 maybeGLUpdatedProject = None,
+                                 maybeDefaultBranch = DefaultBranch.Unprotected(branch).some,
+                                 corePushBranch = branch
+            ).success.value shouldBe TGProjectUpdates(
+              newDescription = updates.newDescription,
+              newImages = None,
+              newKeywords = updates.newKeywords,
+              newVisibility = None
+            )
+        }
+      }
 
-    val updates   = projectUpdatesGen.suchThat(_.newImage.flatten.nonEmpty).generateOne
-    val glUpdated = glUpdatedProjectsGen.suchThat(_.image.isEmpty).generateSome
+    "return an empty TG updates object " +
+      "if there are only Core updatable values and " +
+      "it's confirmed Core pushed to a non default branch" in {
 
-    findTGProjectUpdates(updates, glUpdated).failure.exception.getMessage shouldBe
-      "Image not updated in GL"
-  }
+        val updates = projectUpdatesGen
+          .suchThat(_.coreUpdateNeeded)
+          .map(_.copy(newImage = None, newVisibility = None))
+          .generateOne
+        val branch = branches.generateOne
 
-  it should "fail if there's an image deletion but no GL updated values" in {
+        DefaultBranch.PushProtected(branch).some :: Option.empty[DefaultBranch] :: Nil foreach { maybeDefaultBranch =>
+          findTGProjectUpdates(updates,
+                               maybeGLUpdatedProject = None,
+                               maybeDefaultBranch,
+                               corePushBranch = branch
+          ).success.value shouldBe TGProjectUpdates.empty
+        }
+      }
 
-    val updates = projectUpdatesGen.generateOne.copy(newImage = Some(None))
+    "merge the Project updates with the GL updated values " +
+      "when info about GL updated project given and " +
+      "it's confirmed Core pushed to the default branch" in {
 
-    findTGProjectUpdates(updates, maybeGLUpdatedProject = None).failure.exception.getMessage shouldBe
-      "No info about updated values in GL"
-  }
+        val updates   = projectUpdatesGen.suchThat(u => u.newImage.flatten.nonEmpty && u.coreUpdateNeeded).generateOne
+        val glUpdated = glUpdatedProjectsGen.suchThat(_.image.nonEmpty).generateOne
+        val branch    = branches.generateOne
 
-  it should "fail if there's an image deletion but GL updated values contain some uri" in {
+        findTGProjectUpdates(updates,
+                             glUpdated.some,
+                             maybeDefaultBranch = DefaultBranch.Unprotected(branch).some,
+                             corePushBranch = branch
+        ).success.value shouldBe TGProjectUpdates(
+          newDescription = updates.newDescription,
+          newImages = glUpdated.image.toList.some,
+          newKeywords = updates.newKeywords,
+          newVisibility = updates.newVisibility
+        )
+      }
 
-    val updates   = projectUpdatesGen.generateOne.copy(newImage = Some(None))
-    val glUpdated = glUpdatedProjectsGen.suchThat(_.image.nonEmpty).generateSome
+    "merge the Project updates with the GL updated values and " +
+      "clear the Core updatable values " +
+      "when info about GL updated project given and " +
+      "it's confirmed Core pushed to a non default branch" in {
 
-    findTGProjectUpdates(updates, glUpdated).failure.exception.getMessage shouldBe
-      "Image not deleted in GL"
+        val updates   = projectUpdatesGen.suchThat(u => u.newImage.flatten.nonEmpty && u.coreUpdateNeeded).generateOne
+        val glUpdated = glUpdatedProjectsGen.suchThat(_.image.nonEmpty).generateOne
+        val branch    = branches.generateOne
+
+        DefaultBranch.PushProtected(branch).some :: Option.empty[DefaultBranch] :: Nil foreach { maybeDefaultBranch =>
+          findTGProjectUpdates(updates,
+                               glUpdated.some,
+                               maybeDefaultBranch,
+                               corePushBranch = branch
+          ).success.value shouldBe TGProjectUpdates(
+            newDescription = None,
+            newImages = glUpdated.image.toList.some,
+            newKeywords = None,
+            newVisibility = updates.newVisibility
+          )
+        }
+      }
   }
 }

--- a/renku-core-client/src/main/scala/io/renku/core/client/RenkuCoreClient.scala
+++ b/renku-core-client/src/main/scala/io/renku/core/client/RenkuCoreClient.scala
@@ -36,7 +36,7 @@ trait RenkuCoreClient[F[_]] {
   def updateProject(coreUri:     RenkuCoreUri.Versioned,
                     updates:     ProjectUpdates,
                     accessToken: UserAccessToken
-  ): F[Result[Unit]]
+  ): F[Result[Branch]]
 }
 
 object RenkuCoreClient {
@@ -90,5 +90,5 @@ private class RenkuCoreClientImpl[F[_]: Async: Logger](coreUriForSchemaLoader: R
   override def updateProject(coreUri:     RenkuCoreUri.Versioned,
                              updates:     ProjectUpdates,
                              accessToken: UserAccessToken
-  ): F[Result[Unit]] = lowLevelApis.postProjectUpdate(coreUri, updates, accessToken)
+  ): F[Result[Branch]] = lowLevelApis.postProjectUpdate(coreUri, updates, accessToken)
 }

--- a/renku-core-client/src/main/scala/io/renku/core/client/model.scala
+++ b/renku-core-client/src/main/scala/io/renku/core/client/model.scala
@@ -34,3 +34,8 @@ object MigrationRequired extends TinyTypeFactory[MigrationRequired](new Migratio
   lazy val no:          MigrationRequired          = MigrationRequired(false)
   implicit val decoder: Decoder[MigrationRequired] = TinyTypeDecoders.booleanDecoder(MigrationRequired)
 }
+
+final class Branch private (val value: String) extends AnyVal with StringTinyType
+object Branch extends TinyTypeFactory[Branch](new Branch(_)) with NonBlank[Branch] {
+  implicit val decoder: Decoder[Branch] = TinyTypeDecoders.stringDecoder(Branch)
+}

--- a/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
@@ -43,6 +43,9 @@ object Generators {
   implicit lazy val migrationRequiredGen: Gen[MigrationRequired] =
     Gen.oneOf(MigrationRequired.yes, MigrationRequired.no)
 
+  implicit lazy val branches: Gen[Branch] =
+    nonEmptyStrings().toGeneratorOf(Branch)
+
   implicit lazy val coreLatestUris: Gen[RenkuCoreUri.Latest] =
     httpUrls().map(uri => RenkuCoreUri.Latest(Uri.unsafeFromString(uri)))
 

--- a/renku-core-client/src/test/scala/io/renku/core/client/LowLevelApisSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/LowLevelApisSpec.scala
@@ -115,6 +115,7 @@ class LowLevelApisSpec
 
       otherWireMockResource.evalMap { server =>
         val versionedUri = coreUrisVersioned(server.baseUri).generateOne
+        val remoteBranch = branches.generateOne
 
         server.stubFor {
           post(s"/renku/${versionedUri.apiVersion}/project.edit")
@@ -122,12 +123,12 @@ class LowLevelApisSpec
             .withAccessToken(accessToken.some)
             .withHeader("renku-user-email", equalTo(updates.userInfo.email.value))
             .withHeader("renku-user-fullname", equalTo(updates.userInfo.name.value))
-            .willReturn(ok(Result.success(json"""{"edited": {}}""").asJson.spaces2))
+            .willReturn(ok(Result.success(json"""{"edited": {}, "remote_branch": $remoteBranch}""").asJson.spaces2))
         }
 
         client
           .postProjectUpdate(versionedUri, updates, accessToken)
-          .asserting(_ shouldBe Result.success(()))
+          .asserting(_ shouldBe Result.success(remoteBranch))
       }.use_
     }
   }

--- a/renku-core-client/src/test/scala/io/renku/core/client/RenkuCoreClientSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/RenkuCoreClientSpec.scala
@@ -216,7 +216,7 @@ class RenkuCoreClientSpec
       val updates     = projectUpdatesGen.generateOne
       val accessToken = userAccessTokens.generateOne
 
-      val result = resultsGen(()).generateOne
+      val result = resultsGen(branches).generateOne
       givenPostingProjectUpdate(coreUri, updates, accessToken, returning = result)
 
       client.updateProject(coreUri, updates, accessToken).asserting(_ shouldBe result)
@@ -273,7 +273,7 @@ class RenkuCoreClientSpec
   private def givenPostingProjectUpdate(coreUri:     RenkuCoreUri.Versioned,
                                         updates:     ProjectUpdates,
                                         accessToken: UserAccessToken,
-                                        returning:   Result[Unit]
+                                        returning:   Result[Branch]
   ) = (lowLevelApis.postProjectUpdate _)
     .expects(coreUri, updates, accessToken)
     .returning(returning.pure[IO])

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/images/ImageUri.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/images/ImageUri.scala
@@ -18,9 +18,10 @@
 
 package io.renku.graph.model.images
 
+import cats.Show
 import cats.syntax.all._
-import io.circe.{Decoder, Encoder, Json}
 import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json}
 import io.renku.graph.model.views.TinyTypeJsonLDOps
 import io.renku.tinytypes._
 
@@ -62,4 +63,6 @@ object ImageUri extends From[ImageUri] with TinyTypeConversions[ImageUri] with T
   implicit lazy val decoder: Decoder[ImageUri] = Decoder.decodeString.emap { value =>
     (Relative.from(value) orElse Absolute.from(value)).leftMap(_ => s"Cannot decode $value to $ImageUri")
   }
+
+  implicit lazy val show: Show[ImageUri] = Show.show(_.value)
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -64,9 +64,9 @@ trait ProjectEntitiesGenerators {
   def creatorLens[P <: Project]: Lens[P, Option[Person]] =
     Lens[P, Option[Person]](_.maybeCreator) { maybeCreator =>
       _.fold(_.copy(maybeCreator = maybeCreator),
-        _.copy(maybeCreator = maybeCreator),
-        _.copy(maybeCreator = maybeCreator),
-        _.copy(maybeCreator = maybeCreator)
+             _.copy(maybeCreator = maybeCreator),
+             _.copy(maybeCreator = maybeCreator),
+             _.copy(maybeCreator = maybeCreator)
       ).asInstanceOf[P]
     }
 

--- a/triples-generator-api/src/main/scala/io/renku/triplesgenerator/api/ProjectUpdates.scala
+++ b/triples-generator-api/src/main/scala/io/renku/triplesgenerator/api/ProjectUpdates.scala
@@ -18,6 +18,7 @@
 
 package io.renku.triplesgenerator.api
 
+import cats.Show
 import cats.syntax.all._
 import io.circe.literal._
 import io.circe.syntax._
@@ -61,5 +62,18 @@ object ProjectUpdates {
       newKeywords   <- cur.downField("keywords").as[Option[List[projects.Keyword]]].map(_.map(_.toSet))
       newVisibility <- cur.downField("visibility").as[Option[projects.Visibility]]
     } yield ProjectUpdates(newDesc, newImages, newKeywords, newVisibility)
+  }
+
+  implicit val show: Show[ProjectUpdates] = Show.show {
+    case ProjectUpdates(newDescription, newImages, newKeywords, newVisibility) =>
+      def showOption[T](opt: Option[T])(implicit show: Show[T]) =
+        opt.fold(ifEmpty = "none")(_.show)
+
+      List(
+        newDescription.map(v => s"description=${showOption(v)}"),
+        newImages.map(v => s"image=[${v.mkString_(", ")}]"),
+        newKeywords.map(v => s"keywords=[${v.toList.mkString_(", ")}]"),
+        newVisibility.map(v => s"visibility=$v")
+      ).flatten.mkString(", ")
   }
 }


### PR DESCRIPTION
This PR modifies the Project Update API in a way that the call to update project metadata in the Core is not done asynchronously but synchronously. With the change, eventual problems on the Core side will be reported to the caller.

Another change regards projects with protected branches that Core cannot push to. In such cases, Project Update API returns `Conflict 409` status and updates only GL and TS but only with values that don't have to be passed to the Core. The values that need calling the Core are pushed by the Core to a new branch about the user is informed and for which the user needs to create a PR and merge it. An example response in this case will be:
```json
{
  "message": {
    "details": "Only visibility=public got updated in the TS due to branch protection rules on the default branch 'main'. However, an update commit was pushed to a new branch 'main/344422' which has to be merged to the default branch with a PR",
    "branch": "main/344422"
  }
}
```