### PR TITLE
chore: Add role to a project member

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitHistoryChangesSpec.scala
@@ -28,6 +28,7 @@ import io.renku.graph.acceptancetests.flows.TSProvisioning
 import io.renku.graph.acceptancetests.knowledgegraph.{DatasetsApiEncoders, fullJson}
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.EventsGenerators.commitIds
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities._
 import io.renku.http.client.AccessToken
 import io.renku.http.rest.Links
@@ -54,7 +55,7 @@ class CommitHistoryChangesSpec
 
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commits = commitIds.generateNonEmptyList(min = 3)
 
       Given("there is data in the TS")
@@ -92,7 +93,7 @@ class CommitHistoryChangesSpec
 
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commits = commitIds.generateNonEmptyList(min = 3)
 
       Given("There is data in the triple store")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitSyncFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/CommitSyncFlowsSpec.scala
@@ -30,6 +30,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.events.EventId
 import io.renku.graph.model.events.EventStatus.TriplesStore
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.webhookservice.model.HookToken
@@ -46,7 +47,7 @@ class CommitSyncFlowsSpec extends AcceptanceSpec with ApplicationServices with T
       val project =
         dataProjects(renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()),
                      CommitsCount(2)
-        ).map(addMemberWithId(user.id)).generateOne
+        ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("commit with the commit id matching Push Event's 'after' exists on the project in GitLab")
       And("fetch latest commit endpoint returns the non missed commit")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/EventFlowsSpec.scala
@@ -26,6 +26,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.events.{EventId, EventStatus}
 import io.renku.graph.model.events.EventStatus._
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.webhookservice.model.HookToken
@@ -41,7 +42,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
       val user = authUsers.generateOne
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commitId = commitIds.generateOne
 
       Given("commit with the commit id matching Push Event's 'after' exists on the project in GitLab")
@@ -71,7 +72,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
       val user = authUsers.generateOne
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commitId = commitIds.generateOne
 
       Given("commit with the commit id matching Push Event's 'after' exists on the project in GitLab")
@@ -102,7 +103,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
       val user = authUsers.generateOne
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commitId = commitIds.generateOne
 
       Given("commit with the commit id matching Push Event's 'after' exists on the project in GitLab")
@@ -134,7 +135,7 @@ class EventFlowsSpec extends AcceptanceSpec with ApplicationServices with TSProv
       val user = authUsers.generateOne
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commitId = commitIds.generateOne
 
       Given("commit with the commit id matching Push Event's 'after' exists on the project in GitLab")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/FastTractEventRouteSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/FastTractEventRouteSpec.scala
@@ -24,6 +24,7 @@ import flows.TSProvisioning
 import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.{cliShapedPersons, removeMembers}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{renkuProjectEntities, visibilityPublic}
 import io.renku.webhookservice.model.HookToken
@@ -48,7 +49,7 @@ class FastTractEventRouteSpec
       val user = authUsers.generateOne
       val project = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("commit with the commit id matching Push Event's 'after' exists on the project in GitLab")
       gitLabStub.addAuthenticated(user)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectReProvisioningSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectReProvisioningSpec.scala
@@ -27,6 +27,7 @@ import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.projectSchemaVersions
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{removeMembers, renkuProjectEntities, visibilityPublic}
 import io.renku.graph.model.versions.SchemaVersion
@@ -47,7 +48,7 @@ class ProjectReProvisioningSpec extends AcceptanceSpec with ApplicationServices 
 
       Given("there's data for the project in the TS")
 
-      val project = dataProjects(testProject).map(addMemberWithId(user.id)).generateOne
+      val project = dataProjects(testProject).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       gitLabStub.addAuthenticated(user)
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectStatusResourceSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectStatusResourceSpec.scala
@@ -31,6 +31,7 @@ import io.renku.graph.acceptancetests.testing.AcceptanceTestPatience
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices, ModelImplicits}
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.events.EventStatusProgress
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import org.http4s.Status._
 import org.scalatest.concurrent.Eventually
@@ -52,7 +53,7 @@ class ProjectStatusResourceSpec
     val project =
       dataProjects(renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()),
                    CommitsCount(numberOfEvents.value)
-      ).map(addMemberWithId(memberUser.id)).generateOne
+      ).map(addMemberWithId(memberUser.id, Role.Owner)).generateOne
 
     Scenario("Call be a user who is not a member of the project") {
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectSyncFlowSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ProjectSyncFlowSpec.scala
@@ -28,6 +28,7 @@ import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.projectSlugs
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{removeMembers, renkuProjectEntities, visibilityPublic}
 import org.http4s.Status.{NotFound, Ok}
@@ -45,7 +46,7 @@ class ProjectSyncFlowSpec extends AcceptanceSpec with ApplicationServices with T
       val user = authUsers.generateOne
       val testProject =
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()).generateOne
-      val project = dataProjects(testProject).map(addMemberWithId(user.id)).generateOne
+      val project = dataProjects(testProject).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("repository data in the Triples Store")
       val commitId = commitIds.generateOne

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ReProvisioningSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ReProvisioningSpec.scala
@@ -26,6 +26,7 @@ import io.renku.generators.CommonGraphGenerators.{authUsers, serviceVersions}
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
 import io.renku.graph.model.EventsGenerators.commitIds
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.graph.model.versions.SchemaVersion
@@ -49,7 +50,7 @@ class ReProvisioningSpec extends AcceptanceSpec with ApplicationServices with TS
 
       And("There is data from this version in Jena")
 
-      val project  = dataProjects(testProject).map(addMemberWithId(user.id)).generateOne
+      val project  = dataProjects(testProject).map(addMemberWithId(user.id, Role.Owner)).generateOne
       val commitId = commitIds.generateOne
 
       gitLabStub.addAuthenticated(user)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookCreationSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookCreationSpec.scala
@@ -26,6 +26,7 @@ import io.renku.graph.acceptancetests.data._
 import io.renku.graph.acceptancetests.flows.AccessTokenPresence
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices, ModelImplicits}
 import io.renku.graph.model.EventsGenerators.commitIds
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.http.client.AccessToken
@@ -41,7 +42,7 @@ class WebhookCreationSpec extends AcceptanceSpec with ModelImplicits with Applic
       val project =
         dataProjects(renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()),
                      CommitsCount.one
-        ).map(addMemberWithId(user.id)).generateOne
+        ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("api user is authenticated")
       gitLabStub.addAuthenticated(user)
@@ -77,7 +78,7 @@ class WebhookCreationSpec extends AcceptanceSpec with ModelImplicits with Applic
       val project =
         dataProjects(renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()),
                      CommitsCount.zero
-        ).map(addMemberWithId(user.id)).generateOne
+        ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("api user is authenticated")
       gitLabStub.addAuthenticated(user)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/WebhookValidationEndpointSpec.scala
@@ -24,6 +24,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.graph.acceptancetests.data.Project.Statistics.CommitsCount
 import io.renku.graph.acceptancetests.data._
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.http.client.AccessToken
 import org.http4s.Status._
@@ -38,7 +39,7 @@ class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServi
       val project =
         dataProjects(renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()),
                      CommitsCount.zero
-        ).map(addMemberWithId(user.id)).generateOne
+        ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("api user is authenticated")
       gitLabStub.addAuthenticated(user)
@@ -59,7 +60,7 @@ class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServi
       val project =
         dataProjects(renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()),
                      CommitsCount.zero
-        ).map(addMemberWithId(user.id)).generateOne
+        ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       Given("api user is authenticated")
       gitLabStub.addAuthenticated(user)
@@ -81,7 +82,7 @@ class WebhookValidationEndpointSpec extends AcceptanceSpec with ApplicationServi
       val project =
         dataProjects(renkuProjectEntities(visibilityNonPublic, creatorGen = cliShapedPersons).modify(removeMembers()))
           .map(replaceCreatorFrom(creator, user.id))
-          .map(addMemberFrom(creator, user.id))
+          .map(addMemberFrom(creator, user.id, Role.Owner))
           .generateOne
 
       Given("api user is authenticated")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ZombieEventDetectionSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/ZombieEventDetectionSpec.scala
@@ -70,7 +70,7 @@ class ZombieEventDetectionSpec
     val user = authUsers.generateOne
     val project = dataProjects(
       renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers())
-    ).map(addMemberWithId(user.id)).generateOne
+    ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
     val commitId = commitIds.generateOne
     Given("Triples generation is successful")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/Project.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/Project.scala
@@ -25,7 +25,7 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.numeric.Positive
 import io.renku.graph.acceptancetests.data.Project._
-import io.renku.graph.model.entities.Project.ProjectMember
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabUser}
 import io.renku.graph.model.projects.{GitLabId, Name, Slug}
 import io.renku.graph.model.testentities
 import io.renku.tinytypes._
