### PR TITLE
feat: Secret config reader to work with base64 and ASCII values

### DIFF
--- a/graph-commons/src/main/scala/io/renku/config/ConfigLoader.scala
+++ b/graph-commons/src/main/scala/io/renku/config/ConfigLoader.scala
@@ -78,10 +78,25 @@ object ConfigLoader {
           .getOrElse(Left(CannotConvert(stringValue, ttApply.getClass.toString, "Not an int value")))
       }
 
-  implicit def base64ByteVectorReader: ConfigReader[ByteVector] =
-    ConfigReader.fromString { str =>
+  def asciiByteVectorReader: ConfigReader[ByteVector] =
+    ConfigReader.fromString { v =>
       ByteVector
-        .fromBase64Descriptive(str)
-        .leftMap(err => new FailureReason { override lazy val description: String = s"Cannot read base64: $err" })
+        .encodeAscii(v)
+        .leftMap(err =>
+          new FailureReason {
+            override lazy val description: String = s"Only ASCII characters allowed: $err"
+          }
+        )
+    }
+
+  def base64ByteVectorReader: ConfigReader[ByteVector] =
+    ConfigReader.fromString { v =>
+      ByteVector
+        .fromBase64Descriptive(v)
+        .leftMap(err =>
+          new FailureReason {
+            override lazy val description: String = s"Not a valid Base64 value: $err"
+          }
+        )
     }
 }

--- a/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
+++ b/graph-commons/src/main/scala/io/renku/crypto/AesCrypto.scala
@@ -26,6 +26,7 @@ import pureconfig.ConfigReader
 import pureconfig.error.FailureReason
 import scodec.bits.ByteVector
 
+import java.nio.charset.CharacterCodingException
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Base64
 import javax.crypto.Cipher
