### PR TITLE
chore: upgrade to java 21

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:
@@ -93,7 +93,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Setup cache
         uses: actions/cache@v2
         with:

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/Project.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/data/Project.scala
@@ -31,7 +31,7 @@ import io.renku.graph.model.testentities
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints._
 
-import java.net.{MalformedURLException, URL}
+import java.net.URI
 
 final case class Project(entitiesProject: testentities.RenkuProject,
                          id:              GitLabId,
@@ -120,7 +120,7 @@ object Project {
       addConstraint(
         check = url =>
           (url endsWith ".git") && Validated
-            .catchOnly[MalformedURLException](new URL(url))
+            .catchOnly[IllegalArgumentException](new URI(url).toURL)
             .isValid,
         message = url => s"$url is not a valid repository http url"
       )

--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/stubs/RemoteTriplesGenerator.scala
@@ -32,7 +32,7 @@ import io.renku.graph.model._
 import io.renku.graph.model.events.CommitId
 import io.renku.jsonld.JsonLD
 
-import java.net.URL
+import java.net.URI
 
 trait RemoteTriplesGenerator {
   self: ApplicationServices =>
@@ -122,9 +122,9 @@ trait RemoteTriplesGenerator {
 private object RemoteTriplesGeneratorWiremockInstance {
   private val logger = TestLogger()
 
-  private val remoteTriplesGeneratorUrl = new URL(
+  private val remoteTriplesGeneratorUrl = new URI(
     ConfigFactory.load().getString("services.remote-triples-generator.url")
-  )
+  ).toURL
 
   private val port: Int = remoteTriplesGeneratorUrl.getPort
 

--- a/build.sbt
+++ b/build.sbt
@@ -328,7 +328,7 @@ lazy val commonSettings = Seq(
   // Format: on
   organizationName := "Swiss Data Science Center (SDSC)",
   startYear := Some(java.time.LocalDate.now().getYear),
-  licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+  licenses += ("Apache-2.0", new URI("https://www.apache.org/licenses/LICENSE-2.0.txt").toURL),
   headerLicense := Some(
     HeaderLicense.Custom(
       s"""|Copyright ${java.time.LocalDate.now().getYear} Swiss Data Science Center (SDSC)

--- a/commit-event-service/Dockerfile
+++ b/commit-event-service/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM eclipse-temurin:17-jre-alpine as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project commit-event-service" stage  && \
     apk del .build-dependencies
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /opt/commit-event-service
 

--- a/event-log/Dockerfile
+++ b/event-log/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM eclipse-temurin:17-jre-alpine as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project event-log" stage && \
     apk del .build-dependencies
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /opt/event-log
 

--- a/graph-commons/src/main/scala/io/renku/events/Subscription.scala
+++ b/graph-commons/src/main/scala/io/renku/events/Subscription.scala
@@ -28,7 +28,7 @@ import io.renku.tinytypes.constraints.{NonBlank, PositiveInt, Url}
 import Subscription._
 import io.renku.tinytypes.json.TinyTypeDecoders.{intDecoder, stringDecoder}
 
-import java.net.URL
+import java.net.URI
 
 trait Subscription {
   val categoryName: CategoryName
@@ -64,7 +64,7 @@ object Subscription {
 
     implicit val microserviceBaseUrlConverter: TinyTypeConverter[SubscriberUrl, MicroserviceBaseUrl] =
       (subscriberUrl: SubscriberUrl) => {
-        val url = new URL(subscriberUrl.value)
+        val url = new URI(subscriberUrl.value).toURL
         MicroserviceBaseUrl(s"${url.getProtocol}://${url.getHost}:${url.getPort}").asRight[IllegalArgumentException]
       }
   }

--- a/knowledge-graph/Dockerfile
+++ b/knowledge-graph/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM eclipse-temurin:17-jre-alpine as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project knowledge-graph" stage && \
     apk del .build-dependencies
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /opt/knowledge-graph
 

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
@@ -29,7 +29,7 @@ import io.renku.jsonld.{EntityId, JsonLDDecoder, JsonLDEncoder}
 import io.renku.tinytypes._
 import io.renku.tinytypes.constraints._
 
-import java.net.{MalformedURLException, URL}
+import java.net.URI
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -226,7 +226,7 @@ object projects {
     addConstraint(
       check = url =>
         (url endsWith ".git") && Validated
-          .catchOnly[MalformedURLException](new URL(url))
+          .catchOnly[IllegalArgumentException](new URI(url).toURL)
           .isValid,
       message = url => s"$url is not a valid repository http url"
     )

--- a/tiny-types/src/main/scala/io/renku/tinytypes/constraints/Url.scala
+++ b/tiny-types/src/main/scala/io/renku/tinytypes/constraints/Url.scala
@@ -20,13 +20,13 @@ package io.renku.tinytypes.constraints
 
 import io.renku.tinytypes._
 
-import java.net.URL
+import java.net.URI
 import scala.language.implicitConversions
 import scala.util.Try
 
 trait Url[TT <: TinyType { type V = String }] extends Constraints[TT] {
   addConstraint(
-    check = url => Try(new URL(url)).isSuccess,
+    check = url => Try(new URI(url).toURL).isSuccess,
     message = (url: String) => s"Cannot instantiate $typeName with '$url'"
   )
 }

--- a/token-repository/Dockerfile
+++ b/token-repository/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM eclipse-temurin:17-jre-alpine as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project token-repository" stage && \
     apk del .build-dependencies
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /opt/token-repository
 

--- a/triples-generator/Dockerfile
+++ b/triples-generator/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM eclipse-temurin:17-jre-alpine as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project triples-generator" stage && \
     apk del .build-dependencies
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /opt/triples-generator
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/triplesgeneration/renkulog/Commands.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/awaitinggeneration/triplesgeneration/renkulog/Commands.scala
@@ -54,7 +54,7 @@ private object Commands {
 
   class GitLabRepoUrlFinderImpl[F[_]: MonadThrow](gitLabUrl: GitLabUrl) extends GitLabRepoUrlFinder[F] {
 
-    import java.net.URL
+    import java.net.URI
 
     override def findRepositoryUrl(projectSlug: projects.Slug)(implicit
         maybeAccessToken: Option[AccessToken]
@@ -72,7 +72,7 @@ private object Commands {
       MonadThrow[F].fromEither {
         ServiceUrl.from {
           val url              = gitLabUrl.value
-          val protocol         = new URL(url).getProtocol
+          val protocol         = new URI(url).toURL.getProtocol
           val serviceWithToken = url.replace(s"$protocol://", s"$protocol://$urlTokenPart")
           s"$serviceWithToken/$projectSlug.git"
         }

--- a/webhook-service/Dockerfile
+++ b/webhook-service/Dockerfile
@@ -1,7 +1,7 @@
 # This is a multi-stage build, see reference:
 # https://docs.docker.com/develop/develop-images/multistage-build/
 
-FROM eclipse-temurin:17-jre-alpine as builder
+FROM eclipse-temurin:21-jre-alpine as builder
 
 WORKDIR /work
 
@@ -16,7 +16,7 @@ RUN export PATH="/usr/local/sbt/bin:$PATH" && \
     sbt "project webhook-service" stage  && \
     apk del .build-dependencies
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /opt/webhook-service
 


### PR DESCRIPTION
This PR:
* addresses all compilation issues related to upgrade to Java 21
* switches all the services to run on Java 21
* switches all the GH jobs to run on Java 21

/deploy renku=jena-4.10.0-upgrade