### PR TITLE
fix: StandardTokenizer to be used in instead LetterTokenizer in Jena

### DIFF
--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -29,10 +29,6 @@
 <#indexLucene> a text:TextIndexLucene ;
   text:directory <file:///fuseki/databases/projects/lucene_index> ;
   text:entityMap <#entMap> ;
-  text:analyzer [
-    a text:ConfigurableAnalyzer ;
-    text:tokenizer text:LetterTokenizer
-  ];
 .
 
 <#entMap> a         text:EntityMap ;

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -50,7 +50,7 @@ private[tsmigrationrequest] object Migrations {
     addProjectSlug                 <- projectslug.AddProjectSlug[F]
     datasetsGraphPersonRemover     <- DatasetsGraphPersonRemover[F]
     projectsGraphPersonRemover     <- ProjectsGraphPersonRemover[F]
-    reindexLucene                  <- lucenereindex.ReindexLucene[F]
+    reindexLuceneStdTokenizer      <- lucenereindex.ReindexLucene[F](suffix = "- std tokenizer")
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -69,7 +69,7 @@ private[tsmigrationrequest] object Migrations {
                     addProjectSlug,
                     datasetsGraphPersonRemover,
                     projectsGraphPersonRemover,
-                    reindexLucene
+                    reindexLuceneStdTokenizer
                   )
   } yield migrations
 

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/BacklogCreatorSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/BacklogCreatorSpec.scala
@@ -70,8 +70,10 @@ class BacklogCreatorSpec
 
   private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
   private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
-  private lazy val backlogCreator =
-    new BacklogCreatorImpl[IO](AllProjects[IO](projectsDSConnectionInfo), TSClient[IO](migrationsDSConnectionInfo))
+  private lazy val backlogCreator = new BacklogCreatorImpl[IO](migrationName,
+                                                               AllProjects[IO](projectsDSConnectionInfo),
+                                                               TSClient[IO](migrationsDSConnectionInfo)
+  )
 
   private def fetchBacklogProjects =
     runSelect(
@@ -81,7 +83,7 @@ class BacklogCreatorSpec
         Prefixes of renku -> "renku",
         sparql"""|SELECT ?slug
                  |WHERE {
-                 |  ${ReindexLucene.name.asEntityId} renku:toBeMigrated ?slug
+                 |  ${migrationName.asEntityId} renku:toBeMigrated ?slug
                  |}
                  |""".stripMargin
       )

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersisterSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectDonePersisterSpec.scala
@@ -48,7 +48,7 @@ class ProjectDonePersisterSpec
 
     for {
       _ <- slugs.map { slug =>
-             val insertQuery = BacklogCreator.asToBeMigratedInserts(slug)
+             val insertQuery = BacklogCreator.asToBeMigratedInserts(migrationName, slug)
              runUpdate(on = migrationsDataset, insertQuery)
            }.sequence
 
@@ -64,6 +64,6 @@ class ProjectDonePersisterSpec
   private implicit val logger:        TestLogger[IO]              = TestLogger[IO]()
   private implicit val tr:            SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
   private lazy val tsClient       = TSClient[IO](migrationsDSConnectionInfo)
-  private lazy val progressFinder = new ProgressFinderImpl[IO](tsClient)
-  private lazy val donePersister  = new ProjectDonePersisterImpl[IO](tsClient)
+  private lazy val progressFinder = new ProgressFinderImpl[IO](migrationName, tsClient)
+  private lazy val donePersister  = new ProjectDonePersisterImpl[IO](migrationName, tsClient)
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinderSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ProjectsPageFinderSpec.scala
@@ -55,7 +55,7 @@ class ProjectsPageFinderSpec
         .sorted
 
       slugs foreach (slug =>
-        runUpdate(on = migrationsDataset, BacklogCreator.asToBeMigratedInserts(slug)).unsafeRunSync()
+        runUpdate(on = migrationsDataset, BacklogCreator.asToBeMigratedInserts(migrationName, slug)).unsafeRunSync()
       )
 
       val (page1, page2) = slugs splitAt pageSize
@@ -74,7 +74,7 @@ class ProjectsPageFinderSpec
     implicit val renkuUrl:             RenkuUrl                    = renkuUrls.generateOne
     private implicit val logger:       TestLogger[IO]              = TestLogger[IO]()
     private implicit val timeRecorder: SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
-    val finder        = new ProjectsPageFinderImpl[IO](RecordsFinder[IO](migrationsDSConnectionInfo))
-    val donePersister = new ProjectDonePersisterImpl[IO](TSClient[IO](migrationsDSConnectionInfo))
+    val finder        = new ProjectsPageFinderImpl[IO](migrationName, RecordsFinder[IO](migrationsDSConnectionInfo))
+    val donePersister = new ProjectDonePersisterImpl[IO](migrationName, TSClient[IO](migrationsDSConnectionInfo))
   }
 }

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLuceneSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/ReindexLuceneSpec.scala
@@ -128,15 +128,15 @@ class ReindexLuceneSpec
       recoverableError.asLeft[OUT].pure[F]
     }
   }
-  private lazy val migration = new ReindexLucene[IO](
-    backlogCreator,
-    projectsFinder,
-    progressFinder,
-    envReadinessChecker,
-    elClient,
-    projectDonePersister,
-    executionRegister,
-    recoveryStrategy
+  private lazy val migration = new ReindexLucene[IO](migrationName,
+                                                     backlogCreator,
+                                                     projectsFinder,
+                                                     progressFinder,
+                                                     envReadinessChecker,
+                                                     elClient,
+                                                     projectDonePersister,
+                                                     executionRegister,
+                                                     recoveryStrategy
   )
 
   private def givenBacklogCreated() =

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/package.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/lucenereindex/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import io.renku.triplesgenerator.events.consumers.tsmigrationrequest.Migration
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.nonEmptyStrings
+
+package object lucenereindex {
+  private[lucenereindex] val migrationName = Migration.Name(s"Reindex Lucene ${nonEmptyStrings().generateOne}")
+}

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/QueryTokenizer.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/QueryTokenizer.scala
@@ -46,7 +46,7 @@ object QueryTokenizer {
     (input: String) => input.split(c).toList
 
   def default: QueryTokenizer =
-    luceneLetters
+    luceneStandard
 
   private final class LuceneTokenizer(createDelegate: AttributeFactory => Tokenizer) extends QueryTokenizer {
     override def split(input: String): List[String] = {


### PR DESCRIPTION
This PR reverts the recent changes to the Tokenizer that is used by the Triples Store. Apparently, the `LetterTokenizer` that we switched to does not satisfy some of our key users as currently they heavily rely on keywords containing underscores. This PR changes the Tokenizer to the Standard and adds a new TS migration to reindex the store.