### PR TITLE
feat: Integrate project auth graph into cross entity search

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -27,6 +27,7 @@ import io.renku.graph.model._
 import io.renku.graph.model.entities.Person
 import io.renku.graph.model.projects.Visibility
 import io.renku.http.server.security.model.AuthUser
+import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore.client.sparql.{Fragment, LuceneQuery, VarName}
 import io.renku.triplesstore.client.syntax._
 
@@ -113,7 +114,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
           |        ${namespacesPart(criteria.filters.namespaces)}
           |
           |        # access restriction
-          |        ${accessRightsAndVisibility(criteria.maybeUser, criteria.filters.visibilities)}
+          |        ${accessRightsAndVis(criteria.maybeUser, criteria.filters.visibilities)}
           |
           |        # slug and visibility
           |        $slugVisibility
@@ -144,6 +145,13 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
          |  BIND (CONCAT(STR(?projectSlug), STR(':'),
          |               STR(?visibility)) AS ?idSlugVisibility)
          |""".stripMargin
+
+  private def accessRightsAndVis(maybeUser: Option[AuthUser], visibilities: Set[Visibility]): Fragment =
+    sparql"""
+            |?projId renku:projectVisibility ?visibility .
+            |BIND (?projId AS ${SparqlSnippets.projectId})
+            |${SparqlSnippets.visibleProjects(maybeUser.map(_.id), visibilities)}
+            """
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[Visibility]): Fragment =
     maybeUser match {

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -148,7 +148,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
     sparql"""
             |$projectIdVar renku:projectVisibility $visibilityVar .
             |${SparqlSnippets.visibleProjects(maybeUser.map(_.id), visibilities)}
