### PR TITLE
refactor: extracted Histogram.observe to simplify Histogram API

### DIFF
--- a/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsEndpoint.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.eventdetails
 
-import cats.effect.Concurrent
+import cats.effect.{Async, Concurrent}
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.circe.Encoder
@@ -67,7 +67,7 @@ class EventDetailsEndpointImpl[F[_]: Concurrent: Logger](eventDetailsFinder: Eve
 }
 
 object EventDetailsEndpoint {
-  def apply[F[_]: Concurrent: SessionResource: Logger: QueriesExecutionTimes]: F[EventDetailsEndpoint[F]] = for {
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]: F[EventDetailsEndpoint[F]] = for {
     eventDetailFinder <- EventDetailsFinder[F]
   } yield new EventDetailsEndpointImpl[F](eventDetailFinder)
 }

--- a/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventdetails/EventDetailsFinder.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog.eventdetails
 
 import cats.MonadThrow
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -34,7 +34,7 @@ private trait EventDetailsFinder[F[_]] {
   def findDetails(eventId: CompoundEventId): F[Option[EventDetails]]
 }
 
-private class EventDetailsFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class EventDetailsFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with EventDetailsFinder[F]
     with TypeSerializers {
@@ -56,6 +56,6 @@ private class EventDetailsFinderImpl[F[_]: MonadCancelThrow: SessionResource: Qu
 }
 
 private object EventDetailsFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[EventDetailsFinder[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[EventDetailsFinder[F]] =
     MonadThrow[F].catchNonFatal(new EventDetailsFinderImpl[F])
 }

--- a/event-log/src/main/scala/io/renku/eventlog/eventpayload/EventPayloadEndpoint.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventpayload/EventPayloadEndpoint.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.eventpayload
 
-import cats.effect.Concurrent
+import cats.effect.{Async, Concurrent}
 import cats.syntax.all._
 import io.renku.data.Message
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -38,7 +38,7 @@ trait EventPayloadEndpoint[F[_]] {
 
 object EventPayloadEndpoint {
 
-  def apply[F[_]: Concurrent: SessionResource: Logger: QueriesExecutionTimes]: EventPayloadEndpoint[F] =
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]: EventPayloadEndpoint[F] =
     apply[F](EventPayloadFinder[F])
 
   def apply[F[_]: Concurrent: Logger](payloadFinder: EventPayloadFinder[F]): EventPayloadEndpoint[F] =

--- a/event-log/src/main/scala/io/renku/eventlog/eventpayload/EventPayloadFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/eventpayload/EventPayloadFinder.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.eventpayload
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -43,7 +43,7 @@ object EventPayloadFinder {
     def length: Long = data.length
   }
 
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: EventPayloadFinder[F] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: EventPayloadFinder[F] =
     new DbClient[F](Some(QueriesExecutionTimes[F])) with EventPayloadFinder[F] with TypeSerializers {
 
       override def findEventPayload(eventId: EventId, projectSlug: ProjectSlug): F[Option[PayloadData]] =

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/cleanuprequest/ProjectIdFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/cleanuprequest/ProjectIdFinder.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.consumers.cleanuprequest
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -31,11 +31,11 @@ private trait ProjectIdFinder[F[_]] {
 }
 
 private object ProjectIdFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[ProjectIdFinder[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[ProjectIdFinder[F]] =
     new ProjectIdFinderImpl[F].pure[F].widen
 }
 
-private class ProjectIdFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class ProjectIdFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with ProjectIdFinder[F]
     with TypeSerializers {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/CommitSyncForcer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/CommitSyncForcer.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.commitsyncrequest
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import io.renku.db.{DbClient, SqlStatement}
@@ -41,7 +41,7 @@ private trait CommitSyncForcer[F[_]] {
   def forceCommitSync(projectId: projects.GitLabId, projectSlug: projects.Slug): F[Unit]
 }
 
-private class CommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class CommitSyncForcerImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with CommitSyncForcer[F]
     with TypeSerializers
@@ -83,6 +83,6 @@ private class CommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource: Quer
 }
 
 private object CommitSyncForcer {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[CommitSyncForcer[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[CommitSyncForcer[F]] =
     MonadThrow[F].catchNonFatal(new CommitSyncForcerImpl[F])
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/EventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/EventHandler.scala
@@ -18,13 +18,13 @@
 
 package io.renku.eventlog.events.consumers.commitsyncrequest
 
-import cats.effect.{Concurrent, MonadCancelThrow}
+import cats.effect.{Async, MonadCancelThrow}
 import cats.syntax.all._
 import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.api.events.CommitSyncRequest
 import io.renku.eventlog.metrics.QueriesExecutionTimes
-import io.renku.events.{consumers, CategoryName}
 import io.renku.events.consumers._
+import io.renku.events.{CategoryName, consumers}
 import org.typelevel.log4cats.Logger
 
 private class EventHandler[F[_]: MonadCancelThrow: Logger](
@@ -48,6 +48,6 @@ private class EventHandler[F[_]: MonadCancelThrow: Logger](
 }
 
 private object EventHandler {
-  def apply[F[_]: Concurrent: SessionResource: Logger: QueriesExecutionTimes]: F[consumers.EventHandler[F]] =
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]: F[consumers.EventHandler[F]] =
     CommitSyncForcer[F].map(new EventHandler[F](_))
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/SubscriptionFactory.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/commitsyncrequest/SubscriptionFactory.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.consumers.commitsyncrequest
 
-import cats.effect.Concurrent
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.metrics.QueriesExecutionTimes
@@ -28,7 +28,7 @@ import org.typelevel.log4cats.Logger
 
 object SubscriptionFactory {
 
-  def apply[F[_]: Concurrent: SessionResource: Logger: QueriesExecutionTimes]
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
       : F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     handler <- EventHandler[F]
   } yield handler -> SubscriptionMechanism.noOpSubscriptionMechanism(categoryName)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/creation/EventPersister.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/creation/EventPersister.scala
@@ -196,10 +196,8 @@ private class EventPersisterImpl[F[_]: Async: SessionResource: QueriesExecutionT
 }
 
 private object EventPersister {
-  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes: EventStatusGauges]
-      : F[EventPersisterImpl[F]] = MonadThrow[F].catchNonFatal {
-    new EventPersisterImpl[F]()
-  }
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes: EventStatusGauges]: F[EventPersisterImpl[F]] =
+    MonadThrow[F].catchNonFatal(new EventPersisterImpl[F]())
 
   sealed trait Result extends Product with Serializable
   object Result {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/creation/EventPersister.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/creation/EventPersister.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog.events.consumers.creation
 
 import cats.data.{Kleisli, NonEmptyList}
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import cats.{Applicative, MonadThrow}
 import eu.timepit.refined.auto._
@@ -41,7 +41,7 @@ private trait EventPersister[F[_]] {
   def storeNewEvent(event: Event): F[Result]
 }
 
-private class EventPersisterImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes: EventStatusGauges](
+private class EventPersisterImpl[F[_]: Async: SessionResource: QueriesExecutionTimes: EventStatusGauges](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with EventPersister[F] {
@@ -196,7 +196,7 @@ private class EventPersisterImpl[F[_]: MonadCancelThrow: SessionResource: Querie
 }
 
 private object EventPersister {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes: EventStatusGauges]
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes: EventStatusGauges]
       : F[EventPersisterImpl[F]] = MonadThrow[F].catchNonFatal {
     new EventPersisterImpl[F]()
   }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/EventHandler.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/EventHandler.scala
@@ -18,13 +18,13 @@
 
 package io.renku.eventlog.events.consumers.globalcommitsyncrequest
 
-import cats.effect.{Concurrent, MonadCancelThrow}
+import cats.effect.{Async, MonadCancelThrow}
 import cats.syntax.all._
 import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.metrics.QueriesExecutionTimes
-import io.renku.events.{consumers, CategoryName}
-import io.renku.events.consumers._
 import io.renku.events.consumers.EventDecodingTools._
+import io.renku.events.consumers._
+import io.renku.events.{CategoryName, consumers}
 import org.typelevel.log4cats.Logger
 
 private class EventHandler[F[_]: MonadCancelThrow: Logger](
@@ -47,6 +47,6 @@ private class EventHandler[F[_]: MonadCancelThrow: Logger](
 }
 
 private object EventHandler {
-  def apply[F[_]: Concurrent: SessionResource: Logger: QueriesExecutionTimes]: F[consumers.EventHandler[F]] =
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]: F[consumers.EventHandler[F]] =
     GlobalCommitSyncForcer[F]().map(new EventHandler[F](_))
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/GlobalCommitSyncForcer.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/GlobalCommitSyncForcer.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog.events.consumers.globalcommitsyncrequest
 
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import com.typesafe.config.{Config, ConfigFactory}
 import io.renku.db.{DbClient, SqlStatement}
@@ -39,7 +39,7 @@ private trait GlobalCommitSyncForcer[F[_]] {
   def moveGlobalCommitSync(projectId: projects.GitLabId, projectSlug: projects.Slug): F[Unit]
 }
 
-private class GlobalCommitSyncForcerImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class GlobalCommitSyncForcerImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     syncFrequency:  Duration,
     delayOnRequest: Duration,
     now:            () => Instant = () => Instant.now
@@ -91,7 +91,7 @@ private object GlobalCommitSyncForcer {
 
   import scala.concurrent.duration.FiniteDuration
 
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes](
       config: Config = ConfigFactory.load()
   ): F[GlobalCommitSyncForcer[F]] = for {
     configFrequency      <- find[F, FiniteDuration]("global-commit-sync-frequency", config)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/SubscriptionFactory.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/globalcommitsyncrequest/SubscriptionFactory.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.consumers.globalcommitsyncrequest
 
-import cats.effect.Concurrent
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.eventlog.EventLogDB.SessionResource
 import io.renku.eventlog.metrics.QueriesExecutionTimes
@@ -28,7 +28,7 @@ import org.typelevel.log4cats.Logger
 
 object SubscriptionFactory {
 
-  def apply[F[_]: Concurrent: SessionResource: Logger: QueriesExecutionTimes]
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
       : F[(consumers.EventHandler[F], SubscriptionMechanism[F])] = for {
     handler <- EventHandler[F]
   } yield handler -> SubscriptionMechanism.noOpSubscriptionMechanism(categoryName)

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/projectsync/ProjectRemover.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/projectsync/ProjectRemover.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.projectsync
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -32,7 +32,7 @@ private trait ProjectRemover[F[_]] {
   def removeProject(projectId: projects.GitLabId): F[Unit]
 }
 
-private class ProjectRemoverImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class ProjectRemoverImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with ProjectRemover[F]
     with TypeSerializers {
@@ -80,6 +80,6 @@ private class ProjectRemoverImpl[F[_]: MonadCancelThrow: SessionResource: Querie
 }
 
 private object ProjectRemover {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[ProjectRemover[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[ProjectRemover[F]] =
     MonadThrow[F].catchNonFatal(new ProjectRemoverImpl[F]).widen
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DeliveryInfoRemover.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/DeliveryInfoRemover.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.statuschange
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.TypeSerializers
 import io.renku.eventlog.metrics.QueriesExecutionTimes
@@ -34,12 +34,12 @@ private trait DeliveryInfoRemover[F[_]] {
 }
 
 private object DeliveryInfoRemover {
-  def apply[F[_]: MonadCancelThrow: QueriesExecutionTimes]: F[DeliveryInfoRemover[F]] = MonadThrow[F].catchNonFatal {
+  def apply[F[_]: Async: QueriesExecutionTimes]: F[DeliveryInfoRemover[F]] = MonadThrow[F].catchNonFatal {
     new DeliveryInfoRemoverImpl[F]
   }
 }
 
-private class DeliveryInfoRemoverImpl[F[_]: MonadCancelThrow: QueriesExecutionTimes]
+private class DeliveryInfoRemoverImpl[F[_]: Async: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with DeliveryInfoRemover[F]
     with TypeSerializers {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktoawaitingdeletion/DbUpdater.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog.events.consumers.statuschange
 package rollbacktoawaitingdeletion
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
@@ -40,7 +40,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: Logger: QueriesExecutionTimes](
+private[statuschange] class DbUpdater[F[_]: Async: Logger: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with statuschange.DBUpdater[F, RollbackToAwaitingDeletion] {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktonew/DbUpdater.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.consumers.statuschange.rollbacktonew
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
@@ -37,7 +37,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTimes](
+private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with DBUpdater[F, RollbackToNew] {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/rollbacktotriplesgenerated/DbUpdater.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.consumers.statuschange.rollbacktotriplesgenerated
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
@@ -38,7 +38,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTimes](
+private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with statuschange.DBUpdater[F, RollbackToTriplesGenerated] {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/statuschange/toawaitingdeletion/DbUpdater.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.consumers.statuschange.toawaitingdeletion
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.kernel.Monoid
 import cats.syntax.all._
 import eu.timepit.refined.auto._
@@ -38,7 +38,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private[statuschange] class DbUpdater[F[_]: MonadCancelThrow: QueriesExecutionTimes](
+private[statuschange] class DbUpdater[F[_]: Async: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with statuschange.DBUpdater[F, ToAwaitingDeletion] {

--- a/event-log/src/main/scala/io/renku/eventlog/events/consumers/zombieevents/ZombieStatusCleaner.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/consumers/zombieevents/ZombieStatusCleaner.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.consumers.zombieevents
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
@@ -40,7 +40,7 @@ private trait ZombieStatusCleaner[F[_]] {
   def cleanZombieStatus(event: ZombieEvent): F[UpdateResult]
 }
 
-private class ZombieStatusCleanerImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class ZombieStatusCleanerImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with ZombieStatusCleaner[F]
@@ -86,6 +86,6 @@ private class ZombieStatusCleanerImpl[F[_]: MonadCancelThrow: SessionResource: Q
 }
 
 private object ZombieStatusCleaner {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[ZombieStatusCleaner[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[ZombieStatusCleaner[F]] =
     MonadThrow[F].catchNonFatal(new ZombieStatusCleanerImpl[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/DefaultSubscriberTracker.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/DefaultSubscriberTracker.scala
@@ -18,7 +18,7 @@
 
 package io.renku.eventlog.events.producers
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -40,13 +40,13 @@ private object DefaultSubscriberTracker {
 
   def apply[F[_]](implicit tracker: DefaultSubscriberTracker[F]): DefaultSubscriberTracker[F] = tracker
 
-  def create[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[DefaultSubscriberTracker[F]] = for {
+  def create[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[DefaultSubscriberTracker[F]] = for {
     microserviceUrlFinder <- MicroserviceUrlFinder(Microservice.ServicePort)
     sourceUrl             <- microserviceUrlFinder.findBaseUrl()
   } yield new DefaultSubscriberTrackerImpl[F](sourceUrl)
 }
 
-private class DefaultSubscriberTrackerImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class DefaultSubscriberTrackerImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     sourceUrl: MicroserviceBaseUrl
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with DefaultSubscriberTracker[F]

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/commitsync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/commitsync/EventFinder.scala
@@ -21,7 +21,7 @@ package commitsync
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -37,7 +37,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with EventFinder[F, CommitSyncEvent]
@@ -164,6 +164,6 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
 }
 
 private object EventFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, CommitSyncEvent]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, CommitSyncEvent]] =
     MonadThrow[F].catchNonFatal(new EventFinderImpl[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/eventdelivery/EventDelivery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/eventdelivery/EventDelivery.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.producers
 package eventdelivery
 
 import cats.MonadThrow
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.db.{DbClient, SqlStatement}
@@ -39,7 +39,7 @@ private[producers] trait EventDelivery[F[_], CategoryEvent] {
   def registerSending(event: CategoryEvent, subscriberUrl: SubscriberUrl): F[Unit]
 }
 
-private class EventDeliveryImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes, CategoryEvent](
+private class EventDeliveryImpl[F[_]: Async: SessionResource: QueriesExecutionTimes, CategoryEvent](
     eventDeliveryIdExtractor: CategoryEvent => EventDeliveryId,
     sourceUrl:                MicroserviceBaseUrl
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
@@ -111,7 +111,7 @@ private class EventDeliveryImpl[F[_]: MonadCancelThrow: SessionResource: Queries
 
 private[producers] object EventDelivery {
 
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes, CategoryEvent](
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes, CategoryEvent](
       eventDeliveryIdExtractor: CategoryEvent => EventDeliveryId
   ): F[EventDelivery[F, CategoryEvent]] = for {
     microserviceUrlFinder <- MicroserviceUrlFinder(Microservice.ServicePort)

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/globalcommitsync/LastSyncedDateUpdater.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/globalcommitsync/LastSyncedDateUpdater.scala
@@ -21,7 +21,7 @@ package globalcommitsync
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -38,13 +38,13 @@ private trait LastSyncedDateUpdater[F[_]] {
 }
 
 private object LastSyncedDateUpdater {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[LastSyncedDateUpdater[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[LastSyncedDateUpdater[F]] =
     MonadThrow[F].catchNonFatal(
       new LastSyncedDateUpdateImpl[F]
     )
 }
 
-private class LastSyncedDateUpdateImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class LastSyncedDateUpdateImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with LastSyncedDateUpdater[F]
     with SubscriptionTypeSerializers {

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/membersync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/membersync/EventFinder.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.producers.membersync
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -29,13 +29,13 @@ import io.renku.eventlog.metrics.QueriesExecutionTimes
 import io.renku.events.CategoryName
 import io.renku.graph.model.events.{EventDate, LastSyncedDate}
 import io.renku.graph.model.projects
+import skunk._
 import skunk.data.Completion
 import skunk.implicits._
-import skunk._
 
 import java.time.Instant
 
-private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with EventFinder[F, MemberSyncEvent]
@@ -141,6 +141,6 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
 }
 
 private object EventFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, MemberSyncEvent]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, MemberSyncEvent]] =
     MonadThrow[F].catchNonFatal(new EventFinderImpl[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/DispatchRecovery.scala
@@ -19,7 +19,7 @@
 package io.renku.eventlog.events.producers
 package minprojectinfo
 
-import cats.effect.MonadCancelThrow
+import cats.effect.{Async, MonadCancelThrow}
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -35,7 +35,7 @@ import skunk.data.Completion
 
 import scala.util.control.NonFatal
 
-private class DispatchRecoveryImpl[F[_]: MonadCancelThrow: SessionResource: Logger: QueriesExecutionTimes]
+private class DispatchRecoveryImpl[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with producers.DispatchRecovery[F, MinProjectInfoEvent]
     with SubscriptionTypeSerializers {
@@ -71,7 +71,7 @@ private class DispatchRecoveryImpl[F[_]: MonadCancelThrow: SessionResource: Logg
 }
 
 private object DispatchRecovery {
-  def apply[F[_]: MonadCancelThrow: SessionResource: Logger: QueriesExecutionTimes]
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
       : F[DispatchRecovery[F, MinProjectInfoEvent]] = MonadCancelThrow[F].catchNonFatal {
     new DispatchRecoveryImpl[F]
   }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/DispatchRecovery.scala
@@ -71,8 +71,6 @@ private class DispatchRecoveryImpl[F[_]: Async: SessionResource: Logger: Queries
 }
 
 private object DispatchRecovery {
-  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
-      : F[DispatchRecovery[F, MinProjectInfoEvent]] = MonadCancelThrow[F].catchNonFatal {
-    new DispatchRecoveryImpl[F]
-  }
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]: F[DispatchRecovery[F, MinProjectInfoEvent]] =
+    MonadCancelThrow[F].catchNonFatal(new DispatchRecoveryImpl[F])
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/minprojectinfo/EventFinder.scala
@@ -21,7 +21,7 @@ package minprojectinfo
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -34,7 +34,7 @@ import skunk.data.Completion
 
 import java.time.Instant
 
-private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with EventFinder[F, MinProjectInfoEvent]
@@ -102,6 +102,6 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
 }
 
 private object EventFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, MinProjectInfoEvent]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, MinProjectInfoEvent]] =
     MonadThrow[F].catchNonFatal(new EventFinderImpl[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/DispatchRecovery.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.producers
 package projectsync
 
 import EventsSender.SendingResult
-import cats.effect.MonadCancelThrow
+import cats.effect.{Async, MonadCancelThrow}
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -35,7 +35,7 @@ import skunk.data.Completion
 
 import scala.util.control.NonFatal
 
-private class DispatchRecoveryImpl[F[_]: MonadCancelThrow: SessionResource: Logger: QueriesExecutionTimes]
+private class DispatchRecoveryImpl[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with producers.DispatchRecovery[F, ProjectSyncEvent]
     with SubscriptionTypeSerializers {
@@ -71,7 +71,7 @@ private class DispatchRecoveryImpl[F[_]: MonadCancelThrow: SessionResource: Logg
 }
 
 private object DispatchRecovery {
-  def apply[F[_]: MonadCancelThrow: SessionResource: Logger: QueriesExecutionTimes]
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
       : F[DispatchRecovery[F, ProjectSyncEvent]] = MonadCancelThrow[F].catchNonFatal {
     new DispatchRecoveryImpl[F]()
   }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/DispatchRecovery.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/DispatchRecovery.scala
@@ -71,8 +71,6 @@ private class DispatchRecoveryImpl[F[_]: Async: SessionResource: Logger: Queries
 }
 
 private object DispatchRecovery {
-  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]
-      : F[DispatchRecovery[F, ProjectSyncEvent]] = MonadCancelThrow[F].catchNonFatal {
-    new DispatchRecoveryImpl[F]()
-  }
+  def apply[F[_]: Async: SessionResource: Logger: QueriesExecutionTimes]: F[DispatchRecovery[F, ProjectSyncEvent]] =
+    MonadCancelThrow[F].catchNonFatal(new DispatchRecoveryImpl[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/EventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/projectsync/EventFinder.scala
@@ -21,7 +21,7 @@ package projectsync
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -34,7 +34,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class EventFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with EventFinder[F, ProjectSyncEvent]
@@ -138,6 +138,6 @@ private class EventFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesEx
 }
 
 private object EventFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, ProjectSyncEvent]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[EventFinder[F, ProjectSyncEvent]] =
     MonadThrow[F].catchNonFatal(new EventFinderImpl[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationSubscriberTracker.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/tsmigrationrequest/MigrationSubscriberTracker.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.producers
 package tsmigrationrequest
 
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.{Async, MonadCancelThrow}
 import cats.syntax.all._
 import io.renku.config.ServiceVersion
 import io.renku.db.{DbClient, SqlStatement}
@@ -35,7 +35,7 @@ import skunk.implicits._
 
 import java.time.Instant
 
-private class MigrationSubscriberTracker[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class MigrationSubscriberTracker[F[_]: Async: SessionResource: QueriesExecutionTimes](
     now: () => Instant = () => Instant.now()
 ) extends DbClient(Some(QueriesExecutionTimes[F]))
     with events.producers.SubscriberTracker[F, MigrationSubscriber]
@@ -106,6 +106,6 @@ private class MigrationSubscriberTracker[F[_]: MonadCancelThrow: SessionResource
 }
 
 private object MigrationSubscriberTracker {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[MigrationSubscriberTracker[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[MigrationSubscriberTracker[F]] =
     MonadCancelThrow[F].catchNonFatal(new MigrationSubscriberTracker[F]())
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostSubscriberEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostSubscriberEventFinder.scala
@@ -21,7 +21,7 @@ package zombieevents
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -38,7 +38,7 @@ import skunk.implicits._
 
 import java.time.Instant.now
 
-private class LostSubscriberEventFinder[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class LostSubscriberEventFinder[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with producers.EventFinder[F, ZombieEvent]
     with ZombieEventSubProcess
@@ -110,6 +110,6 @@ private class LostSubscriberEventFinder[F[_]: MonadCancelThrow: SessionResource:
 }
 
 private object LostSubscriberEventFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[producers.EventFinder[F, ZombieEvent]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[producers.EventFinder[F, ZombieEvent]] =
     MonadThrow[F].catchNonFatal(new LostSubscriberEventFinder[F])
 }

--- a/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostZombieEventFinder.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/events/producers/zombieevents/LostZombieEventFinder.scala
@@ -20,7 +20,7 @@ package io.renku.eventlog.events.producers.zombieevents
 
 import cats.MonadThrow
 import cats.data.Kleisli
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.eventlog.EventLogDB.SessionResource
@@ -38,7 +38,7 @@ import skunk.implicits._
 import java.time.Duration
 import java.time.Instant.now
 
-private class LostZombieEventFinder[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class LostZombieEventFinder[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient(Some(QueriesExecutionTimes[F]))
     with producers.EventFinder[F, ZombieEvent]
     with ZombieEventSubProcess
@@ -105,6 +105,6 @@ private class LostZombieEventFinder[F[_]: MonadCancelThrow: SessionResource: Que
 }
 
 private object LostZombieEventFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[producers.EventFinder[F, ZombieEvent]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[producers.EventFinder[F, ZombieEvent]] =
     MonadThrow[F].catchNonFatal(new LostZombieEventFinder[F])
 }

--- a/event-log/src/main/scala/io/renku/eventlog/metrics/QueriesExecutionTimes.scala
+++ b/event-log/src/main/scala/io/renku/eventlog/metrics/QueriesExecutionTimes.scala
@@ -34,7 +34,7 @@ object QueriesExecutionTimes {
       name = "event_log_queries_execution_times",
       help = "Event Log queries execution times",
       labelName = "query_id",
-      buckets = Seq(.05, .1, .5, 1, 2.5, 5, 10, 50),
+      maybeBuckets = Seq(.05, .1, .5, 1, 2.5, 5, 10, 50).some,
       maybeThreshold = (750 millis).some
     ) with QueriesExecutionTimes[F]
   }.widen

--- a/graph-commons/src/main/scala/io/renku/db/DbClient.scala
+++ b/graph-commons/src/main/scala/io/renku/db/DbClient.scala
@@ -19,25 +19,25 @@
 package io.renku.db
 
 import cats.data.Kleisli
+import cats.effect.Clock
 import cats.syntax.all._
 import cats.{Monad, Show}
 import io.renku.metrics.LabeledHistogram
 import skunk.Session
 import skunk.data.Completion
 
-abstract class DbClient[F[_]: Monad](maybeHistogram: Option[LabeledHistogram[F]]) {
+abstract class DbClient[F[_]: Monad: Clock](maybeHistogram: Option[LabeledHistogram[F]]) {
 
   protected def measureExecutionTime[ResultType](
       query: SqlStatement[F, ResultType]
   ): Kleisli[F, Session[F], ResultType] = Kleisli { session =>
     maybeHistogram match {
-      case None => query.queryExecution.run(session)
+      case None =>
+        query.queryExecution.run(session)
       case Some(histogram) =>
-        for {
-          timer  <- histogram.startTimer(query.name.value)
-          result <- query.queryExecution.run(session)
-          _      <- timer.observeDuration
-        } yield result
+        Clock[F]
+          .timed(query.queryExecution.run(session))
+          .flatMap { case (duration, result) => histogram.observe(query.name.value, duration).as(result) }
     }
   }
 

--- a/graph-commons/src/main/scala/io/renku/metrics/GitLabApiCallRecorder.scala
+++ b/graph-commons/src/main/scala/io/renku/metrics/GitLabApiCallRecorder.scala
@@ -33,7 +33,8 @@ object GitLabApiCallRecorder {
                    name = "gitlab_api_calls",
                    help = "GitLab API Calls",
                    labelName = "call_id",
-                   buckets = Seq(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10)
+                   buckets = Seq(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10),
+                   maybeThreshold = None
                  )
     executionTimeRecorder <- ExecutionTimeRecorder[F](maybeHistogram = Some(histogram))
   } yield new GitLabApiCallRecorder(executionTimeRecorder)

--- a/graph-commons/src/test/scala/io/renku/http/client/RestClientSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/http/client/RestClientSpec.scala
@@ -18,7 +18,6 @@
 
 package io.renku.http.client
 
-import cats.Applicative
 import cats.effect.{IO, Ref}
 import cats.syntax.all._
 import com.github.tomakehurst.wiremock.client.WireMock._
@@ -396,8 +395,8 @@ class RestClientSpec
 
     def givenHistogramObservesExecutionTime(maybeLabel: Option[String]) =
       (histogram
-        .observe(_: Option[String], _: FiniteDuration)(_: Logger[IO], _: Applicative[IO]))
-        .expects(maybeLabel, *, *, *)
+        .observe(_: Option[String], _: FiniteDuration))
+        .expects(maybeLabel, *)
         .returning(().pure[IO])
   }
 

--- a/graph-commons/src/test/scala/io/renku/logging/ExecutionTimeRecorderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/logging/ExecutionTimeRecorderSpec.scala
@@ -18,7 +18,6 @@
 
 package io.renku.logging
 
-import cats.Applicative
 import cats.effect.{IO, Temporal}
 import cats.syntax.all._
 import com.typesafe.config.ConfigFactory
@@ -38,7 +37,6 @@ import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AsyncWordSpec
-import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -84,12 +82,8 @@ class ExecutionTimeRecorderSpec
 
       val blockExecutionTime = positiveInts(max = 100).generateOne.value
       (histogram
-        .observe(_: Option[String], _: FiniteDuration)(_: Logger[IO], _: Applicative[IO]))
-        .expects(
-          where((l: Option[String], amt: FiniteDuration, _: Logger[IO], _: Applicative[IO]) =>
-            l.isEmpty && amt.toMillis >= blockExecutionTime
-          )
-        )
+        .observe(_: Option[String], _: FiniteDuration))
+        .expects(where((l: Option[String], amt: FiniteDuration) => l.isEmpty && amt.toMillis >= blockExecutionTime))
         .returning(().pure[IO])
 
       executionTimeRecorder
@@ -110,9 +104,9 @@ class ExecutionTimeRecorderSpec
 
       val blockExecutionTime = positiveInts(max = 100).generateOne.value
       (histogram
-        .observe(_: Option[String], _: FiniteDuration)(_: Logger[IO], _: Applicative[IO]))
+        .observe(_: Option[String], _: FiniteDuration))
         .expects(
-          where((l: Option[String], amt: FiniteDuration, _: Logger[IO], _: Applicative[IO]) =>
+          where((l: Option[String], amt: FiniteDuration) =>
             l == Option(label.value) && amt.toMillis >= blockExecutionTime
           )
         )

--- a/graph-commons/src/test/scala/io/renku/metrics/AllValuesLabeledGaugeSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/AllValuesLabeledGaugeSpec.scala
@@ -45,14 +45,14 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.set(labelValue1 -> value1) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
 
       // iteration 2
       val labelValue2 = projectSlugs.generateOne
       val value2      = nonNegativeDoubles().generateOne.value
       gauge.set(labelValue2 -> value2) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue2.value) shouldBe List(value2)
+      gauge.collectValuesFor(label.value, labelValue2.value) shouldBe List(value2)
     }
 
     "set negative value if one is set" in new TestCase {
@@ -62,7 +62,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.set(labelValue -> value) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
     }
   }
 
@@ -74,7 +74,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
       val update     = nonNegativeDoubles().generateOne.value
       gauge.update(labelValue -> update) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(update)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(update)
     }
 
     "update the value associated with the label - case without a label and negative update" in new TestCase {
@@ -84,7 +84,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.update(labelValue -> -update) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(-update)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(-update)
     }
 
     "update the value associated with the label - case with a positive update value" in new TestCase {
@@ -94,12 +94,12 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.update(labelValue -> initialValue) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue)
 
       val update = nonNegativeDoubles().generateOne.value
       gauge.update(labelValue -> update) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue + update)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue + update)
     }
 
     "update the value associated with the label - case with a negative update value so current + update < 0" in new TestCase {
@@ -112,7 +112,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
       val update = initialValue * ints(min = 2, max = 5).generateOne
       gauge.update(labelValue -> -update) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue - update)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue - update)
     }
   }
 
@@ -126,7 +126,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.update(labelValue1 -> value1) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
 
       // re-provisioning
       val waitingEvents = waitingEventsGen.generateNonEmptyList().toList.flatten.toMap
@@ -134,7 +134,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.reset() shouldBe MonadThrow[Try].unit
 
-      underlying.collectAllSamples should contain theSameElementsAs waitingEvents.map { case (labelValue, value) =>
+      gauge.collectAllSamples should contain theSameElementsAs waitingEvents.map { case (labelValue, value) =>
         (label.value, labelValue.value, value)
       }
     }
@@ -149,11 +149,11 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.update(labelValue -> value) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
 
       gauge.clear() shouldBe MonadThrow[Try].unit
 
-      underlying.collectAllSamples.isEmpty shouldBe true
+      gauge.collectAllSamples.isEmpty shouldBe true
     }
   }
 
@@ -166,12 +166,12 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.update(labelValue -> value) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
 
       // incrementing
       gauge.increment(labelValue) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value + 1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value + 1)
     }
 
     "add label value if one is not present yet" in new TestCase {
@@ -180,7 +180,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.increment(labelValue) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(1)
     }
   }
 
@@ -196,7 +196,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
       // decrementing
       gauge.decrement(labelValue) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value - 1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value - 1)
     }
 
     "add label value with value -1 if one is not present yet" in new TestCase {
@@ -205,7 +205,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
 
       gauge.decrement(labelValue) shouldBe MonadThrow[Try].unit
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(-1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(-1)
     }
   }
 
@@ -214,9 +214,7 @@ class AllValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with should
     val name           = nonBlankStrings().generateOne
     val help           = nonBlankStrings().generateOne
     val resetDataFetch = mockFunction[Try[Map[Slug, Double]]]
-
-    val gauge      = new AllValuesLabeledGauge[Try, Slug](name, help, label, resetDataFetch)
-    val underlying = gauge.wrappedCollector
+    val gauge          = new AllValuesLabeledGauge[Try, Slug](name, help, label, resetDataFetch)
   }
 
   private lazy val waitingEventsGen: Gen[Map[Slug, Double]] = nonEmptySet {

--- a/graph-commons/src/test/scala/io/renku/metrics/HistogramSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/HistogramSpec.scala
@@ -18,18 +18,89 @@
 
 package io.renku.metrics
 
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
+import io.renku.interpreters.TestLogger
+import io.renku.interpreters.TestLogger.Level.Error
 import io.renku.metrics.MetricsTools._
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.{AnyWordSpec, AsyncWordSpec}
 
-import java.lang.Thread.sleep
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
+
+class HistogramSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers with BeforeAndAfterEach {
+
+  "observe" should {
+
+    "update the underlying histogram " +
+      "in case of a non-labelled histogram and no label given" in {
+
+        val histogram = new SingleValueHistogramImpl[IO](nonBlankStrings().generateOne,
+                                                         nonBlankStrings().generateOne,
+                                                         maybeBuckets = Seq(0.1d).some
+        )
+
+        histogram.observe(maybeLabel = None, 101 millis).assertNoException >>
+          IO(histogram.collectAllSamples.map(toValue)).asserting(_ shouldBe List(0d, 1d))
+      }
+
+    "update the underlying histogram " +
+      "in case of a labelled histogram and some label given" in {
+
+        val histogram = new LabeledHistogramImpl[IO](nonBlankStrings().generateOne,
+                                                     nonBlankStrings().generateOne,
+                                                     nonBlankStrings().generateOne,
+                                                     maybeBuckets = Seq(0.1d).some
+        )
+
+        val label    = nonEmptyStrings().generateOne
+        val duration = 101 millis
+
+        histogram.observe(label.some, duration).assertNoException >>
+          IO(histogram.sumValuesFor(label)).asserting(_ shouldBe duration.toMillis.toDouble / 1000)
+      }
+
+    "log an error " +
+      "in case of a non-labelled histogram and some label given" in {
+
+        val histogram = new SingleValueHistogramImpl[IO](nonBlankStrings().generateOne,
+                                                         nonBlankStrings().generateOne,
+                                                         maybeBuckets = Seq(0.1d).some
+        )
+
+        val label = nonEmptyStrings().generateOne
+        histogram.observe(label.some, 101 millis).assertNoException >>
+          logger.loggedOnlyF(Error(s"Label $label sent for a Single Value Histogram ${histogram.name}"))
+      }
+
+    "do nothing " +
+      "in case of a labelled histogram and no label given" in {
+
+        val histogram = new LabeledHistogramImpl[IO](nonBlankStrings().generateOne,
+                                                     nonBlankStrings().generateOne,
+                                                     nonBlankStrings().generateOne,
+                                                     maybeBuckets = Seq(0.1d).some
+        )
+
+        histogram.observe(None, durations().generateOne).assertNoException >>
+          IO(histogram.collectAllSamples).asserting(_ shouldBe Seq.empty)
+      }
+  }
+
+  private implicit lazy val logger: TestLogger[IO] = TestLogger()
+
+  protected override def beforeEach() = {
+    super.beforeEach()
+    logger.reset()
+  }
+}
 
 class SingleValueHistogramSpec extends AnyWordSpec with MockFactory with should.Matchers {
 
@@ -53,53 +124,27 @@ class SingleValueHistogramSpec extends AnyWordSpec with MockFactory with should.
       }
   }
 
-  "startTimer -> observeDuration" should {
-
-    "collect measured duration" in new TestCase {
-
-      val histogram  = new SingleValueHistogramImpl[Try](name, help, Seq(0.1))
-      val underlying = histogram.wrappedCollector
-
-      val simulatedDuration = 500 millis
-      val observedDuration  = histogram.simulateDuration(simulatedDuration)
-
-      (observedDuration * 1000)              should be > simulatedDuration.toMillis.toDouble
-      underlying.collectAllSamples.last._3 shouldBe 1d
-    }
-  }
-
   "observe(Double)" should {
 
     "call the underlying impl" in new TestCase {
-      val histogram = new SingleValueHistogramImpl[Try](name, help, Seq(0.1))
+      val histogram = new SingleValueHistogramImpl[Try](name, help, Seq(0.1).some)
       histogram.observe(101d)
-      histogram.wrappedCollector.collectAllSamples.map(_._3) shouldBe List(0d, 1d)
+      histogram.collectAllSamples.map(toValue) shouldBe List(0d, 1d)
     }
   }
 
   "observe(FiniteDuration)" should {
 
     "convert the duration to seconds in Double format" in new TestCase {
-      val histogram = new SingleValueHistogramImpl[Try](name, help, Seq(0.1))
+      val histogram = new SingleValueHistogramImpl[Try](name, help, Seq(0.1).some)
       histogram.observe(101 millis)
-      histogram.wrappedCollector.collectAllSamples.map(_._3) shouldBe List(0d, 1d)
+      histogram.collectAllSamples.map(toValue) shouldBe List(0d, 1d)
     }
   }
 
   private trait TestCase {
     val name = nonBlankStrings().generateOne
     val help = sentences().generateOne
-  }
-
-  private implicit class HistogramOps(histogram: SingleValueHistogram[Try]) {
-
-    def simulateDuration(duration: Duration): Double = {
-      val Success(timer) = histogram.startTimer()
-
-      sleep(duration.toMillis)
-
-      timer.observeDuration.fold(throw _, identity)
-    }
   }
 }
 
@@ -119,7 +164,7 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
 
         val labelName = nonBlankStrings().generateOne
 
-        val Success(histogram) = Histogram[Try](name, help, labelName, Seq(.1, 1))
+        val Success(histogram) = Histogram[Try](name, help, labelName, Seq(.1, 1), maybeThreshold = None)
 
         histogram.isInstanceOf[LabeledHistogram[Try]] shouldBe true
         histogram.name                                shouldBe name
@@ -127,90 +172,11 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
       }
   }
 
-  "startTimer -> observeDuration" should {
-
-    "collect measured duration for the label" in new TestCase {
-
-      val histogram  = new LabeledHistogramImpl[Try](name, help, label, Seq(0.1))
-      val underlying = histogram.wrappedCollector
-
-      val value             = nonEmptyStrings().generateOne
-      val simulatedDuration = 500 millis
-      val observedDuration  = histogram.simulateDuration(simulatedDuration, value)
-
-      (observedDuration * 1000)                       should be > simulatedDuration.toMillis.toDouble
-      underlying.collectValuesFor(label.value, value) should contain(observedDuration)
-    }
-
-    "collect measured time only for durations longer than threshold" in new TestCase {
-
-      val threshold  = 500 millis
-      val histogram  = new LabeledHistogramImpl[Try](name, help, label, Seq(0.1), maybeThreshold = threshold.some)
-      val underlying = histogram.wrappedCollector
-
-      // process below threshold
-      val value1                  = nonEmptyStrings().generateOne
-      val value1SimulatedDuration = threshold minus (200 millis)
-
-      val value1ObservedDuration = histogram.simulateDuration(value1SimulatedDuration, value1)
-
-      (value1ObservedDuration * 1000) should (
-        (be > value1SimulatedDuration.toMillis.toDouble) and (be < threshold.toMillis.toDouble)
-      )
-      underlying.collectValuesFor(label.value, value1) shouldBe Nil
-
-      // process above threshold
-      val value2                  = nonEmptyStrings().generateOne
-      val value2SimulatedDuration = threshold plus (200 millis)
-
-      val value2ObservedDuration = histogram.simulateDuration(value2SimulatedDuration, value2)
-
-      underlying.collectValuesFor(label.value, value2) should contain(value2ObservedDuration)
-
-      // another process below threshold
-      val value3                  = nonEmptyStrings().generateOne
-      val value3SimulatedDuration = threshold minus (200 millis)
-
-      histogram.simulateDuration(value3SimulatedDuration, value3)
-
-      underlying.collectValuesFor(label.value, value1) shouldBe Nil
-    }
-
-    "remove the collected label value once an observed duration for it gets below the threshold" in new TestCase {
-
-      val threshold  = 500 millis
-      val histogram  = new LabeledHistogramImpl[Try](name, help, label, Seq(0.1), maybeThreshold = threshold.some)
-      val underlying = histogram.wrappedCollector
-      val value      = nonEmptyStrings().generateOne
-
-      // process below threshold
-      val simulatedDuration1 = threshold minus (200 millis)
-
-      histogram.simulateDuration(simulatedDuration1, value)
-
-      underlying.collectValuesFor(label.value, value) shouldBe Nil
-
-      // process above threshold
-      val simulatedDuration2 = threshold plus (200 millis)
-
-      val observedDuration2 = histogram.simulateDuration(simulatedDuration2, value)
-
-      underlying.collectValuesFor(label.value, value) should contain(observedDuration2)
-
-      // another process below threshold
-      val simulatedDuration3 = threshold minus (200 millis)
-
-      histogram.simulateDuration(simulatedDuration3, value)
-
-      underlying.collectValuesFor(label.value, value) shouldBe Nil
-    }
-  }
-
   "observe(Double)" should {
 
     "store the value if no threshold given" in new TestCase {
 
-      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1))
+      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1).some)
 
       histogram.observe("label", 1.001d)
 
@@ -219,7 +185,8 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
 
     "store the value if threshold given but the value >= the threshold" in new TestCase {
 
-      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1), maybeThreshold = (1 second).some)
+      val histogram =
+        new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1).some, maybeThreshold = (1 second).some)
 
       histogram.observe("label", 1.001d)
 
@@ -228,7 +195,8 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
 
     "not store the value if threshold given and the value < the threshold" in new TestCase {
 
-      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1), maybeThreshold = (1 second).some)
+      val histogram =
+        new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1).some, maybeThreshold = (1 second).some)
 
       histogram.observe("label", .999d)
 
@@ -240,7 +208,7 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
 
     "store the value if no threshold given" in new TestCase {
 
-      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1))
+      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1).some)
 
       histogram.observe("label", 1001 millis)
 
@@ -249,7 +217,8 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
 
     "store the value if threshold given but the value >= the threshold" in new TestCase {
 
-      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1), maybeThreshold = (1 second).some)
+      val histogram =
+        new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1).some, maybeThreshold = (1 second).some)
 
       histogram.observe("label", 1001 millis)
 
@@ -258,7 +227,8 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
 
     "not store the value if threshold given and the value < the threshold" in new TestCase {
 
-      val histogram = new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1), maybeThreshold = (1 second).some)
+      val histogram =
+        new LabeledHistogramImpl[Try](name, help, "label", Seq(0.1).some, maybeThreshold = (1 second).some)
 
       histogram.observe("label", 999 millis)
 
@@ -267,19 +237,7 @@ class LabeledHistogramSpec extends AnyWordSpec with MockFactory with should.Matc
   }
 
   private trait TestCase {
-    val label = nonBlankStrings().generateOne
-    val name  = nonBlankStrings().generateOne
-    val help  = sentences().generateOne
-  }
-
-  private implicit class HistogramOps(histogram: LabeledHistogram[Try]) {
-
-    def simulateDuration(duration: Duration, value: String): Double = {
-      val Success(timer) = histogram.startTimer(value)
-
-      sleep(duration.toMillis)
-
-      timer.observeDuration.fold(throw _, identity)
-    }
+    val name = nonBlankStrings().generateOne
+    val help = sentences().generateOne
   }
 }

--- a/graph-commons/src/test/scala/io/renku/metrics/PositiveValuesLabeledGaugeSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/PositiveValuesLabeledGaugeSpec.scala
@@ -46,7 +46,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.set(labelValue1 -> value1).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
 
       // iteration 2
       val labelValue2 = projectSlugs.generateOne
@@ -54,7 +54,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.set(labelValue2 -> value2).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue2.value) shouldBe List(value2)
+      gauge.collectValuesFor(label.value, labelValue2.value) shouldBe List(value2)
     }
 
     "set 0 if negatives value is given" in new TestCase {
@@ -64,7 +64,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.set(labelValue -> value).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
     }
   }
 
@@ -77,7 +77,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue -> update).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(update)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(update)
     }
 
     "update the value associated with the label - case without a label and negative update" in new TestCase {
@@ -87,7 +87,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue -> -update).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(0)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0)
     }
 
     "update the value associated with the label - case with a positive update value" in new TestCase {
@@ -97,13 +97,13 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue -> initialValue).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue)
 
       val update = nonNegativeDoubles().generateOne.value
 
       gauge.update(labelValue -> update).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue + update)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(initialValue + update)
     }
 
     "update the value associated with the label - case with a negative update value so current + update < 0" in new TestCase {
@@ -117,7 +117,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue -> -update).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
     }
   }
 
