### PR TITLE
feat: TS migration to reindex Lucene indices

### DIFF
--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -50,6 +50,7 @@ private[tsmigrationrequest] object Migrations {
     addProjectSlug                 <- projectslug.AddProjectSlug[F]
     datasetsGraphPersonRemover     <- DatasetsGraphPersonRemover[F]
     projectsGraphPersonRemover     <- ProjectsGraphPersonRemover[F]
+    reindexLucene                  <- lucenereindex.ReindexLucene[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -67,7 +68,8 @@ private[tsmigrationrequest] object Migrations {
                     fixMultipleProjectVersions,
                     addProjectSlug,
                     datasetsGraphPersonRemover,
-                    projectsGraphPersonRemover
+                    projectsGraphPersonRemover,
+                    reindexLucene
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/BacklogCreator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/BacklogCreator.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package lucenereindex
+
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.Schemas._
+import io.renku.graph.model.{RenkuUrl, projects}
+import io.renku.jsonld.syntax._
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.model.Triple
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+import tooling.AllProjects
+
+private trait BacklogCreator[F[_]] {
+  def createBacklog(): F[Unit]
+}
+
+private[lucenereindex] object BacklogCreator {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[BacklogCreator[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    allProjects             <- ProjectsConnectionConfig[F]().map(AllProjects[F](_))
+    migrationsDSClient      <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new BacklogCreatorImpl[F](allProjects, migrationsDSClient)
+
+  def asToBeMigratedInserts(slug: projects.Slug)(implicit ru: RenkuUrl): SparqlQuery =
+    toInsertQuery(toTriples(slug))
+
+  private def toTriples(slug: projects.Slug)(implicit ru: RenkuUrl): Triple =
+    Triple(ReindexLucene.name.asEntityId, renku / "toBeMigrated", slug.asObject)
+
+  private def toInsertQuery(triple: Triple): SparqlQuery =
+    SparqlQuery
+      .ofUnsafe(
+        show"${ReindexLucene.name} - store to backlog",
+        sparql"INSERT DATA {$triple}"
+      )
+}
+
+private class BacklogCreatorImpl[F[_]: Async](allProjects: AllProjects[F], migrationsDSClient: TSClient[F])(implicit
+    ru: RenkuUrl
+) extends BacklogCreator[F] {
+
+  import BacklogCreator._
+
+  private val pageSize: Int = 50
+
+  override def createBacklog(): F[Unit] =
+    allProjects
+      .findAll(pageSize)
+      .map(md => asToBeMigratedInserts(md.slug))
+      .evalMap(migrationsDSClient.updateWithNoResult)
+      .compile
+      .drain
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/EnvReadinessChecker.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/EnvReadinessChecker.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.lucenereindex
+
+import cats.effect.{Async, Temporal}
+import cats.syntax.all._
+import io.renku.eventlog.api.EventLogClient
+import io.renku.graph.model.eventlogapi.ServiceStatus
+import io.renku.triplesgenerator.events.consumers.triplesgenerated
+import org.typelevel.log4cats.Logger
+
+import scala.collection.immutable.Queue
+import scala.concurrent.duration._
+
+private trait EnvReadinessChecker[F[_]] {
+  def envReadyToTakeEvent: F[Unit]
+}
+
+private object EnvReadinessChecker {
+  def apply[F[_]: Async: Logger]: F[EnvReadinessChecker[F]] =
+    EventLogClient[F].map(new EnvReadinessCheckerImpl[F](_))
+}
+
+private class EnvReadinessCheckerImpl[F[_]: Async](elClient: EventLogClient[F], retryTimeout: Duration = 1 second)
+    extends EnvReadinessChecker[F] {
+
+  private val consecutiveSuccessesToPass = 3
+
+  override def envReadyToTakeEvent: F[Unit] =
+    waitForSubsequentReadyStatuses(previousChecks = Queue.empty).void
+
+  private def waitForSubsequentReadyStatuses(previousChecks: Queue[Boolean]): F[Boolean] =
+    checkFreeCapacity.map(previousChecks.enqueue) >>= {
+      case checks if checks.size < consecutiveSuccessesToPass => waitAndTryAgain(checks)
+      case checks if !checks.forall(identity)                 => waitAndTryAgain(checks.dequeue._2)
+      case _                                                  => true.pure[F]
+    }
+
+  private def waitAndTryAgain(previousChecks: Queue[Boolean]) =
+    Temporal[F].delayBy(waitForSubsequentReadyStatuses(previousChecks), retryTimeout)
+
+  private def checkFreeCapacity =
+    elClient.getStatus
+      .map(
+        _.toEither
+          .leftMap(_ => false)
+          .map(getTriplesGeneratedFreeCapacity)
+          .flatMap(Either.fromOption(_, ifNone = false))
+          .map(_ > 0)
+          .merge
+      )
+
+  private lazy val getTriplesGeneratedFreeCapacity: ServiceStatus => Option[Int] =
+    _.subscriptions
+      .find(_.name == triplesgenerated.categoryName)
+      .flatMap(_.maybeCapacity)
+      .map(_.free)
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/MigrationStartTimeFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/MigrationStartTimeFinder.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.lucenereindex
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
+import io.renku.graph.model.Schemas.renku
+import io.renku.jsonld.syntax._
+import io.renku.triplesstore._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.model.Triple
+import io.renku.triplesstore.client.syntax._
+import org.typelevel.log4cats.Logger
+
+import java.time.Instant
+
+private trait MigrationStartTimeFinder[F[_]] {
+  def findMigrationStartDate: F[Instant]
+}
+
+private object MigrationStartTimeFinder {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[MigrationStartTimeFinder[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    tsClient                <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new MigrationStartTimeFinderImpl[F](tsClient)
+}
+
+private class MigrationStartTimeFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
+    tsClient: TSClient[F]
+)(implicit ru: RenkuUrl)
+    extends MigrationStartTimeFinder[F] {
+
+  import ResultsDecoder._
+
+  override def findMigrationStartDate: F[Instant] =
+    tsClient.queryExpecting[Option[Instant]](startTimeQuery) >>= {
+      case Some(time) => time.pure[F]
+      case None =>
+        val startTime = Instant.now()
+        tsClient.updateWithNoResult(startTimeTriple(startTime)).as(startTime)
+    }
+
+  private lazy val startTimeQuery =
+    SparqlQuery.ofUnsafe(
+      show"${ReindexLucene.name} - find start time",
+      Prefixes of renku -> "renku",
+      s"""|SELECT ?time
+          |WHERE {
+          |  ${ReindexLucene.name.asEntityId.asSparql.sparql} renku:startTime ?time
+          |}
+          |""".stripMargin
+    )
+
+  private implicit lazy val timeDecoder: Decoder[Option[Instant]] = ResultsDecoder[Option, Instant] { implicit cur =>
+    extract[Instant]("time")
+  }
+
+  private def startTimeTriple(instant: Instant) = {
+    val triple = Triple(ReindexLucene.name.asEntityId, renku / "startTime", instant.asTripleObject)
+    SparqlQuery.ofUnsafe(
+      show"${ReindexLucene.name} - store start time",
+      s"INSERT DATA {${triple.asSparql.sparql}}"
+    )
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProgressFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProgressFinder.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package lucenereindex
+
+import cats.effect.{Async, Ref, Sync}
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
+import io.renku.graph.model.Schemas.renku
+import io.renku.triplesstore._
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import org.typelevel.log4cats.Logger
+
+private trait ProgressFinder[F[_]] {
+  def findProgressInfo: F[String]
+}
+
+private object ProgressFinder {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProgressFinder[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    migrationsDSClient      <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new ProgressFinderImpl[F](migrationsDSClient)
+}
+
+private class ProgressFinderImpl[F[_]: Sync](migrationsDSClient: TSClient[F])(implicit ru: RenkuUrl)
+    extends ProgressFinder[F] {
+
+  import io.renku.jsonld.syntax._
+  import io.renku.triplesstore.ResultsDecoder._
+  import io.renku.triplesstore.client.syntax._
+
+  private val total: Ref[F, Int] = Ref.unsafe[F, Int](0)
+
+  override def findProgressInfo: F[String] = for {
+    left  <- findLeftCount
+    total <- findTotal
+  } yield s"$left left from $total"
+
+  private def findLeftCount =
+    migrationsDSClient.queryExpecting[Int](
+      SparqlQuery.ofUnsafe(
+        show"${ReindexLucene.name} - find left",
+        Prefixes of (renku -> "renku"),
+        s"""|SELECT (COUNT(?slug) AS ?count)
+            |WHERE {
+            |  ${ReindexLucene.name.asEntityId.asSparql.sparql} renku:toBeMigrated ?slug
+            |}
+            |""".stripMargin
+      )
+    )
+
+  private def findTotal: F[Int] =
+    total.get >>= {
+      case 0       => findLeftCount >>= (v => total.updateAndGet(_ => v))
+      case nonZero => nonZero.pure[F]
+    }
+
+  private implicit lazy val countDecoder: Decoder[Int] =
+    ResultsDecoder.single[Int](implicit cur => extract[String]("count").map(_.toInt))
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersister.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersister.scala
@@ -46,13 +46,13 @@ private class ProjectDonePersisterImpl[F[_]](tsClient: TSClient[F])(implicit ru:
   import io.renku.triplesstore.client.syntax._
 
   override def noteDone(slug: projects.Slug): F[Unit] =
-    tsClient.updateWithNoResult(v10MigratedTriple(slug))
+    tsClient.updateWithNoResult(deleteTripleQuery(slug))
 
-  private def v10MigratedTriple(slug: projects.Slug) = {
+  private def deleteTripleQuery(slug: projects.Slug) = {
     val triple = Triple(ReindexLucene.name.asEntityId, renku / "toBeMigrated", slug.asObject)
     SparqlQuery.ofUnsafe(
       show"${ReindexLucene.name} - store migrated",
-      s"DELETE DATA {${triple.asSparql.sparql}}"
+      sparql"DELETE DATA {$triple}"
     )
   }
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersister.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersister.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.lucenereindex
+
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.{RenkuUrl, projects}
+import io.renku.triplesstore.{MigrationsConnectionConfig, SparqlQueryTimeRecorder, TSClient}
+import org.typelevel.log4cats.Logger
+
+private trait ProjectDonePersister[F[_]] {
+  def noteDone(slug: projects.Slug): F[Unit]
+}
+
+private object ProjectDonePersister {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectDonePersister[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    tsClient                <- MigrationsConnectionConfig[F]().map(TSClient[F](_))
+  } yield new ProjectDonePersisterImpl[F](tsClient)
+}
+
+private class ProjectDonePersisterImpl[F[_]](tsClient: TSClient[F])(implicit ru: RenkuUrl)
+    extends ProjectDonePersister[F] {
+
+  import io.renku.graph.model.Schemas.renku
+  import io.renku.jsonld.syntax._
+  import io.renku.triplesstore.SparqlQuery
+  import io.renku.triplesstore.client.model.Triple
+  import io.renku.triplesstore.client.syntax._
+
+  override def noteDone(slug: projects.Slug): F[Unit] =
+    tsClient.updateWithNoResult(v10MigratedTriple(slug))
+
+  private def v10MigratedTriple(slug: projects.Slug) = {
+    val triple = Triple(ReindexLucene.name.asEntityId, renku / "toBeMigrated", slug.asObject)
+    SparqlQuery.ofUnsafe(
+      show"${ReindexLucene.name} - store migrated",
+      s"DELETE DATA {${triple.asSparql.sparql}}"
+    )
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinder.scala
@@ -32,7 +32,7 @@ import org.typelevel.log4cats.Logger
 import tooling.RecordsFinder
 
 private trait ProjectsPageFinder[F[_]] {
-  def nextProjectsPage(): F[List[projects.Slug]]
+  def nextProjectsPage: F[List[projects.Slug]]
 }
 
 private object ProjectsPageFinder {
@@ -55,7 +55,7 @@ private class ProjectsPageFinderImpl[F[_]: Monad](recordsFinder: RecordsFinder[F
 
   private val pageSize: Int = 50
 
-  override def nextProjectsPage(): F[List[projects.Slug]] =
+  override def nextProjectsPage: F[List[projects.Slug]] =
     findRecords[projects.Slug](query)
 
   private lazy val query = SparqlQuery.ofUnsafe(

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinder.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinder.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package lucenereindex
+
+import cats.Monad
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.circe.Decoder
+import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.{RenkuUrl, Schemas, projects}
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import org.typelevel.log4cats.Logger
+import tooling.RecordsFinder
+
+private trait ProjectsPageFinder[F[_]] {
+  def nextProjectsPage(): F[List[projects.Slug]]
+}
+
+private object ProjectsPageFinder {
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder]: F[ProjectsPageFinder[F]] = for {
+    implicit0(ru: RenkuUrl) <- RenkuUrlLoader[F]()
+    recordsFinder           <- MigrationsConnectionConfig[F]().map(RecordsFinder[F](_))
+  } yield new ProjectsPageFinderImpl(recordsFinder)
+}
+
+private class ProjectsPageFinderImpl[F[_]: Monad](recordsFinder: RecordsFinder[F])(implicit
+    ru: RenkuUrl
+) extends ProjectsPageFinder[F]
+    with Schemas {
+
+  import ResultsDecoder._
+  import io.renku.jsonld.syntax._
+  import io.renku.tinytypes.json.TinyTypeDecoders._
+  import io.renku.triplesstore.client.syntax._
+  import recordsFinder._
+
+  private val pageSize: Int = 50
+
+  override def nextProjectsPage(): F[List[projects.Slug]] =
+    findRecords[projects.Slug](query)
+
+  private lazy val query = SparqlQuery.ofUnsafe(
+    show"${ReindexLucene.name} - find projects",
+    Prefixes of renku -> "renku",
+    sparql"""|SELECT DISTINCT ?slug
+             |WHERE {
+             |  ${ReindexLucene.name.asEntityId} renku:toBeMigrated ?slug
+             |}
+             |ORDER BY ?slug
+             |LIMIT $pageSize
+             |""".stripMargin
+  )
+
+  private implicit lazy val decoder: Decoder[List[projects.Slug]] = ResultsDecoder[List, projects.Slug] {
+    implicit cur => extract[projects.Slug]("slug")
+  }
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLucene.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLucene.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+package lucenereindex
+
+import cats.data.EitherT
+import cats.effect.Async
+import cats.syntax.all._
+import io.renku.eventlog
+import io.renku.eventlog.api.events.StatusChangeEvent
+import io.renku.events.CategoryName
+import io.renku.graph.model.projects
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesgenerator.errors.ProcessingRecoverableError
+import io.renku.triplesstore._
+import org.typelevel.log4cats.Logger
+import tooling._
+
+private class ReindexLucene[F[_]: Async: Logger](
+    backlogCreator:       BacklogCreator[F],
+    projectsFinder:       ProjectsPageFinder[F],
+    progressFinder:       ProgressFinder[F],
+    envReadinessChecker:  EnvReadinessChecker[F],
+    elClient:             eventlog.api.events.Client[F],
+    projectDonePersister: ProjectDonePersister[F],
+    executionRegister:    MigrationExecutionRegister[F],
+    recoveryStrategy:     RecoverableErrorsRecovery = RecoverableErrorsRecovery
+) extends RegisteredMigration[F](ReindexLucene.name, executionRegister, recoveryStrategy) {
+
+  import envReadinessChecker._
+  import fs2._
+  import progressFinder._
+  import projectDonePersister._
+  import projectsFinder._
+  import recoveryStrategy._
+
+  private val cleanUpEventCategory = CategoryName("CLEAN_UP_REQUEST")
+
+  protected[lucenereindex] override def migrate(): EitherT[F, ProcessingRecoverableError, Unit] = EitherT {
+    backlogCreator.createBacklog() >>
+      Logger[F].info(show"$categoryName: $name backlog created") >>
+      Stream
+        .iterate(1)(_ + 1)
+        .evalMap(_ => nextProjectsPage())
+        .takeThrough(_.nonEmpty)
+        .flatMap(in => Stream.emits(in))
+        .evalMap(slug => findProgressInfo.map(slug -> _))
+        .evalTap { case (slug, info) => logInfo(show"processing project '$slug'; waiting for free resources", info) }
+        .evalTap(_ => envReadyToTakeEvent)
+        .evalTap { case (slug, info) => logInfo(show"sending $cleanUpEventCategory event for '$slug'", info) }
+        .evalTap(sendRedoProjectTransformation)
+        .evalTap { case (slug, _) => noteDone(slug) }
+        .evalTap { case (slug, info) => logInfo(show"event sent for '$slug'", info) }
+        .compile
+        .drain
+        .map(_.asRight[ProcessingRecoverableError])
+        .recoverWith(maybeRecoverableError[F, Unit])
+  }
+
+  private lazy val sendRedoProjectTransformation: ((projects.Slug, String)) => F[Unit] = { case (slug, _) =>
+    elClient.send(StatusChangeEvent.RedoProjectTransformation(slug))
+  }
+
+  private def logInfo(message: String, progressInfo: String): F[Unit] =
+    Logger[F].info(show"${ReindexLucene.name} - $progressInfo - $message")
+}
+
+private[migrations] object ReindexLucene {
+  val name: Migration.Name = Migration.Name("Reindex Lucene")
+
+  def apply[F[_]: Async: Logger: MetricsRegistry: SparqlQueryTimeRecorder]: F[Migration[F]] = for {
+    backlogCreator       <- BacklogCreator[F]
+    projectsFinder       <- ProjectsPageFinder[F]
+    progressFinder       <- ProgressFinder[F]
+    envReadinessChecker  <- EnvReadinessChecker[F]
+    elClient             <- eventlog.api.events.Client[F]
+    projectDonePersister <- ProjectDonePersister[F]
+    executionRegister    <- MigrationExecutionRegister[F]
+  } yield new ReindexLucene(backlogCreator,
+                            projectsFinder,
+                            progressFinder,
+                            envReadinessChecker,
+                            elClient,
+                            projectDonePersister,
+                            executionRegister
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLucene.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLucene.scala
@@ -58,7 +58,7 @@ private class ReindexLucene[F[_]: Async: Logger](
       Logger[F].info(show"$categoryName: $name backlog created") >>
       Stream
         .iterate(1)(_ + 1)
-        .evalMap(_ => nextProjectsPage())
+        .evalMap(_ => nextProjectsPage)
         .takeThrough(_.nonEmpty)
         .flatMap(in => Stream.emits(in))
         .evalMap(slug => findProgressInfo.map(slug -> _))

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/AllProjects.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/tooling/AllProjects.scala
@@ -64,9 +64,9 @@ object AllProjects {
           s"""
              |SELECT DISTINCT ?projectSlug
              |WHERE {
-             |  Graph ?g {
+             |  Graph ?projectId {
              |    ?projectId a schema:Project;
-             |      renku:projectPath ?projectSlug.
+             |               renku:slug ?projectSlug.
              |  }
              |}
              |ORDER BY ?projectId

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/BacklogCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/BacklogCreatorSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package lucenereindex
+
+import cats.effect.IO
+import eu.timepit.refined.auto._
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import io.renku.graph.model.entities.EntityFunctions
+import io.renku.graph.model.testentities._
+import io.renku.graph.model.versions.SchemaVersion
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.scalacheck.Gen
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import tooling.AllProjects
+
+class BacklogCreatorSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with MigrationsDataset
+    with MockFactory {
+
+  private val pageSize = 50
+
+  "createBacklog" should {
+
+    "find all projects that are in the TS" in new TestCase {
+
+      val projects = anyRenkuProjectEntities
+        .generateList(min = pageSize + 1, max = Gen.choose(pageSize + 1, (2 * pageSize) - 1).generateOne)
+        .map(_.to[entities.Project])
+
+      fetchBacklogProjects shouldBe Nil
+
+      upload(to = projectsDataset, projects: _*)(implicitly[EntityFunctions[entities.Project]],
+                                                 projectsDSGraphsProducer[entities.Project],
+                                                 ioRuntime
+      )
+
+      backlogCreator.createBacklog().unsafeRunSync() shouldBe ()
+
+      fetchBacklogProjects.toSet shouldBe projects.map(_.slug).toSet
+    }
+  }
+
+  private trait TestCase {
+    private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
+    private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    val backlogCreator =
+      new BacklogCreatorImpl[IO](AllProjects[IO](projectsDSConnectionInfo), TSClient[IO](migrationsDSConnectionInfo))
+
+    def fetchBacklogProjects =
+      runSelect(
+        on = migrationsDataset,
+        SparqlQuery.ofUnsafe(
+          "test ReindexLucene backlog",
+          Prefixes of renku -> "renku",
+          sparql"""|SELECT ?slug
+                   |WHERE {
+                   |  ${ReindexLucene.name.asEntityId} renku:toBeMigrated ?slug
+                   |}
+                   |""".stripMargin
+        )
+      ).unsafeRunSync().flatMap(_.get("slug").map(projects.Slug))
+  }
+
+  private def setSchema(version: SchemaVersion): Project => Project =
+    _.fold(_.copy(version = version), _.copy(version = version), identity, identity)
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/EnvReadinessCheckerSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/EnvReadinessCheckerSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.lucenereindex
+
+import cats.effect.{Deferred, IO, Temporal}
+import cats.syntax.all._
+import io.renku.eventlog.api.EventLogClient
+import io.renku.eventlog.api.EventLogClient.Result
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.{ints, positiveInts}
+import io.renku.graph.model.eventlogapi.ServiceStatus
+import io.renku.graph.model.eventlogapi.ServiceStatus.{Capacity, SubscriptionStatus}
+import io.renku.testtools.IOSpec
+import io.renku.triplesgenerator.events.consumers.triplesgenerated
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+
+class EnvReadinessCheckerSpec extends AnyWordSpec with should.Matchers with MockFactory with IOSpec {
+
+  "envReadyToTakeEvent" should {
+
+    "succeed when three subsequent calls to EL's GET /status shows " +
+      "there's some free capacity to process an TRIPLES_GENERATED event" in new TestCase {
+
+        givenELStatusReturning(
+          nonZeroFreeCapacity.generateOne,
+          0,
+          nonZeroFreeCapacity.generateOne,
+          0,
+          0,
+          nonZeroFreeCapacity.generateOne,
+          nonZeroFreeCapacity.generateOne,
+          nonZeroFreeCapacity.generateOne
+        )
+
+        val actual = Deferred.unsafe[IO, Unit]
+
+        val call = checker.envReadyToTakeEvent >> actual.complete(())
+
+        val (elapsed, _) = Temporal[IO].timed((call -> actual.get).parTupled).unsafeRunSync()
+
+        val numberOfTriesBeforeSuccess = 7
+        elapsed.toMillis should be > retryTimeout.toMillis * numberOfTriesBeforeSuccess
+      }
+  }
+
+  private trait TestCase {
+    val retryTimeout          = 500 millis
+    private val totalCapacity = ints(min = 10, max = 20).generateOne
+    def nonZeroFreeCapacity   = positiveInts(max = totalCapacity).map(_.value)
+    private val elClient      = mock[EventLogClient[IO]]
+    val checker               = new EnvReadinessCheckerImpl[IO](elClient, retryTimeout)
+
+    def givenELStatusReturning(capacities: Int*): Unit =
+      capacities foreach { capacity =>
+        (() => elClient.getStatus)
+          .expects()
+          .returning(
+            Result
+              .success(
+                ServiceStatus(
+                  Set(
+                    SubscriptionStatus(triplesgenerated.categoryName, Capacity(totalCapacity, capacity).some)
+                  )
+                )
+              )
+              .pure[IO]
+          )
+      }
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersisterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersisterSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations.lucenereindex
+
+import cats.effect.IO
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators.renkuUrls
+import io.renku.graph.model.RenkuTinyTypeGenerators.projectSlugs
+import io.renku.graph.model.RenkuUrl
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore._
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Random
+
+class ProjectDonePersisterSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with MigrationsDataset
+    with OptionValues {
+
+  "noteDone" should {
+
+    "persist the (MigrationToV10, renku:migrated, slug) triple" in new TestCase {
+
+      val slugs = projectSlugs.generateList(min = 2)
+
+      slugs foreach { slug =>
+        val insertQuery = BacklogCreator.asToBeMigratedInserts(slug)
+        runUpdate(on = migrationsDataset, insertQuery).unsafeRunSync()
+      }
+
+      progressFinder.findProgressInfo.unsafeRunSync() shouldBe s"${slugs.size} left from ${slugs.size}"
+
+      donePersister.noteDone(Random.shuffle(slugs).head).unsafeRunSync()
+
+      progressFinder.findProgressInfo.unsafeRunSync() shouldBe s"${slugs.size - 1} left from ${slugs.size}"
+    }
+  }
+
+  private trait TestCase {
+    implicit val renkuUrl:       RenkuUrl                    = renkuUrls.generateOne
+    private implicit val logger: TestLogger[IO]              = TestLogger[IO]()
+    private implicit val tr:     SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    private val tsClient = TSClient[IO](migrationsDSConnectionInfo)
+    val progressFinder   = new ProgressFinderImpl[IO](tsClient)
+    val donePersister    = new ProjectDonePersisterImpl[IO](tsClient)
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinderSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+package lucenereindex
+
+import cats.effect.IO
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model.GraphModelGenerators.renkuUrls
+import io.renku.graph.model.RenkuTinyTypeGenerators.projectSlugs
+import io.renku.graph.model._
+import io.renku.interpreters.TestLogger
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.testtools.IOSpec
+import io.renku.triplesstore._
+import org.scalacheck.Gen
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import tooling.RecordsFinder
+
+class ProjectsPageFinderSpec
+    extends AnyWordSpec
+    with should.Matchers
+    with IOSpec
+    with InMemoryJenaForSpec
+    with MigrationsDataset
+    with MockFactory
+    with OptionValues {
+
+  private val pageSize = 50
+
+  "nextProjectsPage" should {
+
+    "return next page of projects for migration each time the method is called" in new TestCase {
+
+      val slugs = projectSlugs
+        .generateList(min = pageSize + 1, max = Gen.choose(pageSize + 1, (2 * pageSize) - 1).generateOne)
+        .sorted
+
+      slugs foreach (slug =>
+        runUpdate(on = migrationsDataset, BacklogCreator.asToBeMigratedInserts(slug)).unsafeRunSync()
+      )
+
+      val (page1, page2) = slugs splitAt pageSize
+
+      finder.nextProjectsPage().unsafeRunSync() shouldBe page1
+
+      page1.foreach(donePersister.noteDone(_).unsafeRunSync())
+      finder.nextProjectsPage().unsafeRunSync() shouldBe page2
+
+      page2.foreach(donePersister.noteDone(_).unsafeRunSync())
+      finder.nextProjectsPage().unsafeRunSync() shouldBe Nil
+    }
+  }
+
+  private trait TestCase {
+    implicit val renkuUrl:             RenkuUrl                    = renkuUrls.generateOne
+    private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
+    private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+    val finder        = new ProjectsPageFinderImpl[IO](RecordsFinder[IO](migrationsDSConnectionInfo))
+    val donePersister = new ProjectDonePersisterImpl[IO](TSClient[IO](migrationsDSConnectionInfo))
+  }
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinderSpec.scala
@@ -60,13 +60,13 @@ class ProjectsPageFinderSpec
 
       val (page1, page2) = slugs splitAt pageSize
 
-      finder.nextProjectsPage().unsafeRunSync() shouldBe page1
+      finder.nextProjectsPage.unsafeRunSync() shouldBe page1
 
       page1.foreach(donePersister.noteDone(_).unsafeRunSync())
-      finder.nextProjectsPage().unsafeRunSync() shouldBe page2
+      finder.nextProjectsPage.unsafeRunSync() shouldBe page2
 
       page2.foreach(donePersister.noteDone(_).unsafeRunSync())
-      finder.nextProjectsPage().unsafeRunSync() shouldBe Nil
+      finder.nextProjectsPage.unsafeRunSync() shouldBe Nil
     }
   }
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLuceneSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLuceneSpec.scala
@@ -78,7 +78,7 @@ class ReindexLuceneSpec
       givenBacklogCreated()
 
       val exception = exceptions.generateOne
-      (() => projectsFinder.nextProjectsPage())
+      (() => projectsFinder.nextProjectsPage)
         .expects()
         .returning(exception.raiseError[IO, List[projects.Slug]])
 
@@ -119,7 +119,7 @@ class ReindexLuceneSpec
 
   private def givenProjectsPagesReturned(pages: List[List[projects.Slug]]): Unit =
     pages foreach { page =>
-      (projectsFinder.nextProjectsPage _)
+      (() => projectsFinder.nextProjectsPage)
         .expects()
         .returning(page.pure[IO])
     }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLuceneSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLuceneSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+package lucenereindex
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.renku.eventlog
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import GraphModelGenerators.projectSlugs
+import cats.MonadThrow
+import cats.effect.testing.scalatest.AsyncIOSpec
+import io.renku.eventlog.api.events.StatusChangeEvent
+import io.renku.generators.Generators.{exceptions, nonEmptyStrings, positiveInts}
+import io.renku.interpreters.TestLogger
+import io.renku.triplesgenerator.errors.ErrorGenerators.processingRecoverableErrors
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import tooling._
+
+class ReindexLuceneSpec
+    extends AsyncFlatSpec
+    with AsyncIOSpec
+    with should.Matchers
+    with AsyncMockFactory
+    with EitherValues {
+
+  it should "prepare backlog of all the projects in the TS " +
+    "and start the process that " +
+    "goes through all the projects, " +
+    "wait until the env has capacity to serve a new re-provisioning event, " +
+    "send the RedoProjectTransformation event to EL for each of them, " +
+    "keep a note of the project once an event is sent for it" in {
+
+      givenBacklogCreated()
+
+      val allProjects = projectSlugs.generateList(min = pageSize, max = pageSize * 2)
+
+      val projectsPages = allProjects
+        .sliding(pageSize, pageSize)
+        .toList
+      givenProjectsPagesReturned(projectsPages :+ List.empty[projects.Slug])
+
+      givenProgressInfoFinding(returning = nonEmptyStrings().generateOne.pure[IO], times = allProjects.size)
+
+      givenEnvHasCapabilitiesToTakeNextEvent
+
+      allProjects map givenRedoTransformationEventSent
+
+      allProjects foreach verifyProjectNotedDone
+
+      migration.migrate().value.asserting(_.value shouldBe ())
+    }
+
+  it should "return a Recoverable Error if in case of an exception while finding projects " +
+    "the given strategy returns one" in {
+
+      givenBacklogCreated()
+
+      val exception = exceptions.generateOne
+      (() => projectsFinder.nextProjectsPage())
+        .expects()
+        .returning(exception.raiseError[IO, List[projects.Slug]])
+
+      migration.migrate().value.unsafeRunSync().left.value shouldBe recoverableError
+    }
+
+  private lazy val pageSize = positiveInts(max = 100).generateOne.value
+
+  private implicit val logger: TestLogger[IO] = TestLogger[IO]()
+  private val backlogCreator        = mock[BacklogCreator[IO]]
+  private val projectsFinder        = mock[ProjectsPageFinder[IO]]
+  private val progressFinder        = mock[ProgressFinder[IO]]
+  private val envReadinessChecker   = mock[EnvReadinessChecker[IO]]
+  private val elClient              = mock[eventlog.api.events.Client[IO]]
+  private val projectDonePersister  = mock[ProjectDonePersister[IO]]
+  private val executionRegister     = mock[MigrationExecutionRegister[IO]]
+  private lazy val recoverableError = processingRecoverableErrors.generateOne
+  private val recoveryStrategy = new RecoverableErrorsRecovery {
+    override def maybeRecoverableError[F[_]: MonadThrow, OUT]: RecoveryStrategy[F, OUT] = { _ =>
+      recoverableError.asLeft[OUT].pure[F]
+    }
+  }
+  private lazy val migration = new ReindexLucene[IO](
+    backlogCreator,
+    projectsFinder,
+    progressFinder,
+    envReadinessChecker,
+    elClient,
+    projectDonePersister,
+    executionRegister,
+    recoveryStrategy
+  )
+
+  private def givenBacklogCreated() =
+    (backlogCreator.createBacklog _)
+      .expects()
+      .returning(().pure[IO])
+
+  private def givenProjectsPagesReturned(pages: List[List[projects.Slug]]): Unit =
+    pages foreach { page =>
+      (projectsFinder.nextProjectsPage _)
+        .expects()
+        .returning(page.pure[IO])
+    }
+
+  private def givenProgressInfoFinding(returning: IO[String], times: Int) =
+    (() => progressFinder.findProgressInfo)
+      .expects()
+      .returning(returning)
+      .repeat(times)
+
+  private def givenEnvHasCapabilitiesToTakeNextEvent =
+    (() => envReadinessChecker.envReadyToTakeEvent)
+      .expects()
+      .returning(().pure[IO])
+      .atLeastOnce()
+
+  private def givenRedoTransformationEventSent(slug: projects.Slug) =
+    (elClient
+      .send(_: StatusChangeEvent.RedoProjectTransformation))
+      .expects(StatusChangeEvent.RedoProjectTransformation(slug))
+      .returning(().pure[IO])
+
+  private def verifyProjectNotedDone(slug: projects.Slug) =
+    (projectDonePersister.noteDone _)
+      .expects(slug)
+      .returning(().pure[IO])
+}


### PR DESCRIPTION
This PR adds a TS migration that simply issues a `REDO_PROJECT_TRANSFORMATION` for all the projects existing in the TS so Lucene will reindex all the data.