-              """
+              """.stripMargin
 
   private def namespacesPart(ns: Set[projects.Namespace]): Fragment = {
     val matchFrag =

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -26,7 +26,10 @@ import io.renku.entities.search.model.Entity.Workflow.WorkflowType
 import io.renku.entities.search.model.{Entity, MatchingScore}
 import io.renku.graph.model.entities.{CompositePlan, StepPlan}
 import io.renku.graph.model.{plans, projects}
-import io.renku.triplesstore.client.sparql.{LuceneQuery, VarName}
+import io.renku.http.server.security.model.AuthUser
+import io.renku.projectauth.util.SparqlSnippets
+import io.renku.triplesstore.client.sparql.{Fragment, LuceneQuery, VarName}
+import io.renku.triplesstore.client.syntax._
 
 private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
 
@@ -46,7 +49,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
   override def query(criteria: Criteria) = (criteria.filters whenRequesting entityType) {
     import criteria._
     // format: off
-    s"""|{
+    sparql"""|{
         |  SELECT ?entityType ?matchingScore ?wkId ?name ?date ?maybeDescription ?keywords ?projectIdVisibilities ?workflowTypes
         |  WHERE {
         |    {
@@ -61,6 +64,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |            (GROUP_CONCAT(DISTINCT ?projectIdWhereInvalidated; separator='|') AS ?projectsIdsWhereInvalidated)
         |          WHERE {
         |            ${filters.foldQuery(withQuerySnippet, withoutQuerySnippet)}
+        |            
         |            OPTIONAL {
         |              GRAPH ?childProjectId {
         |                ?childWkId prov:wasDerivedFrom ?wkId;
@@ -80,6 +84,8 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |        FILTER (IF (BOUND(?childProjectsIds), !CONTAINS(STR(?childProjectsIds), STR(?projectId)), true))
         |        FILTER (IF (BOUND(?projectsIdsWhereInvalidated), !CONTAINS(STR(?projectsIdsWhereInvalidated), STR(?projectId)), true))
         |
+        |        ${accessRightsAndVisibility(criteria.maybeUser, criteria.filters.visibilities)}
+        |
         |        GRAPH ?projectId {
         |          ?wkId a prov:Plan;
         |                a ?workflowType;
@@ -87,10 +93,10 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |                schema:dateCreated ?date;
         |                ^renku:hasPlan ?projectId.
         |          ?projectId renku:projectNamespace ?namespace.
-        |          ${criteria.maybeOnAccessRightsAndVisibility("?projectId", "?visibility")}
+        |          ?projectId renku:projectVisibility ?visibility.
         |          BIND (CONCAT(STR(?projectId), STR('::'), STR(?visibility)) AS ?projectIdVisibility)
-        |          ${filters.maybeOnNamespace("?namespace")}
-        |          ${filters.maybeOnDateCreated(VarName("date")).sparql}
+        |          ${filters.maybeOnNamespace(VarName("namespace"))}
+        |          ${filters.maybeOnDateCreated(VarName("date"))}
         |          OPTIONAL { ?wkId schema:description ?maybeDescription }
         |          OPTIONAL { ?wkId schema:keywords ?keyword }
         |        }
@@ -100,33 +106,36 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |    BIND ('workflow' AS ?entityType)
         |  }
         |}
-        |""".stripMargin
+        |""".stripMargin.sparql
     // format: on
   }
 
-  private def withoutQuerySnippet: String =
-    """
-      |BIND (xsd:float(1.0) AS ?matchingScore)
-      |GRAPH ?projectId {
-      |   ?wkId a prov:Plan;
-      |         ^renku:hasPlan ?projectId.
-      |}
-      |""".stripMargin
+  private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[projects.Visibility]): Fragment =
+    SparqlSnippets.visibleProjects(maybeUser.map(_.id), visibilities)
+
+  private def withoutQuerySnippet: Fragment =
+    sparql"""
+            |BIND (xsd:float(1.0) AS ?matchingScore)
+            |GRAPH ?projectId {
+            |   ?wkId a prov:Plan;
+            |         ^renku:hasPlan ?projectId.
+            |}
+            |""".stripMargin
 
   def withQuerySnippet(query: LuceneQuery) =
-    s"""
-       |{
-       |  SELECT ?wkId (MAX(?score) AS ?matchingScore) (SAMPLE(?projId) AS ?projectId)
-       |  WHERE {
-       |    (?wkId ?score) text:query (schema:name schema:keywords schema:description '${query.query}').
-       |    GRAPH ?g {
-       |      ?wkId a prov:Plan;
-       |            ^renku:hasPlan ?projId
-       |      }
-       |    }
-       |    GROUP BY ?wkId
-       |}
-       |""".stripMargin
+    sparql"""
+            |{
+            |  SELECT ?wkId (MAX(?score) AS ?matchingScore) (SAMPLE(?projId) AS ?projectId)
+            |  WHERE {
+            |    (?wkId ?score) text:query (schema:name schema:keywords schema:description $query).
+            |    GRAPH ?g {
+            |      ?wkId a prov:Plan;
+            |            ^renku:hasPlan ?projId
+            |      }
+            |    }
+            |    GROUP BY ?wkId
+            |}
+            |""".stripMargin
 
   override def decoder[EE >: Entity.Workflow]: Decoder[EE] = { implicit cursor =>
     import DecodingTools._

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -1218,5 +1218,27 @@ class EntitiesFinderSpec
         .addAllEntitiesFrom(privateProject)
         .sortBy(_.name)(nameOrdering)
     }
+
+    "not return private projects/datasets of different user" in new TestCase {
+      val otherMember = personEntities(
+        personGitLabIds.suchThat(id => !member.maybeGitLabId.contains(id)).toGeneratorOfSomes
+      ).generateOne
+      val results = IOBody {
+        provisionTestProjects(privateProject, internalProject, publicProject) >>
+          finder
+            .findEntities(
+              Criteria(maybeUser = otherMember.toAuthUser.some,
+                       paging = PagingRequest.default.copy(perPage = PerPage(50))
+              )
+            )
+      }
+      val expected = List
+        .empty[model.Entity]
+        .addAllEntitiesFrom(publicProject)
+        .addAllEntitiesFrom(internalProject)
+        .addAllPersonsFrom(privateProject)
+        .sortBy(_.name)(nameOrdering)
+      results.results shouldBe expected
+    }
   }
 }

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -1221,7 +1221,7 @@ class EntitiesFinderSpec
 
     "not return private projects/datasets of different user" in new TestCase {
       val otherMember = personEntities(
-        personGitLabIds.suchThat(id => !member.maybeGitLabId.contains(id)).toGeneratorOfSomes
+        personGitLabIds.suchThat(id => !member.person.maybeGitLabId.contains(id)).toGeneratorOfSomes
       ).generateOne
       val results = IOBody {
         provisionTestProjects(privateProject, internalProject, publicProject) >>

--- a/entities-search/src/test/scala/io/renku/entities/search/WorkflowsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/WorkflowsEntitiesFinderSpec.scala
@@ -22,6 +22,7 @@ import Criteria._
 import EntityConverters._
 import cats.syntax.all._
 import io.renku.entities.search.model.Entity.Workflow.WorkflowType
+import io.renku.entities.searchgraphs.SearchInfoDatasets
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model._
@@ -40,6 +41,7 @@ class WorkflowsEntitiesFinderSpec
     with FinderSpecOps
     with InMemoryJenaForSpec
     with ProjectsDataset
+    with SearchInfoDatasets
     with IOSpec {
 
   "findEntities - in case of a forks with workflows" should {
@@ -51,7 +53,7 @@ class WorkflowsEntitiesFinderSpec
         .forkOnce()
       val plan :: Nil = fork.plans
 
-      upload(to = projectsDataset, original, fork)
+      provisionTestProjects(original, fork).unsafeRunSync()
 
       val results = finder
         .findEntities(Criteria(Filters(entityTypes = Set(Filters.EntityType.Workflow))))
@@ -80,7 +82,7 @@ class WorkflowsEntitiesFinderSpec
       }
       val plan :: Nil = publicProject.plans
 
-      upload(to = projectsDataset, original, fork)
+      provisionTestProjects(original, fork).unsafeRunSync()
 
       finder
         .findEntities(
@@ -106,7 +108,7 @@ class WorkflowsEntitiesFinderSpec
       }
       val plan :: Nil = internalProject.plans
 
-      upload(to = projectsDataset, original, fork)
+      provisionTestProjects(original, fork).unsafeRunSync()
 
       finder
         .findEntities(
@@ -127,7 +129,7 @@ class WorkflowsEntitiesFinderSpec
         .generateOne
       val plan :: Nil = privateProject.plans
 
-      upload(to = projectsDataset, privateProject)
+      provisionTestProjects(privateProject).unsafeRunSync()
 
       finder
         .findEntities(
@@ -152,7 +154,7 @@ class WorkflowsEntitiesFinderSpec
         p.addUnlinkedStepPlan(p.stepPlans.head.invalidate())
       }
 
-      upload(to = projectsDataset, project)
+      provisionTestProjects(project).unsafeRunSync()
 
       finder
         .findEntities(Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Workflow))))
@@ -170,7 +172,7 @@ class WorkflowsEntitiesFinderSpec
           .generateOne
           .addCompositePlan(CreateCompositePlan(compositePlanEntities(personEntities, _)))
 
-      upload(to = projectsDataset, project)
+      provisionTestProjects(project).unsafeRunSync()
 
       val results = finder
         .findEntities(Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Workflow))))

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
@@ -69,7 +69,7 @@ trait SearchInfoDatasets {
     implicit val sparqlQueryTimeRecorder: SparqlQueryTimeRecorder[IO] =
       new SparqlQueryTimeRecorder[IO](execTimeRecorder)
     val ps      = ProjectSparqlClient[IO](projectsDSConnectionInfo).map(ProjectAuthService[IO](_, renkuUrl))
-    val members = project.members.flatMap(p => p.maybeGitLabId.map(id => ProjectMember(id, Role.Reader)))
+    val members = project.members.flatMap(p => p.person.maybeGitLabId.map(id => ProjectMember(id, Role.Reader)))
     ps.use(_.update(ProjectAuthData(project.slug, members, project.visibility)))
   }
 

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.projectauth.util
 
 import cats.syntax.all._

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -19,7 +19,7 @@
 package io.renku.projectauth.util
 
 import cats.syntax.all._
