### PR TITLE
fix: migration check and better logging on the Project Update API

### DIFF
--- a/graph-commons/src/test/scala/io/renku/interpreters/TestLogger.scala
+++ b/graph-commons/src/test/scala/io/renku/interpreters/TestLogger.scala
@@ -47,6 +47,10 @@ class TestLogger[F[_]: Async] extends Logger[F] with should.Matchers {
     invocations(of = severity).toList.map(_.message)
   }
 
+  def getMessagesF: F[List[LogMessage]] = F.delay {
+    invocations.asScala.toList.map(_.message)
+  }
+
   private def invocations(of: Level): Iterable[LogEntry] =
     invocations.asScala.filter(_.level === of)
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/Endpoint.scala
@@ -90,10 +90,10 @@ private class EndpointImpl[F[_]: Async: Logger](projectCreator: ProjectCreator[F
 
   private lazy val logFailure: Failure => F[Unit] = {
     case f if f.status == BadRequest || f.status == Conflict =>
-      Logger[F].info(show"Creating project failed: ${f.getMessage}")
+      Logger[F].info(show"Creating project failed: ${f.detailedMessage}")
     case f if f.status == Forbidden =>
       ().pure[F]
     case f =>
-      Logger[F].error(f)("Creating project failed")
+      Logger[F].error(f)(show"Creating project failed: ${f.detailedMessage}")
   }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/Endpoint.scala
@@ -95,10 +95,10 @@ private class EndpointImpl[F[_]: Async: Logger](projectUpdater: ProjectUpdater[F
 
   private def logFailure(slug: projects.Slug): Failure => F[Unit] = {
     case f if f.status == BadRequest || f.status == Conflict =>
-      Logger[F].info(show"Updating project $slug failed: ${f.getMessage}")
+      Logger[F].info(show"Updating project $slug failed: ${f.detailedMessage}")
     case f if f.status == Forbidden =>
       ().pure[F]
     case f =>
-      Logger[F].error(f)(show"Updating project $slug failed")
+      Logger[F].error(f)(show"Updating project $slug failed: ${f.detailedMessage}")
   }
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/ProjectUpdater.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/update/ProjectUpdater.scala
@@ -151,7 +151,7 @@ private class ProjectUpdaterImpl[F[_]: Async: NonEmptyParallel: Logger](
 
   private def findCoreUri(updates: CoreProjectUpdates, authUser: AuthUser): F[RenkuCoreUri.Versioned] =
     renkuCoreClient
-      .findCoreUri(updates.projectUrl, authUser.accessToken)
+      .findCoreUri(updates.projectUrl, updates.userInfo, authUser.accessToken)
       .map(_.toEither)
       .handleError(_.asLeft)
       .flatMap(_.fold(UpdateFailures.onFindingCoreUri(_).raiseError[F, RenkuCoreUri.Versioned], _.pure[F]))

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/create/MultipartRequestCodecSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/create/MultipartRequestCodecSpec.scala
@@ -22,14 +22,14 @@ import Generators.newProjects
 import cats.effect.IO
 import io.renku.generators.Generators.Implicits._
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.scalacheck.effect.PropF
+import org.scalacheck.effect.PropF.forAllF
 
 class MultipartRequestCodecSpec extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   private val codec: MultipartRequestCodec[IO] = MultipartRequestCodec[IO]
 
   test("decode/encode the multipart request with multiple values") {
-    PropF.forAllF(newProjects) { newProject =>
+    forAllF(newProjects) { newProject =>
       (codec.encode(newProject) flatMap (MultipartRequestCodec[IO].decode(_)))
         .map(assertEquals(_, newProject))
     }

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/ProjectUpdaterSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/update/ProjectUpdaterSpec.scala
@@ -79,7 +79,7 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val userInfo = userInfos.generateOne
       givenUserInfoFinding(authUser.accessToken, returning = userInfo.some.pure[IO])
       val coreUri = coreUrisVersioned.generateOne
-      givenFindingCoreUri(projectGitUrl, authUser.accessToken, returning = Result.success(coreUri))
+      givenFindingCoreUri(projectGitUrl, userInfo, authUser.accessToken, returning = Result.success(coreUri))
 
       val updates = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
       givenUpdatingProjectInCore(
@@ -156,7 +156,7 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val userInfo = userInfos.generateOne
       givenUserInfoFinding(authUser.accessToken, returning = userInfo.some.pure[IO])
       val coreUri = coreUrisVersioned.generateOne
-      givenFindingCoreUri(projectGitUrl, authUser.accessToken, returning = Result.success(coreUri))
+      givenFindingCoreUri(projectGitUrl, userInfo, authUser.accessToken, returning = Result.success(coreUri))
 
       val updates        = projectUpdatesGen.suchThat(_.coreUpdateNeeded).generateOne
       val corePushBranch = branches.generateOne
@@ -292,10 +292,11 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
 
       val projectGitUrl = projectGitHttpUrls.generateOne
       givenProjectGitUrlFinding(slug, authUser.accessToken, returning = projectGitUrl.some.pure[IO])
-      givenUserInfoFinding(authUser.accessToken, returning = userInfos.generateSome.pure[IO])
+      val userInfo = userInfos.generateOne
+      givenUserInfoFinding(authUser.accessToken, returning = userInfo.some.pure[IO])
 
       val failedResult = resultDetailedFailures.generateOne
-      givenFindingCoreUri(projectGitUrl, authUser.accessToken, returning = failedResult)
+      givenFindingCoreUri(projectGitUrl, userInfo, authUser.accessToken, returning = failedResult)
 
       updater
         .updateProject(slug, updates, authUser)
@@ -317,7 +318,7 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
       val userInfo = userInfos.generateOne
       givenUserInfoFinding(authUser.accessToken, returning = userInfo.some.pure[IO])
       val coreUri = coreUrisVersioned.generateOne
-      givenFindingCoreUri(projectGitUrl, authUser.accessToken, returning = Result.success(coreUri))
+      givenFindingCoreUri(projectGitUrl, userInfo, authUser.accessToken, returning = Result.success(coreUri))
 
       val failedResult = resultDetailedFailures.generateOne
       givenUpdatingProjectInCore(
@@ -477,11 +478,12 @@ class ProjectUpdaterSpec extends AsyncFlatSpec with CustomAsyncIOSpec with shoul
     .returning(returning)
 
   private def givenFindingCoreUri(gitUrl:    projects.GitHttpUrl,
+                                  userInfo:  UserInfo,
                                   at:        UserAccessToken,
                                   returning: Result[RenkuCoreUri.Versioned]
   ) = (renkuCoreClient
-    .findCoreUri(_: projects.GitHttpUrl, _: AccessToken))
-    .expects(gitUrl, at)
+    .findCoreUri(_: projects.GitHttpUrl, _: UserInfo, _: AccessToken))
+    .expects(gitUrl, userInfo, at)
     .returning(returning.pure[IO])
 
   private def givenUpdatingProjectInCore(coreUri:   RenkuCoreUri.Versioned,

--- a/renku-core-client/src/test/scala/io/renku/core/client/ClientToolsSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/ClientToolsSpec.scala
@@ -44,7 +44,7 @@ class ClientToolsSpec extends AsyncWordSpec with CustomAsyncIOSpec with should.M
 
     "decode the failure into Result.Failure.Detailed" in {
 
-      val failure = resultDetailedFailures.generateOne
+      val failure = resultDetailedFailures.suchThat(_.maybeDevMessage.isEmpty).generateOne
 
       val response = Response[IO](Ok)
         .withEntity {
@@ -52,6 +52,24 @@ class ClientToolsSpec extends AsyncWordSpec with CustomAsyncIOSpec with should.M
             "error": {
               "code":        ${failure.code},
               "userMessage": ${failure.userMessage}
+            }
+          }"""
+        }
+
+      ClientTools[IO].toResult[String](response).asserting(_ shouldBe failure)
+    }
+
+    "decode the failure into Result.Failure.Detailed in the presence of devMessage" in {
+
+      val failure = resultDetailedFailures.suchThat(_.maybeDevMessage.isDefined).generateOne
+
+      val response = Response[IO](Ok)
+        .withEntity {
+          json"""{
+            "error": {
+              "code":        ${failure.code},
+              "userMessage": ${failure.userMessage},
+              "devMessage":  ${failure.maybeDevMessage}
             }
           }"""
         }

--- a/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
@@ -33,9 +33,15 @@ object Generators {
   def resultSuccesses[T](payloadGen: Gen[T]): Gen[Result[T]] =
     payloadGen.map(Result.success)
 
+  implicit lazy val resultSimpleFailures: Gen[Result.Failure.Simple] =
+    sentences().map(_.value).map(Result.Failure.Simple(_))
+
   implicit lazy val resultDetailedFailures: Gen[Result.Failure.Detailed] =
-    (positiveInts().map(_.value) -> sentences().map(_.value))
-      .mapN(Result.Failure.Detailed(_, _))
+    (positiveInts().map(_.value), sentences().map(_.value), sentences().map(_.value).toGeneratorOfOptions)
+      .mapN(Result.Failure.Detailed(_, _, _))
+
+  implicit lazy val resultFailures: Gen[Result.Failure] =
+    Gen.oneOf(resultSimpleFailures, resultDetailedFailures)
 
   implicit lazy val apiVersions: Gen[ApiVersion] =
     (positiveInts(), positiveInts()).mapN((major, minor) => ApiVersion(s"$major.$minor"))

--- a/renku-core-client/src/test/scala/io/renku/core/client/RenkuCoreClientSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/RenkuCoreClientSpec.scala
@@ -61,11 +61,13 @@ class RenkuCoreClientSpec
         givenCoreUriForSchemaInConfig(coreUriForSchema)
 
         val projectUrl     = projectGitHttpUrls.generateOne
+        val userInfo       = userInfos.generateOne
         val accessToken    = accessTokens.generateOne
         val migrationCheck = ProjectMigrationCheck(schemaVersion, MigrationRequired.no)
 
         givenMigrationCheckFetching(coreUriForSchema,
                                     projectUrl,
+                                    userInfo,
                                     accessToken,
                                     returning = Result.success(migrationCheck)
         )
@@ -73,7 +75,7 @@ class RenkuCoreClientSpec
         val coreUriVersioned = givenFindCoreUri(migrationCheck.schemaVersion)
 
         client
-          .findCoreUri(projectUrl, accessToken)
+          .findCoreUri(projectUrl, userInfo, accessToken)
           .asserting(_ shouldBe Result.success(coreUriVersioned))
       }
 
@@ -95,12 +97,14 @@ class RenkuCoreClientSpec
         givenCoreUriForSchemaInConfig(coreUriForSchema3)
 
         val projectUrl  = projectGitHttpUrls.generateOne
+        val userInfo    = userInfos.generateOne
         val accessToken = accessTokens.generateOne
 
         // case when Migration not required by different schema version - a weird case
         val migrationCheck1 = ProjectMigrationCheck(projectSchemaVersions.generateOne, MigrationRequired.no)
         givenMigrationCheckFetching(coreUriForSchema1,
                                     projectUrl,
+                                    userInfo,
                                     accessToken,
                                     returning = Result.success(migrationCheck1)
         )
@@ -109,6 +113,7 @@ class RenkuCoreClientSpec
         val migrationCheck2 = ProjectMigrationCheck(schemaVersion2, MigrationRequired.yes)
         givenMigrationCheckFetching(coreUriForSchema2,
                                     projectUrl,
+                                    userInfo,
                                     accessToken,
                                     returning = Result.success(migrationCheck2)
         )
@@ -116,6 +121,7 @@ class RenkuCoreClientSpec
         val migrationCheck3 = ProjectMigrationCheck(schemaVersion3, MigrationRequired.no)
         givenMigrationCheckFetching(coreUriForSchema3,
                                     projectUrl,
+                                    userInfo,
                                     accessToken,
                                     returning = Result.success(migrationCheck3)
         )
@@ -123,7 +129,7 @@ class RenkuCoreClientSpec
         val coreUriVersioned = givenFindCoreUri(migrationCheck3.schemaVersion)
 
         client
-          .findCoreUri(projectUrl, accessToken)
+          .findCoreUri(projectUrl, userInfo, accessToken)
           .asserting(_ shouldBe Result.success(coreUriVersioned))
       }
 
@@ -133,6 +139,7 @@ class RenkuCoreClientSpec
       givenVersionsFinding(returning = Result.success(schemaVersions))
 
       val projectUrl  = projectGitHttpUrls.generateOne
+      val userInfo    = userInfos.generateOne
       val accessToken = accessTokens.generateOne
 
       schemaVersions foreach { sv =>
@@ -141,13 +148,14 @@ class RenkuCoreClientSpec
 
         givenMigrationCheckFetching(coreUriForSchema,
                                     projectUrl,
+                                    userInfo,
                                     accessToken,
                                     returning = Result.success(projectMigrationChecks.generateOne)
         )
       }
 
       client
-        .findCoreUri(projectUrl, accessToken)
+        .findCoreUri(projectUrl, userInfo, accessToken)
         .asserting(_ shouldBe Result.failure("Project in unsupported version. Quite likely migration required"))
     }
 
@@ -160,12 +168,13 @@ class RenkuCoreClientSpec
       givenCoreUriForSchemaInConfig(coreUriForSchema)
 
       val projectUrl  = projectGitHttpUrls.generateOne
+      val userInfo    = userInfos.generateOne
       val accessToken = accessTokens.generateOne
 
       val failure = resultDetailedFailures.generateOne
-      givenMigrationCheckFetching(coreUriForSchema, projectUrl, accessToken, returning = failure)
+      givenMigrationCheckFetching(coreUriForSchema, projectUrl, userInfo, accessToken, returning = failure)
 
-      client.findCoreUri(projectUrl, accessToken).asserting(_ shouldBe failure)
+      client.findCoreUri(projectUrl, userInfo, accessToken).asserting(_ shouldBe failure)
     }
   }
 
@@ -261,10 +270,11 @@ class RenkuCoreClientSpec
 
   private def givenMigrationCheckFetching(coreUri:     RenkuCoreUri,
                                           projectUrl:  projects.GitHttpUrl,
+                                          userInfo:    UserInfo,
                                           accessToken: AccessToken,
                                           returning:   Result[ProjectMigrationCheck]
   ) = (lowLevelApis.getMigrationCheck _)
-    .expects(coreUri, projectUrl, accessToken)
+    .expects(coreUri, projectUrl, userInfo, accessToken)
     .returning(returning.pure[IO])
 
   private def givenVersionsFinding(returning: Result[List[SchemaVersion]]) =

--- a/renku-core-client/src/test/scala/io/renku/core/client/ResultSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/ResultSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.core.client
+
+import Generators.{resultDetailedFailures, resultSimpleFailures}
+import io.renku.generators.Generators.Implicits._
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+class ResultSpec extends AnyWordSpec with should.Matchers with OptionValues {
+
+  "Failure.Simple.detailedMessage" should {
+
+    "return a String with the error" in {
+
+      val failure = resultSimpleFailures.generateOne
+
+      failure.detailedMessage shouldBe failure.error
+    }
+  }
+
+  "Failure.Detailed.detailedMessage" should {
+
+    "return a String with the userMessage and code if no devMessage is present" in {
+
+      val failure = resultDetailedFailures.suchThat(_.maybeDevMessage.isEmpty).generateOne
+
+      failure.detailedMessage shouldBe s"${failure.userMessage}: ${failure.code}"
+    }
+
+    "return a String with the userMessage and code if devMessage is present" in {
+
+      val failure = resultDetailedFailures.suchThat(_.maybeDevMessage.nonEmpty).generateOne
+
+      failure.detailedMessage shouldBe s"${failure.userMessage}: ${failure.code}; devMessage: ${failure.maybeDevMessage.value}"
+    }
+  }
+}

--- a/renku-core-client/src/test/scala/io/renku/core/client/TestModelCodecs.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/TestModelCodecs.scala
@@ -64,12 +64,13 @@ private object TestModelCodecs {
       case Result.Success(obj) => json"""{
           "result": ${obj.asJson}
         }"""
-      case Result.Failure.Detailed(code, userMessage) => json"""{
+      case Result.Failure.Detailed(code, userMessage, maybeDevMessage) => json"""{
           "error": {
             "code":        $code,
-            "userMessage": $userMessage
+            "userMessage": $userMessage,
+            "devMessage":  $maybeDevMessage
           }
-        }"""
+        }""".deepDropNullValues
       case result => throw new Exception(s"$result shouldn't be in the core API response payload")
     }
 }


### PR DESCRIPTION
This PR:
* fixes the call to the Core's `cache.migrations_check` API; user's GitLab token to be passed in the standard `Authorization Bearer` header instead of custom `gitlab-token`.
* improves logging in case of failures coming from calls to the Core APIs; `devMessage` to be added into the logs if present in the response.