### PR TITLE
fix: Fix recently viewed query to not return restricted entities

### DIFF
--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/DatasetQuery.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/DatasetQuery.scala
@@ -21,7 +21,9 @@ package io.renku.entities.viewings.search
 import eu.timepit.refined.auto._
 import io.renku.entities.viewings.search.RecentEntitiesFinder.{Criteria, EntityType}
 import io.renku.graph.model.entities.Person
+import io.renku.graph.model.projects.Visibility
 import io.renku.graph.model.{GraphClass, Schemas}
+import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore.client.syntax.FragmentStringContext
@@ -57,6 +59,8 @@ object DatasetQuery extends (Criteria => Option[SparqlQuery]) {
                |      ?projectLink renku:dataset ?datasetId;
                |                    renku:project ?projectId.
                |    }
+               |
+               |    ${SparqlSnippets.visibleProjects(Some(criteria.authUser.id), Visibility.all)}
                |    
                |    Graph ${GraphClass.Persons.id} {
                |      ?personId a schema:Person;

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/ProjectQuery.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/ProjectQuery.scala
@@ -21,7 +21,9 @@ package io.renku.entities.viewings.search
 import eu.timepit.refined.auto._
 import io.renku.entities.viewings.search.RecentEntitiesFinder.{Criteria, EntityType}
 import io.renku.graph.model.entities.Person
+import io.renku.graph.model.projects.Visibility
 import io.renku.graph.model.{GraphClass, Schemas}
+import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore.client.syntax._
@@ -58,6 +60,8 @@ object ProjectQuery extends (Criteria => Option[SparqlQuery]) {
                |      ?personSameAs schema:additionalType ${Person.gitLabSameAsAdditionalType};
                |                    schema:identifier ${criteria.authUser.id.value}.
                |    }
+               |
+               |    ${SparqlSnippets.visibleProjects(Some(criteria.authUser.id), Visibility.all)}
                |
                |    Graph ?projectId {
                |      ?projectId a schema:Project;

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/search/RecentEntitiesFinderSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/search/RecentEntitiesFinderSpec.scala
@@ -153,4 +153,80 @@ class RecentEntitiesFinderSpec extends SearchTestBase {
         images = project2.images
       )
   }
+
+  it should "return only public projects visible to the caller" in {
+    val project1 = renkuProjectEntities(visibilityPublic)
+      .withActivities(activityEntities(stepPlanEntities()))
+      .withDatasets(datasetEntities(provenanceNonModified))
+      .generateOne
+    val project2 = renkuProjectEntities(visibilityPrivate)
+      .withActivities(activityEntities(stepPlanEntities()))
+      .withDatasets(datasetEntities(provenanceNonModified))
+      .generateOne
+
+    val person = personGen.generateOne
+
+    upload(projectsDataset, person)
+    provisionTestProjects(project1, project2).unsafeRunSync()
+
+    storeProjectViewed(person.maybeGitLabId.get, Instant.now().minus(1, ChronoUnit.DAYS), project1.slug)
+    storeProjectViewed(person.maybeGitLabId.get, Instant.now(), project2.slug)
+
+    val criteria = Criteria(Set(EntityType.Project), AuthUser(person.maybeGitLabId.get, token), 10)
+    val result   = finder.findRecentlyViewedEntities(criteria).unsafeRunSync()
+
+    result.results.size           shouldBe 1
+    result.pagingInfo.total.value shouldBe 1
+    result.results.head shouldMatchTo
+      SearchEntity.Project(
+        matchingScore = MatchingScore(1f),
+        slug = project1.slug,
+        name = project1.name,
+        visibility = project1.visibility,
+        date = project1.dateCreated,
+        dateModified = project1.dateModified,
+        maybeCreator = project1.maybeCreator.map(_.name),
+        keywords = project1.keywords.toList.sorted,
+        maybeDescription = project1.maybeDescription,
+        images = project1.images
+      )
+  }
+
+  it should "return only projects visible to the caller" in {
+    val project1 = renkuProjectEntities(visibilityPublic)
+      .withActivities(activityEntities(stepPlanEntities()))
+      .withDatasets(datasetEntities(provenanceNonModified))
+      .generateOne
+    val project2 = renkuProjectEntities(visibilityPrivate)
+      .withActivities(activityEntities(stepPlanEntities()))
+      .withDatasets(datasetEntities(provenanceNonModified))
+      .generateOne
+
+    val person = project2.maybeCreator.get
+
+    upload(projectsDataset, person)
+    provisionTestProjects(project1, project2).unsafeRunSync()
+
+    storeProjectViewed(person.maybeGitLabId.get, Instant.now().minus(1, ChronoUnit.DAYS), project1.slug)
+    storeProjectViewed(person.maybeGitLabId.get, Instant.now(), project2.slug)
+
+    val criteria = Criteria(Set(EntityType.Project), AuthUser(person.maybeGitLabId.get, token), 10)
+    val result   = finder.findRecentlyViewedEntities(criteria).unsafeRunSync()
+
+    result.results.size           shouldBe 2
+    result.pagingInfo.total.value shouldBe 2
+    result.results.head shouldMatchTo
+      SearchEntity.Project(
+        matchingScore = MatchingScore(1f),
+        slug = project2.slug,
+        name = project2.name,
+        visibility = project2.visibility,
+        date = project2.dateCreated,
+        dateModified = project2.dateModified,
+        maybeCreator = project2.maybeCreator.map(_.name),
+        keywords = project2.keywords.toList.sorted,
+        maybeDescription = project2.maybeDescription,
+        images = project2.images
+      )
+  }
 }

--- a/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/util/SparqlSnippetsSpec.scala
@@ -128,8 +128,7 @@ class SparqlSnippetsSpec extends AsyncFlatSpec with AsyncIOSpec with ProjectAuth
              )
         expected = data.filter(projectFilter(None, Visibility.all)).sortBy(_.slug)
         found    = Stream.emits(r).through(ProjectAuthDataRow.collect).toList
-        _        = found                         shouldBe expected
-        _        = found.map(_.visibility).toSet shouldBe Set(Visibility.Public)
+        _        = found shouldBe expected
       } yield ()
     }
   }


### PR DESCRIPTION
The recently viewed query didn't contain access restriction for projects.