-import io.renku.graph.model.persons
+import io.renku.graph.model.{persons, projects}
 import io.renku.graph.model.projects.Visibility
 import io.renku.projectauth.ProjectAuth
 import io.renku.triplesstore.client.sparql.{Fragment, VarName}
@@ -28,6 +28,17 @@ import io.renku.triplesstore.client.syntax._
 object SparqlSnippets {
   val projectId         = VarName("projectId")
   val projectVisibility = VarName("projectVisibility")
+
+  def changeVisibility(slug: projects.Slug, newValue: projects.Visibility): Fragment =
+    sparql"""|DELETE { GRAPH ${ProjectAuth.graph} { ?id renku:visibility ?visibility } }
+             |INSERT { GRAPH ${ProjectAuth.graph} { ?id renku:visibility ${newValue.asObject} } }
+             |WHERE {
+             |  GRAPH ${ProjectAuth.graph} {
+             |    ?id a schema:Project;
+             |        renku:slug ${slug.asObject};
+             |        renku:visibility ?visibility.
+             |  }
+             |}""".stripMargin
 
   def visibleProjects(userId: Option[persons.GitLabId], selectedVisibility: Set[Visibility]): Fragment = {
     val visibilities =

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -17,11 +17,13 @@ object SparqlSnippets {
       else selectedVisibility
 
     val parts = visibilities.map(visibilityFragment(userId)).filter(_.nonEmpty)
-    val union = parts.toList.foldSmash(sparql"{ ", sparql" } UNION { ", sparql" }")
+    val inner =
+      if (parts.isEmpty) sparql"""VALUES ($projectId) {}"""
+      else parts.toList.foldSmash(sparql"{ ", sparql" } UNION { ", sparql" }")
     sparql"""
             |Graph ${ProjectAuth.graph} {
             |  $projectId a schema:Project.
-            |  $union
+            |  $inner
             |}
             |""".stripMargin
   }

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -1,0 +1,49 @@
+package io.renku.projectauth.util
+
+import cats.syntax.all._
+import io.renku.graph.model.persons
+import io.renku.graph.model.projects.Visibility
+import io.renku.projectauth.ProjectAuth
+import io.renku.triplesstore.client.sparql.{Fragment, VarName}
+import io.renku.triplesstore.client.syntax._
+
+object SparqlSnippets {
+  val projectId         = VarName("projectId")
+  val projectVisibility = VarName("projectVisibility")
+
+  def visibleProjects(userId: Option[persons.GitLabId], selectedVisibility: Set[Visibility]): Fragment = {
+    val visibilities =
+      if (selectedVisibility.isEmpty) Visibility.all
+      else selectedVisibility
+
+    val parts = visibilities.map(visibilityFragment(userId)).filter(_.nonEmpty)
+    val union = parts.toList.foldSmash(sparql"{ ", sparql" } UNION { ", sparql" }")
+    sparql"""
+            |Graph ${ProjectAuth.graph} {
+            |  $projectId a schema:Project.
+            |  $union
+            |}
+            |""".stripMargin
+  }
+
+  private def visibilityFragment(userId: Option[persons.GitLabId])(v: Visibility) = v match {
+    case Visibility.Public => publicProjects
+    case Visibility.Internal =>
+      if (userId.isDefined) internalProjects
+      else Fragment.empty
+    case Visibility.Private =>
+      userId.map(privateProjects).getOrElse(Fragment.empty)
+  }
+
+  private def publicProjects: Fragment =
+    sparql"$projectId renku:visibility ${Visibility.Public.value}."
+
+  private def internalProjects: Fragment =
+    sparql"$projectId renku:visibility ${Visibility.Internal.value}."
+
+  private def privateProjects(user: persons.GitLabId): Fragment =
+    sparql"""
+            |$projectId renku:visibility ${Visibility.Private.value};
+            |           renku:memberId ${user.value}.
+            |""".stripMargin
+}

--- a/project-auth/src/test/scala/io/renku/projectauth/Generators.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/Generators.scala
@@ -42,7 +42,7 @@ object Generators {
 
   final case class ProjectAuthDataBuilder(
       slug:       Gen[Slug] = RenkuTinyTypeGenerators.projectSlugs,
-      members:    Gen[Set[ProjectMember]] = Gen.choose(0, 150).flatMap(n => Gen.listOfN(n, memberGen)).map(_.toSet),
+      members:    Gen[Set[ProjectMember]] = Gen.choose(1, 150).flatMap(n => Gen.listOfN(n, memberGen)).map(_.toSet),
       visibility: Gen[Visibility] = RenkuTinyTypeGenerators.projectVisibilities
   ) {
     def withMembers(members: (Int, Role)*): ProjectAuthDataBuilder =

--- a/project-auth/src/test/scala/io/renku/projectauth/ProjectAuthServiceSupport.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/ProjectAuthServiceSupport.scala
@@ -39,8 +39,11 @@ trait ProjectAuthServiceSupport extends JenaContainerSupport { self: Suite =>
       L:        Logger[IO]
   ) =
     withProjectAuthService.flatMap { s =>
-      val genData = data.toIO.compile.toList
-      val insert  = genData.flatMap(d => Stream.emits(d).through(s.updateAll).compile.drain.as(d))
-      Resource.eval(insert).map(data => (s, data))
+      Resource.eval(insertData(s, data)).map(data => (s, data))
     }
+
+  def insertData(s: ProjectAuthService[IO], data: Stream[Gen, ProjectAuthData]) = {
+    val genData = data.toIO.compile.toList
+    genData.flatMap(d => Stream.emits(d).through(s.updateAll).compile.drain.as(d))
+  }
 }

--- a/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
@@ -7,10 +7,9 @@ import fs2.Stream
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.projects.Visibility
 import io.renku.graph.model.{RenkuUrl, Schemas, persons}
-import io.renku.projectauth.{Generators, ProjectAuth, ProjectAuthService, ProjectAuthServiceSupport}
+import io.renku.projectauth.{Generators, ProjectAuth, ProjectAuthData, ProjectAuthService, ProjectAuthServiceSupport}
 import io.renku.triplesstore.client.sparql.Fragment
 import io.renku.triplesstore.client.syntax._
-import org.scalacheck.Gen
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should
 import org.typelevel.log4cats.Logger
@@ -31,13 +30,14 @@ class SparqlSnippetsSpec extends AsyncFlatSpec with AsyncIOSpec with ProjectAuth
             |
             |SELECT ?slug ?visibility ?memberRole
             |WHERE {
-            |  $snippet
             |  Graph ${ProjectAuth.graph} {
-            |    ${SparqlSnippets.projectId} a schema:Project;
+            |     ${SparqlSnippets.projectId} a schema:Project;
             |         renku:visibility ?visibility;
             |         renku:slug ?slug;
             |         renku:memberRole ?memberRole.
             |  }
+            |
+            |  $snippet
             |}
             |ORDER BY ?slug
             |""".stripMargin
@@ -60,15 +60,8 @@ class SparqlSnippetsSpec extends AsyncFlatSpec with AsyncIOSpec with ProjectAuth
 
   it should "select public and internal if a user is given that is no member" in {
     clientAndData.use { case (client, data) =>
-      val userIds = data.flatMap(x => x.members).map(_.gitLabId.value)
       for {
-        nonExistingUser <- IO {
-                             Gen
-                               .oneOf(1000 to 100000)
-                               .suchThat(id => !userIds.contains(id))
-                               .map(persons.GitLabId(_))
-                               .generateOne
-                           }
+        nonExistingUser <- IO(selectUserNotIn(data).generateOne)
         nonPrivate = data.filter(p => p.visibility != Visibility.Private)
         r <- client.queryDecode[ProjectAuthDataRow](
                selectFragment(SparqlSnippets.visibleProjects(nonExistingUser.some, Visibility.all))
@@ -80,19 +73,81 @@ class SparqlSnippetsSpec extends AsyncFlatSpec with AsyncIOSpec with ProjectAuth
 
   it should "select projects where user is member and public/internal" in {
     clientAndData.use { case (client, data) =>
-      val userIds = data.flatMap(x => x.members).map(_.gitLabId).toSet
       for {
-        existingUser <- IO(Gen.oneOf(userIds).generateOne)
-        myPrivateProj =
-          data.filter(p => p.visibility == Visibility.Private && p.members.map(_.gitLabId).contains(existingUser))
+        existingUser <- IO(selectUserFrom(data).generateOne)
         r <- client.queryDecode[ProjectAuthDataRow](
                selectFragment(SparqlSnippets.visibleProjects(existingUser.some, Visibility.all))
              )
         _ = r.map(_.visibility).max shouldBe data.map(_.visibility).max
 
-        found = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
-        _     = found.filter(_.visibility == Visibility.Private).toSet shouldBe myPrivateProj.toSet
+        expected = data.filter(projectFilter(existingUser.some, Visibility.all)).sortBy(_.slug)
+        found    = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
+        _        = found shouldBe expected
       } yield ()
     }
   }
+
+  it should "select no projects if given visibilities results in empty constraints" in {
+    val internal: Set[Visibility] = Set(Visibility.Internal)
+    clientAndData.use { case (client, _) =>
+      for {
+        r <- client.queryDecode[ProjectAuthDataRow](
+               selectFragment(SparqlSnippets.visibleProjects(None, internal))
+             )
+        _ = r shouldBe Nil
+      } yield ()
+    }
+  }
+
+  it should "select public projects if no visibilities and no user are given" in {
+    clientAndData.use { case (client, data) =>
+      for {
+        r <- client.queryDecode[ProjectAuthDataRow](
+               selectFragment(SparqlSnippets.visibleProjects(None, Set.empty))
+             )
+        expected = data.filter(projectFilter(None, Visibility.all)).sortBy(_.slug)
+        found    = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
+        _        = found                         shouldBe expected
+        _        = found.map(_.visibility).toSet shouldBe Set(Visibility.Public)
+      } yield ()
+    }
+  }
+
+  it should "select all possible projects if no visibilities are given" in {
+    clientAndData.use { case (client, data) =>
+      for {
+        user <- IO(selectUserFrom(data).generateSome)
+        r <- client.queryDecode[ProjectAuthDataRow](
+               selectFragment(SparqlSnippets.visibleProjects(user, Set.empty))
+             )
+        expected = data.filter(projectFilter(user, Visibility.all)).sortBy(_.slug)
+        found    = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
+        _        = found shouldBe expected
+      } yield ()
+    }
+  }
+
+  val allVisibilities =
+    (Visibility.all.map(Set(_)) ++ Visibility.all.toList.permutations.map(_.tail.toSet)) ++ Set(Visibility.all)
+
+  allVisibilities.foreach { givenVisibility =>
+    it should s"select projects with given visibility $givenVisibility" in {
+      clientAndData.use { case (client, data) =>
+        for {
+          existingUser <- IO(selectUserFrom(data).generateSome)
+          r <- client.queryDecode[ProjectAuthDataRow](
+                 selectFragment(SparqlSnippets.visibleProjects(existingUser, givenVisibility))
+               )
+          expected = data.filter(projectFilter(existingUser, givenVisibility)).sortBy(_.slug)
+          found    = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
+          _        = found shouldBe expected
+        } yield ()
+      }
+    }
+  }
+
+  def projectFilter(user: Option[persons.GitLabId], givenVisibility: Set[Visibility])(p: ProjectAuthData): Boolean =
+    givenVisibility.contains(p.visibility) &&
+      (p.visibility != Visibility.Internal || user.isDefined) &&
+      (p.visibility != Visibility.Private || user.exists(id => p.members.map(_.gitLabId).contains(id)))
 }

--- a/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
@@ -1,0 +1,98 @@
+package io.renku.projectauth.util
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import fs2.Stream
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.projects.Visibility
+import io.renku.graph.model.{RenkuUrl, Schemas, persons}
+import io.renku.projectauth.{Generators, ProjectAuth, ProjectAuthService, ProjectAuthServiceSupport}
+import io.renku.triplesstore.client.sparql.Fragment
+import io.renku.triplesstore.client.syntax._
+import org.scalacheck.Gen
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+class SparqlSnippetsSpec extends AsyncFlatSpec with AsyncIOSpec with ProjectAuthServiceSupport with should.Matchers {
+
+  implicit val logger:   Logger[IO] = Slf4jLogger.getLogger[IO]
+  implicit val renkuUrl: RenkuUrl   = RenkuUrl("http://localhost/renku")
+
+  override val datasetName = "sparqlsnippetspec"
+
+  def randomData(num: Int) = Generators.projectAuthDataGen.asStream.take(num)
+
+  def selectFragment(snippet: Fragment) =
+    sparql"""${"renku" -> Schemas.renku}
+            |${"schema" -> Schemas.schema}
+            |
+            |SELECT ?slug ?visibility ?memberRole
+            |WHERE {
+            |  $snippet
+            |  Graph ${ProjectAuth.graph} {
+            |    ${SparqlSnippets.projectId} a schema:Project;
+            |         renku:visibility ?visibility;
+            |         renku:slug ?slug;
+            |         renku:memberRole ?memberRole.
+            |  }
+            |}
+            |ORDER BY ?slug
+            |""".stripMargin
+
+  def clientAndData = withDataset(datasetName).evalMap { sc =>
+    val pa = ProjectAuthService(sc, renkuUrl)
+    insertData(pa, randomData(10)).map(data => (sc, data))
+  }
+
+  it should "select public projects if no user is given" in {
+    clientAndData.use { case (client, _) =>
+      for {
+        r <- client.queryDecode[ProjectAuthDataRow](
+               selectFragment(SparqlSnippets.visibleProjects(None, Visibility.all))
+             )
+        _ = r.map(_.visibility).toSet shouldBe Set(Visibility.Public)
+      } yield ()
+    }
+  }
+
+  it should "select public and internal if a user is given that is no member" in {
+    clientAndData.use { case (client, data) =>
+      val userIds = data.flatMap(x => x.members).map(_.gitLabId.value)
+      for {
+        nonExistingUser <- IO {
+                             Gen
+                               .oneOf(1000 to 100000)
+                               .suchThat(id => !userIds.contains(id))
+                               .map(persons.GitLabId(_))
+                               .generateOne
+                           }
+        nonPrivate = data.filter(p => p.visibility != Visibility.Private)
+        r <- client.queryDecode[ProjectAuthDataRow](
+               selectFragment(SparqlSnippets.visibleProjects(nonExistingUser.some, Visibility.all))
+             )
+        _ = r.map(_.visibility).max shouldBe nonPrivate.map(_.visibility).max
+      } yield ()
+    }
+  }
+
+  it should "select projects where user is member and public/internal" in {
+    clientAndData.use { case (client, data) =>
+      val userIds = data.flatMap(x => x.members).map(_.gitLabId).toSet
+      for {
+        existingUser <- IO(Gen.oneOf(userIds).generateOne)
+        myPrivateProj =
+          data.filter(p => p.visibility == Visibility.Private && p.members.map(_.gitLabId).contains(existingUser))
+        r <- client.queryDecode[ProjectAuthDataRow](
+               selectFragment(SparqlSnippets.visibleProjects(existingUser.some, Visibility.all))
+             )
+        _ = r.map(_.visibility).max shouldBe data.map(_.visibility).max
+
+        found = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
+        _     = found.filter(_.visibility == Visibility.Private).toSet shouldBe myPrivateProj.toSet
+      } yield ()
+    }
+  }
+}

--- a/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.projectauth.util
 
 import cats.effect.IO

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/Microservice.scala
@@ -106,7 +106,7 @@ object Microservice extends IOMicroservice {
     awaitingGenerationSubscription <- awaitinggeneration.SubscriptionFactory[IO]
     membersSyncSubscription        <- membersync.SubscriptionFactory[IO](tsWriteLock, projectSparqlClient)
     triplesGeneratedSubscription   <- triplesgenerated.SubscriptionFactory[IO](tsWriteLock, projectSparqlClient)
-    cleanUpSubscription            <- cleanup.SubscriptionFactory[IO](tsWriteLock)
+    cleanUpSubscription            <- cleanup.SubscriptionFactory[IO](tsWriteLock, projectSparqlClient)
     minProjectInfoSubscription     <- minprojectinfo.SubscriptionFactory[IO](tsWriteLock, projectSparqlClient)
     migrationRequestSubscription   <- tsmigrationrequest.SubscriptionFactory[IO](config)
     syncRepoMetadataSubscription   <- syncrepometadata.SubscriptionFactory[IO](config, tsWriteLock)

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/cleanup/SubscriptionFactory.scala
@@ -23,23 +23,25 @@ import cats.syntax.all._
 import io.renku.events.consumers
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.events.consumers.subscriptions.SubscriptionPayloadComposer.defaultSubscriptionPayloadComposerFactory
+import io.renku.graph.model.RenkuUrl
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.Microservice
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
-import io.renku.triplesstore.SparqlQueryTimeRecorder
+import io.renku.triplesstore.{ProjectSparqlClient, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 
 object SubscriptionFactory {
   def apply[F[_]: Async: ReProvisioningStatus: Logger: MetricsRegistry: SparqlQueryTimeRecorder](
-      tsWriteLock: TsWriteLock[F]
-  ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
+      tsWriteLock:         TsWriteLock[F],
+      projectSparqlClient: ProjectSparqlClient[F]
+  )(implicit renkuUrl: RenkuUrl): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     subscriptionMechanism <-
       SubscriptionMechanism(
         categoryName,
         defaultSubscriptionPayloadComposerFactory(Microservice.ServicePort, Microservice.Identifier)
       )
     _       <- ReProvisioningStatus[F].registerForNotification(subscriptionMechanism)
-    handler <- EventHandler(subscriptionMechanism, tsWriteLock)
+    handler <- EventHandler(subscriptionMechanism, tsWriteLock, projectSparqlClient)
   } yield handler -> subscriptionMechanism
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/SubscriptionFactory.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/SubscriptionFactory.scala
@@ -24,13 +24,14 @@ import cats.syntax.all._
 import io.renku.events.consumers
 import io.renku.events.consumers.subscriptions.SubscriptionMechanism
 import io.renku.events.consumers.subscriptions.SubscriptionPayloadComposer.defaultSubscriptionPayloadComposerFactory
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.tokenrepository.AccessTokenFinder
 import io.renku.http.client.GitLabClient
 import io.renku.metrics.MetricsRegistry
 import io.renku.triplesgenerator.Microservice
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.reprovisioning.ReProvisioningStatus
-import io.renku.triplesstore.SparqlQueryTimeRecorder
+import io.renku.triplesstore.{ProjectSparqlClient, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 
 object SubscriptionFactory {
@@ -38,14 +39,15 @@ object SubscriptionFactory {
   def apply[F[
       _
   ]: Async: NonEmptyParallel: Parallel: ReProvisioningStatus: GitLabClient: AccessTokenFinder: MetricsRegistry: Logger: SparqlQueryTimeRecorder](
-      tsWriteLock: TsWriteLock[F]
-  ): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
+      tsWriteLock:         TsWriteLock[F],
+      projectSparqlClient: ProjectSparqlClient[F]
+  )(implicit renkuUrl: RenkuUrl): F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     subscriptionMechanism <-
       SubscriptionMechanism(
         categoryName,
         defaultSubscriptionPayloadComposerFactory(Microservice.ServicePort, Microservice.Identifier)
       )
     _       <- ReProvisioningStatus[F].registerForNotification(subscriptionMechanism)
-    handler <- EventHandler[F](subscriptionMechanism, tsWriteLock)
+    handler <- EventHandler[F](subscriptionMechanism, tsWriteLock, projectSparqlClient)
   } yield handler -> subscriptionMechanism
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/create/Endpoint.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/create/Endpoint.scala
@@ -23,9 +23,10 @@ import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.data.Message
+import io.renku.graph.model.RenkuUrl
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.api.NewProject
-import io.renku.triplesstore.SparqlQueryTimeRecorder
+import io.renku.triplesstore.{ProjectSparqlClient, SparqlQueryTimeRecorder}
 import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.{Request, Response}
@@ -36,8 +37,11 @@ trait Endpoint[F[_]] {
 }
 
 object Endpoint {
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](tsWriteLock: TsWriteLock[F]): F[Endpoint[F]] =
-    ProjectCreator[F](tsWriteLock).map(new EndpointImpl[F](_))
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      tsWriteLock:         TsWriteLock[F],
+      projectSparqlClient: ProjectSparqlClient[F]
+  )(implicit renkuUrl: RenkuUrl): F[Endpoint[F]] =
+    ProjectCreator[F](tsWriteLock, projectSparqlClient).map(new EndpointImpl[F](_))
 }
 
 private class EndpointImpl[F[_]: Async: Logger](projectCreator: ProjectCreator[F])

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/create/ProjectCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/create/ProjectCreator.scala
@@ -21,12 +21,13 @@ package io.renku.triplesgenerator.projects.create
 import cats.effect.Async
 import cats.effect.kernel.MonadCancelThrow
 import cats.syntax.all._
+import io.renku.graph.model.RenkuUrl
 import io.renku.triplesgenerator.TgLockDB.TsWriteLock
 import io.renku.triplesgenerator.api.NewProject
 import io.renku.triplesgenerator.projects.ProjectExistenceChecker
 import io.renku.triplesgenerator.tsprovisioning.TSProvisioner
 import io.renku.triplesgenerator.tsprovisioning.triplesuploading.TriplesUploadResult
-import io.renku.triplesstore.{ProjectsConnectionConfig, SparqlQueryTimeRecorder}
+import io.renku.triplesstore.{ProjectSparqlClient, ProjectsConnectionConfig, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 
 private trait ProjectCreator[F[_]] {
@@ -34,11 +35,14 @@ private trait ProjectCreator[F[_]] {
 }
 
 private object ProjectCreator {
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](tsWriteLock: TsWriteLock[F]): F[ProjectCreator[F]] =
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      tsWriteLock:         TsWriteLock[F],
+      projectSparqlClient: ProjectSparqlClient[F]
+  )(implicit renkuUrl: RenkuUrl): F[ProjectCreator[F]] =
     for {
       connectionConfig <- ProjectsConnectionConfig[F]()
       payloadConverter <- PayloadConverter[F]
-      tsProvisioner    <- TSProvisioner[F]
+      tsProvisioner    <- TSProvisioner[F](projectSparqlClient)
     } yield new ProjectCreatorImpl[F](ProjectExistenceChecker[F](connectionConfig),
                                       payloadConverter,
                                       tsProvisioner,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/UpdateQueriesCalculator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/UpdateQueriesCalculator.scala
@@ -26,7 +26,6 @@ import io.renku.graph.model.Schemas.{rdf, renku, schema}
 import io.renku.graph.model.images.{Image, ImageUri}
 import io.renku.graph.model.{GraphClass, RenkuUrl, projects}
 import io.renku.jsonld.syntax._
-import io.renku.projectauth.ProjectAuth
 import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesgenerator.api.ProjectUpdates
 import io.renku.triplesstore.SparqlQuery

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/UpdateQueriesCalculator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/UpdateQueriesCalculator.scala
@@ -26,6 +26,8 @@ import io.renku.graph.model.Schemas.{rdf, renku, schema}
 import io.renku.graph.model.images.{Image, ImageUri}
 import io.renku.graph.model.{GraphClass, RenkuUrl, projects}
 import io.renku.jsonld.syntax._
+import io.renku.projectauth.ProjectAuth
+import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesgenerator.api.ProjectUpdates
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
@@ -224,8 +226,16 @@ private class UpdateQueriesCalculatorImpl[F[_]: Applicative: Logger](implicit ru
 
   private def visibilityUpdates(slug: projects.Slug, newValue: projects.Visibility): List[SparqlQuery] = List(
     visibilityInProjectUpdate(slug, newValue),
-    visibilityInProjectsUpdate(slug, newValue)
+    visibilityInProjectsUpdate(slug, newValue),
+    visibilityInProjectAuthUpdate(slug, newValue)
   )
+
+  private def visibilityInProjectAuthUpdate(slug: projects.Slug, newValue: projects.Visibility) =
+    SparqlQuery.ofUnsafe(
+      show"$reportingPrefix: update visibility in ProjectAuth",
+      Prefixes of (renku -> "renku", schema -> "schema"),
+      SparqlSnippets.changeVisibility(slug, newValue)
+    )
 
   private def visibilityInProjectUpdate(slug: projects.Slug, newValue: projects.Visibility) =
     SparqlQuery.ofUnsafe(

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/TSProvisioner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/TSProvisioner.scala
@@ -20,8 +20,9 @@ package io.renku.triplesgenerator.tsprovisioning
 
 import cats.effect.Async
 import cats.syntax.all._
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.entities.Project
-import io.renku.triplesstore.SparqlQueryTimeRecorder
+import io.renku.triplesstore.{ProjectSparqlClient, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 import transformation.TransformationStepsCreator
 import triplesuploading.{TransformationStepsRunner, TriplesUploadResult}
@@ -31,8 +32,10 @@ trait TSProvisioner[F[_]] {
 }
 
 object TSProvisioner {
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[TSProvisioner[F]] =
-    (TransformationStepsCreator[F], TransformationStepsRunner[F])
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      projectSparqlClient: ProjectSparqlClient[F]
+  )(implicit renkuUrl: RenkuUrl): F[TSProvisioner[F]] =
+    (TransformationStepsCreator[F], TransformationStepsRunner[F](projectSparqlClient))
       .mapN(new TSProvisionerImpl[F](_, _))
 }
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunner.scala
@@ -96,7 +96,7 @@ private class TransformationStepsRunnerImpl[F[_]: MonadThrow](
       project.visibility
     )
     EitherT
-      .rightT[F, ProcessingRecoverableError](
+      .liftF[F, ProcessingRecoverableError, Unit](
         projectAuthSync.syncProject(authData)
       )
       .map(_ => (project, queries))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunner.scala
@@ -47,7 +47,8 @@ private class TransformationStepsRunnerImpl[F[_]: MonadThrow](
       executeAllPreDataUploadQueries >>=
       encodeAndSendProject >>=
       executeAllPostDataUploadQueries >>=
-      provisionSearchGraphs
+      provisionSearchGraphs >>=
+      provisionProjectAuthGraph
   }
     .leftMap(RecoverableFailure)
     .map(_ => DeliverySuccess)
@@ -83,6 +84,9 @@ private class TransformationStepsRunnerImpl[F[_]: MonadThrow](
     case projectAndQueries @ (project, _) =>
       searchGraphsProvisioner.provisionSearchGraphs(project).map(_ => projectAndQueries)
   }
+
+  private def provisionProjectAuthGraph: ((Project, Queries)) => ProjectWithQueries[F] =
+    ???
 
   private def execute(queries: List[SparqlQuery]): EitherT[F, ProcessingRecoverableError, Unit] =
     queries.foldLeft(EitherT.rightT[F, ProcessingRecoverableError](())) { (previousResult, query) =>

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunner.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunner.scala
@@ -23,10 +23,13 @@ import cats.MonadThrow
 import cats.data.EitherT
 import cats.effect.Async
 import cats.syntax.all._
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.entities.Project
+import io.renku.projectauth.{ProjectAuthData, ProjectMember}
 import io.renku.triplesgenerator.errors.ProcessingRecoverableError
+import io.renku.triplesgenerator.events.consumers.membersync.ProjectAuthSync
 import io.renku.triplesgenerator.tsprovisioning.TransformationStep.{ProjectWithQueries, Queries}
-import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import io.renku.triplesstore.{ProjectSparqlClient, SparqlQuery, SparqlQueryTimeRecorder}
 import org.typelevel.log4cats.Logger
 
 import scala.util.control.NonFatal
@@ -37,7 +40,8 @@ private[tsprovisioning] trait TransformationStepsRunner[F[_]] {
 
 private class TransformationStepsRunnerImpl[F[_]: MonadThrow](
     resultsUploader:         TransformationResultsUploader[F],
-    searchGraphsProvisioner: SearchGraphsProvisioner[F]
+    searchGraphsProvisioner: SearchGraphsProvisioner[F],
+    projectAuthSync:         ProjectAuthSync[F]
 ) extends TransformationStepsRunner[F] {
 
   import TriplesUploadResult._
@@ -85,8 +89,18 @@ private class TransformationStepsRunnerImpl[F[_]: MonadThrow](
       searchGraphsProvisioner.provisionSearchGraphs(project).map(_ => projectAndQueries)
   }
 
-  private def provisionProjectAuthGraph: ((Project, Queries)) => ProjectWithQueries[F] =
-    ???
+  private def provisionProjectAuthGraph: ((Project, Queries)) => ProjectWithQueries[F] = { case (project, queries) =>
+    val authData = ProjectAuthData(
+      project.slug,
+      project.members.flatMap(m => m.person.maybeGitLabId.map(gId => ProjectMember(gId, m.role))),
+      project.visibility
+    )
+    EitherT
+      .rightT[F, ProcessingRecoverableError](
+        projectAuthSync.syncProject(authData)
+      )
+      .map(_ => (project, queries))
+  }
 
   private def execute(queries: List[SparqlQuery]): EitherT[F, ProcessingRecoverableError, Unit] =
     queries.foldLeft(EitherT.rightT[F, ProcessingRecoverableError](())) { (previousResult, query) =>
@@ -103,8 +117,11 @@ private class TransformationStepsRunnerImpl[F[_]: MonadThrow](
 
 private[tsprovisioning] object TransformationStepsRunner {
 
-  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[TransformationStepsRunner[F]] = for {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+      projectSparqlClient: ProjectSparqlClient[F]
+  )(implicit renkuUrl: RenkuUrl): F[TransformationStepsRunner[F]] = for {
     resultsUploader         <- TransformationResultsUploader[F]
     searchGraphsProvisioner <- SearchGraphsProvisioner.default[F]
-  } yield new TransformationStepsRunnerImpl[F](resultsUploader, searchGraphsProvisioner)
+    projectAuthSync = ProjectAuthSync(projectSparqlClient)
+  } yield new TransformationStepsRunnerImpl[F](resultsUploader, searchGraphsProvisioner, projectAuthSync)
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunnerSpec.scala
@@ -27,8 +27,9 @@ import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators.personNames
 import io.renku.graph.model.entities
 import io.renku.graph.model.testentities._
-import io.renku.triplesgenerator.errors.ProcessingRecoverableError
 import io.renku.triplesgenerator.errors.ErrorGenerators.{logWorthyRecoverableErrors, processingRecoverableErrors}
+import io.renku.triplesgenerator.errors.ProcessingRecoverableError
+import io.renku.triplesgenerator.events.consumers.membersync.ProjectAuthSync
 import io.renku.triplesgenerator.tsprovisioning.Generators._
 import io.renku.triplesgenerator.tsprovisioning.TransformationStep
 import io.renku.triplesgenerator.tsprovisioning.TransformationStep.{ProjectWithQueries, Queries}
@@ -79,6 +80,7 @@ class TransformationStepsRunnerSpec extends AnyWordSpec with MockFactory with sh
         }
 
         givenSearchGraphProvisioning(step2Project, returning = rightT(()))
+        (projectAuthSync.syncProject _).expects(*).returning(Try(()))
       }
 
       stepsRunner.run(
@@ -338,7 +340,8 @@ class TransformationStepsRunnerSpec extends AnyWordSpec with MockFactory with sh
   private trait TestCase {
     val resultsUploader                 = mock[TransformationResultsUploader[Try]]
     private val searchGraphsProvisioner = mock[SearchGraphsProvisioner[Try]]
-    val stepsRunner = new TransformationStepsRunnerImpl[Try](resultsUploader, searchGraphsProvisioner)
+    val projectAuthSync                 = mock[ProjectAuthSync[Try]]
+    val stepsRunner = new TransformationStepsRunnerImpl[Try](resultsUploader, searchGraphsProvisioner, projectAuthSync)
 
     def givenSearchGraphProvisioning(project:   entities.Project,
                                      returning: EitherT[Try, ProcessingRecoverableError, Unit]

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/DefaultFusekiClient.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/DefaultFusekiClient.scala
@@ -42,8 +42,7 @@ final class DefaultFusekiClient[F[_]: Async: Logger](
     new DefaultSparqlClient[F](client, subConfig)
   }
 
-
-  override def datasetExists(name: String): F[Boolean] =  {
+  override def datasetExists(name: String): F[Boolean] = {
     val req = GET(datasetsUri).withBasicAuth(cc.basicAuth)
     client.run(req).use { resp =>
       if (resp.status.isSuccess) true.pure[F]
@@ -71,17 +70,16 @@ final class DefaultFusekiClient[F[_]: Async: Logger](
 
   override def createDatasetIfNotExists(name: String, persistent: Boolean): F[Unit] =
     datasetExists(name).flatMap {
-      case true => ().pure[F]
+      case true  => ().pure[F]
       case false => createDataset(name, persistent)
     }
 
   override def deleteDataset(name: String): F[Unit] =
     retry.fold(deleteDataset0(name))(_.retryConnectionError(deleteDataset0(name)))
 
-
   override def deleteDatasetIfExists(name: String): F[Unit] =
     datasetExists(name).flatMap {
-      case true => deleteDataset(name)
+      case true  => deleteDataset(name)
       case false => ().pure[F]
     }
 

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/DefaultFusekiClient.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/DefaultFusekiClient.scala
@@ -20,11 +20,11 @@ package io.renku.triplesstore.client.http
 
 import cats.effect._
 import cats.syntax.all._
-import org.http4s.Method.{DELETE, POST}
+import org.http4s.Method.{DELETE, GET, POST}
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.headers.Accept
-import org.http4s.{MediaType, UrlForm}
+import org.http4s.{MediaType, Status, UrlForm}
 import org.typelevel.log4cats.Logger
 
 final class DefaultFusekiClient[F[_]: Async: Logger](
@@ -40,6 +40,16 @@ final class DefaultFusekiClient[F[_]: Async: Logger](
   override def sparql(datasetName: String): SparqlClient[F] = {
     val subConfig = cc.copy(baseUrl = cc.baseUrl / datasetName)
     new DefaultSparqlClient[F](client, subConfig)
+  }
+
+
+  override def datasetExists(name: String): F[Boolean] =  {
+    val req = GET(datasetsUri).withBasicAuth(cc.basicAuth)
+    client.run(req).use { resp =>
+      if (resp.status.isSuccess) true.pure[F]
+      else if (resp.status == Status.NotFound) false.pure[F]
+      else SparqlRequestError(s"getDataset($name)", resp).flatMap(Async[F].raiseError)
+    }
   }
 
   override def createDataset(name: String, persistent: Boolean): F[Unit] =
@@ -59,8 +69,21 @@ final class DefaultFusekiClient[F[_]: Async: Logger](
     }
   }
 
+  override def createDatasetIfNotExists(name: String, persistent: Boolean): F[Unit] =
+    datasetExists(name).flatMap {
+      case true => ().pure[F]
+      case false => createDataset(name, persistent)
+    }
+
   override def deleteDataset(name: String): F[Unit] =
     retry.fold(deleteDataset0(name))(_.retryConnectionError(deleteDataset0(name)))
+
+
+  override def deleteDatasetIfExists(name: String): F[Unit] =
+    datasetExists(name).flatMap {
+      case true => deleteDataset(name)
+      case false => ().pure[F]
+    }
 
   private def deleteDataset0(name: String): F[Unit] = {
     val req = DELETE(datasetsUri / name).withBasicAuth(cc.basicAuth)

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/FusekiClient.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/http/FusekiClient.scala
@@ -32,6 +32,12 @@ trait FusekiClient[F[_]] {
 
   def deleteDataset(name: String): F[Unit]
 
+  def datasetExists(name: String): F[Boolean]
+
+  def createDatasetIfNotExists(name: String, persistent: Boolean): F[Unit]
+
+  def deleteDatasetIfExists(name: String): F[Unit]
+
   def sparql(datasetName: String): SparqlClient[F]
 }
 


### PR DESCRIPTION
Cross entity search now uses data from `ProjectAuth` graph to filter visible entities.

/deploy #persist