@@ -130,7 +130,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue1 -> value1).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
 
       // re-provisioning
       val waitingEvents = waitingEventsGen.generateNonEmptyList().toList.flatten.toMap
@@ -138,7 +138,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.reset().unsafeRunSync() shouldBe ()
 
-      underlying.collectAllSamples should contain theSameElementsAs waitingEvents.map { case (labelValue, value) =>
+      gauge.collectAllSamples should contain theSameElementsAs waitingEvents.map { case (labelValue, value) =>
         (label.value, labelValue.value, value)
       }
     }
@@ -153,11 +153,11 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue1 -> value1).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
 
       gauge.clear().unsafeRunSync() shouldBe ()
 
-      underlying.collectAllSamples.isEmpty shouldBe true
+      gauge.collectAllSamples.isEmpty shouldBe true
     }
   }
 
@@ -170,12 +170,12 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.update(labelValue -> value).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
 
       // incrementing
       gauge.increment(labelValue).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value + 1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value + 1)
     }
 
     "add label value if one is not present yet" in new TestCase {
@@ -184,7 +184,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.increment(labelValue).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(1)
     }
   }
 
@@ -200,7 +200,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       // decrementing
       gauge.decrement(labelValue).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(value - 1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value - 1)
     }
 
     "add label value with value 0 if one is not present yet" in new TestCase {
@@ -209,7 +209,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       gauge.decrement(labelValue).unsafeRunSync() shouldBe ()
 
-      underlying.collectValuesFor(label.value, labelValue.value) shouldBe List(0)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0)
     }
   }
 
