### PR TITLE
feat: KG's /knowledge-graph/version to be the same as /version

### DIFF
--- a/graph-commons/src/main/scala/io/renku/http/server/version/Routes.scala
+++ b/graph-commons/src/main/scala/io/renku/http/server/version/Routes.scala
@@ -22,15 +22,18 @@ import cats.MonadThrow
 import cats.effect.Async
 import cats.syntax.all._
 import org.http4s.HttpRoutes
+import org.http4s.Uri.Path
 import org.http4s.dsl.Http4sDsl
 
 trait Routes[F[_]] {
   def apply(): HttpRoutes[F]
+  def on(path: Path): HttpRoutes[F]
 }
 
 class RoutesImpl[F[_]: MonadThrow](endpoint: Endpoint[F]) extends Http4sDsl[F] with Routes[F] {
   import endpoint._
   override def apply(): HttpRoutes[F] = HttpRoutes.of[F] { case GET -> Root / "version" => `GET /version` }
+  override def on(path: Path): HttpRoutes[F] = HttpRoutes.of[F] { case GET -> `path` => `GET /version` }
 }
 
 object Routes {

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -22,9 +22,10 @@ The following routes may be slightly different when accessed via the main Renku 
 | GET    | ```/knowledge-graph/projects/:namespace/:name/files/:location/lineage``` | Returns the lineage for a the path (location) of a file on a project                 |
 | GET    | ```/knowledge-graph/spec.json```                                         | Returns OpenAPI specification of the service's resources                             |
 | GET    | ```/knowledge-graph/users/:id/projects```                                | Returns all user's projects                                                          |
+| GET    | ```/knowledge-graph/version```                                           | Returns info about service version                                                   |
 | GET    | ```/metrics```                                                           | Serves Prometheus metrics                                                            |
 | GET    | ```/ping```                                                              | To check if service is healthy                                                       |
-| GET    | ```/version```                                                           | Returns info about service version                                                   |
+| GET    | ```/version```                                                           | Returns info about service version; same as `GET /knowledge-graph/version`           |
 
 #### GET /knowledge-graph/datasets
 
@@ -1275,6 +1276,30 @@ Response body example:
 ]
 ```
 
+#### GET /knowledge-graph/version
+
+Returns info about service version. It's the same as `GET /version` but it's exposed to the Internet.
+
+**Response**
+
+| Status                       | Description            |
+|------------------------------|------------------------|
+| OK (200)                     | If version is returned |
+| INTERNAL SERVER ERROR (500)  | Otherwise              |
+
+Response body example:
+
+```json
+{
+  "name": "commit-event-service",
+  "versions": [
+    {
+      "version": "2.3.0"
+    }
+  ]
+}
+```
+
 #### GET /metrics  (Internal use only)
 
 Serves Prometheus metrics.
@@ -1297,7 +1322,7 @@ Verifies service health.
 | OK (200)                     | If service is healthy |
 | INTERNAL SERVER ERROR (500)  | Otherwise             |
 
-#### GET /version  (Internal use only)
+#### GET /version (Internal use only)
 
 Returns info about service version
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/MicroserviceRoutes.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/MicroserviceRoutes.scala
@@ -92,7 +92,9 @@ private class MicroserviceRoutes[F[_]: Async](
   import routesMetrics._
 
   lazy val routes: Resource[F, HttpRoutes[F]] =
-    (versionRoutes() <+> nonAuthorizedRoutes <+> authorizedRoutes).withMetrics
+    (versionRoutes() <+>
+      versionRoutes.on(Root / "knowledge-graph" / "version") <+>
+      nonAuthorizedRoutes <+> authorizedRoutes).withMetrics
 
   private lazy val authorizedRoutes: HttpRoutes[F] = authMiddleware {
     `GET /datasets/*` <+> `GET /entities/*` <+> `GET /projects/*` <+> `GET /users/*` <+> getRecentEntities

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/docs/Endpoint.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/docs/Endpoint.scala
@@ -50,6 +50,7 @@ object Endpoint {
                        projects.datasets.tags.EndpointDocs[F],
                        users.projects.EndpointDocs[F],
                        entities.currentuser.recentlyviewed.EndpointDocs[F],
+                       version.EndpointDocs.pure[F].widen[docs.EndpointDocs],
                        EndpointDocs[F]
                      ).sequence
   } yield new EndpointImpl[F](serviceVersion, endpointsDocs)

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/version/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/version/EndpointDocs.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.knowledgegraph.version
+
+import eu.timepit.refined.auto._
+import io.circe.syntax._
+import io.renku.config.{ServiceName, ServiceVersion}
+import io.renku.data.Message
+import io.renku.http.server.version.Endpoint.encoder
+import io.renku.knowledgegraph.docs
+import io.renku.knowledgegraph.docs.model.Operation.GET
+import io.renku.knowledgegraph.docs.model._
+
+trait EndpointDocs {
+  def path: Path
+}
+
+object EndpointDocs extends docs.EndpointDocs {
+
+  override lazy val path: Path = Path(
+    GET(
+      "Version",
+      "Returns info about service version",
+      Uri / "version",
+      Status.Ok -> Response(
+        "Info about service version",
+        Contents(
+          MediaType.`application/json`("Sample response",
+                                       (ServiceName("knowledge-graph") -> ServiceVersion("2.43.0")).asJson
+          )
+        )
+      ),
+      Status.InternalServerError ->
+        Response("Error", Contents(MediaType.`application/json`("Reason", Message.Error("Message"))))
+    )
+  )
+}

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
@@ -1022,6 +1022,12 @@ class MicroserviceRoutesSpec
     }
   }
 
+  "GET /knowledge-graph/version" should {
+    "return response from the version endpoint - the same as /version" in new TestCase {
+      routes().call(Request(GET, uri"/knowledge-graph/version")).status shouldBe versionEndpointResponse.status
+    }
+  }
+
   private trait TestCase {
 
     private implicit val ru: RenkuUrl = renkuUrls.generateOne
@@ -1083,6 +1089,16 @@ class MicroserviceRoutesSpec
         HttpRoutes.of[IO] { case GET -> Root / "version" => versionEndpointResponse.pure[IO] }
       }
       .atLeastOnce()
+
+    {
+      import org.http4s.dsl.io.{GET => _, _}
+      (versionRoutes.on _)
+        .expects(Root / "knowledge-graph" / "version")
+        .returning {
+          HttpRoutes.of[IO] { case GET -> Root / "knowledge-graph" / "version" => versionEndpointResponse.pure[IO] }
+        }
+        .atLeastOnce()
+    }
 
     def givenDSAuthorizer(requestedDS:   RequestedDataset,
                           maybeAuthUser: Option[AuthUser],

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/version/EndpointDocsSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/version/EndpointDocsSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.knowledgegraph.version
+
+import io.renku.knowledgegraph.docs.OpenApiTester._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class EndpointDocsSpec extends AnyFlatSpec with should.Matchers {
+
+  it should "return a valid Path object" in {
+    validatePath(EndpointDocs.path)
+  }
+}


### PR DESCRIPTION
This PR adds another `GET /knowledge-graph/version` endpoint to the knowledge-graph service for our external users.

closes #1748 