### PR TITLE
fix: Split query string on underscores

### DIFF
--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -20,6 +20,7 @@ package io.renku.entities.search
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import eu.timepit.refined.auto._
 import io.renku.entities.search
 import io.renku.entities.search.Criteria.Filters._
 import io.renku.entities.search.Criteria.{Filters, Sort}
@@ -1039,7 +1040,7 @@ class EntitiesFinderSpec
 
     "be sorting by Matching Score if requested" in new TestCase {
 
-      val query = nonBlankStrings(minLength = 6).generateOne
+      val query: NonBlank = "project score"
 
       val ds -> project = renkuProjectEntities(visibilityPublic)
         .modify(replaceProjectName(to = projects.Name(query.value)))

--- a/entities-search/src/test/scala/io/renku/entities/search/PersonsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/PersonsEntitiesFinderSpec.scala
@@ -58,7 +58,8 @@ class PersonsEntitiesFinderSpec
       finder
         .findEntities(Criteria(Filters(maybeQuery = Query(query.value).some)))
         .unsafeRunSync()
-        .resultsWithSkippedMatchingScore should {
+        .resultsWithSkippedMatchingScore
+        .sortBy(_.name)(nameOrdering) should {
         be(List(person1SameName, person3).map(_.to[model.Entity.Person]).sortBy(_.name)(nameOrdering)) or
           be(List(person2SameName, person3).map(_.to[model.Entity.Person]).sortBy(_.name)(nameOrdering))
       }

--- a/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/search/RecentEntitiesFinderSpec.scala
+++ b/entities-viewings-collector/src/test/scala/io/renku/entities/viewings/search/RecentEntitiesFinderSpec.scala
@@ -200,6 +200,7 @@ class RecentEntitiesFinderSpec extends SearchTestBase {
     val project2 = renkuProjectEntities(visibilityPrivate)
       .withActivities(activityEntities(stepPlanEntities()))
       .withDatasets(datasetEntities(provenanceNonModified))
+      .suchThat(_.maybeCreator.isDefined)
       .generateOne
 
     val person = project2.maybeCreator.get

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,6 +95,10 @@ object Dependencies {
     "org.apache.lucene" % "lucene-queryparser" % V.luceneQueryParser
   )
 
+  val luceneAnalyzer = Seq(
+    "org.apache.lucene" % "lucene-analysis-common" % V.luceneQueryParser
+  )
+
   val http4sClient = Seq(
     "org.http4s" %% "http4s-ember-client" % V.http4sEmber
   )

--- a/triples-store-client/build.sbt
+++ b/triples-store-client/build.sbt
@@ -22,6 +22,7 @@ name := "triples-store-client"
 libraryDependencies ++=
   Dependencies.jsonld4s ++
     Dependencies.luceneQueryParser ++
+    Dependencies.luceneAnalyzer ++
     Dependencies.rdf4jQueryParserSparql ++
     Dependencies.http4sClient ++
     Dependencies.http4sCirce

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQuery.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQuery.scala
@@ -33,7 +33,7 @@ object LuceneQuery {
 
   def fuzzy(str: String): LuceneQuery =
     new LuceneQuery(
-      QueryTokenizer.extended
+      QueryTokenizer.default
         .split(str)
         .map(_.trim)
         .map(QueryParserUtil.escape)

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQuery.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQuery.scala
@@ -33,7 +33,7 @@ object LuceneQuery {
 
   def fuzzy(str: String): LuceneQuery =
     new LuceneQuery(
-      QueryTokenizer.luceneStandard
+      QueryTokenizer.extended
         .split(str)
         .map(_.trim)
         .map(QueryParserUtil.escape)

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/QueryTokenizer.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/QueryTokenizer.scala
@@ -25,8 +25,11 @@ import org.apache.lucene.util.AttributeFactory.StaticImplementationAttributeFact
 
 import java.io.StringReader
 
-trait QueryTokenizer {
+trait QueryTokenizer { self =>
   def split(input: String): List[String]
+
+  final def append(next: QueryTokenizer): QueryTokenizer =
+    (input: String) => self.split(input).flatMap(next.split)
 }
 
 object QueryTokenizer {
@@ -53,4 +56,10 @@ object QueryTokenizer {
       loop(Nil).reverse
     }
   }
+
+  def splitOn(c: Char): QueryTokenizer =
+    (input: String) => input.split(c).toList
+
+  def extended: QueryTokenizer =
+    luceneStandard.append(splitOn('_'))
 }

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/QueryTokenizer.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/QueryTokenizer.scala
@@ -18,6 +18,8 @@
 
 package io.renku.triplesstore.client.sparql
 
+import org.apache.lucene.analysis.Tokenizer
+import org.apache.lucene.analysis.core.LetterTokenizer
 import org.apache.lucene.analysis.standard.StandardTokenizer
 import org.apache.lucene.analysis.tokenattributes.{CharTermAttribute, CharTermAttributeImpl}
 import org.apache.lucene.util.AttributeFactory
@@ -34,9 +36,21 @@ trait QueryTokenizer { self =>
 
 object QueryTokenizer {
 
-  def luceneStandard: QueryTokenizer = new QueryTokenizer {
+  def luceneStandard: QueryTokenizer =
+    new LuceneTokenizer(new StandardTokenizer(_))
+
+  def luceneLetters: QueryTokenizer =
+    new LuceneTokenizer(new LetterTokenizer(_))
+
+  def splitOn(c: Char): QueryTokenizer =
+    (input: String) => input.split(c).toList
+
+  def default: QueryTokenizer =
+    luceneLetters
+
+  private final class LuceneTokenizer(createDelegate: AttributeFactory => Tokenizer) extends QueryTokenizer {
     override def split(input: String): List[String] = {
-      val tokenizer = new StandardTokenizer(
+      val tokenizer = createDelegate(
         new StaticImplementationAttributeFactory[CharTermAttributeImpl](
           AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY,
           classOf[CharTermAttributeImpl]
@@ -56,10 +70,4 @@ object QueryTokenizer {
       loop(Nil).reverse
     }
   }
-
-  def splitOn(c: Char): QueryTokenizer =
-    (input: String) => input.split(c).toList
-
-  def extended: QueryTokenizer =
-    luceneStandard.append(splitOn('_'))
 }

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/QueryTokenizerSpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/QueryTokenizerSpec.scala
@@ -34,6 +34,11 @@ class QueryTokenizerSpec extends AnyFlatSpec with should.Matchers {
     tokenizer.split(input) shouldBe List("one", "two", "three")
   }
 
+  it should "split on underscores" in {
+    val input = "01_one_two"
+    QueryTokenizer.extended.split(input) shouldBe List("01", "one", "two")
+  }
+
   it should "return different data" in {
     val input = "one 1 two 2-3-4 \"http://hello.com\" next~"
     tokenizer.split(input) shouldBe List("one", "1", "two", "2", "3", "4", "http", "hello.com", "next")

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/QueryTokenizerSpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/QueryTokenizerSpec.scala
@@ -22,25 +22,40 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
 class QueryTokenizerSpec extends AnyFlatSpec with should.Matchers {
-  val tokenizer = QueryTokenizer.luceneStandard
+  val standard = QueryTokenizer.luceneStandard
+  val letter   = QueryTokenizer.luceneLetters
 
-  it should "split on whitespace" in {
+  "standard" should "split on whitespace" in {
     val input = "  one two\tthree   four\nfive "
-    tokenizer.split(input) shouldBe List("one", "two", "three", "four", "five")
+    standard.split(input) shouldBe List("one", "two", "three", "four", "five")
   }
 
   it should "split on dashes" in {
     val input = "one-two-three-"
-    tokenizer.split(input) shouldBe List("one", "two", "three")
-  }
-
-  it should "split on underscores" in {
-    val input = "01_one_two"
-    QueryTokenizer.extended.split(input) shouldBe List("01", "one", "two")
+    standard.split(input) shouldBe List("one", "two", "three")
   }
 
   it should "return different data" in {
     val input = "one 1 two 2-3-4 \"http://hello.com\" next~"
-    tokenizer.split(input) shouldBe List("one", "1", "two", "2", "3", "4", "http", "hello.com", "next")
+    standard.split(input) shouldBe List("one", "1", "two", "2", "3", "4", "http", "hello.com", "next")
+  }
+
+  "splitOn" should "should split on underscores" in {
+    val input = "01_one_two"
+    QueryTokenizer.splitOn('_').split(input) shouldBe List("01", "one", "two")
+  }
+
+  "letter" should "split on whitespace" in {
+    letter.split("  one two\tthree   four\nfive ") shouldBe List("one", "two", "three", "four", "five")
+  }
+
+  it should "split on underscore" in {
+    val input = "one_two_three"
+    letter.split(input) shouldBe List("one", "two", "three")
+  }
+
+  it should "skip numbers" in {
+    val input = "01_test 02 bar"
+    letter.split(input) shouldBe List("test", "bar")
   }
 }


### PR DESCRIPTION
The standard tokenizer honors unicode tokenization rules, that won't split on underscores. https://unicode.org/reports/tr29/

/deploy #persist