@@ -228,8 +228,8 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       val value2      = nonNegativeDoubles().generateOne.value
       gauge.set(labelValue2 -> value2).unsafeRunSync() shouldBe ()
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue2.value) shouldBe List(value2)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue2.value) shouldBe List(value2)
 
       // one label gets 0
       gauge.set(labelValue2 -> 0d).unsafeRunSync() shouldBe ()
@@ -237,14 +237,14 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       sleep(zeroRemovalTimeout.toMillis - (zerosCheckingInterval.toMillis * 2))
 
       // the 0 should be kept for the grace period
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue2.value) shouldBe List(0d)
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue2.value) shouldBe List(0d)
 
       // the label with 0 should be removed if it's longer than the grace period
       sleep(zeroRemovalTimeout.toMillis + (zerosCheckingInterval.toMillis * 2))
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue2.value) shouldBe List.empty
+      gauge.collectValuesFor(label.value, labelValue1.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue2.value) shouldBe List.empty
     }
 
     "not remove the label if 0 value was updated to non-0" in new TestCase {
@@ -256,7 +256,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       val value1     = nonNegativeDoubles().generateOne.value
       gauge.set(labelValue -> value1).unsafeRunSync() shouldBe ()
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(value1)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value1)
 
       // the value gets 0
       gauge.set(labelValue -> 0d).unsafeRunSync() shouldBe ()