@@ -35,8 +35,8 @@ import java.net.{MalformedURLException, URL}
 
 final case class Project(entitiesProject: testentities.RenkuProject,
                          id:              GitLabId,
-                         maybeCreator:    Option[ProjectMember],
-                         members:         NonEmptyList[ProjectMember],
+                         maybeCreator:    Option[GitLabUser],
+                         members:         NonEmptyList[GitLabMember],
                          urls:            Urls,
                          starsCount:      StarsCount,
                          permissions:     Permissions,

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/ProjectFunctions.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/ProjectFunctions.scala
@@ -58,6 +58,7 @@ trait ProjectFunctions {
   def toPayloadJsonLD(p: testentities.RenkuProject)(implicit renkuUrl: RenkuUrl): JsonLD =
     p.to[CliProject].asJsonLD(CliProject.flatJsonLDEncoder)
 
+  // here we assume GitLab doesn't return an email
   private def toProjectMember(p: testentities.Person, gitLabId: persons.GitLabId, role: Role): GitLabMember =
     GitLabMember(p.name, persons.Username(p.name.show), gitLabId, None, Role.toGitLabAccessLevel(role))
 }

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/package.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/package.scala
@@ -44,7 +44,7 @@ package object data extends TSData with ProjectFunctions {
   ): Gen[Project] = for {
     project     <- projectGen
     id          <- projectIds
-    members     <- EntitiesGenerators.gitLabMemberGen().toGeneratorOfNonEmptyList(max = 3)
+    members     <- EntitiesGenerators.gitLabProjectMembers.toGeneratorOfNonEmptyList(max = 3)
     urls        <- urlsObjects
     starsCount  <- starsCounts
     permissions <- permissionsObjects
@@ -63,7 +63,7 @@ package object data extends TSData with ProjectFunctions {
                   statistics
   )
 
-  private implicit lazy val testPersonToProjectMember: testentities.Person => GitLabUser = { p =>
+  private implicit lazy val testPersonToGitLabUser: testentities.Person => GitLabUser = { p =>
     GitLabUser(p.name, persons.Username(p.name.value), personGitLabIds.generateOne, p.maybeEmail)
   }
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/eventlog/EventsResourceSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/eventlog/EventsResourceSpec.scala
@@ -28,6 +28,7 @@ import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.events.{EventId, EventProcessingTime, EventStatus}
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.cliShapedPersons
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{anyVisibility, removeMembers, renkuProjectEntities}
 import io.renku.http.client.UrlEncoder.urlEncode
@@ -46,7 +47,7 @@ class EventsResourceSpec extends AcceptanceSpec with ApplicationServices with TS
         renkuProjectEntities(anyVisibility, creatorGen = cliShapedPersons).modify(removeMembers()),
         CommitsCount(commits.size)
       ).map(replaceCreatorFrom(cliShapedPersons.generateOne, user.id))
-        .map(addMemberWithId(user.id))
+        .map(addMemberWithId(user.id, Role.Owner))
         .generateOne
 
       Given("there are no events for the given project in EL")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/CrossEntitiesSearchSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/CrossEntitiesSearchSpec.scala
@@ -29,6 +29,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{nonBlankStrings, sentenceContaining}
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model._
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities._
 import io.renku.http.client.UrlEncoder._
 import org.http4s.Status.Ok
@@ -65,7 +66,7 @@ class CrossEntitiesSearchSpec extends AcceptanceSpec with ApplicationServices wi
             .modify(replaceDSName(sentenceContaining(commonPhrase).generateAs[datasets.Name]))
         )
         .generateOne
-    val project = dataProjects(testProject).map(addMemberWithId(user.id)).generateOne
+    val project = dataProjects(testProject).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
     Scenario("As a user I would like to be able to do cross-entity search by calling a REST endpoint") {
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/LineageResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/LineageResourcesSpec.scala
@@ -31,6 +31,7 @@ import io.renku.graph.model
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.Schemas.prov
 import io.renku.graph.model.projects
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities.LineageExemplarData.ExemplarData
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{renkuProjectEntities, visibilityPublic}
 import io.renku.graph.model.testentities.{LineageExemplarData, NodeDef, cliShapedPersons, removeMembers, replaceProjectCreator, visibilityPrivate}
@@ -58,7 +59,7 @@ class LineageResourcesSpec extends AcceptanceSpec with ApplicationServices with 
           .generateOne,
         personGen = cliShapedPersons
       )
-      (lineageData, dataProjects(lineageData.project).map(addMemberWithId(user.id)).generateOne)
+      (lineageData, dataProjects(lineageData.project).map(addMemberWithId(user.id, Role.Owner)).generateOne)
     }
 
     /** Expected data structure when looking for the grid_plot file
@@ -110,7 +111,7 @@ class LineageResourcesSpec extends AcceptanceSpec with ApplicationServices with 
 
       Given("some data in the Triples Store with a project I am a member of")
       val commitId = commitIds.generateOne
-      val project  = dataProjects(accessibleExemplarData.project).map(addMemberWithId(user.id)).generateOne
+      val project  = dataProjects(accessibleExemplarData.project).map(addMemberWithId(user.id, Role.Owner)).generateOne
       mockCommitDataOnTripleGenerator(project, toPayloadJsonLD(project), commitId)
       gitLabStub.setupProject(project, commitId)
       gitLabStub.addAuthenticated(user)
@@ -145,7 +146,7 @@ class LineageResourcesSpec extends AcceptanceSpec with ApplicationServices with 
       val project =
         dataProjects(privateExemplarData.project)
           .map(replaceCreatorFrom(creatorPerson, creator.id))
-          .map(addMemberFrom(creatorPerson, creator.id))
+          .map(addMemberFrom(creatorPerson, creator.id, Role.Owner))
           .generateOne
 
       Given("I am authenticated")

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectDatasetTagsResourceSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectDatasetTagsResourceSpec.scala
@@ -28,6 +28,7 @@ import io.renku.graph.acceptancetests.flows.TSProvisioning
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.RenkuTinyTypeGenerators.{personEmails, personGitLabIds}
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.publicationEvents
 import io.renku.graph.model.testentities._
 import io.renku.tinytypes.json.TinyTypeDecoders._
@@ -63,7 +64,7 @@ class ProjectDatasetTagsResourceSpec
 
         val project = dataProjects(testProject)
           .map(replaceCreatorFrom(creator, creatorGitLabId))
-          .map(addMemberFrom(creator, creatorGitLabId) >>> addMemberWithId(user.id))
+          .map(addMemberFrom(creator, creatorGitLabId, Role.Owner) >>> addMemberWithId(user.id, Role.Maintainer))
           .generateOne
 
         ds -> project

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectsResourcesSpec.scala
@@ -26,7 +26,8 @@ import io.renku.graph.acceptancetests.data._
 import io.renku.graph.acceptancetests.flows.TSProvisioning
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.EventsGenerators.commitIds
-import io.renku.graph.model.RenkuTinyTypeGenerators.{personEmails, personGitLabIds}
+//import io.renku.graph.model.RenkuTinyTypeGenerators.{personEmails, personGitLabIds}
+import io.renku.graph.model.persons
 import io.renku.graph.model.projects.{Role, Visibility}
 import io.renku.graph.model.testentities._
 import io.renku.http.rest.Links
@@ -45,9 +46,12 @@ class ProjectsResourcesSpec
   private val accessToken = user.accessToken
 
   private val parentProject -> project = {
-    val creatorGitLabId = personGitLabIds.generateOne
-    val creatorEmail    = personEmails.generateOne
-    val creator         = cliShapedPersons.generateOne.copy(maybeEmail = creatorEmail.some)
+    val creatorGitLabId = persons.GitLabId(999999)
+    val creatorEmail    = persons.Email("creator@theemail.ch")
+    val creator = cliShapedPersons.generateOne.copy(
+      name = persons.Name("Parent Creator"),
+      maybeEmail = creatorEmail.some
+    )
 
     val (parent, child) = renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons)
       .withDatasets(datasetEntities(provenanceInternal(cliShapedPersons)))
@@ -71,6 +75,15 @@ class ProjectsResourcesSpec
   Feature("GET knowledge-graph/projects/<namespace>/<name> to find project's details") {
 
     Scenario("As a user I would like to find project's details by calling a REST endpoint") {
+      println("---------TEST DATA--------------------")
+      println(s"Parent Project: id=${parentProject.id}, slug=${parentProject.slug}")
+      println(s"           +++: slug*=${parentProject.entitiesProject.slug}")
+      println(s"ParentProject Creator (GitLabUser): ${parentProject.maybeCreator}")
+      println(s"ParentProject Creator (entitiesProject): ${parentProject.entitiesProject.maybeCreator}")
+      println(s"Child Project: id=${project.id}, slug=${project.slug}")
+      println(s"           +++: slug*=${project.entitiesProject.slug}")
+      println(s"ChildProject Creator (GitLabUser): ${project.maybeCreator}")
+      println(s"ChildProject Creator (entitiesProject): ${project.entitiesProject.maybeCreator}")
 
       Given("the user is authenticated")
       gitLabStub.addAuthenticated(user)
@@ -79,11 +92,12 @@ class ProjectsResourcesSpec
       val parentCommitId = commitIds.generateOne
       mockCommitDataOnTripleGenerator(parentProject, toPayloadJsonLD(parentProject), parentCommitId)
       gitLabStub.setupProject(parentProject, parentCommitId)
-
       `data in the Triples Store`(parentProject, parentCommitId, accessToken)
+      waitForAllEventsInFinalState(parentProject.id)
 
-      val commitId = commitIds.generateOne
-      mockCommitDataOnTripleGenerator(project, toPayloadJsonLD(project.entitiesProject), commitId)
+      val commitId    = commitIds.generateOne
+      val jsonPayload = toPayloadJsonLD(project.entitiesProject)
+      mockCommitDataOnTripleGenerator(project, jsonPayload, commitId)
       gitLabStub.setupProject(project, commitId)
       `data in the Triples Store`(project, commitId, accessToken)
       waitForAllEventsInFinalState(project.id)

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectsResourcesSpec.scala
@@ -26,8 +26,6 @@ import io.renku.graph.acceptancetests.data._
 import io.renku.graph.acceptancetests.flows.TSProvisioning
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.EventsGenerators.commitIds
-//import io.renku.graph.model.RenkuTinyTypeGenerators.{personEmails, personGitLabIds}
-import io.renku.graph.model.persons
 import io.renku.graph.model.projects.{Role, Visibility}
 import io.renku.graph.model.testentities._
 import io.renku.http.rest.Links
@@ -46,12 +44,9 @@ class ProjectsResourcesSpec
   private val accessToken = user.accessToken
 
   private val parentProject -> project = {
-    val creatorGitLabId = persons.GitLabId(999999)
-    val creatorEmail    = persons.Email("creator@theemail.ch")
-    val creator = cliShapedPersons.generateOne.copy(
-      name = persons.Name("Parent Creator"),
-      maybeEmail = creatorEmail.some
-    )
+    val creatorGitLabId = personGitLabIds.generateOne
+    val creatorEmail    = personEmails.generateOne
+    val creator         = cliShapedPersons.generateOne.copy(maybeEmail = creatorEmail.some)
 
     val (parent, child) = renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons)
       .withDatasets(datasetEntities(provenanceInternal(cliShapedPersons)))
@@ -75,16 +70,6 @@ class ProjectsResourcesSpec
   Feature("GET knowledge-graph/projects/<namespace>/<name> to find project's details") {
 
     Scenario("As a user I would like to find project's details by calling a REST endpoint") {
-      println("---------TEST DATA--------------------")
-      println(s"Parent Project: id=${parentProject.id}, slug=${parentProject.slug}")
-      println(s"           +++: slug*=${parentProject.entitiesProject.slug}")
-      println(s"ParentProject Creator (GitLabUser): ${parentProject.maybeCreator}")
-      println(s"ParentProject Creator (entitiesProject): ${parentProject.entitiesProject.maybeCreator}")
-      println(s"Child Project: id=${project.id}, slug=${project.slug}")
-      println(s"           +++: slug*=${project.entitiesProject.slug}")
-      println(s"ChildProject Creator (GitLabUser): ${project.maybeCreator}")
-      println(s"ChildProject Creator (entitiesProject): ${project.entitiesProject.maybeCreator}")
-
       Given("the user is authenticated")
       gitLabStub.addAuthenticated(user)
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectsResourcesSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/ProjectsResourcesSpec.scala
@@ -27,7 +27,7 @@ import io.renku.graph.acceptancetests.flows.TSProvisioning
 import io.renku.graph.acceptancetests.tooling.{AcceptanceSpec, ApplicationServices}
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.RenkuTinyTypeGenerators.{personEmails, personGitLabIds}
-import io.renku.graph.model.projects.Visibility
+import io.renku.graph.model.projects.{Role, Visibility}
 import io.renku.graph.model.testentities._
 import io.renku.http.rest.Links
 import io.renku.http.server.EndpointTester.{JsonOps, jsonEntityDecoder}
@@ -57,12 +57,12 @@ class ProjectsResourcesSpec
 
     val parentDataProject = dataProjects(parent)
       .map(replaceCreatorFrom(creator, creatorGitLabId))
-      .map(addMemberFrom(creator, creatorGitLabId) >>> addMemberWithId(user.id))
+      .map(addMemberFrom(creator, creatorGitLabId, Role.Owner) >>> addMemberWithId(user.id, Role.Maintainer))
       .generateOne
 
     val childDataProject =
       dataProjects(child.copy(visibility = Visibility.Private, parent = parentDataProject.entitiesProject))
-        .map(addMemberWithId(user.id))
+        .map(addMemberWithId(user.id, Role.Owner))
         .generateOne
 
     parentDataProject -> childDataProject

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/UserProjectsResourceSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/UserProjectsResourceSpec.scala
@@ -28,6 +28,7 @@ import io.renku.generators.CommonGraphGenerators.authUsers
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.projects
+import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities._
 import io.renku.tinytypes.json.TinyTypeDecoders._
 import org.http4s.Status.Ok
@@ -46,7 +47,7 @@ class UserProjectsResourceSpec extends AcceptanceSpec with ApplicationServices w
 
       val activatedProject = dataProjects(
         renkuProjectEntities(anyVisibility, creatorGen = cliShapedPersons).modify(removeMembers()).generateOne
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       val commitId = commitIds.generateOne
       mockCommitDataOnTripleGenerator(activatedProject, toPayloadJsonLD(activatedProject), commitId)
@@ -56,7 +57,7 @@ class UserProjectsResourceSpec extends AcceptanceSpec with ApplicationServices w
       And("he has a not activated project")
       val notActivatedProject = dataProjects(
         renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons).modify(removeMembers()).generateOne
-      ).map(addMemberWithId(user.id)).generateOne
+      ).map(addMemberWithId(user.id, Role.Owner)).generateOne
 
       gitLabStub.addProject(notActivatedProject)
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
@@ -113,10 +113,10 @@ package object knowledgegraph {
     }"""
   }
 
+  //TODO email removed here
   private implicit lazy val personEncoder: Encoder[Person] = Encoder.instance {
-    case Person(name, Some(email), _, _, maybeAffiliation) => json"""{
-      "name":  $name,
-      "email": $email
+    case Person(name, Some(_), _, _, maybeAffiliation) => json"""{
+      "name":  $name
     }""" addIfDefined ("affiliation" -> maybeAffiliation)
     case Person(name, _, _, _, maybeAffiliation) => json"""{
       "name": $name

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/package.scala
@@ -113,10 +113,10 @@ package object knowledgegraph {
     }"""
   }
 
-  //TODO email removed here
   private implicit lazy val personEncoder: Encoder[Person] = Encoder.instance {
-    case Person(name, Some(_), _, _, maybeAffiliation) => json"""{
-      "name":  $name
+    case Person(name, Some(email), _, _, maybeAffiliation) => json"""{
+      "name":  $name,
+      "email": $email
     }""" addIfDefined ("affiliation" -> maybeAffiliation)
     case Person(name, _, _, _, maybeAffiliation) => json"""{
       "name": $name

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabApiStub.scala
@@ -128,7 +128,7 @@ final class GitLabApiStub[F[_]: Async: Logger](private val stateRef: Ref[F, Stat
 
         case GET -> Root / ProjectId(projectId) / "members" / "all" / UserGitLabId(userId) =>
           query(findProjectById(projectId, maybeAuthedReq))
-            .map(_.toList.flatMap(_.members.toList).find(_.gitLabId == userId))
+            .map(_.toList.flatMap(_.members.toList).find(_.user.gitLabId == userId))
             .flatMap(OkOrNotFound(_))
 
         case GET -> Root / ProjectId(id) / "repository" / "commits" =>

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateQueries.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateQueries.scala
@@ -92,13 +92,13 @@ trait GitLabStateQueries {
   def projectsFor(userId: Option[persons.GitLabId]): StateQuery[List[Project]] =
     _.projects.filter { p =>
       p.entitiesProject.visibility == projects.Visibility.Public ||
-      userId.exists(p.members.map(_.gitLabId).contains_) ||
+      userId.exists(p.members.map(_.user.gitLabId).contains_) ||
       p.maybeCreator.map(_.gitLabId) == userId
     }
 
   def projectsWhereUserIsMember(userId: persons.GitLabId): StateQuery[List[Project]] =
     _.projects.filter { p =>
-      p.members.map(_.gitLabId).contains_(userId) || p.maybeCreator.forall(_.gitLabId == userId)
+      p.members.map(_.user.gitLabId).contains_(userId) || p.maybeCreator.forall(_.gitLabId == userId)
     }
 
   def findCallerProjects: Option[AuthedReq] => StateQuery[List[Project]] = {

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateQueries.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/GitLabStateQueries.scala
@@ -18,16 +18,16 @@
 
 package io.renku.graph.acceptancetests.stubs.gitlab
 
-import GitLabApiStub._
 import cats.Monad
 import cats.syntax.all._
+import io.renku.graph.acceptancetests.stubs.gitlab.GitLabApiStub._
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.acceptancetests.data.Project
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabAuth.AuthedReq
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabAuth.AuthedReq.{AuthedProject, AuthedUser}
-import io.renku.graph.model.{persons, projects, GraphModelGenerators}
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.testentities.Person
+import io.renku.graph.model.{GraphModelGenerators, persons, projects}
 import io.renku.http.client.AccessToken.ProjectAccessToken
 import io.renku.http.client.UserAccessToken
 

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/JsonEncoders.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/gitlab/JsonEncoders.scala
@@ -27,7 +27,7 @@ import io.renku.graph.acceptancetests.data.Project.{Permissions, Statistics}
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabApiStub._
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabAuth.AuthedReq
 import io.renku.graph.acceptancetests.stubs.gitlab.GitLabAuth.AuthedReq.{AuthedProject, AuthedUser}
-import io.renku.graph.model.entities.Project.ProjectMember
+import io.renku.graph.model.gitlab.GitLabMember
 import io.renku.graph.model.testentities.{Parent, Person}
 import org.http4s.Uri
 
@@ -41,12 +41,13 @@ trait JsonEncoders {
     Map("id" -> person.maybeGitLabId.asJson, "username" -> person.name.asJson, "name" -> person.name.asJson).asJson
   }
 
-  implicit val projectMemberEncoder: Encoder[ProjectMember] = Encoder.instance { pm =>
-    Map("id"           -> pm.gitLabId.asJson,
-        "username"     -> pm.username.asJson,
-        "name"         -> pm.name.asJson,
-        "access_level" -> 40.asJson,
-        "state"        -> "active".asJson
+  implicit val projectMemberEncoder: Encoder[GitLabMember] = Encoder.instance { pm =>
+    Map(
+      "id"           -> pm.user.gitLabId.asJson,
+      "username"     -> pm.user.username.asJson,
+      "name"         -> pm.user.name.asJson,
+      "access_level" -> pm.accessLevel.asJson,
+      "state"        -> "active".asJson
     ).asJson
   }
 

--- a/entities-search/src/test/scala/io/renku/entities/search/DatasetsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/DatasetsEntitiesFinderSpec.scala
@@ -179,7 +179,7 @@ class DatasetsEntitiesFinderSpec
         .importDataset(externalDS)
         .generateOne
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val original -> fork = {
         val original -> fork = publicProject.forkOnce()
         original -> fork.copy(visibility = visibilityNonPublic.generateOne, members = Set(member))
@@ -189,7 +189,7 @@ class DatasetsEntitiesFinderSpec
         provisionTestProjects(original, fork) >> finder
           .findEntities(
             Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Dataset)),
-                     maybeUser = member.toAuthUser.some
+                     maybeUser = member.person.toAuthUser.some
             )
           )
       }
@@ -200,7 +200,7 @@ class DatasetsEntitiesFinderSpec
     "favour dataset on internal projects over private projects if exist" in new TestCase {
       val externalDS = datasetEntities(provenanceImportedExternal).decoupledFromProject.generateOne
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val dsAndInternalProject @ _ -> internalProject = renkuProjectEntities(fixed(projects.Visibility.Internal))
         .modify(replaceMembers(to = Set(member)))
         .importDataset(externalDS)
@@ -215,7 +215,7 @@ class DatasetsEntitiesFinderSpec
         provisionTestProjects(original, fork) >> finder
           .findEntities(
             Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Dataset)),
-                     maybeUser = member.toAuthUser.some
+                     maybeUser = member.person.toAuthUser.some
             )
           )
       }
@@ -226,7 +226,7 @@ class DatasetsEntitiesFinderSpec
     "select dataset on private project if there's no project with broader visibility" in new TestCase {
       val externalDS = datasetEntities(provenanceImportedExternal).decoupledFromProject.generateOne
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val dsAndProject @ _ -> privateProject = renkuProjectEntities(fixed(projects.Visibility.Private))
         .modify(replaceMembers(to = Set(member)))
         .importDataset(externalDS)
@@ -236,7 +236,7 @@ class DatasetsEntitiesFinderSpec
         provisionTestProjects(privateProject) >> finder
           .findEntities(
             Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Dataset)),
-                     maybeUser = member.toAuthUser.some
+                     maybeUser = member.person.toAuthUser.some
             )
           )
       }

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -557,7 +557,7 @@ class EntitiesFinderSpec
         .withDatasets(datasetEntities(provenanceNonModified))
         .generateOne
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val privateProject = renkuProjectEntities(fixed(projects.Visibility.Private))
         .modify(replaceMembers(to = Set(member)))
         .withActivities(activityEntities(stepPlanEntities()))
@@ -570,7 +570,7 @@ class EntitiesFinderSpec
             .findEntities(
               Criteria(
                 Filters(visibilities = Set(projects.Visibility.Public, projects.Visibility.Private)),
-                maybeUser = member.toAuthUser.some,
+                maybeUser = member.person.toAuthUser.some,
                 paging = PagingRequest(Page.first, PerPage(50))
               )
             )
@@ -1146,7 +1146,7 @@ class EntitiesFinderSpec
 
   "findEntities - security" should {
 
-    val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+    val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
 
     val privateProject = renkuProjectEntities(fixed(Visibility.Private))
       .modify(replaceMembers(to = Set(member)))
@@ -1205,7 +1205,9 @@ class EntitiesFinderSpec
         List(privateProject, internalProject, publicProject).traverse_(provisionTestProject) *>
           finder
             .findEntities(
-              Criteria(maybeUser = member.toAuthUser.some, paging = PagingRequest.default.copy(perPage = PerPage(50)))
+              Criteria(maybeUser = member.person.toAuthUser.some,
+                       paging = PagingRequest.default.copy(perPage = PerPage(50))
+              )
             )
       }
 

--- a/entities-search/src/test/scala/io/renku/entities/search/FinderSpecOps.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/FinderSpecOps.scala
@@ -95,7 +95,7 @@ trait FinderSpecOps {
     }.distinct
 
     def addAllPersonsFrom(project: RenkuProject): List[model.Entity] =
-      addPersons((project.members ++ project.maybeCreator).toList)
+      addPersons((project.members.map(_.person) ++ project.maybeCreator).toList)
         .addPersons(project.datasets.flatMap(_.provenance.creators.toList))
         .addPersons(project.activities.map(_.author))
         .addPersons(project.plans.flatMap(_.creators))

--- a/entities-search/src/test/scala/io/renku/entities/search/WorkflowsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/WorkflowsEntitiesFinderSpec.scala
@@ -73,7 +73,7 @@ class WorkflowsEntitiesFinderSpec
         .withActivities(activityEntities(stepPlanEntities()))
         .generateOne
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val original -> fork = {
         val original -> fork = publicProject.forkOnce()
         original -> fork.copy(visibility = visibilityNonPublic.generateOne, members = Set(member))
@@ -85,7 +85,7 @@ class WorkflowsEntitiesFinderSpec
       finder
         .findEntities(
           Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Workflow)),
-                   maybeUser = member.toAuthUser.some
+                   maybeUser = member.person.toAuthUser.some
           )
         )
         .unsafeRunSync()
@@ -94,7 +94,7 @@ class WorkflowsEntitiesFinderSpec
 
     "favour workflows on internal projects over private projects if exist" in new TestCase {
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val internalProject = renkuProjectEntities(fixed(projects.Visibility.Internal))
         .modify(replaceMembers(to = Set(member)))
         .withActivities(activityEntities(stepPlanEntities()))
@@ -111,7 +111,7 @@ class WorkflowsEntitiesFinderSpec
       finder
         .findEntities(
           Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Workflow)),
-                   maybeUser = member.toAuthUser.some
+                   maybeUser = member.person.toAuthUser.some
           )
         )
         .unsafeRunSync()
@@ -120,7 +120,7 @@ class WorkflowsEntitiesFinderSpec
 
     "select workflows on private projects if there are no projects with broader visibility" in new TestCase {
 
-      val member = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val member = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val privateProject = renkuProjectEntities(fixed(projects.Visibility.Private))
         .modify(replaceMembers(to = Set(member)))
         .withActivities(activityEntities(stepPlanEntities()))
@@ -132,7 +132,7 @@ class WorkflowsEntitiesFinderSpec
       finder
         .findEntities(
           Criteria(filters = Filters(entityTypes = Set(Filters.EntityType.Workflow)),
-                   maybeUser = member.toAuthUser.some
+                   maybeUser = member.person.toAuthUser.some
           )
         )
         .unsafeRunSync()

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/DatasetProvision.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/DatasetProvision.scala
@@ -21,8 +21,7 @@ package io.renku.knowledgegraph
 import cats.effect.IO
 import io.renku.entities.searchgraphs.SearchInfoDatasets
 import io.renku.graph.model.entities.EntityFunctions
-import io.renku.graph.model.projects.Role
-import io.renku.graph.model.{RenkuUrl, entities, testentities}
+import io.renku.graph.model.{RenkuUrl, entities}
 import io.renku.projectauth.{ProjectAuthData, ProjectAuthService, ProjectMember}
 import io.renku.triplesstore._
 
@@ -38,38 +37,9 @@ trait DatasetProvision extends SearchInfoDatasets { self: ProjectsDataset with I
       graphsProducer:  GraphsProducer[entities.Project],
       renkuUrl:        RenkuUrl
   ): IO[Unit] = {
-    val members  = project.members.flatMap(p => p.maybeGitLabId.map(id => ProjectMember(id, Role.Reader)))
+    val members  = project.members.flatMap(p => p.person.maybeGitLabId.map(gid => ProjectMember(gid, p.role)))
     val authData = ProjectAuthData(project.slug, members, project.visibility)
     super.provisionProject(project) *> projectAuthServiceR.use(_.update(authData))
   }
 
-  def provisionProjectAndMembers(
-      project:    entities.Project,
-      memberRole: PartialFunction[entities.Person, Role] = PartialFunction.empty
-  )(implicit
-      entityFunctions: EntityFunctions[entities.Project],
-      graphsProducer:  GraphsProducer[entities.Project],
-      renkuUrl:        RenkuUrl
-  ) = {
-    val members = project.members.flatMap(p =>
-      p.maybeGitLabId.map(gid => ProjectMember(gid, memberRole.lift.apply(p).getOrElse(Role.Reader)))
-    )
-    val authData = ProjectAuthData(project.slug, members, project.visibility)
-    super.provisionProject(project) *> projectAuthServiceR.use(_.update(authData))
-  }
-
-  def provisionTestProjectAndMembers(
-      project:    testentities.Project,
-      memberRole: PartialFunction[testentities.Person, Role] = PartialFunction.empty
-  )(implicit
-      entityFunctions: EntityFunctions[entities.Project],
-      graphsProducer:  GraphsProducer[entities.Project],
-      renkuUrl:        RenkuUrl
-  ) = {
-    val members = project.members.flatMap(p =>
-      p.maybeGitLabId.map(gid => ProjectMember(gid, memberRole.lift.apply(p).getOrElse(Role.Reader)))
-    )
-    val authData = ProjectAuthData(project.slug, members, project.visibility)
-    super.provisionTestProject(project) *> projectAuthServiceR.use(_.update(authData))
-  }
 }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
@@ -794,7 +794,7 @@ class DatasetsFinderSpec
       val (publicDataset, publicProject) =
         publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne
 
-      val userWithGitlabId = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+      val userWithGitlabId = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
       val (internalDatasetWithAccess, internalProjectWithAccess) =
         renkuProjectEntities(fixed(Visibility.Internal))
           .modify(_.copy(members = Set(userWithGitlabId)))
@@ -813,7 +813,7 @@ class DatasetsFinderSpec
         .findDatasets(maybePhrase = None,
                       Sorting(Sort.By(TitleProperty, Direction.Asc)),
                       PagingRequest.default,
-                      userWithGitlabId.toAuthUser.some
+                      userWithGitlabId.person.toAuthUser.some
         )
         .unsafeRunSync()
 
@@ -873,7 +873,7 @@ class DatasetsFinderSpec
         val (privateDatasetWithoutAccess, privateProjectWithoutAccess) =
           renkuProjectEntities(fixed(Visibility.Private)).addDataset(datasetEntities(provenanceInternal)).generateOne
 
-        val userWithGitlabId = personEntities(personGitLabIds.toGeneratorOfSomes).generateOne
+        val userWithGitlabId = projectMemberEntities(personGitLabIds.toGeneratorOfSomes).generateOne
         val (internalDatasetWithAccess, internalProjectWithAccess) = renkuProjectEntities(fixed(Visibility.Internal))
           .modify(_.copy(members = Set(userWithGitlabId)))
           .importDataset(internalDatasetWithoutAccess)
@@ -895,7 +895,7 @@ class DatasetsFinderSpec
           .findDatasets(maybePhrase = None,
                         Sorting(Sort.By(TitleProperty, Direction.Asc)),
                         PagingRequest.default,
-                        userWithGitlabId.toAuthUser.some
+                        userWithGitlabId.person.toAuthUser.some
           )
           .unsafeRunSync()
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/SecurityRecordFinderSupport.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/SecurityRecordFinderSupport.scala
@@ -46,7 +46,7 @@ abstract class SecurityRecordFinderSupport
   implicit val sqtr:      SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder.createUnsafe
 
   def toSecRecord(p: testentities.Project) =
-    Authorizer.SecurityRecord(p.visibility, p.slug, p.members.flatMap(_.maybeGitLabId))
+    Authorizer.SecurityRecord(p.visibility, p.slug, p.members.flatMap(_.person.maybeGitLabId))
 
   def projectWithDatasetAndMembers =
     EntitiesGenerators

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/DatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/DatasetFinderSpec.scala
@@ -214,11 +214,11 @@ class DatasetFinderSpec
 
       val authUser = authUsers.generateOne
       val (dataset, project) = renkuProjectEntities(visibilityNonPublic)
-        .map(replaceMembers(Set(personEntities(authUser.id.some).generateOne)))
+        .map(replaceMembers(Set(projectMemberEntities(authUser.id.some).generateOne)))
         .addDataset(datasetEntities(provenanceInternal))
         .generateOne
       val (_, otherProject) = renkuProjectEntities(visibilityNonPublic)
-        .map(replaceMembers(Set(personEntities(withGitLabId).generateOne)))
+        .map(replaceMembers(Set(projectMemberEntities(withGitLabId).generateOne)))
         .importDataset(dataset)
         .generateOne
 
@@ -233,11 +233,11 @@ class DatasetFinderSpec
 
       val authUser = authUsers.generateOne
       val (dataset, project) = renkuProjectEntities(visibilityNonPublic)
-        .map(replaceMembers(Set(personEntities(authUser.id.some).generateOne)))
+        .map(replaceMembers(Set(projectMemberEntities(authUser.id.some).generateOne)))
         .addDataset(datasetEntities(provenanceInternal))
         .generateOne
       val (otherDS, otherProject) = renkuProjectEntities(visibilityNonPublic)
-        .map(replaceMembers(personEntities(withGitLabId).generateSet() ++ project.members))
+        .map(replaceMembers(projectMemberEntities(withGitLabId).generateSet() ++ project.members))
         .importDataset(dataset)
         .generateOne
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/KGProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/details/KGProjectFinderSpec.scala
@@ -68,7 +68,8 @@ class KGProjectFinderSpec
 
     "return details of the project with the given slug if it has a parent project - non-public projects" in new TestCase {
       val user         = authUsers.generateOne
-      val userAsMember = personEntities.generateOne.copy(maybeGitLabId = user.id.some)
+      val userAsMember = projectMemberEntities(Gen.const(user.id.some)).generateOne
+
       val project = Gen
         .oneOf(
           renkuProjectWithParentEntities(visibilityNonPublic).modify(replaceMembers(Set(userAsMember))),
@@ -90,9 +91,9 @@ class KGProjectFinderSpec
         val project = Gen
           .oneOf(
             renkuProjectWithParentEntities(visibilityNonPublic)
-              .modify(replaceMembers(Set(personEntities.generateOne.copy(maybeGitLabId = user.id.some)))),
+              .modify(replaceMembers(Set(projectMemberEntities(Gen.const(user.id.some)).generateOne))),
             nonRenkuProjectWithParentEntities(visibilityNonPublic)
-              .modify(replaceMembers(Set(personEntities.generateOne.copy(maybeGitLabId = user.id.some))))
+              .modify(replaceMembers(Set(projectMemberEntities(Gen.const(user.id.some)).generateOne)))
           )
           .generateOne
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
@@ -172,7 +172,7 @@ class EdgesFinderSpec
 
           val exemplarData = LineageExemplarData(
             renkuProjectEntities(fixed(visibility)).generateOne.copy(
-              members = Set(memberPersonGitLabIdLens.set(Some(authUser.id))(projectMemberEntities().generateOne))
+              members = Set(memberPersonGitLabIdLens.replace(Some(authUser.id))(projectMemberEntities().generateOne))
             )
           )
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
@@ -172,7 +172,7 @@ class EdgesFinderSpec
 
           val exemplarData = LineageExemplarData(
             renkuProjectEntities(fixed(visibility)).generateOne.copy(
-              members = Set(personEntities.generateOne.copy(maybeGitLabId = Some(authUser.id)))
+              members = Set(memberPersonGitLabIdLens.set(Some(authUser.id))(projectMemberEntities().generateOne))
             )
           )
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinderSpec.scala
@@ -50,12 +50,15 @@ class TSProjectFinderSpec
         c.copy(maybeUser = authUsers.generateOne.copy(id = c.userId).some)
       }
 
-      val matchingMember = personEntities(withGitLabId).generateOne.copy(maybeGitLabId = criteria.userId.some)
+      val matchingMember =
+        memberPersonGitLabIdLens.set(criteria.userId.some)(
+          projectMemberEntities(withGitLabId).generateOne
+        )
       val project1WithMatchingMember = anyProjectEntities
-        .map(replaceMembers(Set(personEntities(withGitLabId).generateOne, matchingMember)))
+        .map(replaceMembers(Set(projectMemberEntities(withGitLabId).generateOne, matchingMember)))
         .generateOne
       val project2WithMatchingMember = anyProjectEntities
-        .map(replaceMembers(personEntities(withGitLabId).generateSet() + matchingMember))
+        .map(replaceMembers(projectMemberEntities(withGitLabId).generateSet() + matchingMember))
         .generateOne
 
       val projectWithoutMatchingMember = projectEntities(visibilityPublic).generateOne
@@ -68,24 +71,28 @@ class TSProjectFinderSpec
 
     "not see projects the authUser has no access to" in new TestCase {
 
-      val authUser = personEntities(withGitLabId).generateOne
+      val authUserMember = projectMemberEntities(withGitLabId).generateOne
+      val authUser       = authUserMember.person
       val criteria = criterias.generateOne.copy(maybeUser =
         AuthUser(authUser.maybeGitLabId.getOrElse(fail("AuthUser without GL id")), userAccessTokens.generateOne).some
       )
 
-      val matchingMember = personEntities(withGitLabId).generateOne.copy(maybeGitLabId = criteria.userId.some)
+      val matchingMember =
+        memberPersonGitLabIdLens.set(criteria.userId.some)(
+          projectMemberEntities(withGitLabId).generateOne
+        )
       val privateProjectWithMatchingMemberAndAuthUser = projectEntities(visibilityPrivate)
-        .map(replaceMembers(Set(authUser, matchingMember)))
+        .map(replaceMembers(Set(authUserMember, matchingMember)))
         .generateOne
       val privateProjectWithMatchingMemberOnly = projectEntities(visibilityPrivate)
-        .map(replaceMembers(personEntities(withGitLabId).generateSet() + matchingMember))
+        .map(replaceMembers(projectMemberEntities(withGitLabId).generateSet() + matchingMember))
         .generateOne
       val nonPrivateProjectWithMatchingMemberOnly =
         projectEntities(Gen.oneOf(projects.Visibility.Public, projects.Visibility.Internal))
-          .map(replaceMembers(personEntities(withGitLabId).generateSet() + matchingMember))
+          .map(replaceMembers(projectMemberEntities(withGitLabId).generateSet() + matchingMember))
           .generateOne
       val projectWithMatchingAuthUserOnly = anyProjectEntities
-        .map(replaceMembers(Set(authUser)))
+        .map(replaceMembers(Set(authUserMember)))
         .generateOne
 
       upload(

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinderSpec.scala
@@ -51,7 +51,7 @@ class TSProjectFinderSpec
       }
 
       val matchingMember =
-        memberPersonGitLabIdLens.set(criteria.userId.some)(
+        memberPersonGitLabIdLens.replace(criteria.userId.some)(
           projectMemberEntities(withGitLabId).generateOne
         )
       val project1WithMatchingMember = anyProjectEntities
@@ -78,7 +78,7 @@ class TSProjectFinderSpec
       )
 
       val matchingMember =
-        memberPersonGitLabIdLens.set(criteria.userId.some)(
+        memberPersonGitLabIdLens.replace(criteria.userId.some)(
           projectMemberEntities(withGitLabId).generateOne
         )
       val privateProjectWithMatchingMemberAndAuthUser = projectEntities(visibilityPrivate)

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/ModelTinyTypesDiffInstances.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/diffx/ModelTinyTypesDiffInstances.scala
@@ -60,6 +60,9 @@ trait ModelTinyTypesDiffInstances extends TinyTypeDiffInstances {
     Diff.derived[commandParameters.IOStream.StdErr]
 
   implicit val visibilityDiff: Diff[projects.Visibility] = Diff.derived[projects.Visibility]
+
+  implicit val roleDiff: Diff[projects.Role] =
+    Diff.derived[projects.Role]
 }
 
 object ModelTinyTypesDiffInstances extends ModelTinyTypesDiffInstances

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
@@ -194,7 +194,7 @@ private[entities] object CliProjectConverter {
   )(gitLabInfo: GitLabProjectInfo)(implicit renkuUrl: RenkuUrl): Set[Project.Member] =
     gitLabInfo.members.map(member =>
       allJsonLdPersons
-        .find(byEmailOrUsername(member.asUser))
+        .find(byEmailOrUsername(member.user))
         .map(merge(member))
         .getOrElse(toMember(member))
     )
@@ -213,7 +213,7 @@ private[entities] object CliProjectConverter {
     _.add(user.gitLabId).copy(name = user.name, maybeEmail = user.email)
 
   private def merge(member: GitLabMember)(implicit renkuUrl: RenkuUrl): Person => Project.Member = { p =>
-    Project.Member(merge(member.asUser).apply(p), member.role)
+    Project.Member(merge(member.user).apply(p), member.role)
   }
 
   private def toPerson(user: GitLabUser)(implicit renkuUrl: RenkuUrl): Person =
@@ -227,5 +227,5 @@ private[entities] object CliProjectConverter {
     )
 
   private def toMember(projectMember: GitLabMember)(implicit renkuUrl: RenkuUrl): Project.Member =
-    Project.Member(toPerson(projectMember.asUser), projectMember.role)
+    Project.Member(toPerson(projectMember.user), projectMember.role)
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/CliProjectConverter.scala
@@ -210,7 +210,7 @@ private[entities] object CliProjectConverter {
   }
 
   private def merge(user: GitLabUser)(implicit renkuUrl: RenkuUrl): Person => Person =
-    _.add(user.gitLabId).copy(name = user.name, maybeEmail = user.email)
+    p => p.add(user.gitLabId).copy(name = user.name, maybeEmail = user.email.orElse(p.maybeEmail))
 
   private def merge(member: GitLabMember)(implicit renkuUrl: RenkuUrl): Person => Project.Member = { p =>
     Project.Member(merge(member.user).apply(p), member.role)

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Project.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Project.scala
@@ -30,8 +30,8 @@ import io.renku.graph.model.gitlab.GitLabProjectInfo
 import io.renku.graph.model.images.Image
 import io.renku.graph.model.projects._
 import io.renku.graph.model.versions.{CliVersion, SchemaVersion}
+import io.renku.jsonld.Property
 import io.renku.jsonld.ontology._
-import io.renku.jsonld.{JsonLDEncoder, Property}
 import io.renku.tinytypes.InstantTinyType
 import monocle.{Lens, Traversal}
 
@@ -585,12 +585,6 @@ object RenkuProject {
 
 object Project {
   final case class Member(person: Person, role: Role)
-  object Member {
-    implicit def jsonLDEncoder(implicit glUrl: GitLabApiUrl, graph: GraphClass): JsonLDEncoder[Member] =
-      JsonLDEncoder.instance { _ =>
-        ??? // TODO hm, this changes the ontology of a project. need a new entity that points to person and stores role
-      }
-  }
 
   import io.renku.jsonld.{EntityTypes, JsonLD, JsonLDEncoder}
 
@@ -639,7 +633,7 @@ object Project {
           schema / "creator"          -> project.maybeCreator.asJsonLD,
           renku / "projectVisibility" -> project.visibility.asJsonLD,
           schema / "keywords"         -> project.keywords.asJsonLD,
-          schema / "member"           -> project.members.toList.asJsonLD,
+          schema / "member"           -> project.members.map(_.person).toList.asJsonLD,
           schema / "schemaVersion"    -> project.version.asJsonLD,
           renku / "hasActivity"       -> project.activities.asJsonLD,
           renku / "hasPlan"           -> project.plans.asJsonLD,
@@ -669,7 +663,7 @@ object Project {
           schema / "creator"          -> project.maybeCreator.asJsonLD,
           renku / "projectVisibility" -> project.visibility.asJsonLD,
           schema / "keywords"         -> project.keywords.asJsonLD,
-          schema / "member"           -> project.members.toList.asJsonLD,
+          schema / "member"           -> project.members.map(_.person).toList.asJsonLD,
           prov / "wasDerivedFrom"     -> maybeDerivedFrom.asJsonLD,
           schema / "image"            -> project.images.asJsonLD
         )

--- a/renku-model/src/main/scala/io/renku/graph/model/entities/Project.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/entities/Project.scala
@@ -18,23 +18,24 @@
 
 package io.renku.graph.model.entities
 
-import PlanLens.{getPlanDerivation, setPlanDerivation}
 import cats.Show
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.syntax.all._
 import io.renku.cli.model.{CliPerson, CliProject}
 import io.renku.graph.model._
 import io.renku.graph.model.entities.Dataset.Provenance
+import io.renku.graph.model.entities.PlanLens.{getPlanDerivation, setPlanDerivation}
 import io.renku.graph.model.entities.RenkuProject.ProjectFactory
-import io.renku.graph.model.images.{Image, ImageUri}
+import io.renku.graph.model.gitlab.GitLabProjectInfo
+import io.renku.graph.model.images.Image
 import io.renku.graph.model.projects._
 import io.renku.graph.model.versions.{CliVersion, SchemaVersion}
-import io.renku.jsonld.{JsonLDEncoder, Property}
 import io.renku.jsonld.ontology._
+import io.renku.jsonld.{JsonLDEncoder, Property}
 import io.renku.tinytypes.InstantTinyType
 import monocle.{Lens, Traversal}
 
-import Ordered.orderingToOrdered
+import scala.math.Ordered.orderingToOrdered
 
 sealed trait Project extends Product with Serializable {
   val resourceId:       ResourceId
@@ -727,56 +728,5 @@ object Project {
           schemaVersionProperty
         )
       )
-  }
-
-  final case class GitLabProjectInfo(id:               GitLabId,
-                                     name:             Name,
-                                     slug:             Slug,
-                                     dateCreated:      DateCreated,
-                                     dateModified:     DateModified,
-                                     maybeDescription: Option[Description],
-                                     maybeCreator:     Option[ProjectMember],
-                                     keywords:         Set[Keyword],
-                                     members:          Set[ProjectMember],
-                                     visibility:       Visibility,
-                                     maybeParentSlug:  Option[Slug],
-                                     avatarUrl:        Option[ImageUri]
-  )
-
-  sealed trait ProjectMember {
-    val name:        persons.Name
-    val username:    persons.Username
-    val gitLabId:    persons.GitLabId
-    val accessLevel: Int
-    def role: Role = Role.fromGitLabAccessLevel(accessLevel)
-  }
-  object ProjectMember {
-
-    def apply(
-        name:        persons.Name,
-        username:    persons.Username,
-        gitLabId:    persons.GitLabId,
-        accessLevel: Int
-    ): ProjectMemberNoEmail =
-      ProjectMemberNoEmail(name, username, gitLabId, accessLevel: Int)
-
-    final case class ProjectMemberNoEmail(
-        name:        persons.Name,
-        username:    persons.Username,
-        gitLabId:    persons.GitLabId,
-        accessLevel: Int
-    ) extends ProjectMember {
-
-      def add(email: persons.Email): ProjectMemberWithEmail =
-        ProjectMemberWithEmail(name, username, gitLabId, email, accessLevel)
-    }
-
-    final case class ProjectMemberWithEmail(
-        name:        persons.Name,
-        username:    persons.Username,
-        gitLabId:    persons.GitLabId,
-        email:       persons.Email,
-        accessLevel: Int
-    ) extends ProjectMember
   }
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabMember.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabMember.scala
@@ -22,15 +22,24 @@ import io.renku.graph.model.persons._
 import io.renku.graph.model.projects.Role
 
 final case class GitLabMember(
-    name:        Name,
-    username:    Username,
-    gitLabId:    GitLabId,
-    email:       Option[Email],
+    user:        GitLabUser,
     accessLevel: Int
 ) {
 
-  def asUser: GitLabUser = GitLabUser(name, username, gitLabId, email)
-  def withEmail(email: Email): GitLabMember = copy(email = Some(email))
+  def withEmail(email: Email): GitLabMember = copy(user = user.withEmail(email))
 
   def role: Role = Role.fromGitLabAccessLevel(accessLevel)
+}
+
+object GitLabMember {
+  def apply(
+      name:        Name,
+      username:    Username,
+      gitLabId:    GitLabId,
+      email:       Option[Email],
+      accessLevel: Int
+  ): GitLabMember = GitLabMember(
+    GitLabUser(name, username, gitLabId, email),
+    accessLevel
+  )
 }

--- a/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabMember.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabMember.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.gitlab
+
+import io.renku.graph.model.persons._
+import io.renku.graph.model.projects.Role
+
+final case class GitLabMember(
+    name:        Name,
+    username:    Username,
+    gitLabId:    GitLabId,
+    email:       Option[Email],
+    accessLevel: Int
+) {
+
+  def asUser: GitLabUser = GitLabUser(name, username, gitLabId, email)
+  def withEmail(email: Email): GitLabMember = copy(email = Some(email))
+
+  def role: Role = Role.fromGitLabAccessLevel(accessLevel)
+}

--- a/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabProjectInfo.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabProjectInfo.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.gitlab
+
+import io.renku.graph.model.images.ImageUri
+import io.renku.graph.model.projects._
+
+final case class GitLabProjectInfo(
+    id:               GitLabId,
+    name:             Name,
+    slug:             Slug,
+    dateCreated:      DateCreated,
+    dateModified:     DateModified,
+    maybeDescription: Option[Description],
+    maybeCreator:     Option[GitLabUser],
+    keywords:         Set[Keyword],
+    members:          Set[GitLabMember],
+    visibility:       Visibility,
+    maybeParentSlug:  Option[Slug],
+    avatarUrl:        Option[ImageUri]
+)
+
+object GitLabProjectInfo {}

--- a/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabUser.scala
+++ b/renku-model/src/main/scala/io/renku/graph/model/gitlab/GitLabUser.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.graph.model.gitlab
+
+import io.renku.graph.model.persons.{Email, GitLabId, Name, Username}
+import io.renku.graph.model.projects.Role
+
+final case class GitLabUser(
+    name:     Name,
+    username: Username,
+    gitLabId: GitLabId,
+    email:    Option[Email]
+) {
+  def withEmail(email:      Email): GitLabUser   = copy(email = Some(email))
+  def toMember(accessLevel: Int):   GitLabMember = GitLabMember(name, username, gitLabId, email, accessLevel)
+  def toMember(role:        Role):  GitLabMember = toMember(Role.toGitLabAccessLevel(role))
+}

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/DiffInstances.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/DiffInstances.scala
@@ -133,6 +133,9 @@ trait DiffInstances extends CliDiffInstances {
 
   implicit val nonRenkuProjectDiff: Diff[NonRenkuProject] = Diff.derived[NonRenkuProject]
 
+  implicit val projectMemberDiff: Diff[Project.Member] =
+    Diff.derived[Project.Member]
+
   implicit val projectDiff: Diff[Project] = Diff.derived[Project]
 }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/DiffInstances.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/DiffInstances.scala
@@ -117,6 +117,9 @@ trait DiffInstances extends CliDiffInstances {
 
   implicit def datasetDiff: Diff[Dataset[Provenance]] = Diff.derived[Dataset[Provenance]]
 
+  implicit val projectMemberDiff: Diff[Project.Member] =
+    Diff.derived[Project.Member]
+
   implicit val renkuProjectWithParentDiff: Diff[RenkuProject.WithParent] =
     Diff.derived[RenkuProject.WithParent]
 
@@ -132,9 +135,6 @@ trait DiffInstances extends CliDiffInstances {
     Diff.derived[NonRenkuProject.WithParent]
 
   implicit val nonRenkuProjectDiff: Diff[NonRenkuProject] = Diff.derived[NonRenkuProject]
-
-  implicit val projectMemberDiff: Diff[Project.Member] =
-    Diff.derived[Project.Member]
 
   implicit val projectDiff: Diff[Project] = Diff.derived[Project]
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -226,7 +226,7 @@ class ProjectSpec
     "turn non-renku CliProject entity without parent into the NonRenkuProject object" in {
       forAll(gitLabProjectInfos.map(projectInfoMaybeParent.replace(None))) { projectInfo =>
         val creator = projectMembersWithEmail.generateOne
-        val members = gitLapProjectMembers.generateSet()
+        val members = gitLabProjectMembers.generateSet()
         val info    = projectInfo.copy(maybeCreator = creator.user.some, members = members)
         val testProject: testentities.Project = createNonRenkuProject(info)
 
@@ -247,7 +247,7 @@ class ProjectSpec
     "turn non-renku CliProject entity with parent into the NonRenkuProject object" in {
       forAll(gitLabProjectInfos.map(projectInfoMaybeParent.replace(projectSlugs.generateSome))) { projectInfo =>
         val creator = projectMembersWithEmail.generateOne
-        val members = gitLapProjectMembers.generateSet()
+        val members = gitLabProjectMembers.generateSet()
         val info    = projectInfo.copy(maybeCreator = creator.user.some, members = members)
         val testProject: testentities.Project = createNonRenkuProject(info)
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -1032,7 +1032,7 @@ class ProjectSpec
               schema / "creator"          -> project.maybeCreator.asJsonLD,
               renku / "projectVisibility" -> project.visibility.asJsonLD,
               schema / "keywords"         -> project.keywords.asJsonLD,
-              schema / "member"           -> project.members.toList.asJsonLD,
+              schema / "member"           -> project.members.map(_.person).toList.asJsonLD,
               schema / "schemaVersion"    -> project.version.asJsonLD,
               renku / "hasActivity"       -> project.activities.asJsonLD,
               renku / "hasPlan"           -> project.plans.asJsonLD,
@@ -1068,7 +1068,7 @@ class ProjectSpec
               schema / "creator"          -> project.maybeCreator.asJsonLD,
               renku / "projectVisibility" -> project.visibility.asJsonLD,
               schema / "keywords"         -> project.keywords.asJsonLD,
-              schema / "member"           -> project.members.toList.asJsonLD,
+              schema / "member"           -> project.members.map(_.person).toList.asJsonLD,
               prov / "wasDerivedFrom"     -> maybeParentId.map(_.asEntityId).asJsonLD,
               schema / "image"            -> project.images.asJsonLD
             )

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -31,8 +31,7 @@ import io.renku.graph.model.GraphModelGenerators._
 import io.renku.graph.model.Schemas.{prov, renku, schema}
 import io.renku.graph.model._
 import io.renku.graph.model.entities.Generators.{compositePlanNonEmptyMappings, stepPlanGenFactory}
-import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail, ProjectMemberWithEmail}
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabProjectInfo, GitLabUser}
 import io.renku.graph.model.images.Image
 import io.renku.graph.model.projects.ForksCount
 import io.renku.graph.model.testentities.RenkuProject.CreateCompositePlan
@@ -69,10 +68,12 @@ class ProjectSpec
       val member = projectMembersNoEmail.generateOne
       val email  = personEmails.generateOne
 
-      (member add email) shouldBe ProjectMember.ProjectMemberWithEmail(member.name,
-                                                                       member.username,
-                                                                       member.gitLabId,
-                                                                       email
+      (member withEmail email) shouldBe GitLabMember(
+        member.user.name,
+        member.user.username,
+        member.user.gitLabId,
+        email.some,
+        member.accessLevel
       )
     }
   }
@@ -102,11 +103,12 @@ class ProjectSpec
 
     "turn CliProject entity without parent into the Project object" in new TestCase {
       forAll(gitLabProjectInfos.map(projectInfoMaybeParent.replace(None))) { projectInfo =>
-        val creator            = projectMembersWithEmail.generateOne
-        val member1            = projectMembersNoEmail.generateOne
-        val member2            = projectMembersWithEmail.generateOne
-        val member3            = projectMembersWithEmail.generateOne
-        val info               = projectInfo.copy(maybeCreator = creator.some, members = Set(member1, member2, member3))
+        val creator = projectMembersWithEmail.generateOne
+        val member1 = projectMembersNoEmail.generateOne
+        val member2 = projectMembersWithEmail.generateOne
+        val member3 = projectMembersWithEmail.generateOne
+        val info    = projectInfo.copy(maybeCreator = creator.user.some, members = Set(member1, member2, member3))
+
         val creatorAsCliPerson = creator.toTestPerson.copy(maybeGitLabId = None)
         val activity1          = activityWith(member2.toTestPerson.copy(maybeGitLabId = None))(info.dateCreated)
         val activity2          = activityWith(cliShapedPersons.generateOne)(info.dateCreated)
@@ -131,10 +133,12 @@ class ProjectSpec
         val mergedMember3 = dataset1.provenance.creators
           .find(byEmail(member3))
           .map(merge(_, member3))
-          .getOrElse(fail(show"No dataset1 creator with ${member3.email}"))
+          .getOrElse(fail(show"No dataset1 creator with ${member3.user.email}"))
 
         val expectedActivities: List[testentities.Activity] =
-          (activity1.copy(author = mergedMember2) :: activity2 :: replaceAgent(activity3, mergedCreator) :: Nil)
+          (activity1.copy(author = mergedMember2.person) :: activity2 :: replaceAgent(activity3,
+                                                                                      mergedCreator.person
+          ) :: Nil)
             .sortBy(_.startTime)
 
         val decoded = Project.fromCli(cliProject, allPersons, info)
@@ -144,25 +148,29 @@ class ProjectSpec
           .copy(
             dateModified = List(cliProject.dateModified, info.dateModified).max,
             activities = expectedActivities.map(_.to[entities.Activity]),
-            maybeCreator = mergedCreator.to[entities.Person].some,
+            maybeCreator = mergedCreator.to[entities.Project.Member].person.some,
             datasets = List(
-              addTo(dataset1, NonEmptyList.one(mergedMember3))
+              addTo(dataset1, NonEmptyList.one(mergedMember3.person))
                 .to[entities.Dataset[entities.Dataset.Provenance]],
               dataset2
                 .to[entities.Dataset[entities.Dataset.Provenance]]
             ),
-            members = Set(member1.toPerson, mergedMember2.to[entities.Person], mergedMember3.to[entities.Person])
+            members = Set(member1.toMember,
+                          mergedMember2.to[entities.Project.Member],
+                          mergedMember3.to[entities.Project.Member]
+            )
           )
       }
     }
 
     "turn CliProject entity with parent into the Project object" in new TestCase {
       forAll(gitLabProjectInfos.map(projectInfoMaybeParent.replace(projectSlugs.generateSome))) { projectInfo =>
-        val creator            = projectMembersWithEmail.generateOne
-        val member1            = projectMembersNoEmail.generateOne
-        val member2            = projectMembersWithEmail.generateOne
-        val member3            = projectMembersWithEmail.generateOne
-        val info               = projectInfo.copy(maybeCreator = creator.some, members = Set(member1, member2, member3))
+        val creator = projectMembersWithEmail.generateOne
+        val member1 = projectMembersNoEmail.generateOne
+        val member2 = projectMembersWithEmail.generateOne
+        val member3 = projectMembersWithEmail.generateOne
+        val info    = projectInfo.copy(maybeCreator = creator.user.some, members = Set(member1, member2, member3))
+
         val creatorAsCliPerson = creator.toTestPerson.copy(maybeGitLabId = None)
         val activity1          = activityWith(member2.toTestPerson.copy(maybeGitLabId = None))(info.dateCreated)
         val activity2          = activityWith(cliShapedPersons.generateOne)(info.dateCreated)
@@ -186,10 +194,12 @@ class ProjectSpec
         val mergedMember3 = dataset1.provenance.creators
           .find(byEmail(member3))
           .map(merge(_, member3))
-          .getOrElse(fail(show"No dataset1 creator with ${member3.email}"))
+          .getOrElse(fail(show"No dataset1 creator with ${member3.user.email}"))
 
         val expectedActivities: List[testentities.Activity] =
-          (activity1.copy(author = mergedMember2) :: activity2 :: replaceAgent(activity3, mergedCreator) :: Nil)
+          (activity1.copy(author = mergedMember2.person) :: activity2 :: replaceAgent(activity3,
+                                                                                      mergedCreator.person
+          ) :: Nil)
             .sortBy(_.startTime)
 
         val decoded = Project.fromCli(cliProject, allPersons, info)
@@ -199,11 +209,14 @@ class ProjectSpec
           .asInstanceOf[entities.RenkuProject.WithParent]
           .copy(
             dateModified = List(cliProject.dateModified, info.dateModified).max,
-            members = Set(member1.toPerson, mergedMember2.to[entities.Person], mergedMember3.to[entities.Person]),
-            maybeCreator = mergedCreator.to[entities.Person].some,
+            members = Set(member1.toMember,
+                          mergedMember2.to[entities.Project.Member],
+                          mergedMember3.to[entities.Project.Member]
+            ),
+            maybeCreator = mergedCreator.to[entities.Project.Member].person.some,
             activities = expectedActivities.map(_.to[entities.Activity]),
             datasets = List(
-              addTo(dataset1, NonEmptyList.one(mergedMember3)).to[entities.Dataset[entities.Dataset.Provenance]],
+              addTo(dataset1, NonEmptyList.one(mergedMember3.person)).to[entities.Dataset[entities.Dataset.Provenance]],
               dataset2.to[entities.Dataset[entities.Dataset.Provenance]]
             )
           )
@@ -213,8 +226,8 @@ class ProjectSpec
     "turn non-renku CliProject entity without parent into the NonRenkuProject object" in {
       forAll(gitLabProjectInfos.map(projectInfoMaybeParent.replace(None))) { projectInfo =>
         val creator = projectMembersWithEmail.generateOne
-        val members = projectMembers.generateSet()
-        val info    = projectInfo.copy(maybeCreator = creator.some, members = members)
+        val members = gitLapProjectMembers.generateSet()
+        val info    = projectInfo.copy(maybeCreator = creator.user.some, members = members)
         val testProject: testentities.Project = createNonRenkuProject(info)
 
         val cliProject = testProject.to[CliProject]
@@ -225,7 +238,7 @@ class ProjectSpec
             .to[entities.Project]
             .asInstanceOf[entities.NonRenkuProject.WithoutParent]
             .copy(
-              members = members.map(_.toPerson),
+              members = members.map(_.toMember),
               maybeCreator = creator.toPerson.some
             )
       }
@@ -234,8 +247,8 @@ class ProjectSpec
     "turn non-renku CliProject entity with parent into the NonRenkuProject object" in {
       forAll(gitLabProjectInfos.map(projectInfoMaybeParent.replace(projectSlugs.generateSome))) { projectInfo =>
         val creator = projectMembersWithEmail.generateOne
-        val members = projectMembers.generateSet()
-        val info    = projectInfo.copy(maybeCreator = creator.some, members = members)
+        val members = gitLapProjectMembers.generateSet()
+        val info    = projectInfo.copy(maybeCreator = creator.user.some, members = members)
         val testProject: testentities.Project = createNonRenkuProject(info)
 
         val cliProject = testProject.to[CliProject]
@@ -245,7 +258,7 @@ class ProjectSpec
           testProject
             .to[entities.Project]
             .asInstanceOf[entities.NonRenkuProject.WithParent]
-            .copy(members = members.map(_.toPerson), maybeCreator = creator.toPerson.some)
+            .copy(members = members.map(_.toMember), maybeCreator = creator.toPerson.some)
       }
     }
 
@@ -253,7 +266,7 @@ class ProjectSpec
       Table(
         "Project type"   -> "Project Info",
         "without parent" -> gitLabProjectInfos.map(projectInfoMaybeParent.replace(None)).generateOne,
-        "with parent"    -> gitLabProjectInfos.map(projectInfoMaybeParent.replace(projectSlugs.generateSome)).generateOne
+        "with parent" -> gitLabProjectInfos.map(projectInfoMaybeParent.replace(projectSlugs.generateSome)).generateOne
       )
     } { (projectType, info) =>
       s"match persons in plan.creators for project $projectType" in new TestCase {
@@ -261,7 +274,7 @@ class ProjectSpec
         val creator = projectMembersWithEmail.generateOne
         val member2 = projectMembersWithEmail.generateOne
 
-        val projectInfo        = info.copy(maybeCreator = creator.some, members = Set(member2))
+        val projectInfo        = info.copy(maybeCreator = creator.user.some, members = Set(member2))
         val creatorAsCliPerson = creator.toTestPerson.copy(maybeGitLabId = None)
         val activity =
           testentities.Activity.Lenses.planCreators.replace(List(creatorAsCliPerson))(
@@ -282,12 +295,12 @@ class ProjectSpec
         val actual =
           Project.fromCli(cliProject, allPersons, projectInfo).fold(errs => fail(errs.intercalate("; ")), identity)
 
-        actual.maybeCreator shouldBe mergedCreator.to[entities.Person].some
-        actual.members      shouldBe Set(mergedMember2.to[entities.Person])
-        actual.activities shouldBe ActivityLens.activityAuthor.replace(mergedMember2.to[entities.Person])(
+        actual.maybeCreator shouldBe mergedCreator.to[entities.Project.Member].person.some
+        actual.members      shouldBe Set(mergedMember2.to[entities.Project.Member])
+        actual.activities shouldBe ActivityLens.activityAuthor.replace(mergedMember2.to[entities.Project.Member].person)(
           activity.to[entities.Activity]
         ) :: Nil
-        actual.plans shouldBe PlanLens.planCreators.replace(List(mergedCreator.to[entities.Person]))(
+        actual.plans shouldBe PlanLens.planCreators.replace(List(mergedCreator.to[entities.Project.Member].person))(
           activity.plan.to[entities.Plan]
         ) :: Nil
       }
@@ -635,7 +648,7 @@ class ProjectSpec
       Project.fromCli(cliProject, allPersons, projectInfo) shouldMatchToValid testProject
         .to[entities.RenkuProject.WithParent]
         .copy(
-          members = projectInfo.members.map(_.toPerson),
+          members = projectInfo.members.map(_.toMember),
           maybeCreator = projectInfo.maybeCreator.map(_.toPerson)
         )
     }
@@ -695,7 +708,7 @@ class ProjectSpec
       Project.fromCli(cliProject, allPersons, projectInfo) shouldMatchToValid testProject
         .to[entities.RenkuProject.WithoutParent]
         .copy(
-          members = projectInfo.members.map(_.toPerson),
+          members = projectInfo.members.map(_.toMember),
           maybeCreator = projectInfo.maybeCreator.map(_.toPerson)
         )
     }
@@ -751,7 +764,7 @@ class ProjectSpec
       Project.fromCli(cliProject, allPersons, projectInfo) shouldMatchToValid testProject
         .to[entities.RenkuProject.WithoutParent]
         .copy(
-          members = projectInfo.members.map(_.toPerson),
+          members = projectInfo.members.map(_.toMember),
           maybeCreator = projectInfo.maybeCreator.map(_.toPerson),
           dateCreated = earliestDate,
           dateModified = List(cliProject.dateModified, projectInfo.dateModified).max
@@ -787,7 +800,7 @@ class ProjectSpec
       Project.fromCli(cliProject, allPersons, projectInfo) shouldMatchToValid testProject
         .to[entities.RenkuProject.WithoutParent]
         .copy(
-          members = projectInfo.members.map(_.toPerson),
+          members = projectInfo.members.map(_.toMember),
           maybeCreator = projectInfo.maybeCreator.map(_.toPerson),
           dateCreated = earliestDate,
           dateModified = List(projectInfo.dateModified, cliProject.dateModified).max
@@ -820,7 +833,7 @@ class ProjectSpec
       Project.fromCli(cliProject, allPersons, projectInfo) shouldMatchToValid testProject
         .to[entities.RenkuProject.WithoutParent]
         .copy(
-          members = projectInfo.members.map(_.toPerson),
+          members = projectInfo.members.map(_.toMember),
           maybeCreator = projectInfo.maybeCreator.map(_.toPerson),
           dateCreated = earliestDate,
           dateModified = List(projectInfo.dateModified, cliProject.dateModified).max,
@@ -857,7 +870,7 @@ class ProjectSpec
       Project.fromCli(cliProject, allPersons, projectInfo) shouldMatchToValid testProject
         .to[entities.RenkuProject.WithoutParent]
         .copy(
-          members = projectInfo.members.map(_.toPerson),
+          members = projectInfo.members.map(_.toMember),
           maybeCreator = projectInfo.maybeCreator.map(_.toPerson),
           dateCreated = earliestDate,
           dateModified = List(projectInfo.dateModified, cliProject.dateModified).max,
@@ -1073,7 +1086,7 @@ class ProjectSpec
     "produce JsonLD with all the relevant properties and only links to Person entities" in {
       forAll(
         renkuProjectEntitiesWithDatasetsAndActivities
-          .modify(replaceMembers(personEntities(withoutGitLabId).generateFixedSizeSet(ofSize = 1)))
+          .modify(replaceMembers(projectMemberEntities(withoutGitLabId).generateFixedSizeSet(ofSize = 1)))
           .map(_.to[entities.RenkuProject])
       ) { project =>
         val maybeParentId = project match {
@@ -1098,7 +1111,7 @@ class ProjectSpec
               schema / "creator"          -> project.maybeCreator.map(_.resourceId.asEntityId).asJsonLD,
               renku / "projectVisibility" -> project.visibility.asJsonLD,
               schema / "keywords"         -> project.keywords.asJsonLD,
-              schema / "member"           -> project.members.map(_.resourceId.asEntityId).toList.asJsonLD,
+              schema / "member"           -> project.members.map(_.person.resourceId.asEntityId).toList.asJsonLD,
               schema / "schemaVersion"    -> project.version.asJsonLD,
               renku / "hasActivity"       -> project.activities.asJsonLD,
               renku / "hasPlan"           -> project.plans.asJsonLD,
@@ -1114,7 +1127,7 @@ class ProjectSpec
     "produce JsonLD with all the relevant properties or a non-Renku Project" in {
       forAll(
         anyNonRenkuProjectEntities
-          .modify(replaceMembers(personEntities(withoutGitLabId).generateFixedSizeSet(ofSize = 1)))
+          .modify(replaceMembers(projectMemberEntities(withoutGitLabId).generateFixedSizeSet(ofSize = 1)))
           .map(_.to[entities.NonRenkuProject])
       ) { project =>
         val maybeParentId = project match {
@@ -1138,7 +1151,7 @@ class ProjectSpec
               schema / "creator"          -> project.maybeCreator.map(_.resourceId.asEntityId).asJsonLD,
               renku / "projectVisibility" -> project.visibility.asJsonLD,
               schema / "keywords"         -> project.keywords.asJsonLD,
-              schema / "member"           -> project.members.map(_.resourceId.asEntityId).toList.asJsonLD,
+              schema / "member"           -> project.members.map(_.person.resourceId.asEntityId).toList.asJsonLD,
               prov / "wasDerivedFrom"     -> maybeParentId.map(_.asEntityId).asJsonLD,
               schema / "image"            -> project.images.asJsonLD
             )
@@ -1150,7 +1163,7 @@ class ProjectSpec
     "produce JsonLD with all the relevant properties without images" in {
       forAll(
         anyNonRenkuProjectEntities
-          .modify(replaceMembers(personEntities(withoutGitLabId).generateFixedSizeSet(ofSize = 1)))
+          .modify(replaceMembers(projectMemberEntities(withoutGitLabId).generateFixedSizeSet(ofSize = 1)))
           .modify(replaceImages(Nil))
           .map(_.to[entities.NonRenkuProject])
       ) { project =>
@@ -1182,7 +1195,7 @@ class ProjectSpec
               schema / "creator"          -> project.maybeCreator.map(_.resourceId.asEntityId).asJsonLD,
               renku / "projectVisibility" -> project.visibility.asJsonLD,
               schema / "keywords"         -> project.keywords.asJsonLD,
-              schema / "member"           -> project.members.map(_.resourceId.asEntityId).toList.asJsonLD,
+              schema / "member"           -> project.members.map(_.person.resourceId.asEntityId).toList.asJsonLD,
               prov / "wasDerivedFrom"     -> maybeParentId.map(_.asEntityId).asJsonLD
             )
           )
@@ -1345,44 +1358,36 @@ class ProjectSpec
         )
     }
 
-  private implicit class ProjectMemberOps(gitLabPerson: ProjectMember) {
+  private implicit class GitLabMemberOps(gitLabPerson: GitLabMember) {
+    lazy val toPerson: entities.Person =
+      gitLabPerson.user.toPerson
 
-    lazy val toPerson: entities.Person = gitLabPerson match {
-      case ProjectMemberNoEmail(name, _, gitLabId) =>
-        entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                     gitLabId,
-                                     name,
-                                     maybeEmail = None,
-                                     maybeOrcidId = None,
-                                     maybeAffiliation = None
-        )
-      case ProjectMemberWithEmail(name, _, gitLabId, email) =>
-        entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                     gitLabId,
-                                     name,
-                                     email.some,
-                                     maybeOrcidId = None,
-                                     maybeAffiliation = None
-        )
-    }
+    lazy val toTestPerson: testentities.Person =
+      gitLabPerson.user.toTestPerson
 
-    lazy val toTestPerson: testentities.Person = gitLabPerson match {
-      case ProjectMemberNoEmail(_, username, gitLabId) =>
-        testentities.Person(
-          persons.Name(username.value),
-          maybeEmail = None,
-          gitLabId.some,
-          maybeOrcidId = None,
-          maybeAffiliation = None
-        )
-      case ProjectMemberWithEmail(_, username, gitLabId, email) =>
-        testentities.Person(persons.Name(username.value),
-                            email.some,
-                            gitLabId.some,
-                            maybeOrcidId = None,
-                            maybeAffiliation = None
-        )
-    }
+    lazy val toMember: entities.Project.Member =
+      entities.Project.Member(toPerson, gitLabPerson.role)
+
+    lazy val toTestMember: testentities.Project.Member =
+      testentities.Project.Member(toTestPerson, gitLabPerson.role)
+  }
+
+  private implicit class GitLabUserOps(gitLabUser: GitLabUser) {
+    lazy val toPerson: entities.Person = entities.Person.WithGitLabId(
+      persons.ResourceId(gitLabUser.gitLabId),
+      gitLabUser.gitLabId,
+      gitLabUser.name,
+      maybeEmail = gitLabUser.email,
+      maybeOrcidId = None,
+      maybeAffiliation = None
+    )
+    lazy val toTestPerson: testentities.Person = testentities.Person(
+      persons.Name(gitLabUser.username.value),
+      gitLabUser.email,
+      gitLabUser.gitLabId.some,
+      maybeOrcidId = None,
+      maybeAffiliation = None
+    )
   }
 
   private implicit class CliProjectOps(self: CliProject) {
@@ -1438,11 +1443,14 @@ class ProjectSpec
   private def replaceAgent(activity: testentities.Activity, newAgent: testentities.Person): testentities.Activity =
     testentities.Activity.Lenses.associationAgent.replace(Right(newAgent))(activity)
 
-  private def byEmail(member: ProjectMemberWithEmail): testentities.Person => Boolean =
-    _.maybeEmail.exists(_ == member.email)
+  private def byEmail(member: GitLabMember): testentities.Person => Boolean =
+    p => (p.maybeEmail, member.user.email).mapN(_ == _).getOrElse(false)
 
-  private def merge(person: testentities.Person, member: ProjectMemberWithEmail): testentities.Person =
-    person.copy(maybeGitLabId = member.gitLabId.some, name = member.name, maybeEmail = member.email.some)
+  private def merge(person: testentities.Person, member: GitLabMember): testentities.Project.Member = {
+    val p =
+      person.copy(maybeGitLabId = member.user.gitLabId.some, name = member.user.name, maybeEmail = member.user.email)
+    testentities.Project.Member(p, member.role)
+  }
 
   private lazy val projectInfoMaybeParent: Lens[GitLabProjectInfo, Option[projects.Slug]] =
     Lens[GitLabProjectInfo, Option[projects.Slug]](_.maybeParentSlug)(mpp => _.copy(maybeParentSlug = mpp))

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -297,7 +297,9 @@ class ProjectSpec
 
         actual.maybeCreator shouldBe mergedCreator.to[entities.Project.Member].person.some
         actual.members      shouldBe Set(mergedMember2.to[entities.Project.Member])
-        actual.activities shouldBe ActivityLens.activityAuthor.replace(mergedMember2.to[entities.Project.Member].person)(
+        actual.activities shouldBe ActivityLens.activityAuthor.replace(
+          mergedMember2.to[entities.Project.Member].person
+        )(
           activity.to[entities.Activity]
         ) :: Nil
         actual.plans shouldBe PlanLens.planCreators.replace(List(mergedCreator.to[entities.Project.Member].person))(
@@ -1448,7 +1450,11 @@ class ProjectSpec
 
   private def merge(person: testentities.Person, member: GitLabMember): testentities.Project.Member = {
     val p =
-      person.copy(maybeGitLabId = member.user.gitLabId.some, name = member.user.name, maybeEmail = member.user.email)
+      person.copy(
+        maybeGitLabId = member.user.gitLabId.some,
+        name = member.user.name,
+        maybeEmail = member.user.email.orElse(person.maybeEmail)
+      )
     testentities.Project.Member(p, member.role)
   }
 

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ProjectSpec.scala
@@ -1212,7 +1212,7 @@ class ProjectSpec
 
       EntityFunctions[entities.Project].findAllPersons(project) shouldBe
         project.maybeCreator.toSet ++
-        project.members ++
+        project.members.map(_.person) ++
         project.activities.flatMap(EntityFunctions[entities.Activity].findAllPersons).toSet ++
         project.datasets.flatMap(EntityFunctions[entities.Dataset[entities.Dataset.Provenance]].findAllPersons).toSet ++
         project.plans.flatMap(EntityFunctions[entities.Plan].findAllPersons).toSet

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/ModelOps.scala
@@ -49,6 +49,11 @@ trait ModelOps extends Dataset.ProvenanceOps {
     def toMaybe[T](implicit convert: Person => Option[T]): Option[T] = convert(person)
   }
 
+  implicit class MemberOps(m: Project.Member) {
+    def to[T](implicit convert:      Project.Member => T):         T         = convert(m)
+    def toMaybe[T](implicit convert: Project.Member => Option[T]): Option[T] = convert(m)
+  }
+
   implicit class ProjectOps(project: Project)(implicit
       renkuUrl: RenkuUrl
   ) extends AbstractProjectOps[Project](project)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/NonRenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/NonRenkuProject.scala
@@ -48,7 +48,7 @@ object NonRenkuProject {
                                  visibility:       Visibility,
                                  forksCount:       ForksCount,
                                  keywords:         Set[Keyword],
-                                 members:          Set[Person],
+                                 members:          Set[Project.Member],
                                  images:           List[ImageUri]
   ) extends NonRenkuProject {
     override type ProjectType = NonRenkuProject.WithoutParent
@@ -64,7 +64,7 @@ object NonRenkuProject {
                               visibility:       Visibility,
                               forksCount:       ForksCount,
                               keywords:         Set[Keyword],
-                              members:          Set[Person],
+                              members:          Set[Project.Member],
                               parent:           NonRenkuProject,
                               images:           List[ImageUri]
   ) extends NonRenkuProject
@@ -93,7 +93,7 @@ object NonRenkuProject {
         project.maybeCreator.map(_.to[entities.Person]),
         project.visibility,
         project.keywords,
-        project.members.map(_.to[entities.Person]),
+        project.members.map(_.to[entities.Project.Member]),
         convertImageUris(project.asEntityId)(project.images)
       )
 
@@ -111,7 +111,7 @@ object NonRenkuProject {
         project.maybeCreator.map(_.to[entities.Person]),
         project.visibility,
         project.keywords,
-        project.members.map(_.to[entities.Person]),
+        project.members.map(_.to[entities.Project.Member]),
         projects.ResourceId(project.parent.asEntityId),
         convertImageUris(project.asEntityId)(project.images)
       )

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/Project.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/Project.scala
@@ -23,7 +23,7 @@ import io.renku.cli.model.CliProject
 import io.renku.graph.model.cli.CliConverters
 import io.renku.graph.model.entities.EntityFunctions
 import io.renku.graph.model.images.ImageUri
-import io.renku.graph.model.projects.{DateCreated, DateModified, Description, ForksCount, Keyword, Name, Slug, Visibility}
+import io.renku.graph.model.projects.{DateCreated, DateModified, Description, ForksCount, Keyword, Name, Role, Slug, Visibility}
 import io.renku.graph.model.testentities.NonRenkuProject._
 import io.renku.graph.model.testentities.RenkuProject._
 import io.renku.graph.model.{GitLabApiUrl, GraphClass, RenkuUrl, entities}
@@ -39,7 +39,7 @@ trait Project extends Product with Serializable {
   val visibility:       Visibility
   val forksCount:       ForksCount
   val keywords:         Set[Keyword]
-  val members:          Set[Person]
+  val members:          Set[Project.Member]
   val images:           List[ImageUri]
 
   type ProjectType <: Project
@@ -61,6 +61,11 @@ trait Parent {
 }
 
 object Project {
+  final case class Member(person: Person, role: Role)
+  object Member {
+    implicit def toEntitiesMember(implicit renkuUrl: RenkuUrl): Member => entities.Project.Member =
+      m => entities.Project.Member(m.person.to[entities.Person], m.role)
+  }
 
   import cats.syntax.all._
   import io.renku.jsonld.syntax._

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/RenkuProject.scala
@@ -42,7 +42,7 @@ sealed trait RenkuProject extends Project with RenkuProject.RenkuProjectAlg with
   val visibility:           Visibility
   val forksCount:           ForksCount
   val keywords:             Set[Keyword]
-  val members:              Set[Person]
+  val members:              Set[Project.Member]
   val version:              SchemaVersion
   val activities:           List[Activity]
   val datasets:             List[Dataset[Dataset.Provenance]]
@@ -92,7 +92,7 @@ object RenkuProject {
                                  visibility:           Visibility,
                                  forksCount:           ForksCount,
                                  keywords:             Set[Keyword],
-                                 members:              Set[Person],
+                                 members:              Set[Project.Member],
                                  version:              SchemaVersion,
                                  activities:           List[Activity],
                                  datasets:             List[Dataset[Dataset.Provenance]],
@@ -170,7 +170,7 @@ object RenkuProject {
                               visibility:           Visibility,
                               forksCount:           ForksCount,
                               keywords:             Set[Keyword],
-                              members:              Set[Person],
+                              members:              Set[Project.Member],
                               version:              SchemaVersion,
                               activities:           List[Activity],
                               datasets:             List[Dataset[Dataset.Provenance]],
@@ -260,7 +260,7 @@ object RenkuProject {
           project.maybeCreator.map(_.to[entities.Person]),
           project.visibility,
           project.keywords,
-          project.members.map(_.to[entities.Person]),
+          project.members.map(_.to[entities.Project.Member]),
           project.version,
           project.activities.map(_.to[entities.Activity]),
           project.datasets.map(_.to[entities.Dataset[entities.Dataset.Provenance]]),
@@ -285,7 +285,7 @@ object RenkuProject {
           project.maybeCreator.map(_.to[entities.Person]),
           project.visibility,
           project.keywords,
-          project.members.map(_.to[entities.Person]),
+          project.members.map(_.to[entities.Project.Member]),
           project.version,
           project.activities.map(_.to[entities.Activity]),
           project.datasets.map(_.to[entities.Dataset[entities.Dataset.Provenance]]),

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/NonRenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/NonRenkuProjectEntitiesGenerators.scala
@@ -21,7 +21,7 @@ package generators
 
 import io.renku.generators.Generators.Implicits._
 import io.renku.graph.model.projects
-import io.renku.graph.model.projects.{ForksCount, Visibility}
+import io.renku.graph.model.projects.{ForksCount, Role, Visibility}
 import org.scalacheck.Gen
 
 import java.time.Instant
@@ -48,11 +48,11 @@ trait NonRenkuProjectEntitiesGenerators {
     maybeDescription <- projectDescriptions.toGeneratorOfOptions
     dateCreated      <- projectCreatedDates(minDateCreated.value)
     dateModified     <- projectModifiedDates(dateCreated.value)
-    maybeCreator     <- creatorGen.toGeneratorOfOptions
+    maybeCreator     <- creatorGen.map(p => Project.Member(p, Role.Owner)).toGeneratorOfOptions
     visibility       <- visibilityGen
     forksCount       <- forksCountGen
     keywords         <- projectKeywords.toGeneratorOfSet(min = 0)
-    members          <- personEntities(withGitLabId).toGeneratorOfSet(min = 0)
+    members          <- projectMemberEntities(withGitLabId).toGeneratorOfSet(min = 0)
     images           <- imageUris.toGeneratorOfList()
   } yield NonRenkuProject.WithoutParent(
     slug,
@@ -60,11 +60,11 @@ trait NonRenkuProjectEntitiesGenerators {
     maybeDescription,
     dateCreated,
     dateModified,
-    maybeCreator,
+    maybeCreator.map(_.person),
     visibility,
     forksCount,
     keywords,
-    members ++ maybeCreator,
+    members ++ maybeCreator.toSet,
     images
   )
 

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -75,6 +75,12 @@ trait ProjectEntitiesGenerators {
   def memberPersonLens: Lens[Project.Member, Person] =
     Lens[Project.Member, Person](_.person)(a => b => b.copy(person = a))
 
+  def personNameLens: Lens[Person, persons.Name] =
+    Lens[Person, persons.Name](_.name)(a => b => b.copy(name = a))
+
+  def memberPersonNameLens: Lens[Project.Member, persons.Name] =
+    memberPersonLens.composeLens(personNameLens)
+
   def projectMembersPersonLens[P <: Project]: Traversal[P, Person] = {
     val t = Traversal.fromTraverse[List, Project.Member]
     membersLensAsList.andThen(t).andThen(memberPersonLens)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -53,8 +53,14 @@ trait ProjectEntitiesGenerators {
   lazy val gitLabUserIdLens: Lens[GitLabUser, persons.GitLabId] =
     Lens[GitLabUser, persons.GitLabId](_.gitLabId)(a => b => b.copy(gitLabId = a))
 
+  lazy val gitLabUserEmailLens: Lens[GitLabUser, Option[persons.Email]] =
+    Lens[GitLabUser, Option[persons.Email]](_.email)(a => b => b.copy(email = a))
+
   lazy val memberGitLabIdLens: Lens[GitLabMember, persons.GitLabId] =
     memberGitLabUserLens.andThen(gitLabUserIdLens)
+
+  lazy val memberGitLabEmailLens: Lens[GitLabMember, Option[persons.Email]] =
+    memberGitLabUserLens.composeLens(gitLabUserEmailLens)
 
   def membersLens[P <: Project]: Lens[P, Set[Project.Member]] =
     Lens[P, Set[Project.Member]](_.members) { members =>

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -78,8 +78,14 @@ trait ProjectEntitiesGenerators {
   def personNameLens: Lens[Person, persons.Name] =
     Lens[Person, persons.Name](_.name)(a => b => b.copy(name = a))
 
+  def personGitLabIdLens: Lens[Person, Option[persons.GitLabId]] =
+    Lens[Person, Option[persons.GitLabId]](_.maybeGitLabId)(a => b => b.copy(maybeGitLabId = a))
+
   def memberPersonNameLens: Lens[Project.Member, persons.Name] =
     memberPersonLens.composeLens(personNameLens)
+
+  def memberPersonGitLabIdLens: Lens[Project.Member, Option[persons.GitLabId]] =
+    memberPersonLens.composeLens(personGitLabIdLens)
 
   def projectMembersPersonLens[P <: Project]: Traversal[P, Person] = {
     val t = Traversal.fromTraverse[List, Project.Member]

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -60,7 +60,7 @@ trait ProjectEntitiesGenerators {
     memberGitLabUserLens.andThen(gitLabUserIdLens)
 
   lazy val memberGitLabEmailLens: Lens[GitLabMember, Option[persons.Email]] =
-    memberGitLabUserLens.composeLens(gitLabUserEmailLens)
+    memberGitLabUserLens.andThen(gitLabUserEmailLens)
 
   def membersLens[P <: Project]: Lens[P, Set[Project.Member]] =
     Lens[P, Set[Project.Member]](_.members) { members =>
@@ -88,10 +88,10 @@ trait ProjectEntitiesGenerators {
     Lens[Person, Option[persons.GitLabId]](_.maybeGitLabId)(a => b => b.copy(maybeGitLabId = a))
 
   def memberPersonNameLens: Lens[Project.Member, persons.Name] =
-    memberPersonLens.composeLens(personNameLens)
+    memberPersonLens.andThen(personNameLens)
 
   def memberPersonGitLabIdLens: Lens[Project.Member, Option[persons.GitLabId]] =
-    memberPersonLens.composeLens(personGitLabIdLens)
+    memberPersonLens.andThen(personGitLabIdLens)
 
   def projectMembersPersonLens[P <: Project]: Traversal[P, Person] = {
     val t = Traversal.fromTraverse[List, Project.Member]

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -21,13 +21,13 @@ package generators
 
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
-import io.renku.graph.model.entities.Project.ProjectMember
 import io.renku.graph.model.entities.ProjectIdentification
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabUser}
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.projects.Visibility
 import io.renku.graph.model.versions.SchemaVersion
 import io.renku.graph.model.{persons, projects}
-import monocle.Lens
+import monocle.{Lens, Traversal}
 import org.scalacheck.Gen
 
 trait ProjectEntitiesGenerators {
@@ -47,19 +47,38 @@ trait ProjectEntitiesGenerators {
     nonRenkuProjectWithParentEntities(visibilityGen, creatorGen = creatorGen)
   )
 
-  lazy val memberGitLabIdLens: Lens[ProjectMember, persons.GitLabId] =
-    Lens[ProjectMember, persons.GitLabId](_.gitLabId) { gitLabId =>
-      {
-        case member: ProjectMember.ProjectMemberNoEmail   => member.copy(gitLabId = gitLabId)
-        case member: ProjectMember.ProjectMemberWithEmail => member.copy(gitLabId = gitLabId)
-      }
-    }
+  lazy val memberGitLabUserLens: Lens[GitLabMember, GitLabUser] =
+    Lens[GitLabMember, GitLabUser](_.user)(a => b => b.copy(user = a))
 
-  def membersLens[P <: Project]: Lens[P, Set[Person]] =
-    Lens[P, Set[Person]](_.members) { members =>
+  lazy val gitLabUserIdLens: Lens[GitLabUser, persons.GitLabId] =
+    Lens[GitLabUser, persons.GitLabId](_.gitLabId)(a => b => b.copy(gitLabId = a))
+
+  lazy val memberGitLabIdLens: Lens[GitLabMember, persons.GitLabId] =
+    memberGitLabUserLens.andThen(gitLabUserIdLens)
+
+  def membersLens[P <: Project]: Lens[P, Set[Project.Member]] =
+    Lens[P, Set[Project.Member]](_.members) { members =>
       _.fold(_.copy(members = members), _.copy(members = members), _.copy(members = members), _.copy(members = members))
         .asInstanceOf[P]
     }
+
+  def membersLensAsList[P <: Project]: Lens[P, List[Project.Member]] =
+    Lens[P, List[Project.Member]](_.members.toList.sortBy(_.person.name.value)) { members =>
+      _.fold(_.copy(members = members.toSet),
+             _.copy(members = members.toSet),
+             _.copy(members = members.toSet),
+             _.copy(members = members.toSet)
+      )
+        .asInstanceOf[P]
+    }
+
+  def memberPersonLens: Lens[Project.Member, Person] =
+    Lens[Project.Member, Person](_.person)(a => b => b.copy(person = a))
+
+  def projectMembersPersonLens[P <: Project]: Traversal[P, Person] = {
+    val t = Traversal.fromTraverse[List, Project.Member]
+    membersLensAsList.andThen(t).andThen(memberPersonLens)
+  }
 
   def creatorLens[P <: Project]: Lens[P, Option[Person]] =
     Lens[P, Option[Person]](_.maybeCreator) { maybeCreator =>
@@ -82,7 +101,7 @@ trait ProjectEntitiesGenerators {
 
   def removeMembers[P <: Project](): P => P = membersLens.modify(_ => Set.empty)
 
-  def replaceMembers[P <: Project](to: Set[Person]): P => P =
+  def replaceMembers[P <: Project](to: Set[Project.Member]): P => P =
     _.fold(_.copy(members = to), _.copy(members = to), _.copy(members = to), _.copy(members = to)).asInstanceOf[P]
 
   def replaceProjectName[P <: Project](to: projects.Name): P => P =

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -138,7 +138,7 @@ trait RenkuProjectEntitiesGenerators {
                             maybeDescription,
                             maybeCreator.map(_.user),
                             keywords,
-                            members,
+                            members ++ maybeCreator,
                             visibility,
                             maybeParentSlug,
                             avatarUri

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -124,9 +124,9 @@ trait RenkuProjectEntitiesGenerators {
     maybeDescription <- projectDescriptions.toGeneratorOfOptions
     dateCreated      <- projectCreatedDates()
     dateModified     <- projectModifiedDates(dateCreated.value)
-    maybeCreator     <- gitLapProjectMembers.toGeneratorOfOptions
+    maybeCreator     <- gitLabProjectMembers.toGeneratorOfOptions
     keywords         <- projectKeywords.toGeneratorOfSet(min = 0)
-    members          <- gitLapProjectMembers.toGeneratorOfList(min = 1).map(_.toSet)
+    members          <- gitLabProjectMembers.toGeneratorOfList(min = 1).map(_.toSet)
     visibility       <- projectVisibilities
     maybeParentSlug  <- projectSlugs.toGeneratorOfOptions
     avatarUri        <- imageUris.toGeneratorOfOptions
@@ -156,7 +156,7 @@ trait RenkuProjectEntitiesGenerators {
     email         <- personEmails
   } yield memberNoEmail withEmail email
 
-  lazy val gitLapProjectMembers: Gen[GitLabMember] = Gen.oneOf(projectMembersNoEmail, projectMembersWithEmail)
+  lazy val gitLabProjectMembers: Gen[GitLabMember] = Gen.oneOf(projectMembersNoEmail, projectMembersWithEmail)
 
   implicit class ProjectMemberGenOps(membersGen: Gen[GitLabMember]) {
     def modify(f: GitLabMember => GitLabMember): Gen[GitLabMember] = membersGen.map(f)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -158,10 +158,6 @@ trait RenkuProjectEntitiesGenerators {
 
   lazy val gitLabProjectMembers: Gen[GitLabMember] = Gen.oneOf(projectMembersNoEmail, projectMembersWithEmail)
 
-  implicit class ProjectMemberGenOps(membersGen: Gen[GitLabMember]) {
-    def modify(f: GitLabMember => GitLabMember): Gen[GitLabMember] = membersGen.map(f)
-  }
-
   implicit class RenkuProjectGenFactoryOps(projectGen: Gen[RenkuProject])(implicit renkuUrl: RenkuUrl) {
 
     def withDatasets[P <: Dataset.Provenance](factories: DatasetGenFactory[P]*): Gen[RenkuProject] = for {

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -24,9 +24,8 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{fixed, nonNegativeInts, positiveInts}
-import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail, ProjectMemberWithEmail}
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
-import io.renku.graph.model.projects.{ForksCount, Visibility}
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabProjectInfo}
+import io.renku.graph.model.projects.{ForksCount, Role, Visibility}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.{ActivityGenFactory, DatasetGenFactory}
 import io.renku.graph.model.{RenkuUrl, projects}
 import org.scalacheck.Gen
@@ -83,7 +82,7 @@ trait RenkuProjectEntitiesGenerators {
     visibility       <- visibilityGen
     forksCount       <- forksCountGen
     keywords         <- projectKeywords.toGeneratorOfSet(min = 0)
-    members          <- personEntities(withGitLabId).toGeneratorOfSet(min = 0)
+    members          <- projectMemberEntities(withGitLabId).toGeneratorOfSet(min = 0)
     version          <- projectSchemaVersions
     activities       <- activityFactories.map(_.apply(dateCreated)).sequence
     datasets         <- datasetFactories.map(_.apply(dateCreated)).sequence
@@ -99,7 +98,7 @@ trait RenkuProjectEntitiesGenerators {
     visibility,
     forksCount,
     keywords,
-    members ++ maybeCreator,
+    members ++ maybeCreator.map(p => Project.Member(p, Role.Owner)),
     version,
     activities,
     datasets,
@@ -125,9 +124,9 @@ trait RenkuProjectEntitiesGenerators {
     maybeDescription <- projectDescriptions.toGeneratorOfOptions
     dateCreated      <- projectCreatedDates()
     dateModified     <- projectModifiedDates(dateCreated.value)
-    maybeCreator     <- projectMembers.toGeneratorOfOptions
+    maybeCreator     <- gitLapProjectMembers.toGeneratorOfOptions
     keywords         <- projectKeywords.toGeneratorOfSet(min = 0)
-    members          <- projectMembers.toGeneratorOfList(min = 1).map(_.toSet)
+    members          <- gitLapProjectMembers.toGeneratorOfList(min = 1).map(_.toSet)
     visibility       <- projectVisibilities
     maybeParentSlug  <- projectSlugs.toGeneratorOfOptions
     avatarUri        <- imageUris.toGeneratorOfOptions
@@ -137,7 +136,7 @@ trait RenkuProjectEntitiesGenerators {
                             dateCreated,
                             dateModified,
                             maybeDescription,
-                            maybeCreator,
+                            maybeCreator.map(_.user),
                             keywords,
                             members,
                             visibility,
@@ -145,21 +144,22 @@ trait RenkuProjectEntitiesGenerators {
                             avatarUri
   )
 
-  implicit lazy val projectMembersNoEmail: Gen[ProjectMemberNoEmail] = for {
+  implicit lazy val projectMembersNoEmail: Gen[GitLabMember] = for {
     name     <- personNames
     username <- personUsernames
     gitLabId <- personGitLabIds
-  } yield ProjectMemberNoEmail(name, username, gitLabId)
+    role     <- roleGen
+  } yield GitLabMember(name, username, gitLabId, None, Role.toGitLabAccessLevel(role))
 
-  implicit lazy val projectMembersWithEmail: Gen[ProjectMemberWithEmail] = for {
+  implicit lazy val projectMembersWithEmail: Gen[GitLabMember] = for {
     memberNoEmail <- projectMembersNoEmail
     email         <- personEmails
-  } yield memberNoEmail add email
+  } yield memberNoEmail withEmail email
 
-  lazy val projectMembers: Gen[ProjectMember] = Gen.oneOf(projectMembersNoEmail, projectMembersWithEmail)
+  lazy val gitLapProjectMembers: Gen[GitLabMember] = Gen.oneOf(projectMembersNoEmail, projectMembersWithEmail)
 
-  implicit class ProjectMemberGenOps(membersGen: Gen[ProjectMember]) {
-    def modify(f: ProjectMember => ProjectMember): Gen[ProjectMember] = membersGen.map(f)
+  implicit class ProjectMemberGenOps(membersGen: Gen[GitLabMember]) {
+    def modify(f: GitLabMember => GitLabMember): Gen[GitLabMember] = membersGen.map(f)
   }
 
   implicit class RenkuProjectGenFactoryOps(projectGen: Gen[RenkuProject])(implicit renkuUrl: RenkuUrl) {
@@ -244,7 +244,7 @@ trait RenkuProjectEntitiesGenerators {
     }
 
     def noEmailsOnMembers: Gen[RenkuProject] =
-      modify(membersLens.modify(_.map(_.copy(maybeEmail = None))))
+      modify(projectMembersPersonLens.modify(_.copy(maybeEmail = None)))
         .modify(creatorLens[RenkuProject].modify(_.map(_.copy(maybeEmail = None))))
 
     def forkOnce(): Gen[(RenkuProject, RenkuProject.WithParent)] = projectGen.map(_.forkOnce())

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/EntityBuilder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/EntityBuilder.scala
@@ -135,7 +135,7 @@ private class EntityBuilderImpl[F[_]: MonadThrow](projectInfoFinder: ProjectInfo
     )
 
   private def toMember(projectMember: GitLabMember): Project.Member =
-    Project.Member(toPerson(projectMember.asUser), projectMember.role)
+    Project.Member(toPerson(projectMember.user), projectMember.role)
 }
 
 private object EntityBuilder {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/EntityBuilder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/EntityBuilder.scala
@@ -90,10 +90,10 @@ private class EntityBuilderImpl[F[_]: MonadThrow](projectInfoFinder: ProjectInfo
         maybeDescription,
         dateCreated,
         dateModified,
-        maybeCreator.map(toPerson),
+        maybeCreator.map(toMember).map(_.person),
         visibility,
         keywords,
-        members.map(toPerson),
+        members.map(toMember),
         ResourceId(parentSlug),
         avatarUrl.map(Image.projectImage(ResourceId(slug), _)).toList
       )
@@ -117,30 +117,36 @@ private class EntityBuilderImpl[F[_]: MonadThrow](projectInfoFinder: ProjectInfo
         maybeDescription,
         dateCreated,
         dateModified,
-        maybeCreator.map(toPerson),
+        maybeCreator.map(toMember).map(_.person),
         visibility,
         keywords,
-        members.map(toPerson),
+        members.map(toMember),
         avatarUrl.map(Image.projectImage(ResourceId(slug), _)).toList
       )
   }
 
-  private def toPerson(projectMember: ProjectMember): entities.Person = projectMember match {
-    case ProjectMemberNoEmail(name, _, gitLabId) =>
-      entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                   gitLabId,
-                                   name,
-                                   maybeEmail = None,
-                                   maybeOrcidId = None,
-                                   maybeAffiliation = None
+  private def toMember(projectMember: ProjectMember): Project.Member = projectMember match {
+    case ProjectMemberNoEmail(name, _, gitLabId, _) =>
+      Project.Member(
+        entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
+                                     gitLabId,
+                                     name,
+                                     maybeEmail = None,
+                                     maybeOrcidId = None,
+                                     maybeAffiliation = None
+        ),
+        projectMember.role
       )
-    case ProjectMemberWithEmail(name, _, gitLabId, email) =>
-      entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                   gitLabId,
-                                   name,
-                                   email.some,
-                                   maybeOrcidId = None,
-                                   maybeAffiliation = None
+    case ProjectMemberWithEmail(name, _, gitLabId, email, _) =>
+      Project.Member(
+        entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
+                                     gitLabId,
+                                     name,
+                                     email.some,
+                                     maybeOrcidId = None,
+                                     maybeAffiliation = None
+        ),
+        projectMember.role
       )
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/GitlabJsonDecoder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/GitlabJsonDecoder.scala
@@ -19,18 +19,28 @@
 package io.renku.triplesgenerator.events.consumers.projectinfo
 
 import io.circe.Decoder
-import io.renku.graph.model.entities.Project.ProjectMember
-import io.renku.graph.model.persons
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabUser}
+import io.renku.graph.model.persons._
 import io.renku.tinytypes.json.TinyTypeDecoders._
 
 trait GitlabJsonDecoder {
 
-  implicit val memberDecoder: Decoder[ProjectMember] = cursor =>
+  implicit val memberDecoder: Decoder[GitLabMember] = cursor =>
     for {
-      gitLabId    <- cursor.downField("id").as[persons.GitLabId]
-      name        <- cursor.downField("name").as[persons.Name]
-      username    <- cursor.downField("username").as[persons.Username]
+      gitLabId    <- cursor.downField("id").as[GitLabId]
+      name        <- cursor.downField("name").as[Name]
+      username    <- cursor.downField("username").as[Username]
       accessLevel <- cursor.downField("access_level").as[Int]
-    } yield ProjectMember(name, username, gitLabId, accessLevel)
+      email       <- cursor.downField("email").as[Option[Email]]
+    } yield GitLabMember(name, username, gitLabId, email, accessLevel)
+
+  implicit val userDecoder: Decoder[GitLabUser] = cursor =>
+    for {
+      gitLabId <- cursor.downField("id").as[GitLabId]
+      name     <- cursor.downField("name").as[Name]
+      username <- cursor.downField("username").as[Username]
+      email1   <- cursor.downField("email").as[Option[Email]]
+      email2   <- cursor.downField("public_email").as[Option[Email]]
+    } yield GitLabUser(name, username, gitLabId, email1.orElse(email2))
 
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/GitlabJsonDecoder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/GitlabJsonDecoder.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.projectinfo
+
+import io.circe.Decoder
+import io.renku.graph.model.entities.Project.ProjectMember
+import io.renku.graph.model.persons
+import io.renku.tinytypes.json.TinyTypeDecoders._
+
+trait GitlabJsonDecoder {
+
+  implicit val memberDecoder: Decoder[ProjectMember] = cursor =>
+    for {
+      gitLabId    <- cursor.downField("id").as[persons.GitLabId]
+      name        <- cursor.downField("name").as[persons.Name]
+      username    <- cursor.downField("username").as[persons.Username]
+      accessLevel <- cursor.downField("access_level").as[Int]
+    } yield ProjectMember(name, username, gitLabId, accessLevel)
+
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinder.scala
@@ -53,7 +53,7 @@ private class MemberEmailFinderImpl[F[_]: Async: Logger](
       maybeAccessToken: Option[AccessToken]
   ): EitherT[F, ProcessingRecoverableError, GitLabMember] = EitherT {
     member match {
-      case member if member.email.isDefined =>
+      case member if member.user.email.isDefined =>
         member.asRight[ProcessingRecoverableError].pure[F]
       case member =>
         findInCommitsAndEvents(member, project).value
@@ -78,7 +78,7 @@ private class MemberEmailFinderImpl[F[_]: Async: Logger](
   private def filterEventsFor(
       member: GitLabMember
   ): ((List[PushEvent], PagingInfo)) => (List[PushEvent], PagingInfo) = { case (events, paging) =>
-    events.filter(ev => ev.authorId == member.gitLabId) -> paging
+    events.filter(ev => ev.authorId == member.user.gitLabId) -> paging
   }
 
   private def addEmailOrCheckNextPage(member:     GitLabMember,

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinder.scala
@@ -22,17 +22,16 @@ import cats.data.EitherT
 import cats.data.EitherT.rightT
 import cats.effect.Async
 import cats.syntax.all._
+import io.renku.graph.model.gitlab.GitLabMember
 import io.renku.graph.model.{persons, projects}
-import io.renku.graph.model.entities.Project.ProjectMember
-import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail, ProjectMemberWithEmail}
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.triplesgenerator.errors.{ProcessingRecoverableError, RecoverableErrorsRecovery}
 import org.typelevel.log4cats.Logger
 
 private trait MemberEmailFinder[F[_]] {
-  def findMemberEmail(member: ProjectMember, project: Project)(implicit
+  def findMemberEmail(member: GitLabMember, project: Project)(implicit
       maybeAccessToken: Option[AccessToken]
-  ): EitherT[F, ProcessingRecoverableError, ProjectMember]
+  ): EitherT[F, ProcessingRecoverableError, GitLabMember]
 }
 
 private object MemberEmailFinder {
@@ -50,22 +49,22 @@ private class MemberEmailFinderImpl[F[_]: Async: Logger](
 
   import commitAuthorFinder._
 
-  override def findMemberEmail(member: ProjectMember, project: Project)(implicit
+  override def findMemberEmail(member: GitLabMember, project: Project)(implicit
       maybeAccessToken: Option[AccessToken]
-  ): EitherT[F, ProcessingRecoverableError, ProjectMember] = EitherT {
+  ): EitherT[F, ProcessingRecoverableError, GitLabMember] = EitherT {
     member match {
-      case member: ProjectMemberWithEmail =>
-        member.asRight[ProcessingRecoverableError].widen[ProjectMember].pure[F]
-      case member: ProjectMemberNoEmail =>
+      case member if member.email.isDefined =>
+        member.asRight[ProcessingRecoverableError].pure[F]
+      case member =>
         findInCommitsAndEvents(member, project).value
-          .recoverWith(recoveryStrategy.maybeRecoverableError[F, ProjectMember])
+          .recoverWith(recoveryStrategy.maybeRecoverableError[F, GitLabMember])
     }
   }
 
-  private def findInCommitsAndEvents(member:  ProjectMemberNoEmail,
+  private def findInCommitsAndEvents(member:  GitLabMember,
                                      project: Project,
                                      paging:  PagingInfo = PagingInfo(maybeNextPage = Some(1), maybeTotalPages = None)
-  )(implicit maybeAccessToken: Option[AccessToken]): EitherT[F, ProcessingRecoverableError, ProjectMember] =
+  )(implicit maybeAccessToken: Option[AccessToken]): EitherT[F, ProcessingRecoverableError, GitLabMember] =
     paging.findNextPage match {
       case None => rightT[F, ProcessingRecoverableError](member)
       case Some(nextPage) =>
@@ -77,18 +76,18 @@ private class MemberEmailFinderImpl[F[_]: Async: Logger](
     }
 
   private def filterEventsFor(
-      member: ProjectMember
+      member: GitLabMember
   ): ((List[PushEvent], PagingInfo)) => (List[PushEvent], PagingInfo) = { case (events, paging) =>
     events.filter(ev => ev.authorId == member.gitLabId) -> paging
   }
 
-  private def addEmailOrCheckNextPage(member:     ProjectMemberNoEmail,
+  private def addEmailOrCheckNextPage(member:     GitLabMember,
                                       maybeEmail: Option[persons.Email],
                                       project:    Project,
                                       paging:     PagingInfo
   )(implicit maybeAccessToken: Option[AccessToken]) = maybeEmail match {
     case None        => findInCommitsAndEvents(member, project, paging)
-    case Some(email) => rightT[F, ProcessingRecoverableError](member add email)
+    case Some(email) => rightT[F, ProcessingRecoverableError](member withEmail email)
   }
 
   private def matchEmailFromCommits(events:  List[PushEvent],

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinder.scala
@@ -71,16 +71,7 @@ private class MemberEmailFinderImpl[F[_]: Async: Logger](
         for {
           (allEvents, pagingInfo) <- projectEventsFinder.find(project, nextPage)
           pushEvents = allEvents.filter(eventForMember(member))
-          maybeEmail <- matchEmailFromCommits(pushEvents, project)
-          _ = {
-            println("-----findCommitsAndEvents------------------------------")
-            println(s"Member: $member")
-            println(s"AllEvents: $allEvents")
-            println(s"Owned: $pushEvents")
-            println(s"Found E-Mail: $maybeEmail")
-            ()
-          }
-
+          maybeEmail    <- matchEmailFromCommits(pushEvents, project)
           updatedMember <- addEmailOrCheckNextPage(member, maybeEmail, project, pagingInfo)
         } yield updatedMember
     }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectFinder.scala
@@ -29,6 +29,7 @@ import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.triplesgenerator.errors.{ProcessingRecoverableError, RecoverableErrorsRecovery}
+import org.http4s.circe.CirceEntityDecoder._
 import org.http4s.dsl.io.{NotFound, Ok}
 import org.http4s.implicits._
 import org.http4s.{EntityDecoder, Request, Response, Status}
@@ -49,7 +50,8 @@ private object ProjectFinder {
 
 private class ProjectFinderImpl[F[_]: Async: GitLabClient: Logger](
     recoveryStrategy: RecoverableErrorsRecovery = RecoverableErrorsRecovery
-) extends ProjectFinder[F] {
+) extends ProjectFinder[F]
+    with GitlabJsonDecoder {
 
   import io.circe.Decoder.decodeOption
   import io.renku.tinytypes.json.TinyTypeDecoders._
@@ -127,13 +129,4 @@ private class ProjectFinderImpl[F[_]: Async: GitLabClient: Logger](
           GitLabClient[F].get(uri"users" / creatorId, "single-user")(mapTo[ProjectMember])
         }
     }
-
-  private implicit val memberDecoder: Decoder[ProjectMember] = cursor =>
-    for {
-      gitLabId <- cursor.downField("id").as[persons.GitLabId]
-      name     <- cursor.downField("name").as[persons.Name]
-      username <- cursor.downField("username").as[persons.Username]
-    } yield ProjectMember(name, username, gitLabId)
-
-  private implicit lazy val memberEntityDecoder: EntityDecoder[F, ProjectMember] = jsonOf[F, ProjectMember]
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectFinder.scala
@@ -23,7 +23,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.circe.Decoder
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
+import io.renku.graph.model.gitlab.{GitLabProjectInfo, GitLabUser}
 import io.renku.graph.model.images.ImageUri
 import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.{AccessToken, GitLabClient}
@@ -121,12 +121,12 @@ private class ProjectFinderImpl[F[_]: Async: GitLabClient: Logger](
 
   private def fetchCreator(
       maybeCreatorId: Option[persons.GitLabId]
-  )(implicit maybeAccessToken: Option[AccessToken]): OptionT[F, Option[ProjectMember]] =
+  )(implicit maybeAccessToken: Option[AccessToken]): OptionT[F, Option[GitLabUser]] =
     maybeCreatorId match {
-      case None => OptionT.some[F](Option.empty[ProjectMember])
+      case None => OptionT.some[F](Option.empty[GitLabUser])
       case Some(creatorId) =>
         OptionT.liftF {
-          GitLabClient[F].get(uri"users" / creatorId, "single-user")(mapTo[ProjectMember])
+          GitLabClient[F].get(uri"users" / creatorId, "single-user")(mapTo[GitLabUser])
         }
     }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/EntityBuilder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/EntityBuilder.scala
@@ -25,8 +25,8 @@ import cats.{Applicative, MonadThrow, NonEmptyParallel, Parallel}
 import io.circe.DecodingFailure
 import io.renku.graph.config.RenkuUrlLoader
 import io.renku.graph.model.RenkuUrl
-import io.renku.graph.model.entities.Project.GitLabProjectInfo
 import io.renku.graph.model.entities._
+import io.renku.graph.model.gitlab.GitLabProjectInfo
 import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.triplesgenerator.errors.{ProcessingNonRecoverableError, ProcessingRecoverableError}
 import io.renku.triplesgenerator.events.consumers.projectinfo.ProjectInfoFinder

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/ProjectJsonLDDecoder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/ProjectJsonLDDecoder.scala
@@ -22,7 +22,7 @@ import cats.syntax.all._
 import io.renku.cli.model.CliProject
 import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.entities.Project
-import io.renku.graph.model.entities.Project.GitLabProjectInfo
+import io.renku.graph.model.gitlab.GitLabProjectInfo
 import io.renku.jsonld.JsonLDDecoder
 
 trait ProjectJsonLDDecoder {

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/create/PayloadConverter.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/create/PayloadConverter.scala
@@ -49,7 +49,7 @@ private class PayloadConverterImpl(implicit renkuUrl: RenkuUrl) extends PayloadC
       Some(creator),
       newProject.visibility,
       newProject.keywords,
-      members = Set(creator),
+      members = Set(entities.Project.Member(creator, newProject.creator.role)),
       Image.projectImage(resourceId, newProject.images)
     )
   }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctions.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctions.scala
@@ -130,7 +130,7 @@ private object ProjectFunctions extends ProjectFunctions {
 
     def updateMember(person: Person, f: Project.Member => Project.Member): Project =
       projectMembersLens
-        .composeTraversal(membersLens)
+        .andThen(membersLens)
         .modify { member =>
           if (member.person == person) f(member)
           else member

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctions.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctions.scala
@@ -36,7 +36,7 @@ private trait ProjectFunctions {
 
   def update(oldPerson: Person, newPerson: Person): Project => Project = project =>
     project
-      .updateMember(oldPerson, newPerson)
+      .updateMember(oldPerson, _.copy(person = newPerson))
       .updateCreator(oldPerson, newPerson)
       .updateActivities(updateAuthorsAndAgents(oldPerson, newPerson))
       .updateDatasets(updateDatasetCreators(oldPerson, newPerson))
@@ -120,12 +120,20 @@ private object ProjectFunctions extends ProjectFunctions {
 
   private implicit class ProjectOps(project: Project) {
 
-    def updateMember(oldPerson: Person, newPerson: Person): Project =
+    def updateMember(oldMember: Project.Member, newMember: Project.Member): Project =
       projectMembersLens
         .andThen(membersLens)
         .modify {
-          case `oldPerson` => newPerson
+          case `oldMember` => newMember
           case p           => p
+        }(project)
+
+    def updateMember(person: Person, f: Project.Member => Project.Member): Project =
+      projectMembersLens
+        .composeTraversal(membersLens)
+        .modify { member =>
+          if (member.person == person) f(member)
+          else member
         }(project)
 
     def updateCreator(oldPerson: Person, newPerson: Person): Project =
@@ -184,8 +192,8 @@ private object ProjectFunctions extends ProjectFunctions {
       }
 
   private object Lenses {
-    val membersLens = Traversal.fromTraverse[List, Person]
-    val projectMembersLens = Lens[Project, List[Person]](_.members.toList)(persons => {
+    val membersLens = Traversal.fromTraverse[List, Project.Member]
+    val projectMembersLens = Lens[Project, List[Project.Member]](_.members.toList)(persons => {
       case p: RenkuProject.WithoutParent    => p.copy(members = persons.toSet)
       case p: RenkuProject.WithParent       => p.copy(members = persons.toSet)
       case p: NonRenkuProject.WithoutParent => p.copy(members = persons.toSet)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/DatasetProvision.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/DatasetProvision.scala
@@ -41,7 +41,7 @@ trait DatasetProvision extends SearchInfoDatasets { self: ProjectsDataset with I
     implicit val sparqlQueryTimeRecorder: SparqlQueryTimeRecorder[IO] =
       new SparqlQueryTimeRecorder[IO](execTimeRecorder)
     val ps      = ProjectSparqlClient[IO](projectsDSConnectionInfo).map(ProjectAuthSync[IO](_))
-    val members = project.members.flatMap(p => p.maybeGitLabId.map(id => ProjectMember(id, Role.Reader)))
+    val members = project.members.flatMap(p => p.person.maybeGitLabId.map(id => ProjectMember(id, Role.Reader)))
     super.provisionProject(project) *> ps.use(_.syncProject(ProjectAuthData(project.slug, members, project.visibility)))
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/Generators.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/Generators.scala
@@ -26,7 +26,7 @@ import io.renku.graph.model.projects.Role
 import io.renku.graph.model.{RenkuTinyTypeGenerators, RenkuUrl}
 import org.scalacheck.Gen
 
-private object Generators {
+private trait Generators {
 
   implicit def kgProjectMembers(implicit renkuUrl: RenkuUrl): Gen[KGProjectMember] = for {
     memberId <- personResourceIds
@@ -42,3 +42,5 @@ private object Generators {
     role <- RenkuTinyTypeGenerators.roleGen
   } yield GitLabProjectMember(id, name, Role.toGitLabAccessLevel(role))
 }
+
+private object Generators extends Generators

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/KGPersonFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/KGPersonFinderSpec.scala
@@ -18,12 +18,12 @@
 
 package io.renku.triplesgenerator.events.consumers.membersync
 
-import Generators._
 import cats.effect.IO
 import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.testentities._
+import io.renku.graph.model.testentities.generators.EntitiesGenerators
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
@@ -44,9 +44,9 @@ class KGPersonFinderSpec
 
     "return person resourceIds if found in the triples store" in new TestCase {
 
-      val memberNonExistingInKG = gitLabProjectMembers.generateOne
-      val memberExistingInKG    = gitLabProjectMembers.generateOne
-      val person                = personEntities(fixed(memberExistingInKG.gitLabId.some)).generateOne
+      val memberNonExistingInKG = EntitiesGenerators.gitLabProjectMembers.generateOne
+      val memberExistingInKG    = EntitiesGenerators.gitLabProjectMembers.generateOne
+      val person                = personEntities(fixed(memberExistingInKG.user.gitLabId.some)).generateOne
 
       upload(to = projectsDataset, person)
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/KGPersonFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/KGPersonFinderSpec.scala
@@ -23,7 +23,6 @@ import cats.syntax.all._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.testentities._
-import io.renku.graph.model.testentities.generators.EntitiesGenerators
 import io.renku.interpreters.TestLogger
 import io.renku.logging.TestSparqlQueryTimeRecorder
 import io.renku.testtools.IOSpec
@@ -44,9 +43,9 @@ class KGPersonFinderSpec
 
     "return person resourceIds if found in the triples store" in new TestCase {
 
-      val memberNonExistingInKG = EntitiesGenerators.gitLabProjectMembers.generateOne
-      val memberExistingInKG    = EntitiesGenerators.gitLabProjectMembers.generateOne
-      val person                = personEntities(fixed(memberExistingInKG.user.gitLabId.some)).generateOne
+      val memberNonExistingInKG = Generators.gitLabProjectMembers.generateOne
+      val memberExistingInKG    = Generators.gitLabProjectMembers.generateOne
+      val person                = personEntities(fixed(memberExistingInKG.gitLabId.some)).generateOne
 
       upload(to = projectsDataset, person)
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/KGProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/KGProjectMembersFinderSpec.scala
@@ -42,7 +42,7 @@ class KGProjectMembersFinderSpec
   "findProjectMembers" should {
 
     "return all members of a given project" in new TestCase {
-      val members = personEntities(withGitLabId).generateFixedSizeSet()
+      val members = projectMemberEntities(withGitLabId).generateFixedSizeSet()
       val project = anyRenkuProjectEntities.modify(membersLens.modify(_ => members)).generateOne
 
       upload(to = projectsDataset, project)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/PersonOps.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/PersonOps.scala
@@ -18,10 +18,10 @@
 
 package io.renku.triplesgenerator.events.consumers.membersync
 
-import io.renku.graph.model.testentities.Person
+import io.renku.graph.model.testentities.Project
 
 private object PersonOps {
 
-  implicit lazy val toKGProjectMember: Person => Option[KGProjectMember] =
-    person => person.maybeGitLabId.map(gitLabId => KGProjectMember(person.resourceId, gitLabId))
+  implicit lazy val toKGProjectMember: Project.Member => Option[KGProjectMember] =
+    member => member.person.maybeGitLabId.map(gitLabId => KGProjectMember(member.person.resourceId, gitLabId))
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/UpdatesCreatorSpec.scala
@@ -46,15 +46,15 @@ class UpdatesCreatorSpec
   "removal" should {
 
     "prepare query to delete the member links to project" in {
-      val memberToRemove0 = personEntities(withGitLabId).generateOne
-      val memberToRemove1 = personEntities(withGitLabId).generateOne
-      val memberToStay    = personEntities(withGitLabId).generateOne
+      val memberToRemove0 = projectMemberEntities(withGitLabId).generateOne
+      val memberToRemove1 = projectMemberEntities(withGitLabId).generateOne
+      val memberToStay    = projectMemberEntities(withGitLabId).generateOne
       val allMembers      = Set(memberToRemove0, memberToRemove1, memberToStay)
       val project         = anyRenkuProjectEntities.modify(membersLens.modify(_ => allMembers)).generateOne
 
       upload(to = projectsDataset, project)
 
-      findMembers(project.slug) shouldBe allMembers.flatMap(_.maybeGitLabId)
+      findMembers(project.slug) shouldBe allMembers.map(_.person).flatMap(_.maybeGitLabId)
 
       val queries = updatesCreator.removal(
         project.slug,
@@ -63,7 +63,7 @@ class UpdatesCreatorSpec
 
       queries.runAll(on = projectsDataset).unsafeRunSync()
 
-      findMembers(project.slug) shouldBe Set(memberToStay.maybeGitLabId).flatten
+      findMembers(project.slug) shouldBe Set(memberToStay.person.maybeGitLabId).flatten
     }
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/UpdatesCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/UpdatesCreatorSpec.scala
@@ -18,7 +18,6 @@
 
 package io.renku.triplesgenerator.events.consumers.membersync
 
-import Generators._
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.generators.Generators.Implicits._
@@ -30,6 +29,7 @@ import io.renku.graph.model.testentities._
 import io.renku.graph.model.views.RdfResource
 import io.renku.graph.model.{GraphClass, persons, projects}
 import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.events.consumers.membersync.Generators._
 import io.renku.triplesgenerator.events.consumers.membersync.PersonOps._
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset, SparqlQuery}
@@ -70,7 +70,7 @@ class UpdatesCreatorSpec
   "insertion" should {
 
     "prepare queries to insert links for members existing in KG" in {
-      val member     = gitLabProjectMembers.generateOne
+      val member     = Generators.gitLabProjectMembers.generateOne
       val personInKG = personEntities(fixed(member.gitLabId.some), withEmail).generateOne
       val project    = anyRenkuProjectEntities.modify(membersLens.modify(_ => Set.empty)).generateOne
 
@@ -97,7 +97,7 @@ class UpdatesCreatorSpec
 
       findMembers(project.slug) shouldBe Set.empty
 
-      val member = gitLabProjectMembers.generateOne
+      val member = Generators.gitLabProjectMembers.generateOne
       val queries = updatesCreator.insertion(
         project.slug,
         Set(member -> Option.empty[persons.ResourceId])
@@ -114,7 +114,7 @@ class UpdatesCreatorSpec
 
       findMembers(projectSlug) shouldBe Set.empty
 
-      val member = gitLabProjectMembers.generateOne
+      val member = Generators.gitLabProjectMembers.generateOne
       val queries = updatesCreator.insertion(
         projectSlug,
         Set(member -> Option.empty[persons.ResourceId])
@@ -129,7 +129,7 @@ class UpdatesCreatorSpec
 
     "prepare queries to insert a project and attach a member already in KG when the project didn't previously exist" in {
 
-      val member     = gitLabProjectMembers.generateOne
+      val member     = Generators.gitLabProjectMembers.generateOne
       val personInKG = personEntities(fixed(member.gitLabId.some), withEmail).generateOne
 
       upload(to = projectsDataset, personInKG)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/EntityBuilderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/minprojectinfo/EntityBuilderSpec.scala
@@ -26,9 +26,8 @@ import io.renku.generators.CommonGraphGenerators.accessTokens
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model._
-import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail, ProjectMemberWithEmail}
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
 import io.renku.graph.model.projects._
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabProjectInfo, GitLabUser}
 import io.renku.graph.model.testentities.ModelOps
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
 import io.renku.http.client.AccessToken
@@ -150,7 +149,7 @@ class EntityBuilderSpec
         maybeCreator.map(toPerson),
         visibility,
         keywords,
-        members.map(toPerson),
+        members.map(toMember),
         ResourceId(parentSlug),
         convertImageUris(ResourceId(slug).asEntityId)(avatarUrl.toList)
       )
@@ -177,28 +176,21 @@ class EntityBuilderSpec
         maybeCreator.map(toPerson),
         visibility,
         keywords,
-        members.map(toPerson),
+        members.map(toMember),
         convertImageUris(ResourceId(slug).asEntityId)(avatarUrl.toList)
       )
   }
 
-  private def toPerson(projectMember: ProjectMember)(implicit renkuUrl: RenkuUrl): entities.Person =
-    projectMember match {
-      case ProjectMemberNoEmail(name, _, gitLabId) =>
-        entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                     gitLabId,
-                                     name,
-                                     maybeEmail = None,
-                                     maybeOrcidId = None,
-                                     maybeAffiliation = None
-        )
-      case ProjectMemberWithEmail(name, _, gitLabId, email) =>
-        entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                     gitLabId,
-                                     name,
-                                     email.some,
-                                     maybeOrcidId = None,
-                                     maybeAffiliation = None
-        )
-    }
+  private def toMember(member: GitLabMember)(implicit renkuUrl: RenkuUrl): entities.Project.Member =
+    entities.Project.Member(toPerson(member.user), member.role)
+
+  private def toPerson(user: GitLabUser)(implicit renkuUrl: RenkuUrl): entities.Person =
+    entities.Person.WithGitLabId(
+      persons.ResourceId(user.gitLabId),
+      user.gitLabId,
+      user.name,
+      maybeEmail = user.email,
+      maybeOrcidId = None,
+      maybeAffiliation = None
+    )
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/MemberEmailFinderSpec.scala
@@ -26,7 +26,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.ints
 import io.renku.graph.model.EventsGenerators._
 import io.renku.graph.model.GraphModelGenerators.{personEmails, personGitLabIds, personNames, projectIds, projectSlugs}
-import io.renku.graph.model.entities.Project.ProjectMember
+import io.renku.graph.model.gitlab.GitLabUser
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.graph.model.{persons, projects}
@@ -56,7 +56,7 @@ class MemberEmailFinderSpec
 
     "iterate over project's push events " +
       "until commit info for the commit found on the push event lists an author with the same name" in new TestCase {
-        val event  = pushEvents.generateOne.forMember(member).forProject(project)
+        val event  = pushEvents.generateOne.forMember(member.user).forProject(project)
         val events = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
 
         val returningVal = EitherT.fromEither[IO]((events, PagingInfo(None, None)).asRight[ProcessingRecoverableError])
@@ -73,20 +73,20 @@ class MemberEmailFinderSpec
             event.commitId,
             maybeAccessToken
           )
-          .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.name -> authorEmail).some))
+          .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.user.name -> authorEmail).some))
 
-        finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member add authorEmail).asRight
+        finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member withEmail authorEmail).asRight
       }
 
     "do nothing if email is already set on the given member" in new TestCase {
-      val memberWithEmail = member add personEmails.generateOne
+      val memberWithEmail = member withEmail personEmails.generateOne
       finder.findMemberEmail(memberWithEmail, project).value.unsafeRunSync() shouldBe memberWithEmail.asRight
     }
 
     "take the email from commitTo and skip commitFrom if both commitIds exist on the event" in new TestCase {
       val commit = commitIds.generateOne
       val event = pushEvents.generateOne
-        .forMember(member)
+        .forMember(member.user)
         .forProject(project)
         .copy(commitId = commit)
       val events = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
@@ -102,13 +102,13 @@ class MemberEmailFinderSpec
       (commitAuthorFinder
         .findCommitAuthor(_: projects.Slug, _: CommitId)(_: Option[AccessToken]))
         .expects(project.slug, commit, maybeAccessToken)
-        .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.name -> authorEmail).some))
+        .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.user.name -> authorEmail).some))
 
-      finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member add authorEmail).asRight
+      finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member withEmail authorEmail).asRight
     }
 
     "find the email if a matching commit exists on the second page" in new TestCase {
-      val event       = pushEvents.generateOne.forMember(member).forProject(project)
+      val event       = pushEvents.generateOne.forMember(member.user).forProject(project)
       val eventsPage2 = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
 
       val returnedFirstTime =
@@ -137,9 +137,9 @@ class MemberEmailFinderSpec
           event.commitId,
           maybeAccessToken
         )
-        .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.name -> authorEmail).some))
+        .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.user.name -> authorEmail).some))
 
-      finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member add authorEmail).asRight
+      finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member withEmail authorEmail).asRight
     }
 
     /* checking all events is really inefficient
@@ -173,7 +173,7 @@ class MemberEmailFinderSpec
               .returning(nextPageResults)
           }
 
-        val event = pushEvents.generateOne.forMember(member).forProject(project)
+        val event = pushEvents.generateOne.forMember(member.user).forProject(project)
 
         def setExpectationForLastPage = {
           val nextPageEvents  = event :: pushEvents.generateNonEmptyList(min = 20, max = 20).toList
@@ -194,28 +194,28 @@ class MemberEmailFinderSpec
               event.commitId,
               maybeAccessToken
             )
-            .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.name -> authorEmail).some))
+            .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.user.name -> authorEmail).some))
 
         setExpectationForFirstPage
         setExpectationForMiddlePages
         setExpectationForLastPage
         setExpectationForCommitAuthorFinder
 
-        finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member add authorEmail).asRight
+        finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member withEmail authorEmail).asRight
       }
 
     "find the email if a matching commits exist on both pages, " +
       "however, the first matching commit has author with a different name" in new TestCase {
         val eventPage1 = pushEvents.generateOne
-          .forMember(member)
+          .forMember(member.user)
           .forProject(project)
         val eventsPage1 = Random.shuffle(eventPage1 :: pushEvents.generateNonEmptyList().toList)
         val eventPage2 = pushEvents.generateOne
-          .forMember(member)
+          .forMember(member.user)
           .forProject(project)
         val eventsPage2 = Random.shuffle(eventPage2 :: pushEvents.generateNonEmptyList().toList)
 
-        val firstEvent = pushEvents.generateOne.forMember(member).forProject(project)
+        val firstEvent = pushEvents.generateOne.forMember(member.user).forProject(project)
 
         (projectEventsFinder
           .find(_: Project, _: Int)(_: Option[AccessToken]))
@@ -244,18 +244,18 @@ class MemberEmailFinderSpec
             eventPage2.commitId,
             maybeAccessToken
           )
-          .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.name -> authorEmail).some))
+          .returning(EitherT.rightT[IO, ProcessingRecoverableError]((member.user.name -> authorEmail).some))
 
-        finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member add authorEmail).asRight
+        finder.findMemberEmail(member, project).value.unsafeRunSync() shouldBe (member withEmail authorEmail).asRight
       }
 
     "return the given member back if a matching commit author cannot be found on any events" in new TestCase {
       val eventPage1 = pushEvents.generateOne
-        .forMember(member)
+        .forMember(member.user)
         .forProject(project)
       val eventsPage1 = Random.shuffle(eventPage1 :: pushEvents.generateNonEmptyList().toList)
       val eventPage2 = pushEvents.generateOne
-        .forMember(member)
+        .forMember(member.user)
         .forProject(project)
       val eventsPage2 = Random.shuffle(eventPage2 :: pushEvents.generateNonEmptyList().toList)
 
@@ -316,7 +316,7 @@ class MemberEmailFinderSpec
     }
 
     s"return a Recoverable Failure when returned when fetching commit info" in new TestCase {
-      val event  = pushEvents.generateOne.forMember(member).forProject(project)
+      val event  = pushEvents.generateOne.forMember(member.user).forProject(project)
       val events = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
 
       (projectEventsFinder
@@ -354,7 +354,7 @@ class MemberEmailFinderSpec
   }
 
   private implicit class PushEventOps(event: PushEvent) {
-    def forMember(member: ProjectMember): PushEvent =
+    def forMember(member: GitLabUser): PushEvent =
       event.copy(authorId = member.gitLabId, authorName = member.name)
 
     def forProject(project: Project): PushEvent = event.copy(projectId = project.id)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectEventsFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectEventsFinderSpec.scala
@@ -32,8 +32,8 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.{personGitLabIds, personNames, projectIds, projectSlugs}
-import io.renku.graph.model.gitlab.{GitLabMember, GitLabUser}
 import io.renku.graph.model.events.CommitId
+import io.renku.graph.model.gitlab.GitLabUser
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.projectMembersNoEmail
 import io.renku.graph.model.{persons, projects}
 import io.renku.http.client.RestClient.ResponseMappingF

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectEventsFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectEventsFinderSpec.scala
@@ -32,7 +32,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.EventsGenerators.commitIds
 import io.renku.graph.model.GraphModelGenerators.{personGitLabIds, personNames, projectIds, projectSlugs}
-import io.renku.graph.model.entities.Project.ProjectMember
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabUser}
 import io.renku.graph.model.events.CommitId
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.projectMembersNoEmail
 import io.renku.graph.model.{persons, projects}
@@ -64,7 +64,7 @@ class ProjectEventsFinderSpec
 
   "find" should {
     "return a list of events for a given page" in new TestCase {
-      val event  = pushEvents.generateOne.forMember(member).forProject(project)
+      val event  = pushEvents.generateOne.forMember(member.user).forProject(project)
       val events = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
       val endpointName: String Refined NonEmpty = "project-events"
       val page        = 1
@@ -93,7 +93,7 @@ class ProjectEventsFinderSpec
       val commitFrom = commitIds.generateSome
       val commitTo   = commitIds.generateSome
       val event = pushEvents.generateOne
-        .forMember(member)
+        .forMember(member.user)
         .forProject(project)
         .copy(maybeCommitFrom = commitFrom, maybeCommitTo = commitTo)
       val events = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
@@ -108,7 +108,7 @@ class ProjectEventsFinderSpec
     "take commitFrom if commitTo doesn't exist on the event" in new TestCase {
       val commitFrom = commitIds.generateSome
       val event = pushEvents.generateOne
-        .forMember(member)
+        .forMember(member.user)
         .forProject(project)
         .copy(maybeCommitFrom = commitFrom, maybeCommitTo = None)
       val events = Random.shuffle(event :: pushEvents.generateNonEmptyList().toList)
@@ -183,7 +183,7 @@ class ProjectEventsFinderSpec
                                      authorId:        persons.GitLabId,
                                      authorName:      persons.Name
   ) {
-    def forMember(member: ProjectMember): GitLabPushEvent =
+    def forMember(member: GitLabUser): GitLabPushEvent =
       copy(authorId = member.gitLabId, authorName = member.name)
 
     def forProject(project: Project): GitLabPushEvent = copy(projectId = project.id)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectFinderSpec.scala
@@ -30,8 +30,7 @@ import io.renku.generators.CommonGraphGenerators.accessTokens
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.GraphModelGenerators.projectSlugs
-import io.renku.graph.model.entities.Project.ProjectMember.ProjectMemberNoEmail
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabProjectInfo, GitLabUser}
 import io.renku.graph.model.projects.Slug
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.graph.model.{persons, projects}
@@ -65,7 +64,8 @@ class ProjectFinderSpec
   "findProject" should {
 
     "fetch info about the project with the given slug from GitLab" in new TestCase {
-      forAll { (projectInfoRaw: GitLabProjectInfo, creator: ProjectMemberNoEmail) =>
+      implicit val gitLabUser: Gen[GitLabUser] = gitLabUserGen(maybeEmails = Gen.const(None))
+      forAll { (projectInfoRaw: GitLabProjectInfo, creator: GitLabUser) =>
         val projectInfo = projectInfoRaw.copy(maybeCreator = creator.some, members = Set.empty)
 
         setGitLabClientExpectationProjects(projectInfo.slug, (projectInfo, creator.gitLabId.some).some.pure[IO])
@@ -77,7 +77,8 @@ class ProjectFinderSpec
     }
 
     "fetch info about the project without creator if it does not exist" in new TestCase {
-      forAll { (projectInfoRaw: GitLabProjectInfo, creator: ProjectMemberNoEmail) =>
+      implicit val gitLabUser: Gen[GitLabUser] = gitLabUserGen(maybeEmails = Gen.const(None))
+      forAll { (projectInfoRaw: GitLabProjectInfo, creator: GitLabUser) =>
         val projectInfo = projectInfoRaw.copy(maybeCreator = creator.some, members = Set.empty)
 
         setGitLabClientExpectationProjects(projectInfo.slug, (projectInfo, creator.gitLabId.some).some.pure[IO])
@@ -114,7 +115,7 @@ class ProjectFinderSpec
 
       s"return a Recoverable Failure for $problemName when fetching creator" in new TestCase {
         val creator     = projectMembersNoEmail.generateOne
-        val projectInfo = gitLabProjectInfos.generateOne.copy(maybeCreator = creator.some)
+        val projectInfo = gitLabProjectInfos.generateOne.copy(maybeCreator = creator.user.some)
 
         setGitLabClientExpectationProjects(projectInfo.slug, IO.raiseError(error))
 
@@ -160,19 +161,21 @@ class ProjectFinderSpec
 
     private implicit val logger: TestLogger[IO]   = TestLogger[IO]()
     implicit val gitLabClient:   GitLabClient[IO] = mock[GitLabClient[IO]]
+
     val finder = new ProjectFinderImpl[IO]
 
     private type ProjectAndCreators = (GitLabProjectInfo, Option[persons.GitLabId])
 
-    def setGitLabClientExpectationUsers(id: persons.GitLabId, returning: IO[Option[ProjectMember]]) =
+    def setGitLabClientExpectationUsers(id: persons.GitLabId, returning: IO[Option[GitLabUser]]) =
       setGitLabClientExpectation("single-user", id.show, returning)
 
     def setGitLabClientExpectationProjects(id: projects.Slug, returning: IO[Option[ProjectAndCreators]]) =
       setGitLabClientExpectation("single-project", id.show, returning)
 
-    private def setGitLabClientExpectation[ResultType](endpointName: String Refined NonEmpty,
-                                                       id:           String,
-                                                       returning:    IO[ResultType]
+    private def setGitLabClientExpectation[ResultType](
+        endpointName: String Refined NonEmpty,
+        id:           String,
+        returning:    IO[ResultType]
     ) = {
       val endpointStart = if (endpointName.value == "single-project") uri"projects" else uri"users"
       (gitLabClient
@@ -212,11 +215,21 @@ class ProjectFinderSpec
       .addIfDefined("avatar_url" -> project.avatarUrl)
   }
 
-  private implicit lazy val memberEncoder: Encoder[ProjectMemberNoEmail] = Encoder.instance { member =>
+  private implicit lazy val userEncoder: Encoder[GitLabUser] = Encoder.instance { user =>
     json"""{
-      "id":       ${member.gitLabId},     
-      "name":     ${member.name},
-      "username": ${member.username}
+      "id":       ${user.gitLabId},
+      "name":     ${user.name},
+      "username": ${user.username}
     }"""
   }
+
+  private implicit lazy val memberEncoder: Encoder[GitLabMember] =
+    Encoder.instance { member =>
+      json"""{
+          "id":       ${member.user.gitLabId},
+          "name":     ${member.user.name},
+          "username": ${member.user.username},
+          "access_level": ${member.accessLevel}
+        }"""
+    }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectInfoFinderSpec.scala
@@ -75,7 +75,7 @@ class ProjectInfoFinderSpec
           val updatedCreator = memberGitLabEmailLens.set(Some(personEmails.generateOne))(creator)
           (memberEmailFinder
             .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
-            .expects(creator.withReaderLevel, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
+            .expects(creator.withOwnerLevel, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
             .returning(rightT[IO, ProcessingRecoverableError](updatedCreator))
 
           finder
@@ -115,7 +115,7 @@ class ProjectInfoFinderSpec
         gitLabProjectMembers.map(memberGitLabIdLens.modify(_ => creator.user.gitLabId)).generateOne
       (memberEmailFinder
         .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
-        .expects(creator.withReaderLevel, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
+        .expects(creator.withOwnerLevel, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](updatedCreator))
 
       finder.findProjectInfo(projectInfo.slug).value.unsafeRunSync() shouldBe projectInfo
@@ -329,7 +329,7 @@ class ProjectInfoFinderSpec
     lazy val finder       = new ProjectInfoFinderImpl[IO](projectFinder, membersFinder, memberEmailFinder)
 
     implicit class GitLabMemberOps(m: GitLabMember) {
-      def withReaderLevel: GitLabMember = m.copy(accessLevel = Role.toGitLabAccessLevel(Role.Reader))
+      def withOwnerLevel: GitLabMember = m.copy(accessLevel = Role.toGitLabAccessLevel(Role.Owner))
     }
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectInfoFinderSpec.scala
@@ -65,14 +65,14 @@ class ProjectInfoFinderSpec
             .expects(infoWithCreator.slug, maybeAccessToken)
             .returning(rightT[IO, ProcessingRecoverableError](members))
           val updatedMembers = members map { member =>
-            val updatedMember = memberGitLabEmailLens.set(Some(personEmails.generateOne))(member)
+            val updatedMember = memberGitLabEmailLens.replace(Some(personEmails.generateOne))(member)
             (memberEmailFinder
               .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
               .expects(member, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
               .returning(rightT[IO, ProcessingRecoverableError](updatedMember))
             updatedMember
           }
-          val updatedCreator = memberGitLabEmailLens.set(Some(personEmails.generateOne))(creator)
+          val updatedCreator = memberGitLabEmailLens.replace(Some(personEmails.generateOne))(creator)
           (memberEmailFinder
             .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
             .expects(creator.withOwnerLevel, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectInfoFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectInfoFinderSpec.scala
@@ -26,8 +26,7 @@ import io.renku.generators.CommonGraphGenerators.accessTokens
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.exceptions
 import io.renku.graph.model.GraphModelGenerators.{personEmails, personNames, projectSlugs}
-import io.renku.graph.model.entities.Project.ProjectMember.ProjectMemberNoEmail
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabProjectInfo}
 import io.renku.graph.model.projects
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.http.client.AccessToken
@@ -35,6 +34,7 @@ import io.renku.interpreters.TestLogger
 import io.renku.testtools.IOSpec
 import io.renku.triplesgenerator.errors.ProcessingRecoverableError
 import io.renku.triplesgenerator.errors.ErrorGenerators.processingRecoverableErrors
+import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -50,37 +50,43 @@ class ProjectInfoFinderSpec
   "findProjectInfo" should {
 
     "return info about the project, its creator and members with matched emails" in new TestCase {
-      forAll { (info: GitLabProjectInfo, creator: ProjectMemberNoEmail, members: Set[ProjectMemberNoEmail]) =>
-        val infoWithCreator = info.copy(maybeCreator = creator.some, members = Set.empty)
-        (projectFinder
-          .findProject(_: projects.Slug)(_: Option[AccessToken]))
-          .expects(infoWithCreator.slug, maybeAccessToken)
-          .returning(rightT[IO, ProcessingRecoverableError](infoWithCreator.some))
-        (membersFinder
-          .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
-          .expects(infoWithCreator.slug, maybeAccessToken)
-          .returning(rightT[IO, ProcessingRecoverableError](members.map(_.asInstanceOf[ProjectMember])))
-        val updatedMembers = members map { member =>
-          val updatedMember = projectMembers.modify(memberGitLabIdLens.modify(_ => member.gitLabId)).generateOne
-          (memberEmailFinder
-            .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
-            .expects(member, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
-            .returning(rightT[IO, ProcessingRecoverableError](updatedMember))
-          updatedMember
-        }
-        val updatedCreator = projectMembers.modify(memberGitLabIdLens.modify(_ => creator.gitLabId)).generateOne
-        (memberEmailFinder
-          .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
-          .expects(creator, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
-          .returning(rightT[IO, ProcessingRecoverableError](updatedCreator))
+      implicit val gitLabMemberNoEmail:    Gen[GitLabMember]      = gitLabMemberGen(maybeEmails = Gen.const(None))
+      implicit val gitLabMemberNoEmailSet: Gen[Set[GitLabMember]] = gitLabMemberNoEmail.toGeneratorOfSet()
 
-        finder
-          .findProjectInfo(infoWithCreator.slug)
-          .value
-          .unsafeRunSync() shouldBe infoWithCreator
-          .copy(maybeCreator = updatedCreator.some, members = updatedMembers)
-          .some
-          .asRight
+      forAll(gitLabProjectInfos, gitLabMemberNoEmail, gitLabMemberNoEmailSet) {
+        (info: GitLabProjectInfo, creator: GitLabMember, members: Set[GitLabMember]) =>
+          val infoWithCreator = info.copy(maybeCreator = creator.user.some, members = Set.empty)
+          (projectFinder
+            .findProject(_: projects.Slug)(_: Option[AccessToken]))
+            .expects(infoWithCreator.slug, maybeAccessToken)
+            .returning(rightT[IO, ProcessingRecoverableError](infoWithCreator.some))
+          (membersFinder
+            .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
+            .expects(infoWithCreator.slug, maybeAccessToken)
+            .returning(rightT[IO, ProcessingRecoverableError](members))
+          val updatedMembers = members map { member =>
+            val updatedMember =
+              gitLabMemberGen().modify(memberGitLabIdLens.modify(_ => member.user.gitLabId)).generateOne
+            (memberEmailFinder
+              .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
+              .expects(member, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
+              .returning(rightT[IO, ProcessingRecoverableError](updatedMember))
+            updatedMember
+          }
+          val updatedCreator =
+            gitLabMemberGen().modify(memberGitLabIdLens.modify(_ => creator.user.gitLabId)).generateOne
+          (memberEmailFinder
+            .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
+            .expects(creator, Project(infoWithCreator.id, infoWithCreator.slug), maybeAccessToken)
+            .returning(rightT[IO, ProcessingRecoverableError](updatedCreator))
+
+          finder
+            .findProjectInfo(infoWithCreator.slug)
+            .value
+            .unsafeRunSync() shouldBe infoWithCreator
+            .copy(maybeCreator = updatedCreator.user.some, members = updatedMembers)
+            .some
+            .asRight
       }
     }
 
@@ -97,7 +103,7 @@ class ProjectInfoFinderSpec
 
     "return project info with creator only if no members can be found" in new TestCase {
       val creator     = projectMembersNoEmail.generateOne
-      val projectInfo = gitLabProjectInfos.generateOne.copy(maybeCreator = Some(creator), members = Set.empty)
+      val projectInfo = gitLabProjectInfos.generateOne.copy(maybeCreator = Some(creator.user), members = Set.empty)
 
       (projectFinder
         .findProject(_: projects.Slug)(_: Option[AccessToken]))
@@ -107,14 +113,15 @@ class ProjectInfoFinderSpec
         .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](Set.empty))
-      val updatedCreator = projectMembers.modify(memberGitLabIdLens.modify(_ => creator.gitLabId)).generateOne
+      val updatedCreator =
+        gitLabProjectMembers.modify(memberGitLabIdLens.modify(_ => creator.user.gitLabId)).generateOne
       (memberEmailFinder
-        .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
+        .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
         .expects(creator, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](updatedCreator))
 
       finder.findProjectInfo(projectInfo.slug).value.unsafeRunSync() shouldBe projectInfo
-        .copy(maybeCreator = Some(updatedCreator))
+        .copy(maybeCreator = Some(updatedCreator.user))
         .some
         .asRight
     }
@@ -126,15 +133,15 @@ class ProjectInfoFinderSpec
         .findProject(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](projectInfo.some))
-      val members: Set[ProjectMember] = projectMembersNoEmail.generateNonEmptyList().toList.toSet
+      val members: Set[GitLabMember] = projectMembersNoEmail.generateNonEmptyList().toList.toSet
       (membersFinder
         .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](members))
       val updatedMembers = members map { member =>
-        val updatedMember = projectMembers.modify(memberGitLabIdLens.modify(_ => member.gitLabId)).generateOne
+        val updatedMember = gitLabMemberGen().modify(memberGitLabIdLens.modify(_ => member.user.gitLabId)).generateOne
         (memberEmailFinder
-          .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
+          .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
           .expects(member, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
           .returning(rightT[IO, ProcessingRecoverableError](updatedMember))
         updatedMember
@@ -185,7 +192,7 @@ class ProjectInfoFinderSpec
       (membersFinder
         .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
-        .returning(EitherT.leftT[IO, Set[ProjectMember]](error))
+        .returning(EitherT.leftT[IO, Set[GitLabMember]](error))
 
       finder.findProjectInfo(projectInfo.slug).value.unsafeRunSync() shouldBe error.asLeft
     }
@@ -197,7 +204,7 @@ class ProjectInfoFinderSpec
         .findProject(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](projectInfo.some))
-      val members: Set[ProjectMember] = projectMembersNoEmail.generateNonEmptyList().toList.toSet
+      val members: Set[GitLabMember] = projectMembersNoEmail.generateNonEmptyList().toList.toSet
       (membersFinder
         .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
@@ -205,9 +212,9 @@ class ProjectInfoFinderSpec
       val error = processingRecoverableErrors.generateOne
       members foreach { member =>
         (memberEmailFinder
-          .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
+          .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
           .expects(member, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
-          .returning(EitherT.leftT[IO, ProjectMember](error))
+          .returning(EitherT.leftT[IO, GitLabMember](error))
       }
 
       finder.findProjectInfo(projectInfo.slug).value.unsafeRunSync() shouldBe error.asLeft
@@ -237,7 +244,7 @@ class ProjectInfoFinderSpec
       (membersFinder
         .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
-        .returning(EitherT(exception.raiseError[IO, Either[ProcessingRecoverableError, Set[ProjectMember]]]))
+        .returning(EitherT(exception.raiseError[IO, Either[ProcessingRecoverableError, Set[GitLabMember]]]))
 
       intercept[Exception](finder.findProjectInfo(projectInfo.slug).value.unsafeRunSync()) shouldBe exception
     }
@@ -249,7 +256,7 @@ class ProjectInfoFinderSpec
         .findProject(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
         .returning(rightT[IO, ProcessingRecoverableError](projectInfo.some))
-      val members: Set[ProjectMember] = projectMembersNoEmail.generateNonEmptyList().toList.toSet
+      val members: Set[GitLabMember] = projectMembersNoEmail.generateNonEmptyList().toList.toSet
       (membersFinder
         .findProjectMembers(_: projects.Slug)(_: Option[AccessToken]))
         .expects(projectInfo.slug, maybeAccessToken)
@@ -257,9 +264,9 @@ class ProjectInfoFinderSpec
       val exception = exceptions.generateOne
       members foreach { member =>
         (memberEmailFinder
-          .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
+          .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
           .expects(member, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
-          .returning(EitherT(exception.raiseError[IO, Either[ProcessingRecoverableError, ProjectMember]]))
+          .returning(EitherT(exception.raiseError[IO, Either[ProcessingRecoverableError, GitLabMember]]))
       }
 
       intercept[Exception](finder.findProjectInfo(projectInfo.slug).value.unsafeRunSync()) shouldBe exception
@@ -269,11 +276,11 @@ class ProjectInfoFinderSpec
   "findProjectInfo - members de-duplication" should {
 
     val sameNameMember1 = projectMembersNoEmail.generateOne
-    val sameNameMember2 = sameNameMember1.copy(name = personNames.generateOne)
-    val members         = Set(sameNameMember1, sameNameMember2).toSet[ProjectMember]
+    val sameNameMember2 = sameNameMember1.copy(user = sameNameMember1.user.copy(name = personNames.generateOne))
+    val members         = Set(sameNameMember1, sameNameMember2)
 
-    val sameNameMember1Updated = sameNameMember1.add(personEmails.generateOne)
-    val sameNameMember2Updated = sameNameMember2.add(personEmails.generateOne)
+    val sameNameMember1Updated = sameNameMember1.withEmail(personEmails.generateOne)
+    val sameNameMember2Updated = sameNameMember2.withEmail(personEmails.generateOne)
 
     forAll {
       Table(
@@ -297,11 +304,11 @@ class ProjectInfoFinderSpec
           .returning(rightT[IO, ProcessingRecoverableError](members))
 
         (memberEmailFinder
-          .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
+          .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
           .expects(sameNameMember1, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
           .returning(rightT[IO, ProcessingRecoverableError](member1AfterEmailFinding))
         (memberEmailFinder
-          .findMemberEmail(_: ProjectMember, _: Project)(_: Option[AccessToken]))
+          .findMemberEmail(_: GitLabMember, _: Project)(_: Option[AccessToken]))
           .expects(sameNameMember2, Project(projectInfo.id, projectInfo.slug), maybeAccessToken)
           .returning(rightT[IO, ProcessingRecoverableError](member2AfterEmailFinding))
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectMembersFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/projectinfo/ProjectMembersFinderSpec.scala
@@ -30,7 +30,7 @@ import io.renku.generators.CommonGraphGenerators.accessTokens
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
 import io.renku.graph.model.GraphModelGenerators.projectSlugs
-import io.renku.graph.model.entities.Project.ProjectMember.ProjectMemberNoEmail
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabUser}
 import io.renku.graph.model.projects
 import io.renku.graph.model.testentities.generators.EntitiesGenerators._
 import io.renku.http.client.RestClient.ResponseMappingF
@@ -65,7 +65,8 @@ class ProjectMembersFinderSpec
   "findProject" should {
 
     "fetch and merge project users and members" in new TestCase {
-      forAll { members: Set[ProjectMemberNoEmail] =>
+      val gitLabMember: Gen[Set[GitLabMember]] = gitLabMemberGen(maybeEmails = Gen.const(None)).toGeneratorOfSet()
+      forAll(gitLabMember) { members: Set[GitLabMember] =>
         setGitLabClientExpectation(projectSlug, returning = (members, None).pure[IO])
 
         finder.findProjectMembers(projectSlug).value.unsafeRunSync().value shouldBe members
@@ -84,7 +85,7 @@ class ProjectMembersFinderSpec
 
     "return an empty set even if GL endpoint responds with NOT_FOUND" in new TestCase {
 
-      setGitLabClientExpectation(projectSlug, returning = (Set.empty[ProjectMemberNoEmail], None).pure[IO])
+      setGitLabClientExpectation(projectSlug, returning = (Set.empty[GitLabMember], None).pure[IO])
 
       finder.findProjectMembers(projectSlug).value.unsafeRunSync().value shouldBe Set.empty
     }
@@ -128,7 +129,7 @@ class ProjectMembersFinderSpec
 
     def setGitLabClientExpectation(projectSlug: projects.Slug,
                                    maybePage:   Option[Int] = None,
-                                   returning:   IO[(Set[ProjectMemberNoEmail], Option[Int])]
+                                   returning:   IO[(Set[GitLabMember], Option[Int])]
     ) = {
       val endpointName: String Refined NonEmpty = "project-members"
       val uri = {
@@ -141,7 +142,7 @@ class ProjectMembersFinderSpec
 
       (gitLabClient
         .get(_: Uri, _: String Refined NonEmpty)(
-          _: ResponseMappingF[IO, (Set[ProjectMemberNoEmail], Option[Int])]
+          _: ResponseMappingF[IO, (Set[GitLabMember], Option[Int])]
         )(_: Option[AccessToken]))
         .expects(uri, endpointName, *, maybeAccessToken)
         .returning(returning)
@@ -150,16 +151,25 @@ class ProjectMembersFinderSpec
     val mapResponse =
       captureMapping(gitLabClient)(
         finder.findProjectMembers(projectSlug)(maybeAccessToken).value.unsafeRunSync(),
-        Gen.const((Set.empty[ProjectMemberNoEmail], Option.empty[Int])),
+        Gen.const((Set.empty[GitLabMember], Option.empty[Int])),
         underlyingMethod = Get
       )
   }
 
-  private implicit lazy val memberEncoder: Encoder[ProjectMemberNoEmail] = Encoder.instance { member =>
+  private implicit val userEncoder: Encoder[GitLabUser] = Encoder.instance { user =>
     json"""{
-      "id":       ${member.gitLabId},     
-      "name":     ${member.name},
-      "username": ${member.username}
+          "id":       ${user.gitLabId},
+          "name":     ${user.name},
+          "username": ${user.username}
+        }"""
+  }
+
+  private implicit lazy val memberEncoder: Encoder[GitLabMember] = Encoder.instance { member =>
+    json"""{
+      "id":       ${member.user.gitLabId},
+      "name":     ${member.user.name},
+      "username": ${member.user.username},
+      "access_level": ${member.accessLevel}
     }"""
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/EntityBuilderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/EntityBuilderSpec.scala
@@ -286,7 +286,7 @@ class EntityBuilderSpec
       project.maybeDescription,
       project.maybeCreator.map(_.to[GitLabUser]),
       project.keywords,
-      gitLapProjectMembers.generateSet(),
+      gitLabProjectMembers.generateSet(),
       project.visibility,
       maybeParentSlug = project match {
         case p: Project with Parent => p.parent.slug.some

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/EntityBuilderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/triplesgenerated/EntityBuilderSpec.scala
@@ -32,8 +32,7 @@ import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model._
 import io.renku.graph.model.entities.DiffInstances
-import io.renku.graph.model.entities.Project.ProjectMember.{ProjectMemberNoEmail, ProjectMemberWithEmail}
-import io.renku.graph.model.entities.Project.{GitLabProjectInfo, ProjectMember}
+import io.renku.graph.model.gitlab.{GitLabMember, GitLabProjectInfo, GitLabUser}
 import io.renku.graph.model.testentities.StepPlanCommandParameter.{CommandInput, CommandOutput, CommandParameter}
 import io.renku.graph.model.testentities.generators.EntitiesGenerators
 import io.renku.graph.model.testentities.generators.EntitiesGenerators.ActivityGenFactory
@@ -285,9 +284,9 @@ class EntityBuilderSpec
       project.dateCreated,
       project.dateModified,
       project.maybeDescription,
-      project.maybeCreator.map(_.to[ProjectMember]),
+      project.maybeCreator.map(_.to[GitLabUser]),
       project.keywords,
-      projectMembers.generateSet(),
+      gitLapProjectMembers.generateSet(),
       project.visibility,
       maybeParentSlug = project match {
         case p: Project with Parent => p.parent.slug.some
@@ -299,13 +298,8 @@ class EntityBuilderSpec
     private val projectInfoFinder = mock[ProjectInfoFinder[Try]]
     val entityBuilder             = new EntityBuilderImpl[Try](projectInfoFinder, renkuUrl)
 
-    private implicit lazy val toProjectMember: Person => ProjectMember = person => {
-      val member = ProjectMember(person.name, persons.Username(person.name.value), personGitLabIds.generateOne)
-      person.maybeEmail match {
-        case Some(email) => member.add(email)
-        case None        => member
-      }
-    }
+    private implicit lazy val toGitLabUser: Person => GitLabUser = person =>
+      GitLabUser(person.name, persons.Username(person.name.value), personGitLabIds.generateOne, person.maybeEmail)
 
     def givenFindProjectInfo(projectSlug: projects.Slug) = new {
       def returning(result: EitherT[Try, ProcessingRecoverableError, Option[GitLabProjectInfo]]) =
@@ -343,16 +337,14 @@ class EntityBuilderSpec
     val creatorWithGLId = blend(modelProject.maybeCreator, glProject.maybeCreator)
     val dateModified    = List(cliProject.dateModified, glProject.dateModified).max
     modelProject.fold(
-      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toPerson), dateModified = dateModified),
-      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toPerson), dateModified = dateModified),
-      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toPerson), dateModified = dateModified),
-      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toPerson), dateModified = dateModified)
+      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toMember), dateModified = dateModified),
+      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toMember), dateModified = dateModified),
+      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toMember), dateModified = dateModified),
+      _.copy(maybeCreator = creatorWithGLId, members = glProject.members.map(toMember), dateModified = dateModified)
     )
   }
 
-  private def blend[F[_]: Functor: Foldable](persons: F[entities.Person],
-                                             members: F[ProjectMember]
-  ): F[entities.Person] =
+  private def blend[F[_]: Functor: Foldable](persons: F[entities.Person], members: F[GitLabUser]): F[entities.Person] =
     persons.map(p =>
       members
         .find(m => m.name == p.name || m.username.value == p.name.value)
@@ -360,22 +352,16 @@ class EntityBuilderSpec
         .getOrElse(p)
     )
 
-  private def toPerson(projectMember: ProjectMember): entities.Person = projectMember match {
-    case ProjectMemberNoEmail(name, _, gitLabId) =>
-      entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                   gitLabId,
-                                   name,
-                                   maybeEmail = None,
-                                   maybeOrcidId = None,
-                                   maybeAffiliation = None
-      )
-    case ProjectMemberWithEmail(name, _, gitLabId, email) =>
-      entities.Person.WithGitLabId(persons.ResourceId(gitLabId),
-                                   gitLabId,
-                                   name,
-                                   email.some,
-                                   maybeOrcidId = None,
-                                   maybeAffiliation = None
-      )
-  }
+  private def toMember(member: GitLabMember)(implicit renkuUrl: RenkuUrl): entities.Project.Member =
+    entities.Project.Member(toPerson(member.user), member.role)
+
+  private def toPerson(user: GitLabUser)(implicit renkuUrl: RenkuUrl): entities.Person =
+    entities.Person.WithGitLabId(
+      persons.ResourceId(user.gitLabId),
+      user.gitLabId,
+      user.name,
+      maybeEmail = user.email,
+      maybeOrcidId = None,
+      maybeAffiliation = None
+    )
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/projects/create/PayloadConverterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/projects/create/PayloadConverterSpec.scala
@@ -47,7 +47,7 @@ class PayloadConverterSpec extends AnyFlatSpec with should.Matchers with ScalaCh
         Some(creator),
         newProject.visibility,
         newProject.keywords,
-        members = Set(creator),
+        members = Set(entities.Project.Member(creator, newProject.creator.role)),
         Image.projectImage(resourceId, newProject.images)
       )
     }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctionsSpec.scala
@@ -37,35 +37,36 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
   import ProjectFunctions._
 
   "update - person" should {
-    val oldPerson = personEntities().generateOne
+    val oldMember = projectMemberEntities().generateOne
+    val oldPerson = oldMember.person
 
     "replace the old person with the new on project" in {
       Set(
         renkuProjectEntities(anyVisibility)
           .modify(
-            _.copy(maybeCreator = Some(oldPerson), members = Set(oldPerson, personEntities.generateOne))
+            _.copy(maybeCreator = Some(oldPerson), members = Set(oldMember, projectMemberEntities().generateOne))
           ),
         renkuProjectWithParentEntities(anyVisibility)
           .modify(
-            _.copy(maybeCreator = Some(oldPerson), members = Set(oldPerson, personEntities.generateOne))
+            _.copy(maybeCreator = Some(oldPerson), members = Set(oldMember, projectMemberEntities().generateOne))
           ),
         nonRenkuProjectEntities(anyVisibility)
           .modify(
-            _.copy(maybeCreator = Some(oldPerson), members = Set(oldPerson, personEntities.generateOne))
+            _.copy(maybeCreator = Some(oldPerson), members = Set(oldMember, projectMemberEntities().generateOne))
           ),
         nonRenkuProjectWithParentEntities(anyVisibility)
           .modify(
-            _.copy(maybeCreator = Some(oldPerson), members = Set(oldPerson, personEntities.generateOne))
+            _.copy(maybeCreator = Some(oldPerson), members = Set(oldMember, projectMemberEntities().generateOne))
           )
       ) foreach { projectGen =>
         val project           = projectGen.generateOne.to[entities.Project]
-        val entitiesOldPerson = oldPerson.to[entities.Person]
+        val entitiesOldMember = oldMember.to[entities.Project.Member]
 
         val newPerson = personEntities().generateOne.to[entities.Person]
 
-        val updatedProject = update(entitiesOldPerson, newPerson)(project)
+        val updatedProject = update(entitiesOldMember.person, newPerson)(project)
 
-        updatedProject.members      shouldBe project.members - entitiesOldPerson + newPerson
+        updatedProject.members      shouldBe project.members - entitiesOldMember + entitiesOldMember.copy(person = newPerson)
         updatedProject.maybeCreator shouldBe Some(newPerson)
       }
     }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/transformation/namedgraphs/persons/PersonTransformerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/transformation/namedgraphs/persons/PersonTransformerSpec.scala
@@ -81,9 +81,10 @@ class PersonTransformerSpec extends AnyWordSpec with should.Matchers with MockFa
       }
 
     "fail with RecoverableFailure if finding matching Person in KG fails with a network or HTTP error" in new TestCase {
-      val person = personEntities.generateOne
+      val member = projectMemberEntities().generateOne
+      val person = member.person
       val project = anyProjectEntities
-        .map(membersLens.modify(_ => Set(person)) andThen creatorLens.modify(_ => None))
+        .map(membersLens.modify(_ => Set(member)) andThen creatorLens.modify(_ => None))
         .generateOne
         .to[entities.Project]
 
@@ -101,9 +102,10 @@ class PersonTransformerSpec extends AnyWordSpec with should.Matchers with MockFa
     }
 
     "fail with NonRecoverableFailure if finding matching Person in KG fails with an unknown exception" in new TestCase {
-      val person = personEntities.generateOne
+      val member = projectMemberEntities().generateOne
+      val person = member.person
       val project = anyProjectEntities
-        .map(membersLens.modify(_ => Set(person)) andThen creatorLens.modify(_ => None))
+        .map(membersLens.modify(_ => Set(member)) andThen creatorLens.modify(_ => None))
         .generateOne
         .to[entities.Project]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/transformation/namedgraphs/persons/PersonTransformerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/transformation/namedgraphs/persons/PersonTransformerSpec.scala
@@ -44,9 +44,10 @@ class PersonTransformerSpec extends AnyWordSpec with should.Matchers with MockFa
       "try to find matching Person in KG, " +
       "merge the data and update the project " +
       "and generate relevant pre data upload queries" in new TestCase {
-        val persons = personEntities.generateSet()
+        val members = projectMemberEntities().generateSet()
+        val persons = members.map(_.person)
         val project = anyProjectEntities
-          .map(membersLens.modify(_ => persons) andThen creatorLens.modify(_ => None))
+          .map(membersLens.modify(_ => members) andThen creatorLens.modify(_ => None))
           .generateOne
           .to[entities.Project]
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunnerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/triplesuploading/TransformationStepsRunnerSpec.scala
@@ -171,12 +171,13 @@ class TransformationStepsRunnerSpec extends AnyWordSpec with MockFactory with sh
       val step1Transformation = mockFunction[entities.Project, ProjectWithQueries[Try]]
 
       // preparing a project for which json-ld flattening fails
-      val Some(person) = personEntities(withGitLabId).generateOne.toMaybe[entities.Person.WithGitLabId]
+      val member = projectMemberEntities(withGitLabId).generateOne
       val step1Project = renkuProjectEntities(anyVisibility).generateOne
         .to[entities.RenkuProject.WithoutParent]
         .copy(
-          maybeCreator = person.some,
-          members = Set(person.copy(name = personNames.generateOne))
+          maybeCreator = member.person.to[entities.Person].some,
+          members =
+            Set(member.copy(person = member.person.copy(name = personNames.generateOne)).to[entities.Project.Member])
         )
       step1Transformation
         .expects(originalProject)


### PR DESCRIPTION
Maintain the role of a project member in our model, so we can transport the information to our database.