@@ -63,7 +64,8 @@ abstract class AesCrypto[F[_]: MonadThrow, NONENCRYPTED, ENCRYPTED](secret: Secr
 object AesCrypto {
 
   final class Secret private (val value: ByteVector) extends AnyVal {
-    override def toString: String = "<sensitive>"
+    override def toString: String                                   = "<sensitive>"
+    def decodeAscii:       Either[CharacterCodingException, String] = value.decodeAscii
   }
 
   object Secret {

--- a/graph-commons/src/test/scala/io/renku/cache/CacheConfigLoaderSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/cache/CacheConfigLoaderSpec.scala
@@ -27,6 +27,7 @@ import scala.concurrent.duration._
 class CacheConfigLoaderSpec extends AnyWordSpec with should.Matchers {
 
   "CacheConfigLoader" should {
+
     "load from given config" in {
       val cfg = ConfigFactory.parseString("""evict-strategy = oldest
                                             |ignore-empty-values = true
@@ -39,7 +40,7 @@ class CacheConfigLoaderSpec extends AnyWordSpec with should.Matchers {
                                             |""".stripMargin)
 
       val cc = CacheConfigLoader.unsafeRead(cfg)
-      cc shouldBe CacheConfig(EvictStrategy.Oldest, true, 5.seconds, Periodic(1000, 10.minutes))
+      cc shouldBe CacheConfig(EvictStrategy.Oldest, ignoreEmptyValues = true, 5.seconds, Periodic(1000, 10.minutes))
     }
   }
 }

--- a/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
@@ -44,7 +44,7 @@ class SecretSpec extends AnyWordSpec with should.Matchers with EitherValues with
 
       forAll(aesCryptoSecrets) { secret =>
         val config = ConfigFactory.parseMap(
-          Map(keyName -> new String(secret.value.toArray, "US-ASCII")).asJava
+          Map(keyName -> secret.decodeAscii.fold(throw _, identity)).asJava
         )
 
         ConfigSource.fromConfig(config).at(keyName).load[Secret].value shouldBe secret

--- a/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
+++ b/graph-commons/src/test/scala/io/renku/crypto/SecretSpec.scala
@@ -23,6 +23,7 @@ import io.renku.crypto.AesCrypto.Secret
 import io.renku.generators.CommonGraphGenerators.aesCryptoSecrets
 import io.renku.generators.Generators.Implicits._
 import org.scalacheck.Gen
+import org.scalacheck.Gen.hexChar
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -31,44 +32,72 @@ import pureconfig.ConfigSource
 import scodec.bits.Bases.Alphabets
 import scodec.bits.ByteVector
 
+import scala.jdk.CollectionConverters._
+
 class SecretSpec extends AnyWordSpec with should.Matchers with EitherValues with ScalaCheckPropertyChecks {
 
   "secretReader" should {
 
     val keyName = "secret"
 
-    "decode Base64 encoded secret" in {
-      forAll(aesCryptoSecrets) { secret =>
-        val config = ConfigFactory.parseString(s"""$keyName = "${secret.toBase64}"""")
+    "read an ASCII secret" in {
 
-        ConfigSource.fromConfig(config).at(keyName).load[Secret].value.toBase64 shouldBe secret.toBase64
+      forAll(aesCryptoSecrets) { secret =>
+        val config = ConfigFactory.parseMap(
+          Map(keyName -> new String(secret.value.toArray, "US-ASCII")).asJava
+        )
+
+        ConfigSource.fromConfig(config).at(keyName).load[Secret].value shouldBe secret
       }
     }
 
-    "decode Base64 encoded secret ending with LF char" in {
+    // we need to keep this functionality due to backward compatibility
+    // where Base64 encoded values were coming to the reader
+    "read a Base64 encoded secret" in {
+
+      val secret = generateHexSecret
+
+      val config = ConfigFactory.parseMap(Map(keyName -> secret.toBase64).asJava)
+
+      ConfigSource.fromConfig(config).at(keyName).load[Secret].value.value shouldBe secret.takeWhile(_ != 10)
+    }
+
+    "decode Base64 encoded secret ending with a LF char" in {
 
       val secret = aesCryptoSecrets.generateOne
 
-      val config = ConfigFactory.parseString(s"""$keyName = "${(secret.value :+ 10.toByte).toBase64}"""")
+      val config = ConfigFactory.parseMap(
+        Map(keyName -> (secret.value :+ 10.toByte).toBase64).asJava
+      )
 
-      ConfigSource.fromConfig(config).at(keyName).load[Secret].value.toBase64 shouldBe secret.toBase64
+      ConfigSource.fromConfig(config).at(keyName).load[Secret].value shouldBe secret
     }
 
     "fail and not print the secret if decoding fails" in {
 
-      val value = Gen
+      val secret = Gen
         .listOfN(2, Gen.hexChar)
         .map(_.mkString.toLowerCase)
         .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
         .generateOne
         .toBase64
 
-      val config = ConfigFactory.parseString(s"""$keyName = "$value"""")
+      val config = ConfigFactory.parseMap(Map(keyName -> secret).asJava)
 
       val failure = ConfigSource.fromConfig(config).at(keyName).load[Secret].left.value.prettyPrint()
 
       failure should include("Cannot read AES secret")
-      failure should not include value
+      failure should not include secret
     }
+  }
+
+  private def generateHexSecret = {
+    val secretLength = Gen.oneOf(16, 24, 32).generateOne * 2
+    hexChar
+      .toGeneratorOfList(min = secretLength, max = secretLength)
+      .map(_.mkString.toLowerCase)
+      .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
+      .retryUntil(_.takeWhile(_ != 10.toByte).length == secretLength / 2)
+      .generateOne
   }
 }

--- a/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
+++ b/graph-commons/src/test/scala/io/renku/generators/CommonGraphGenerators.scala
@@ -49,8 +49,8 @@ import io.renku.microservices.{MicroserviceBaseUrl, MicroserviceIdentifier}
 import io.renku.triplesstore._
 import org.http4s.Status
 import org.http4s.Status._
+import org.scalacheck.Gen.asciiPrintableChar
 import org.scalacheck.{Arbitrary, Gen}
-import scodec.bits.Bases.Alphabets
 import scodec.bits.ByteVector
 
 import scala.language.implicitConversions
@@ -63,10 +63,10 @@ object CommonGraphGenerators {
       .oneOf(16, 24, 32)
       .flatMap { length =>
         Gen
-          .listOfN(length * 2, Gen.hexChar)
-          .map(_.mkString.toLowerCase)
-          .map(ByteVector.fromValidHex(_, Alphabets.HexLowercase))
-          .retryUntil(_.takeWhile(_ != 10.toByte).length == length) // this is to prevent LF chars to be generated
+          .listOfN(length, asciiPrintableChar)
+          .map(_.mkString)
+          .map(_.getBytes("US-ASCII"))
+          .map(ByteVector(_))
           .map(Secret.unsafe)
       }
 

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/AccessTokenCryptoSpec.scala
@@ -86,7 +86,7 @@ class AccessTokenCryptoSpec extends AnyWordSpec with should.Matchers with TableD
       val config = ConfigFactory.parseMap(
         Map(
           "projects-tokens" -> Map(
-            "secret" -> aesCryptoSecrets.generateOne.toBase64
+            "secret" -> aesCryptoSecrets.generateOne.decodeAscii.fold(throw _, identity)
           ).asJava
         ).asJava
       )

--- a/webhook-service/src/test/scala/io/renku/webhookservice/crypto/HookTokenCryptoSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/crypto/HookTokenCryptoSpec.scala
@@ -80,7 +80,7 @@ class HookTokenCryptoSpec extends AnyWordSpec with should.Matchers with TryValue
         Map(
           "services" -> Map(
             "gitlab" -> Map(
-              "hook-token-secret" -> aesCryptoSecrets.generateOne.toBase64
+              "hook-token-secret" -> aesCryptoSecrets.generateOne.decodeAscii.fold(throw _, identity)
             ).asJava
           ).asJava
         ).asJava


### PR DESCRIPTION
This PR changes the crypt secret config reader so it can read ASCII and base64 encoded values.

closes #1768 

/deploy