@@ -264,7 +264,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       sleep(zeroRemovalTimeout.toMillis - (zerosCheckingInterval.toMillis * 2))
 
       // the 0 should be kept for the grace period
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
 
       // before the grace period the value is changed again to non-0
       val value2 = nonNegativeDoubles().generateOne.value
@@ -272,7 +272,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
       sleep(zeroRemovalTimeout.toMillis + (zerosCheckingInterval.toMillis * 2))
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(value2)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value2)
     }
 
     "remove the label after the value was updated to 0" in new TestCase {
@@ -284,7 +284,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       val value      = nonNegativeDoubles().generateOne.value
       gauge.update(labelValue -> value).unsafeRunSync() shouldBe ()
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
 
       // the value gets 0
       gauge.update(labelValue -> -value * 2).unsafeRunSync() shouldBe ()
@@ -292,12 +292,12 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       sleep(zeroRemovalTimeout.toMillis - (zerosCheckingInterval.toMillis * 2))
 
       // the 0 should be kept for the grace period
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
 
       // after the grace period the label should be removed
       sleep(zeroRemovalTimeout.toMillis + (zerosCheckingInterval.toMillis * 2))
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List.empty
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List.empty
     }
 
     "remove the label after the value was decremented to 0" in new TestCase {
@@ -309,7 +309,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       val value      = 1d
       gauge.set(labelValue -> value).unsafeRunSync() shouldBe ()
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(value)
 
       // the value gets 0
       gauge.decrement(labelValue).unsafeRunSync() shouldBe ()
@@ -317,12 +317,12 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
       sleep(zeroRemovalTimeout.toMillis - (zerosCheckingInterval.toMillis * 2))
 
       // the 0 should be kept for the grace period
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List(0d)
 
       // after the grace period the label should be removed
       sleep(zeroRemovalTimeout.toMillis + (zerosCheckingInterval.toMillis * 2))
 
-      gauge.wrappedCollector.collectValuesFor(label.value, labelValue.value) shouldBe List.empty
+      gauge.collectValuesFor(label.value, labelValue.value) shouldBe List.empty
     }
   }
 
