### PR TITLE
feat: Adopt remaining queries to use project-auth graph

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -46,7 +46,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
   val keywordsVar             = VarName("keywords")
   val imagesVar               = VarName("images")
 
-  private val authSnippets = SparqlSnippets(VarName("projId"), VarName("projectVisibility"))
+  private val authSnippets = SparqlSnippets(VarName("projId"))
 
   override val selectVariables = Set(
     entityTypeVar,

--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -46,6 +46,8 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
   val keywordsVar             = VarName("keywords")
   val imagesVar               = VarName("images")
 
+  private val authSnippets = SparqlSnippets(VarName("projId"), VarName("projectVisibility"))
+
   override val selectVariables = Set(
     entityTypeVar,
     matchingScoreVar,
@@ -148,8 +150,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[Visibility]): Fragment =
     sparql"""
             |?projId renku:projectVisibility ?visibility .
-            |BIND (?projId AS ${SparqlSnippets.projectId})
-            |${SparqlSnippets.visibleProjects(maybeUser.map(_.id), visibilities)}
+            |${authSnippets.visibleProjects(maybeUser.map(_.id), visibilities)}
             """
 
   private def images: Fragment =

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -50,7 +50,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
   private val someCreatorNameVar  = VarName("someCreatorName")
   private val keywordVar          = VarName("keyword")
   private val encodedImageUrlVar  = VarName("encodedImageUrl")
-  private val authSnippets        = SparqlSnippets(projectIdVar, visibilityVar)
+  private val authSnippets        = SparqlSnippets(projectIdVar)
 
   override val selectVariables: Set[String] =
     Set(

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -50,6 +50,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
   private val someCreatorNameVar  = VarName("someCreatorName")
   private val keywordVar          = VarName("keyword")
   private val encodedImageUrlVar  = VarName("encodedImageUrl")
+  private val authSnippets        = SparqlSnippets(projectIdVar, visibilityVar)
 
   override val selectVariables: Set[String] =
     Set(
@@ -147,7 +148,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[projects.Visibility]): Fragment =
     sparql"""
             |$projectIdVar renku:projectVisibility $visibilityVar .
-            |${SparqlSnippets.visibleProjects(maybeUser.map(_.id), visibilities)}
+            |${authSnippets.visibleProjects(maybeUser.map(_.id), visibilities)}
               """.stripMargin
 
   private def namespacesPart(ns: Set[projects.Namespace]): Fragment = {

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -46,6 +46,8 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
                                      "?workflowTypes"
   )
 
+  private val authSnippets = SparqlSnippets(VarName("projectId"), VarName("projectVisibility"))
+
   override def query(criteria: Criteria) = (criteria.filters whenRequesting entityType) {
     import criteria._
     // format: off
@@ -111,7 +113,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
   }
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[projects.Visibility]): Fragment =
-    SparqlSnippets.visibleProjects(maybeUser.map(_.id), visibilities)
+    authSnippets.visibleProjects(maybeUser.map(_.id), visibilities)
 
   private def withoutQuerySnippet: Fragment =
     sparql"""

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -46,7 +46,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
                                      "?workflowTypes"
   )
 
-  private val authSnippets = SparqlSnippets(VarName("projectId"), VarName("projectVisibility"))
+  private val authSnippets = SparqlSnippets(VarName("projectId"))
 
   override def query(criteria: Criteria) = (criteria.filters whenRequesting entityType) {
     import criteria._

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/DatasetQuery.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/DatasetQuery.scala
@@ -26,10 +26,12 @@ import io.renku.graph.model.{GraphClass, Schemas}
 import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.sparql.VarName
 import io.renku.triplesstore.client.syntax.FragmentStringContext
 
 object DatasetQuery extends (Criteria => Option[SparqlQuery]) {
-  private[this] val v = Variables.Dataset
+  private[this] val v            = Variables.Dataset
+  private[this] val authSnippets = SparqlSnippets(VarName("projectId"), v.projectVisibility)
 
   def apply(criteria: Criteria): Option[SparqlQuery] =
     Option.when(criteria.forType(EntityType.Dataset))(makeQuery(criteria))
@@ -60,7 +62,7 @@ object DatasetQuery extends (Criteria => Option[SparqlQuery]) {
                |                    renku:project ?projectId.
                |    }
                |
-               |    ${SparqlSnippets.visibleProjects(Some(criteria.authUser.id), Visibility.all)}
+               |    ${authSnippets.visibleProjects(Some(criteria.authUser.id), Visibility.all)}
                |    
                |    Graph ${GraphClass.Persons.id} {
                |      ?personId a schema:Person;

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/DatasetQuery.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/DatasetQuery.scala
@@ -31,7 +31,7 @@ import io.renku.triplesstore.client.syntax.FragmentStringContext
 
 object DatasetQuery extends (Criteria => Option[SparqlQuery]) {
   private[this] val v            = Variables.Dataset
-  private[this] val authSnippets = SparqlSnippets(VarName("projectId"), v.projectVisibility)
+  private[this] val authSnippets = SparqlSnippets(VarName("projectId"))
 
   def apply(criteria: Criteria): Option[SparqlQuery] =
     Option.when(criteria.forType(EntityType.Dataset))(makeQuery(criteria))

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/ProjectQuery.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/ProjectQuery.scala
@@ -31,7 +31,7 @@ import io.renku.triplesstore.client.syntax._
 
 object ProjectQuery extends (Criteria => Option[SparqlQuery]) {
   private[this] val v            = Variables.Project
-  private[this] val authSnippets = SparqlSnippets(VarName("projectId"), v.visibility)
+  private[this] val authSnippets = SparqlSnippets(VarName("projectId"))
 
   def apply(criteria: Criteria): Option[SparqlQuery] =
     Option.when(criteria.forType(EntityType.Project))(makeQuery(criteria))

--- a/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/ProjectQuery.scala
+++ b/entities-viewings-collector/src/main/scala/io/renku/entities/viewings/search/ProjectQuery.scala
@@ -26,10 +26,12 @@ import io.renku.graph.model.{GraphClass, Schemas}
 import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore.SparqlQuery
 import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.sparql.VarName
 import io.renku.triplesstore.client.syntax._
 
 object ProjectQuery extends (Criteria => Option[SparqlQuery]) {
-  private[this] val v = Variables.Project
+  private[this] val v            = Variables.Project
+  private[this] val authSnippets = SparqlSnippets(VarName("projectId"), v.visibility)
 
   def apply(criteria: Criteria): Option[SparqlQuery] =
     Option.when(criteria.forType(EntityType.Project))(makeQuery(criteria))
@@ -61,7 +63,7 @@ object ProjectQuery extends (Criteria => Option[SparqlQuery]) {
                |                    schema:identifier ${criteria.authUser.id.value}.
                |    }
                |
-               |    ${SparqlSnippets.visibleProjects(Some(criteria.authUser.id), Visibility.all)}
+               |    ${authSnippets.visibleProjects(Some(criteria.authUser.id), Visibility.all)}
                |
                |    Graph ?projectId {
                |      ?projectId a schema:Project;

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
@@ -199,7 +199,7 @@ private class BaseDetailsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder
   )
 
   private lazy val allowedProjectFilterQuery: Option[AuthUser] => Fragment = { user =>
-    SparqlSnippets(VarName("originalDsProjId"), VarName("visibility")).visibleProjects(user.map(_.id), Visibility.all)
+    SparqlSnippets(VarName("originalDsProjId")).visibleProjects(user.map(_.id), Visibility.all)
   }
 
   def findKeywords(dataset: Dataset): F[List[Keyword]] =

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/datasets/details/BaseDetailsFinder.scala
@@ -180,10 +180,10 @@ private class BaseDetailsFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder
              |               schema:version ?version;
              |               schema:sameAs/schema:url ?originalDsId
              |  }
+             |  ${allowedProjectFilterQuery(authContext.maybeAuthUser)}
              |  GRAPH ?originalDsProjId {
              |    ?originalDsProjId renku:hasDataset ?originalDsId;
              |                      renku:projectPath ?projectSlug.
-             |    ${allowedProjectFilterQuery(authContext.maybeAuthUser)}
              |    ?originalDsTagId schema:about/schema:url ?originalDsId;
              |                     schema:name ?version
              |  }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinder.scala
@@ -143,7 +143,15 @@ private class EdgesFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     case _                                       => false
   }
 
-  private def projectMemberFilterQuery(projectResourceId: String): Option[AuthUser] => String = {
+  // TODO
+  private def projectMemberFilterQuery(projectResourceId: String): Option[AuthUser] => String = { _ =>
+    s"""
+       |# $projectResourceId
+       |""".stripMargin
+
+  }
+
+  private def projectMemberFilterQuery2(projectResourceId: String): Option[AuthUser] => String = {
     case Some(user) =>
       s"""|$projectResourceId renku:projectVisibility ?visibility .
           |OPTIONAL {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinder.scala
@@ -22,17 +22,17 @@ import cats.effect._
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import io.renku.graph.config.RenkuUrlLoader
+import io.renku.graph.model.RenkuUrl
 import io.renku.graph.model.Schemas._
-import io.renku.graph.model.entities.Person
-import io.renku.graph.model.projects.{Slug, ResourceId, Visibility}
+import io.renku.graph.model.projects.{ResourceId, Slug, Visibility}
 import io.renku.graph.model.views.RdfResource
-import io.renku.graph.model.{GraphClass, RenkuUrl}
 import io.renku.http.server.security.model.AuthUser
 import io.renku.jsonld.EntityId
+import io.renku.knowledgegraph.projects.files.lineage.model.Node.Location
+import io.renku.knowledgegraph.projects.files.lineage.model._
+import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore.SparqlQuery.Prefixes
 import io.renku.triplesstore._
-import model.Node.Location
-import model._
 import org.typelevel.log4cats.Logger
 
 private trait EdgesFinder[F[_]] {
@@ -143,31 +143,12 @@ private class EdgesFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
     case _                                       => false
   }
 
-  // TODO
-  private def projectMemberFilterQuery(projectResourceId: String): Option[AuthUser] => String = { _ =>
+  private def projectMemberFilterQuery(projectResourceId: String): Option[AuthUser] => String = { user =>
     s"""
-       |# $projectResourceId
+       |BIND($projectResourceId as ${SparqlSnippets.default.projectId.name})
+       |${SparqlSnippets.default.visibleProjects(user.map(_.id), Visibility.all).sparql}
        |""".stripMargin
 
-  }
-
-  private def projectMemberFilterQuery2(projectResourceId: String): Option[AuthUser] => String = {
-    case Some(user) =>
-      s"""|$projectResourceId renku:projectVisibility ?visibility .
-          |OPTIONAL {
-          |  $projectResourceId schema:member ?memberId
-          |  GRAPH <${GraphClass.Persons.id}> {
-          |    ?memberId schema:sameAs ?sameAsId.
-          |    ?sameAsId schema:additionalType '${Person.gitLabSameAsAdditionalType}';
-          |              schema:identifier ?userGitlabId .
-          |  }
-          |}
-          |FILTER ( ?visibility != '${Visibility.Private.value}' || ?userGitlabId = ${user.id.value} )
-          |""".stripMargin
-    case _ =>
-      s"""|$projectResourceId renku:projectVisibility ?visibility .
-          |FILTER(?visibility = '${Visibility.Public.value}')
-          |""".stripMargin
   }
 }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinder.scala
@@ -19,14 +19,16 @@
 package io.renku.knowledgegraph.users.projects
 package finder
 
-import Endpoint.Criteria
 import cats.effect.Async
 import cats.syntax.all._
 import io.circe.Decoder
-import io.renku.graph.model.{projects, GraphClass}
-import io.renku.graph.model.entities.Person
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.projects.Visibility
+import io.renku.knowledgegraph.users.projects.Endpoint.Criteria
 import io.renku.knowledgegraph.users.projects.model.Project
+import io.renku.projectauth.util.SparqlSnippets
 import io.renku.triplesstore._
+import io.renku.triplesstore.client.sparql.{Fragment, VarName}
 import io.renku.triplesstore.client.syntax._
 import org.typelevel.log4cats.Logger
 
@@ -51,76 +53,56 @@ private class TSProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
   override def findProjectsInTS(criteria: Criteria): F[List[Project.Activated]] =
     queryExpecting[List[Project.Activated]](query(criteria))
 
+  private val authSnippets = SparqlSnippets(VarName("projectId"))
+
   private def query(criteria: Criteria) = SparqlQuery.of(
     name = "user projects by id",
     Prefixes of (prov -> "prov", renku -> "renku", schema -> "schema"),
-    s"""|SELECT ?name ?slug ?visibility ?dateCreated ?maybeCreatorName
-        |       (GROUP_CONCAT(?keyword; separator=',') AS ?keywords)
-        |       ?maybeDescription 
-        |WHERE {
-        |  GRAPH ${GraphClass.Persons.id.asSparql.sparql} {
-        |    ?memberSameAs schema:additionalType ${Person.gitLabSameAsAdditionalType.asTripleObject.asSparql.sparql};
-        |                  schema:identifier ${criteria.userId.asObject.asSparql.sparql};
-        |                  ^schema:sameAs ?memberId
-        |  }
-        |  GRAPH ?projectId {
-        |    ?projectId schema:member ?memberId;
-        |               a schema:Project;
-        |               renku:projectPath ?slug;
-        |               schema:name ?name;
-        |               renku:projectVisibility ?visibility;
-        |               schema:dateCreated ?dateCreated.
-        |    ${criteria.maybeOnAccessRights("?projectId", "?visibility")}
-        |    OPTIONAL { ?projectId schema:description ?maybeDescription }
-        |    OPTIONAL { ?projectId schema:keywords ?keyword }
-        |    OPTIONAL {
-        |      ?projectId schema:creator ?maybeCreatorResourceId.
-        |      GRAPH ${GraphClass.Persons.id.asSparql.sparql} {
-        |        ?maybeCreatorResourceId schema:name ?maybeCreatorName
-        |      }
-        |    }
-        |  }
-        |}
-        |GROUP BY ?projectId ?name ?slug ?visibility ?dateCreated ?maybeCreatorName ?maybeDescription
-        |""".stripMargin
+    sparql"""|SELECT ?name ?slug ?visibility ?dateCreated ?maybeCreatorName
+             |       (GROUP_CONCAT(?keyword; separator=',') AS ?keywords)
+             |       ?maybeDescription 
+             |WHERE {
+             |
+             |  ${memberProjects(criteria)}
+             |
+             |  ${maybeOnAccessRights2(criteria)}
+             |
+             |  GRAPH ?projectId {
+             |    ?projectId 
+             |               a schema:Project;
+             |               renku:projectPath ?slug;
+             |               schema:name ?name;
+             |               renku:projectVisibility ?visibility;
+             |               schema:dateCreated ?dateCreated.
+             |
+             |    OPTIONAL { ?projectId schema:description ?maybeDescription }
+             |    OPTIONAL { ?projectId schema:keywords ?keyword }
+             |    OPTIONAL {
+             |      ?projectId schema:creator ?maybeCreatorResourceId.
+             |      GRAPH ${GraphClass.Persons.id} {
+             |        ?maybeCreatorResourceId schema:name ?maybeCreatorName
+             |      }
+             |    }
+             |  }
+             |}
+             |GROUP BY ?projectId ?name ?slug ?visibility ?dateCreated ?maybeCreatorName ?maybeDescription
+             |""".stripMargin
   )
 
-  private implicit class CriteriaOps(criteria: Criteria) {
+  def memberProjects(criteria: Criteria): Fragment =
+    authSnippets.memberProjects(criteria.userId)
 
-    def maybeOnAccessRights(projectIdVariable: String, visibilityVariable: String): String =
-      criteria.maybeUser match {
-        case Some(user) =>
-          s"""|{
-              |  VALUES ($visibilityVariable) {
-              |    (${projects.Visibility.Public.asObject.asSparql.sparql})
-              |    (${projects.Visibility.Internal.asObject.asSparql.sparql})
-              |  }
-              |} UNION {
-              |  VALUES ($visibilityVariable) {
-              |    (${projects.Visibility.Private.asObject.asSparql.sparql})
-              |  }
-              |  $projectIdVariable schema:member ?projectMemberId
-              |  GRAPH ${GraphClass.Persons.id.asSparql.sparql} {
-              |    ?projectMemberId schema:sameAs ?projectMemberSameAs.
-              |    ?projectMemberSameAs schema:additionalType ${Person.gitLabSameAsAdditionalType.asTripleObject.asSparql.sparql};
-              |                         schema:identifier ${user.id.asObject.asSparql.sparql}
-              |  }
-              |}
-              |""".stripMargin
-        case _ =>
-          s"""|VALUES ($visibilityVariable) {
-              |  (${projects.Visibility.Public.asObject.asSparql.sparql})
-              |}""".stripMargin
-      }
-  }
+  def maybeOnAccessRights2(criteria: Criteria): Fragment =
+    authSnippets
+      .visibleProjects(criteria.maybeUser.map(_.id), Visibility.all)
 
   private implicit lazy val recordsDecoder: Decoder[List[Project.Activated]] = {
     import Decoder._
+    import ResultsDecoder._
     import io.circe.DecodingFailure
     import io.renku.graph.model.persons
     import io.renku.graph.model.projects._
     import io.renku.tinytypes.json.TinyTypeDecoders._
-    import ResultsDecoder._
 
     val toSetOfKeywords: Option[String] => Decoder.Result[Set[Keyword]] =
       _.map(_.split(',').toList.map(Keyword.from).sequence.map(_.toSet)).sequence

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/users/projects/finder/TSProjectFinder.scala
@@ -65,7 +65,7 @@ private class TSProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
              |
              |  ${memberProjects(criteria)}
              |
-             |  ${maybeOnAccessRights2(criteria)}
+             |  ${maybeOnAccessRights(criteria)}
              |
              |  GRAPH ?projectId {
              |    ?projectId 
@@ -89,10 +89,10 @@ private class TSProjectFinderImpl[F[_]: Async: Logger: SparqlQueryTimeRecorder](
              |""".stripMargin
   )
 
-  def memberProjects(criteria: Criteria): Fragment =
+  private def memberProjects(criteria: Criteria): Fragment =
     authSnippets.memberProjects(criteria.userId)
 
-  def maybeOnAccessRights2(criteria: Criteria): Fragment =
+  private def maybeOnAccessRights(criteria: Criteria): Fragment =
     authSnippets
       .visibleProjects(criteria.maybeUser.map(_.id), Visibility.all)
 

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/DatasetsFinderSpec.scala
@@ -21,6 +21,7 @@ package io.renku.knowledgegraph.datasets
 import cats.effect.IO
 import cats.syntax.all._
 import eu.timepit.refined.auto._
+import io.renku.entities.searchgraphs.SearchInfoDatasets
 import io.renku.generators.CommonGraphGenerators._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
@@ -44,6 +45,7 @@ import org.scalacheck.Gen
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.log4cats.Logger
 
 class DatasetsFinderSpec
     extends AnyWordSpec
@@ -51,8 +53,11 @@ class DatasetsFinderSpec
     with EntitiesGenerators
     with InMemoryJenaForSpec
     with ProjectsDataset
+    with SearchInfoDatasets
     with ScalaCheckPropertyChecks
     with IOSpec {
+
+  implicit override val ioLogger: Logger[IO] = TestLogger()
 
   "findDatasets - no phrase" should {
 
@@ -64,7 +69,7 @@ class DatasetsFinderSpec
           val (dataset1ImportedToProject2, project2) = publicProjectEntities.importDataset(dataset1).generateOne
           val (dataset3, project3) = publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne
 
-          upload(to = projectsDataset, project1, project2, project3)
+          provisionTestProjects(project1, project2, project3).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -90,7 +95,7 @@ class DatasetsFinderSpec
             .generateNonEmptyList(max = PagingRequest.default.perPage.value)
             .toList
 
-          upload(to = projectsDataset, projects: _*)
+          provisionTestProjects(projects: _*).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -111,7 +116,7 @@ class DatasetsFinderSpec
           val (dataset2, project2) = publicProjectEntities.importDataset(dataset).generateOne
           val (dataset3, project3) = publicProjectEntities.importDataset(dataset).generateOne
 
-          upload(to = projectsDataset, project1, project2, project3)
+          provisionTestProjects(project1, project2, project3).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -132,8 +137,8 @@ class DatasetsFinderSpec
           val (dataset2, project2) = publicProjectEntities.importDataset(dataset).generateOne
           val (dataset2Modified, project2Updated) = project2.addDataset(dataset2.createModification())
 
-          upload(to = projectsDataset, project1)
-          upload(to = projectsDataset, project2Updated)
+          provisionTestProjects(project1).unsafeRunSync()
+          provisionTestProjects(project2Updated).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -154,7 +159,7 @@ class DatasetsFinderSpec
           val (dataset2, project2 -> project2Fork) =
             publicProjectEntities.importDataset(dataset).forkOnce().generateOne
 
-          upload(to = projectsDataset, project1, project2, project2Fork)
+          provisionTestProjects(project1, project2, project2Fork).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -178,7 +183,7 @@ class DatasetsFinderSpec
           val ((_, dataset2Modified), project2) =
             publicProjectEntities.addDatasetAndModification(datasetEntities(provenanceImportedExternal)).generateOne
 
-          upload(to = projectsDataset, project1, project2)
+          provisionTestProjects(project1, project2).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -197,7 +202,7 @@ class DatasetsFinderSpec
             publicProjectEntities.addDatasetAndModification(datasetEntities(provenanceInternal)).generateOne
           val (modification2, projectWithAllDatasets) = project.addDataset(modification1.createModification())
 
-          upload(to = projectsDataset, projectWithAllDatasets)
+          provisionTestProjects(projectWithAllDatasets).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -215,7 +220,7 @@ class DatasetsFinderSpec
           val (dataset2, project2) =
             publicProjectEntities.addDataset(datasetEntities(provenanceImportedExternal)).generateOne
 
-          upload(to = projectsDataset, project1, project2)
+          provisionTestProjects(project1, project2).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -236,7 +241,7 @@ class DatasetsFinderSpec
           val (dataset2, project2) = publicProjectEntities.importDataset(dataset).generateOne
           val (dataset2Modified, project2Updated) = project2.addDataset(dataset2.createModification())
 
-          upload(to = projectsDataset, project1, project2Updated)
+          provisionTestProjects(project1, project2Updated).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(None, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -257,7 +262,7 @@ class DatasetsFinderSpec
             .forkOnce()
             .generateOne
 
-          upload(to = projectsDataset, project, fork)
+          provisionTestProjects(project, fork).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -276,7 +281,7 @@ class DatasetsFinderSpec
             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).forkOnce().generateOne
           val (datasetModified, projectUpdated) = project.addDataset(dataset.createModification())
 
-          upload(to = projectsDataset, projectUpdated, fork)
+          provisionTestProjects(projectUpdated, fork).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -301,7 +306,7 @@ class DatasetsFinderSpec
           val (modificationOfModificationOnFork, forkUpdated) =
             fork.addDataset(datasetModification.createModification())
 
-          upload(to = projectsDataset, project, forkUpdated)
+          provisionTestProjects(project, forkUpdated).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -321,7 +326,7 @@ class DatasetsFinderSpec
           val (_, project2) =
             publicProjectEntities.addDatasetAndInvalidation(datasetEntities(provenanceImportedExternal)).generateOne
 
-          upload(to = projectsDataset, project1, project2)
+          provisionTestProjects(project1, project2).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -337,7 +342,7 @@ class DatasetsFinderSpec
             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).forkOnce().generateOne
           val forkUpdated = fork.addDatasets(dataset.invalidateNow(personEntities))
 
-          upload(to = projectsDataset, project, forkUpdated)
+          provisionTestProjects(project, forkUpdated).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -353,7 +358,7 @@ class DatasetsFinderSpec
             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).forkOnce().generateOne
           val afterForkingUpdated = project.addDatasets(dataset.invalidateNow(personEntities))
 
-          upload(to = projectsDataset, afterForkingUpdated, fork)
+          provisionTestProjects(afterForkingUpdated, fork).unsafeRunSync()
 
           val result = datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -369,7 +374,7 @@ class DatasetsFinderSpec
             publicProjectEntities.addDatasetAndModification(datasetEntities(provenanceInternal)).generateOne
           val projectUpdated = project.addDatasets(datasetModified.invalidateNow(personEntities))
 
-          upload(to = projectsDataset, projectUpdated)
+          provisionTestProjects(projectUpdated).unsafeRunSync()
 
           datasetsFinder
             .findDatasets(maybePhrase, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -403,7 +408,7 @@ class DatasetsFinderSpec
         val (_, projectWithoutPhrase) =
           publicProjectEntities.addDataset(datasetEntities(provenanceNonModified)).generateOne
 
-        upload(to = projectsDataset, project1, project2, project3, project4, project5, projectWithoutPhrase)
+        provisionTestProjects(project1, project2, project3, project4, project5, projectWithoutPhrase).unsafeRunSync()
 
         val result = datasetsFinder
           .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -422,7 +427,7 @@ class DatasetsFinderSpec
 
       val (_, project) = publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne
 
-      upload(to = projectsDataset, project)
+      provisionTestProjects(project).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrases.generateOne),
@@ -441,7 +446,7 @@ class DatasetsFinderSpec
         .addDatasetAndModification(datasetEntities(provenanceInternal).modify(_.makeKeywordsContaining(phrase.value)))
         .generateOne
 
-      upload(to = projectsDataset, project)
+      provisionTestProjects(project).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -461,7 +466,7 @@ class DatasetsFinderSpec
         )
         .generateOne
 
-      upload(to = projectsDataset, project1, project2)
+      provisionTestProjects(project1, project2).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -479,7 +484,7 @@ class DatasetsFinderSpec
       val (dataset2Modified, project2Updated) =
         project2.addDataset(dataset2.createModification(_.makeKeywordsContaining(phrase.value)))
 
-      upload(to = projectsDataset, project1, project2Updated)
+      provisionTestProjects(project1, project2Updated).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -495,7 +500,7 @@ class DatasetsFinderSpec
         project.addDataset(dataset.createModification(_.makeKeywordsContaining(phrase.value)))
       val (_, projectUpdate2) = projectUpdate1.addDataset(datasetModification1.createModification())
 
-      upload(to = projectsDataset, projectUpdate2)
+      provisionTestProjects(projectUpdate2).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -512,7 +517,7 @@ class DatasetsFinderSpec
         .generateOne
       val _ -> forkUpdated = fork.addDataset(dataset.createModification())
 
-      upload(to = projectsDataset, project, forkUpdated)
+      provisionTestProjects(project, forkUpdated).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -528,7 +533,7 @@ class DatasetsFinderSpec
       val (datasetModified, forkUpdated) =
         fork.addDataset(dataset.createModification(_.makeKeywordsContaining(phrase.value)))
 
-      upload(to = projectsDataset, project, forkUpdated)
+      provisionTestProjects(project, forkUpdated).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -544,7 +549,7 @@ class DatasetsFinderSpec
           .addDatasetAndInvalidation(datasetEntities(provenanceInternal).modify(_.makeDescContaining(phrase.value)))
           .generateOne
 
-        upload(to = projectsDataset, project)
+        provisionTestProjects(project).unsafeRunSync()
 
         datasetsFinder
           .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -571,7 +576,7 @@ class DatasetsFinderSpec
 
       val (_, projectNonPhrased) = publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne
 
-      upload(to = projectsDataset, project1, project2, project3, projectNonPhrased)
+      provisionTestProjects(project1, project2, project3, projectNonPhrased).unsafeRunSync()
 
       val results = datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -596,12 +601,12 @@ class DatasetsFinderSpec
         .addDataset(datasetEntities(provenanceImportedExternal).modify(_.makeKeywordsContaining(phrase.value)))
         .generateOne
 
-      upload(to = projectsDataset,
-             project1,
-             project2,
-             project3,
-             publicProjectEntities.addDataset(datasetEntities(provenanceImportedExternal)).generateOne._2
-      )
+      provisionTestProjects(
+        project1,
+        project2,
+        project3,
+        publicProjectEntities.addDataset(datasetEntities(provenanceImportedExternal)).generateOne._2
+      ).unsafeRunSync()
 
       val results = datasetsFinder
         .findDatasets(Some(phrase),
@@ -630,12 +635,12 @@ class DatasetsFinderSpec
         .addDataset(datasetEntities(provenanceInternal).modify(_.makeKeywordsContaining(phrase.value)))
         .generateOne
 
-      upload(to = projectsDataset,
-             project1,
-             project2,
-             project3,
-             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2
-      )
+      provisionTestProjects(
+        project1,
+        project2,
+        project3,
+        publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2
+      ).unsafeRunSync()
 
       val results = datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(DateProperty, Direction.Desc)), PagingRequest.default, None)
@@ -663,12 +668,13 @@ class DatasetsFinderSpec
         .addDataset(datasetEntities(provenanceInternal).modify(_.makeKeywordsContaining(phrase.value)))
         .generateOne
 
-      upload(to = projectsDataset, project1)
-      upload(to = projectsDataset, project1Fork)
-      upload(to = projectsDataset, project2)
-      upload(to = projectsDataset, project2Forks.toList: _*)
-      upload(to = projectsDataset, project3)
-      upload(to = projectsDataset, publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2)
+      provisionTestProjects(
+        project1 ::
+          project1Fork ::
+          project2 ::
+          project2Forks.toList :::
+          List(project3, publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2): _*
+      ).unsafeRunSync()
 
       val results = datasetsFinder
         .findDatasets(Some(phrase), Sorting(Sort.By(ProjectsCountProperty, Direction.Asc)), PagingRequest.default, None)
@@ -700,12 +706,12 @@ class DatasetsFinderSpec
         .addDataset(datasetEntities(provenanceInternal).modify(_.makeKeywordsContaining(phrase.value)))
         .generateOne
 
-      upload(to = projectsDataset,
-             project1,
-             project2,
-             project3,
-             publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2
-      )
+      provisionTestProjects(
+        project1,
+        project2,
+        project3,
+        publicProjectEntities.addDataset(datasetEntities(provenanceInternal)).generateOne._2
+      ).unsafeRunSync()
 
       val pagingRequest = PagingRequest(Page(2), PerPage(1))
 
@@ -735,7 +741,7 @@ class DatasetsFinderSpec
         .addDataset(datasetEntities(provenanceInternal).modify(_.makeKeywordsContaining(phrase.value)))
         .generateOne
 
-      upload(to = projectsDataset, project1, project2, project3)
+      provisionTestProjects(project1, project2, project3).unsafeRunSync()
 
       val pagingRequest = PagingRequest(Page(2), PerPage(3))
 
@@ -758,7 +764,7 @@ class DatasetsFinderSpec
         val (_, privateProject) =
           renkuProjectEntities(fixed(nonPublic)).addDataset(datasetEntities(provenanceInternal)).generateOne
 
-        upload(to = projectsDataset, publicProject, privateProject)
+        provisionTestProjects(publicProject, privateProject).unsafeRunSync()
 
         val result = datasetsFinder
           .findDatasets(None, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, maybeUser = None)
@@ -775,7 +781,7 @@ class DatasetsFinderSpec
         val (_, privateProjectWithPublicDataset) =
           renkuProjectEntities(fixed(nonPublic)).importDataset(publicDataset).generateOne
 
-        upload(to = projectsDataset, publicProject, privateProjectWithPublicDataset)
+        provisionTestProjects(publicProject, privateProjectWithPublicDataset).unsafeRunSync()
 
         val result = datasetsFinder
           .findDatasets(None, Sorting(Sort.By(TitleProperty, Direction.Asc)), PagingRequest.default, None)
@@ -807,7 +813,7 @@ class DatasetsFinderSpec
           .addDataset(datasetEntities(provenanceInternal))
           .generateOne
 
-      upload(to = projectsDataset, publicProject, internalProjectWithAccess, privateProjectWithAccess)
+      provisionTestProjects(publicProject, internalProjectWithAccess, privateProjectWithAccess).unsafeRunSync()
 
       val result = datasetsFinder
         .findDatasets(maybePhrase = None,
@@ -832,7 +838,7 @@ class DatasetsFinderSpec
       val (internalDatasetWithoutAccess, internalProjectWithoutAccess) =
         renkuProjectEntities(fixed(Visibility.Internal)).addDataset(datasetEntities(provenanceInternal)).generateOne
 
-      upload(to = projectsDataset, internalProjectWithoutAccess)
+      provisionTestProjects(internalProjectWithoutAccess).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(maybePhrase = None,
@@ -851,7 +857,7 @@ class DatasetsFinderSpec
       val privateProjectWithoutAccess =
         renkuProjectEntities(fixed(Visibility.Private)).withDatasets(datasetEntities(provenanceInternal)).generateOne
 
-      upload(to = projectsDataset, privateProjectWithoutAccess)
+      provisionTestProjects(privateProjectWithoutAccess).unsafeRunSync()
 
       datasetsFinder
         .findDatasets(maybePhrase = None,
@@ -883,13 +889,13 @@ class DatasetsFinderSpec
           .importDataset(privateDatasetWithoutAccess)
           .generateOne
 
-        upload(to = projectsDataset,
-               publicProject,
-               internalProjectWithoutAccess,
-               internalProjectWithAccess,
-               privateProjectWithoutAccess,
-               privateProjectWithAccess
-        )
+        provisionTestProjects(
+          publicProject,
+          internalProjectWithoutAccess,
+          internalProjectWithAccess,
+          privateProjectWithoutAccess,
+          privateProjectWithAccess
+        ).unsafeRunSync()
 
         val result = datasetsFinder
           .findDatasets(maybePhrase = None,

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/DatasetFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/datasets/details/DatasetFinderSpec.scala
@@ -217,7 +217,7 @@ class DatasetFinderSpec
         .map(replaceMembers(Set(projectMemberEntities(authUser.id.some).generateOne)))
         .addDataset(datasetEntities(provenanceInternal))
         .generateOne
-      val (_, otherProject) = renkuProjectEntities(visibilityNonPublic)
+      val (_, otherProject) = renkuProjectEntities(visibilityPrivate)
         .map(replaceMembers(Set(projectMemberEntities(withGitLabId).generateOne)))
         .importDataset(dataset)
         .generateOne
@@ -225,8 +225,10 @@ class DatasetFinderSpec
       provisionTestProjects(project, otherProject).unsafeRunSync()
 
       val expectedDS = internalToNonModified(dataset, project)
-      findById(dataset.identifier, authUser, project.slug).value                          shouldBe expectedDS
-      findByTopmostSameAs(dataset.provenance.topmostSameAs, authUser, project.slug).value shouldBe expectedDS
+      val byId       = findById(dataset.identifier, authUser, project.slug).value
+      val byTopmost  = findByTopmostSameAs(dataset.provenance.topmostSameAs, authUser, project.slug).value
+      byId      shouldBe expectedDS
+      byTopmost shouldBe expectedDS
     }
 
     "return dataset with usedIn to which the user has access" in new TestCase {

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/files/lineage/EdgesFinderSpec.scala
@@ -241,7 +241,7 @@ class EdgesFinderSpec
       }
 
     "return no the edges of the internal project " +
-      "case when the user anonymous" in new TestCase {
+      "case when the user is anonymous" in new TestCase {
         val authUser = authUsers.generateOne
 
         val exemplarData = LineageExemplarData(renkuProjectEntities(fixed(Visibility.Internal)).generateOne)

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -25,7 +25,7 @@ import io.renku.projectauth.ProjectAuth
 import io.renku.triplesstore.client.sparql.{Fragment, VarName}
 import io.renku.triplesstore.client.syntax._
 
-final class SparqlSnippets(val projectId: VarName, val projectVisibility: VarName) {
+final class SparqlSnippets(val projectId: VarName) {
 
   def changeVisibility(slug: projects.Slug, newValue: projects.Visibility): Fragment =
     sparql"""|DELETE { GRAPH ${ProjectAuth.graph} { ?id renku:visibility ?visibility } }
@@ -78,9 +78,9 @@ final class SparqlSnippets(val projectId: VarName, val projectVisibility: VarNam
 }
 
 object SparqlSnippets {
-  def apply(projectVar: VarName, visibilityVar: VarName): SparqlSnippets =
-    new SparqlSnippets(projectVar, visibilityVar)
+  def apply(projectVar: VarName): SparqlSnippets =
+    new SparqlSnippets(projectVar)
 
   val default =
-    SparqlSnippets(VarName("projectId"), VarName("projectVisibility"))
+    SparqlSnippets(VarName("projectId"))
 }

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -38,6 +38,14 @@ final class SparqlSnippets(val projectId: VarName) {
              |  }
              |}""".stripMargin
 
+  def memberProjects(userId: persons.GitLabId): Fragment =
+    sparql"""
+            |Graph renku:ProjectAuth {
+            |   $projectId a schema:Project;
+            |              renku:memberId ${userId.value}.
+            |}
+            | """.stripMargin
+
   def visibleProjects(userId: Option[persons.GitLabId], selectedVisibility: Set[Visibility]): Fragment = {
     val visibilities =
       if (selectedVisibility.isEmpty) Visibility.all

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -25,9 +25,7 @@ import io.renku.projectauth.ProjectAuth
 import io.renku.triplesstore.client.sparql.{Fragment, VarName}
 import io.renku.triplesstore.client.syntax._
 
-object SparqlSnippets {
-  val projectId         = VarName("projectId")
-  val projectVisibility = VarName("projectVisibility")
+final class SparqlSnippets(val projectId: VarName, val projectVisibility: VarName) {
 
   def changeVisibility(slug: projects.Slug, newValue: projects.Visibility): Fragment =
     sparql"""|DELETE { GRAPH ${ProjectAuth.graph} { ?id renku:visibility ?visibility } }
@@ -77,4 +75,12 @@ object SparqlSnippets {
             |$projectId renku:visibility ${Visibility.Private.value};
             |           renku:memberId ${user.value}.
             |""".stripMargin
+}
+
+object SparqlSnippets {
+  def apply(projectVar: VarName, visibilityVar: VarName): SparqlSnippets =
+    new SparqlSnippets(projectVar, visibilityVar)
+
+  val default =
+    SparqlSnippets(VarName("projectId"), VarName("projectVisibility"))
 }

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/UpdateQueriesCalculator.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/projects/update/UpdateQueriesCalculator.scala
@@ -233,7 +233,7 @@ private class UpdateQueriesCalculatorImpl[F[_]: Applicative: Logger](implicit ru
     SparqlQuery.ofUnsafe(
       show"$reportingPrefix: update visibility in ProjectAuth",
       Prefixes of (renku -> "renku", schema -> "schema"),
-      SparqlSnippets.changeVisibility(slug, newValue)
+      SparqlSnippets.default.changeVisibility(slug, newValue)
     )
 
   private def visibilityInProjectUpdate(slug: projects.Slug, newValue: projects.Visibility) =


### PR DESCRIPTION
Refactors remaining queries to use the project-auth graph to determine memberships.