@@ -336,7 +336,6 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
 
     val resetDataFetch = mockFunction[IO[Map[Slug, Double]]]
     val gauge      = new PositiveValuesLabeledGauge[IO, Slug](name, help, label, resetDataFetch, zerosCheckingInterval)
-    val underlying = gauge.wrappedCollector
   }
 
   private lazy val waitingEventsGen: Gen[Map[Slug, Double]] = nonEmptySet {

--- a/graph-commons/src/test/scala/io/renku/metrics/PositiveValuesLabeledGaugeSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/PositiveValuesLabeledGaugeSpec.scala
@@ -335,7 +335,7 @@ class PositiveValuesLabeledGaugeSpec extends AnyWordSpec with MockFactory with s
     val zerosCheckingInterval = 100 millis
 
     val resetDataFetch = mockFunction[IO[Map[Slug, Double]]]
-    val gauge      = new PositiveValuesLabeledGauge[IO, Slug](name, help, label, resetDataFetch, zerosCheckingInterval)
+    val gauge = new PositiveValuesLabeledGauge[IO, Slug](name, help, label, resetDataFetch, zerosCheckingInterval)
   }
 
   private lazy val waitingEventsGen: Gen[Map[Slug, Double]] = nonEmptySet {

--- a/graph-commons/src/test/scala/io/renku/metrics/TestLabeledHistogram.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/TestLabeledHistogram.scala
@@ -46,7 +46,7 @@ class TestLabeledHistogram(labelName: String) extends LabeledHistogram[IO] with 
     .create()
 
   def verifyExecutionTimeMeasured(forLabelValue: String, other: String*): Unit =
-    (forLabelValue +: other) diff wrappedCollector.collectAllSamples.map(_._2) match {
+    (forLabelValue +: other) diff this.collectAllSamples.map(_._2) match {
       case Nil     => ()
       case missing => fail(s"Execution time was not measured for '${missing.mkString(", ")}'")
     }
@@ -55,16 +55,12 @@ class TestLabeledHistogram(labelName: String) extends LabeledHistogram[IO] with 
     verifyExecutionTimeMeasured(forLabelValues.head, forLabelValues.tail: _*)
 
   def verifyNoInteractions(): Unit = {
-    if (wrappedCollector.collectAllSamples.nonEmpty)
+    if (this.collectAllSamples.nonEmpty)
       fail(
         "Expected no interaction with histogram but " +
-          s"execution time was measured for ${wrappedCollector.collectAllSamples.map(_._2).toSet.mkString(",")}"
+          s"execution time was measured for ${this.collectAllSamples.map(_._2).toSet.mkString(",")}"
       )
     ()
-  }
-
-  override def startTimer(labelValue: String): IO[Histogram.Timer[IO]] = IO {
-    new LabeledHistogram.NoThresholdTimerImpl[IO](wrappedCollector.labels(labelValue).startTimer())
   }
 
   override def observe(labelValue: String, amt: FiniteDuration): IO[Unit] =

--- a/graph-commons/src/test/scala/io/renku/metrics/TestLabeledHistogram.scala
+++ b/graph-commons/src/test/scala/io/renku/metrics/TestLabeledHistogram.scala
@@ -20,6 +20,7 @@ package io.renku.metrics
 
 import cats.data.NonEmptyList
 import cats.effect.IO
+import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection.NonEmpty
@@ -70,6 +71,9 @@ class TestLabeledHistogram(labelName: String) extends LabeledHistogram[IO] with 
     IO {
       wrappedCollector.labels(labelValue).observe(amt)
     }
+
+  override def observe(maybeLabel: Option[String], duration: FiniteDuration): IO[Unit] =
+    maybeLabel.map(observe(_, duration)).getOrElse(().pure[IO])
 }
 
 object TestLabeledHistogram {

--- a/renku-model/src/test/scala/io/renku/graph/model/entities/ActivityLensSpec.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/entities/ActivityLensSpec.scala
@@ -30,7 +30,7 @@ class ActivityLensSpec extends AnyWordSpec with should.Matchers with EntitiesGen
     "get and set" in {
       val a1 = createActivity
       val a2 = createActivity
-      ActivityLens.activityAssociation.get(a1)                 shouldBe a1.association
+      ActivityLens.activityAssociation.get(a1)                     shouldBe a1.association
       ActivityLens.activityAssociation.replace(a2.association)(a1) shouldBe a1.copy(association = a2.association)
     }
   }
@@ -39,7 +39,7 @@ class ActivityLensSpec extends AnyWordSpec with should.Matchers with EntitiesGen
     "get and set" in {
       val activity = createActivity
       val person   = createActivity.author
-      ActivityLens.activityAuthor.get(activity)         shouldBe activity.author
+      ActivityLens.activityAuthor.get(activity)             shouldBe activity.author
       ActivityLens.activityAuthor.replace(person)(activity) shouldBe activity.copy(author = person)
     }
   }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/PersistedSlugFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/PersistedSlugFinder.scala
@@ -18,7 +18,7 @@
 
 package io.renku.tokenrepository.repository.creation
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import io.renku.db.DbClient
 import io.renku.graph.model.projects
 import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
@@ -30,11 +30,11 @@ private trait PersistedSlugFinder[F[_]] {
 }
 
 private object PersistedSlugFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: PersistedSlugFinder[F] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: PersistedSlugFinder[F] =
     new PersistedSlugFinderImpl[F]
 }
 
-private class PersistedSlugFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class PersistedSlugFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with PersistedSlugFinder[F]
     with TokenRepositoryTypeSerializers {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokenDueChecker.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokenDueChecker.scala
@@ -20,7 +20,7 @@ package io.renku.tokenrepository.repository
 package creation
 
 import ProjectsTokensDB.SessionResource
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import creation.TokenDates.ExpiryDate
 import io.renku.db.{DbClient, SqlStatement}
@@ -35,11 +35,11 @@ private trait TokenDueChecker[F[_]] {
 }
 
 private object TokenDueChecker {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[TokenDueChecker[F]] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[TokenDueChecker[F]] =
     ProjectTokenDuePeriod[F]().map(new TokenDueCheckerImpl[F](_))
 }
 
-private class TokenDueCheckerImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes](
+private class TokenDueCheckerImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
     tokenDuePeriod: Period
 ) extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with TokenDueChecker[F]

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensPersister.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/creation/TokensPersister.scala
@@ -39,11 +39,11 @@ private[repository] trait TokensPersister[F[_]] {
 }
 
 private[repository] object TokensPersister {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: TokensPersister[F] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: TokensPersister[F] =
     new TokensPersisterImpl[F]
 }
 
-private class TokensPersisterImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class TokensPersisterImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with TokensPersister[F]
     with TokenRepositoryTypeSerializers {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/deletion/PersistedTokenRemover.scala
@@ -18,7 +18,7 @@
 
 package io.renku.tokenrepository.repository.deletion
 
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.renku.db.{DbClient, SqlStatement}
 import io.renku.graph.model.projects.GitLabId
@@ -33,11 +33,11 @@ private[repository] trait PersistedTokenRemover[F[_]] {
 }
 
 private[repository] object PersistedTokenRemover {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: PersistedTokenRemover[F] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: PersistedTokenRemover[F] =
     new PersistedTokenRemoverImpl[F]
 }
 
-private class PersistedTokenRemoverImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class PersistedTokenRemoverImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with PersistedTokenRemover[F]
     with TokenRepositoryTypeSerializers {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/FetchTokenEndpoint.scala
@@ -20,7 +20,7 @@ package io.renku.tokenrepository.repository.fetching
 
 import cats.MonadThrow
 import cats.data.OptionT
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import io.circe.syntax._
 import io.renku.data.Message
@@ -74,6 +74,6 @@ class FetchTokenEndpointImpl[F[_]: MonadThrow: Logger](tokenFinder: TokenFinder[
 }
 
 object FetchTokenEndpoint {
-  def apply[F[_]: MonadCancelThrow: Logger: SessionResource: QueriesExecutionTimes]: F[FetchTokenEndpoint[F]] =
+  def apply[F[_]: Async: Logger: SessionResource: QueriesExecutionTimes]: F[FetchTokenEndpoint[F]] =
     TokenFinder[F].map(new FetchTokenEndpointImpl[F](_))
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/PersistedTokensFinder.scala
@@ -35,11 +35,11 @@ private[repository] trait PersistedTokensFinder[F[_]] {
 }
 
 private[repository] object PersistedTokensFinder {
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: PersistedTokensFinder[F] =
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: PersistedTokensFinder[F] =
     new PersistedTokensFinderImpl[F]
 }
 
-private class PersistedTokensFinderImpl[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]
+private class PersistedTokensFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes]
     extends DbClient[F](Some(QueriesExecutionTimes[F]))
     with PersistedTokensFinder[F]
     with TokenRepositoryTypeSerializers {

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/TokenFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/fetching/TokenFinder.scala
@@ -20,7 +20,7 @@ package io.renku.tokenrepository.repository.fetching
 
 import cats.MonadThrow
 import cats.data.OptionT
-import cats.effect.MonadCancelThrow
+import cats.effect.Async
 import cats.syntax.all._
 import eu.timepit.refined.types.numeric
 import io.renku.graph.model.projects.{GitLabId, Slug}
@@ -77,7 +77,7 @@ private object TokenFinder {
 
   private val maxRetries = numeric.NonNegInt.unsafeFrom(3)
 
-  def apply[F[_]: MonadCancelThrow: SessionResource: QueriesExecutionTimes]: F[TokenFinder[F]] = for {
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[TokenFinder[F]] = for {
     accessTokenCrypto <- AccessTokenCrypto[F]()
   } yield new TokenFinderImpl[F](new PersistedTokensFinderImpl[F], accessTokenCrypto, maxRetries)
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/metrics/QueriesExecutionTimes.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/metrics/QueriesExecutionTimes.scala
@@ -34,7 +34,7 @@ object QueriesExecutionTimes {
       name = "token_repository_queries_execution_times",
       help = "Token Repository queries execution times",
       labelName = "query_id",
-      buckets = Seq(.05, .075, .1, .5, 1, 2.5, 5),
+      maybeBuckets = Seq(.05, .075, .1, .5, 1, 2.5, 5).some,
       maybeThreshold = (750 millis).some
     ) with QueriesExecutionTimes[F]
   }.widen

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockHistogram.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/metrics/PostgresLockHistogram.scala
@@ -33,7 +33,7 @@ object PostgresLockHistogram {
       name = "postgres_lock_wait_times",
       help = "PostgresLock wait times",
       labelName = "object_id",
-      buckets = Seq(.05, .1, .5, 1, 2.5, 5, 10, 50),
+      maybeBuckets = Seq(.05, .1, .5, 1, 2.5, 5, 10, 50).some,
       maybeThreshold = 200.millis.some
     ) with PostgresLockHistogram[F]
   }.widen

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctionsSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/tsprovisioning/ProjectFunctionsSpec.scala
@@ -66,7 +66,7 @@ class ProjectFunctionsSpec extends AnyWordSpec with should.Matchers with ScalaCh
 
         val updatedProject = update(entitiesOldMember.person, newPerson)(project)
 
-        updatedProject.members      shouldBe project.members - entitiesOldMember + entitiesOldMember.copy(person = newPerson)
+        updatedProject.members shouldBe project.members - entitiesOldMember + entitiesOldMember.copy(person = newPerson)
         updatedProject.maybeCreator shouldBe Some(newPerson)
       }
     }


### PR DESCRIPTION
This PR:
* adds a new `Histogram.observe` as a common API for labelled and non-labelled Histogram
* removes `Histogram.startTime` as it's perceived as complicated and buggy
* refactors the usage of `MetricsCollector`s