### PR TITLE
refactor: Search graphs properties clean-up 

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/DatasetInfoDeleteQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/DatasetInfoDeleteQuery.scala
@@ -34,7 +34,6 @@ private object DatasetInfoDeleteQuery {
       Prefixes of (renku -> "renku", schema -> "schema"),
       sparql"""|DELETE {
                |  GRAPH ${GraphClass.Datasets.id} {
-               |    ?imageId ?imagePred ?imageObj.
                |    ?linkId ?linkPred ?linkObj.
                |    ?topSameAs ?dsPred ?dsObj.
                |  }
@@ -42,11 +41,6 @@ private object DatasetInfoDeleteQuery {
                |WHERE {
                |  GRAPH ${GraphClass.Datasets.id} {
                |    BIND (${topmostSameAs.asEntityId} AS ?topSameAs)
-               |
-               |    OPTIONAL {
-               |      ?topSameAs schema:image ?imageId.
-               |      ?imageId ?imagePred ?imageObj.
-               |    }
 
                |    OPTIONAL {
                |      ?topSameAs renku:datasetProjectLink ?linkId.

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/Encoders.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/Encoders.scala
@@ -33,14 +33,6 @@ import io.renku.triplesstore.client.syntax._
 
 private[datasets] object Encoders {
 
-  implicit val imageEncoder: QuadsEncoder[Image] = QuadsEncoder.instance { case Image(resourceId, uri, position) =>
-    Set(
-      DatasetsQuad(resourceId, rdf / "type", Image.Ontology.typeClass.id),
-      DatasetsQuad(resourceId, Image.Ontology.contentUrlProperty.id, uri.asObject),
-      DatasetsQuad(resourceId, Image.Ontology.positionProperty.id, position.asObject)
-    )
-  }
-
   implicit val linkEncoder: QuadsEncoder[Link] = QuadsEncoder.instance { link =>
     val typeQuads = link match {
       case _: OriginalDataset =>
@@ -93,17 +85,8 @@ private[datasets] object Encoders {
     val maybeCreatorsNamesConcatQuad =
       maybeConcatQuad[persons.Name](creatorsNamesConcatProperty.id, info.creators.toList.map(_.name).distinct, _.value)
 
-    val keywordsQuads = info.keywords.toSet.map { (k: datasets.Keyword) =>
-      searchInfoQuad(keywordsProperty.id, k.asObject)
-    }
-
     val maybeKeywordsConcatQuad =
       maybeConcatQuad[datasets.Keyword](keywordsConcatProperty.id, info.keywords.distinct, _.value)
-
-    val imagesQuads = info.images.toSet.flatMap { (i: Image) =>
-      i.asQuads +
-        searchInfoQuad(imageProperty, i.resourceId.asEntityId)
-    }
 
     val maybeImagesConcatQuad =
       maybeConcatQuad[Image](imagesConcatProperty.id,
@@ -129,6 +112,6 @@ private[datasets] object Encoders {
       maybeCreatorsNamesConcatQuad,
       maybeKeywordsConcatQuad,
       maybeImagesConcatQuad
-    ).flatten ++ projectsVisibilitiesConcatQuads ++ creatorsQuads ++ keywordsQuads ++ imagesQuads ++ linksQuads
+    ).flatten ++ projectsVisibilitiesConcatQuads ++ creatorsQuads ++ linksQuads
   }
 }

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/Encoders.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/commands/Encoders.scala
@@ -22,7 +22,7 @@ package commands
 import DatasetSearchInfoOntology._
 import Link.{ImportedDataset, OriginalDataset}
 import cats.syntax.all._
-import io.renku.entities.searchgraphs.toConcatValue
+import io.renku.entities.searchgraphs.maybeTripleObject
 import io.renku.graph.model.Schemas.{rdf, renku}
 import io.renku.graph.model.images.Image
 import io.renku.graph.model.{datasets, persons}
@@ -51,7 +51,7 @@ private[datasets] object Encoders {
 
   implicit val projectsVisibilitiesConcatEncoder: QuadsEncoder[(datasets.TopmostSameAs, List[Link])] =
     QuadsEncoder.instance { case (topSameAs, links) =>
-      toConcatValue[Link](links, link => s"${link.projectSlug.value}:${link.visibility.value}")
+      maybeTripleObject[Link](links, link => s"${link.projectSlug.value}:${link.visibility.value}")
         .map(DatasetsQuad(topSameAs, projectsVisibilitiesConcatProperty.id, _))
         .toSet
     }
@@ -61,7 +61,7 @@ private[datasets] object Encoders {
       DatasetsQuad(info.topmostSameAs, predicate, obj)
 
     def maybeConcatQuad[A](property: Property, values: List[A], toValue: A => String): Option[Quad] =
-      toConcatValue(values, toValue).map(searchInfoQuad(property, _))
+      maybeTripleObject(values, toValue).map(searchInfoQuad(property, _))
 
     val createdOrPublishedQuad = info.createdOrPublished match {
       case d: datasets.DateCreated =>

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/ontology.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/datasets/ontology.scala
@@ -20,7 +20,6 @@ package io.renku.entities.searchgraphs.datasets
 
 import io.renku.graph.model.Schemas.{xsd, _}
 import io.renku.graph.model.entities.{Dataset, Person, Project}
-import io.renku.graph.model.images.Image
 import io.renku.jsonld.Property
 import io.renku.jsonld.ontology._
 
@@ -31,12 +30,10 @@ object DatasetSearchInfoOntology {
   val dateCreatedProperty:         DataProperty.Def = Dataset.Ontology.dateCreatedProperty
   val datePublishedProperty:       DataProperty.Def = Dataset.Ontology.datePublishedProperty
   val dateModifiedProperty:        DataProperty.Def = DataProperty(schema / "dateModified", xsd / "dateTime")
-  val keywordsProperty:            DataProperty.Def = Dataset.Ontology.keywordsProperty
   val keywordsConcatProperty:      DataProperty.Def = DataProperty(renku / "keywordsConcat", xsd / "string")
   val descriptionProperty:         DataProperty.Def = Dataset.Ontology.descriptionProperty
   val creatorProperty:             Property         = Dataset.Ontology.creator
   val creatorsNamesConcatProperty: DataProperty.Def = DataProperty(renku / "creatorsNamesConcat", xsd / "string")
-  val imageProperty:               Property         = Dataset.Ontology.image
   val imagesConcatProperty:        DataProperty.Def = DataProperty(renku / "imagesConcat", xsd / "string")
   val linkProperty:                Property         = renku / "datasetProjectLink"
   val projectsVisibilitiesConcatProperty: DataProperty.Def =
@@ -46,7 +43,6 @@ object DatasetSearchInfoOntology {
     Class(renku / "DiscoverableDataset"),
     ObjectProperties(
       ObjectProperty(creatorProperty, Person.Ontology.typeDef),
-      ObjectProperty(imageProperty, Image.Ontology.typeDef),
       ObjectProperty(linkProperty, LinkOntology.typeDef)
     ),
     DataProperties(
@@ -55,7 +51,6 @@ object DatasetSearchInfoOntology {
       dateCreatedProperty,
       datePublishedProperty,
       dateModifiedProperty,
-      keywordsProperty,
       keywordsConcatProperty,
       descriptionProperty,
       creatorsNamesConcatProperty,

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/package.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/package.scala
@@ -24,7 +24,7 @@ import io.renku.triplesstore.client.syntax._
 package object searchgraphs {
   val concatSeparator: Char = ';'
 
-  private[searchgraphs] def toConcatValue[A](values: List[A], toValue: A => String): Option[TripleObject] =
+  private[searchgraphs] def maybeTripleObject[A](values: List[A], toValue: A => String): Option[TripleObject] =
     values match {
       case Nil => Option.empty[TripleObject]
       case vls =>

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/commands/Encoders.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/commands/Encoders.scala
@@ -32,14 +32,6 @@ import io.renku.triplesstore.client.syntax._
 
 private object Encoders {
 
-  implicit val imageEncoder: QuadsEncoder[Image] = QuadsEncoder.instance { case Image(resourceId, uri, position) =>
-    Set(
-      ProjectsQuad(resourceId, rdf / "type", Image.Ontology.typeClass.id),
-      ProjectsQuad(resourceId, Image.Ontology.contentUrlProperty.id, uri.asObject),
-      ProjectsQuad(resourceId, Image.Ontology.positionProperty.id, position.asObject)
-    )
-  }
-
   implicit val searchInfoEncoder: QuadsEncoder[ProjectSearchInfo] = QuadsEncoder.instance { info =>
     def searchInfoQuad(predicate: Property, obj: TripleObject): Quad =
       ProjectsQuad(info.id, predicate, obj)
@@ -55,16 +47,8 @@ private object Encoders {
       searchInfoQuad(creatorProperty, resourceId.asEntityId)
     }
 
-    val keywordsQuads = info.keywords.toSet.map { (k: projects.Keyword) =>
-      searchInfoQuad(keywordsProperty.id, k.asObject)
-    }
-
     val maybeKeywordsConcatQuad =
       maybeConcatQuad[projects.Keyword](keywordsConcatProperty.id, info.keywords.distinct, _.value)
-
-    val imagesQuads = info.images.toSet.flatMap { (i: Image) =>
-      i.asQuads + searchInfoQuad(imageProperty, i.resourceId.asEntityId)
-    }
 
     val maybeImagesConcatQuad =
       maybeConcatQuad[Image](imagesConcatProperty.id,
@@ -83,6 +67,6 @@ private object Encoders {
       maybeKeywordsConcatQuad,
       maybeImagesConcatQuad,
       maybeDescriptionQuad
-    ).flatten ++ creatorQuads ++ keywordsQuads ++ imagesQuads
+    ).flatten ++ creatorQuads
   }
 }

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/commands/ProjectInfoDeleteQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/commands/ProjectInfoDeleteQuery.scala
@@ -34,19 +34,12 @@ private[projects] object ProjectInfoDeleteQuery {
       Prefixes of schema -> "schema",
       sparql"""|DELETE {
                |  GRAPH ${GraphClass.Projects.id} {
-               |    ?imageId ?imagePred ?imageObj.
                |    ?projId ?projPred ?projObj.
                |  }
                |}
                |WHERE {
                |  GRAPH ${GraphClass.Projects.id} {
                |    BIND (${projectId.asEntityId} AS ?projId)
-               |
-               |    OPTIONAL {
-               |      ?projId schema:image ?imageId.
-               |      ?imageId ?imagePred ?imageObj.
-               |    }
-               |
                |    ?projId ?projPred ?projObj.
                |  }
                |}

--- a/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/ontology.scala
+++ b/entities-search/src/main/scala/io/renku/entities/searchgraphs/projects/ontology.scala
@@ -19,8 +19,7 @@
 package io.renku.entities.searchgraphs.projects
 
 import io.renku.graph.model.Schemas.renku
-import io.renku.graph.model.entities.{Dataset, Person, Project}
-import io.renku.graph.model.images.Image
+import io.renku.graph.model.entities.{Person, Project}
 import io.renku.jsonld.Property
 import io.renku.jsonld.ontology._
 
@@ -32,18 +31,15 @@ object ProjectSearchInfoOntology {
   val visibilityProperty:     DataProperty.Def = Project.Ontology.visibilityProperty
   val dateCreatedProperty:    DataProperty.Def = Project.Ontology.dateCreatedProperty
   val dateModifiedProperty:   DataProperty.Def = Project.Ontology.dateModifiedProperty
-  val keywordsProperty:       DataProperty.Def = Project.Ontology.keywordsProperty
   val keywordsConcatProperty: DataProperty.Def = DataProperty(renku / "keywordsConcat", xsd / "string")
   val descriptionProperty:    DataProperty.Def = Project.Ontology.descriptionProperty
   val creatorProperty:        Property         = Project.Ontology.creator
-  val imageProperty:          Property         = Project.Ontology.image
   val imagesConcatProperty:   DataProperty.Def = DataProperty(renku / "imagesConcat", xsd / "string")
 
   lazy val typeDef: Type = Type.Def(
     Class(renku / "DiscoverableProject"),
     ObjectProperties(
-      ObjectProperty(creatorProperty, Person.Ontology.typeDef),
-      ObjectProperty(imageProperty, Image.Ontology.typeDef)
+      ObjectProperty(creatorProperty, Person.Ontology.typeDef)
     ),
     DataProperties(
       nameProperty,
@@ -52,25 +48,9 @@ object ProjectSearchInfoOntology {
       visibilityProperty,
       dateCreatedProperty,
       dateModifiedProperty,
-      keywordsProperty,
       keywordsConcatProperty,
       descriptionProperty,
       imagesConcatProperty
     )
-  )
-}
-
-object LinkOntology {
-
-  val project: Property = renku / "project"
-  val dataset: Property = renku / "dataset"
-
-  lazy val typeDef: Type = Type.Def(
-    Class(renku / "DatasetProjectLink"),
-    ObjectProperties(
-      ObjectProperty(project, Project.Ontology.typeDef),
-      ObjectProperty(dataset, Dataset.Ontology.typeDef)
-    ),
-    DataProperties()
   )
 }

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/datasets/commands/EncodersSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/datasets/commands/EncodersSpec.scala
@@ -24,12 +24,9 @@ import Generators.{datasetSearchInfoObjects, importedDatasetLinkObjectsGen, orig
 import cats.syntax.all._
 import io.renku.entities.searchgraphs.concatSeparator
 import io.renku.generators.Generators.Implicits._
-import io.renku.generators.Generators.positiveInts
-import io.renku.generators.jsonld.JsonLDGenerators.entityIds
-import io.renku.graph.model.GraphModelGenerators.{datasetTopmostSameAs, imageUris}
-import io.renku.graph.model.Schemas.{rdf, renku, schema}
+import io.renku.graph.model.GraphModelGenerators.datasetTopmostSameAs
+import io.renku.graph.model.Schemas.{rdf, renku}
 import io.renku.graph.model.datasets
-import io.renku.graph.model.images.{Image, ImagePosition, ImageResourceId}
 import io.renku.jsonld.syntax._
 import io.renku.triplesstore.client.model.Quad
 import io.renku.triplesstore.client.syntax._
@@ -40,26 +37,6 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class EncodersSpec extends AnyWordSpec with should.Matchers with ScalaCheckPropertyChecks {
 
   import io.renku.entities.searchgraphs.datasets.commands.Encoders._
-
-  "imageEncoder" should {
-
-    "turn an Image object into a Set of relevant Quads" in {
-
-      val image = {
-        for {
-          id       <- entityIds.toGeneratorOf(id => ImageResourceId(id.toString))
-          uri      <- imageUris
-          position <- positiveInts().toGeneratorOf(p => ImagePosition(p.value))
-        } yield Image(id, uri, position)
-      }.generateOne
-
-      image.asQuads shouldBe Set(
-        DatasetsQuad(image.resourceId, rdf / "type", schema / "ImageObject"),
-        DatasetsQuad(image.resourceId, Image.Ontology.contentUrlProperty.id, image.uri.asObject),
-        DatasetsQuad(image.resourceId, Image.Ontology.positionProperty.id, image.position.asObject)
-      )
-    }
-  }
 
   "linkEncoder" should {
 
@@ -105,11 +82,9 @@ class EncodersSpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
         ) ++
           maybeDateModifiedToQuad(searchInfo.topmostSameAs)(searchInfo.maybeDateModified) ++
           creatorsToQuads(searchInfo) ++
-          keywordsToQuads(searchInfo) ++
           maybeDescToQuad(searchInfo.topmostSameAs)(searchInfo.maybeDescription) ++
           maybeKeywordsConcatToQuad(searchInfo).toSet ++
           maybeImagesConcatToQuad(searchInfo).toSet ++
-          imagesToQuads(searchInfo) ++
           linksToQuads(searchInfo)
       }
     }
@@ -139,11 +114,6 @@ class EncodersSpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
   private def creatorsNamesConcat(searchInfo: DatasetSearchInfo) =
     searchInfo.creators.map(_.name.value).intercalate(concatSeparator.toString).asTripleObject
 
-  private def keywordsToQuads(searchInfo: DatasetSearchInfo): Set[Quad] =
-    searchInfo.keywords
-      .map(k => DatasetsQuad(searchInfo.topmostSameAs, keywordsProperty.id, k.asObject))
-      .toSet
-
   private def maybeKeywordsConcatToQuad(searchInfo: DatasetSearchInfo): Option[Quad] =
     searchInfo.keywords match {
       case Nil => Option.empty[Quad]
@@ -170,12 +140,6 @@ class EncodersSpec extends AnyWordSpec with should.Matchers with ScalaCheckPrope
                      images.map(i => s"${i.position}:${i.uri}").mkString(concatSeparator.toString).asTripleObject
         ).some
     }
-
-  private def imagesToQuads(searchInfo: DatasetSearchInfo): Set[Quad] =
-    searchInfo.images
-      .map(i => i.asQuads + DatasetsQuad(searchInfo.topmostSameAs, imageProperty, i.resourceId.asEntityId))
-      .toSet
-      .flatten
 
   private def linksToQuads(searchInfo: DatasetSearchInfo): Set[Quad] =
     searchInfo.links

--- a/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
+++ b/graph-commons/src/test/scala/io/renku/triplesstore/InMemoryJena.scala
@@ -105,6 +105,9 @@ trait InMemoryJena {
   def runUpdate(on: DatasetName, query: SparqlQuery): IO[Unit] =
     queryRunnerFor(on).flatMap(_.runUpdate(query))
 
+  def runUpdates(on: DatasetName, queries: List[SparqlQuery]): IO[Unit] =
+    queries.map(runUpdate(on, _)).sequence.void
+
   def triplesCount(on: DatasetName): IO[Long] =
     queryRunnerFor(on)
       .flatMap(

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/DatasetsGraphImagesRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/DatasetsGraphImagesRemover.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas.schema
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import migrations.tooling.RegisteredUpdateQueryMigration
+import org.typelevel.log4cats.Logger
+
+private object DatasetsGraphImagesRemover {
+
+  private lazy val name = Migration.Name("Datasets graph images remover")
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    RegisteredUpdateQueryMigration[F](name, query).widen
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of schema -> "schema",
+    sparql"""|DELETE {
+             |  GRAPH ${GraphClass.Datasets.id} {
+             |    ?topSameAs schema:image ?imageId.
+             |    ?imageId ?imagePred ?imageObj.
+             |  }
+             |}
+             |WHERE {
+             |  GRAPH ${GraphClass.Datasets.id} {
+             |    OPTIONAL {
+             |      ?topSameAs schema:image ?imageId.
+             |      ?imageId ?imagePred ?imageObj.
+             |    }
+             |  }
+             |}
+             |""".stripMargin
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/DatasetsGraphKeywordsRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/DatasetsGraphKeywordsRemover.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas.schema
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import migrations.tooling.RegisteredUpdateQueryMigration
+import org.typelevel.log4cats.Logger
+
+private object DatasetsGraphKeywordsRemover {
+
+  private lazy val name = Migration.Name("Datasets graph keywords remover")
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    RegisteredUpdateQueryMigration[F](name, query).widen
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of schema -> "schema",
+    sparql"""|DELETE {
+             |  GRAPH ${GraphClass.Datasets.id} {
+             |    ?topSameAs schema:keywords ?keywords.
+             |  }
+             |}
+             |WHERE {
+             |  GRAPH ${GraphClass.Datasets.id} {
+             |    OPTIONAL {
+             |      ?topSameAs schema:keywords ?keywords
+             |    }
+             |  }
+             |}
+             |""".stripMargin
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/Migrations.scala
@@ -60,6 +60,10 @@ private[tsmigrationrequest] object Migrations {
     datasetsGraphCreatorsFlattener      <- DatasetsGraphCreatorsFlattener[F]
     datasetsGraphSlugsVisibsFlattener   <- DatasetsGraphSlugsVisibilitiesFlattener[F]
     projectMembersRemover               <- ProjectMembersRemover[F]
+    datasetsGraphKeywordsRemover        <- DatasetsGraphKeywordsRemover[F]
+    datasetsGraphImagesRemover          <- DatasetsGraphImagesRemover[F]
+    projectsGraphKeywordsRemover        <- ProjectsGraphKeywordsRemover[F]
+    projectsGraphImagesRemover          <- ProjectsGraphImagesRemover[F]
     migrations <- validateNames(
                     datasetsCreator,
                     datasetsRemover,
@@ -86,7 +90,11 @@ private[tsmigrationrequest] object Migrations {
                     datasetsGraphImagesFlattener,
                     datasetsGraphCreatorsFlattener,
                     datasetsGraphSlugsVisibsFlattener,
-                    projectMembersRemover
+                    projectMembersRemover,
+                    datasetsGraphKeywordsRemover,
+                    datasetsGraphImagesRemover,
+                    projectsGraphKeywordsRemover,
+                    projectsGraphImagesRemover
                   )
   } yield migrations
 

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsGraphImagesRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsGraphImagesRemover.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas.schema
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import migrations.tooling.RegisteredUpdateQueryMigration
+import org.typelevel.log4cats.Logger
+
+private object ProjectsGraphImagesRemover {
+
+  private lazy val name = Migration.Name("Projects graph images remover")
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    RegisteredUpdateQueryMigration[F](name, query).widen
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of schema -> "schema",
+    sparql"""|DELETE {
+             |  GRAPH ${GraphClass.Projects.id} {
+             |    ?projectId schema:image ?imageId.
+             |    ?imageId ?imagePred ?imageObj.
+             |  }
+             |}
+             |WHERE {
+             |  GRAPH ${GraphClass.Projects.id} {
+             |    OPTIONAL {
+             |      ?projectId schema:image ?imageId.
+             |      ?imageId ?imagePred ?imageObj.
+             |    }
+             |  }
+             |}
+             |""".stripMargin
+  )
+}

--- a/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsGraphKeywordsRemover.scala
+++ b/triples-generator/src/main/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsGraphKeywordsRemover.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest
+package migrations
+
+import cats.effect.Async
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.graph.model.GraphClass
+import io.renku.graph.model.Schemas.schema
+import io.renku.metrics.MetricsRegistry
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore.client.syntax._
+import io.renku.triplesstore.{SparqlQuery, SparqlQueryTimeRecorder}
+import migrations.tooling.RegisteredUpdateQueryMigration
+import org.typelevel.log4cats.Logger
+
+private object ProjectsGraphKeywordsRemover {
+
+  private lazy val name = Migration.Name("Projects graph keywords remover")
+
+  def apply[F[_]: Async: Logger: SparqlQueryTimeRecorder: MetricsRegistry]: F[Migration[F]] =
+    RegisteredUpdateQueryMigration[F](name, query).widen
+
+  private[migrations] lazy val query = SparqlQuery.of(
+    name.asRefined,
+    Prefixes of schema -> "schema",
+    sparql"""|DELETE {
+             |  GRAPH ${GraphClass.Projects.id} {
+             |    ?projectId schema:keywords ?keywords
+             |  }
+             |}
+             |WHERE {
+             |  GRAPH ${GraphClass.Projects.id} {
+             |    OPTIONAL {
+             |      ?projectId schema:keywords ?keywords
+             |    }
+             |  }
+             |}
+             |""".stripMargin
+  )
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/DatasetsGraphPropertiesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/DatasetsGraphPropertiesRemoverSpec.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.entities.searchgraphs.SearchInfoDatasets
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.metrics.TestMetricsRegistry
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.Succeeded
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+import tooling.RegisteredUpdateQueryMigration
+
+class DatasetsGraphPropertiesRemoverSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with SearchInfoDatasets
+    with AsyncMockFactory {
+
+  it should "be a RegisteredUpdateQueryMigration" in {
+    implicit val metricsRegistry: TestMetricsRegistry[IO]     = TestMetricsRegistry[IO]
+    implicit val timeRecorder:    SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+
+    DatasetsGraphKeywordsRemover[IO].asserting(
+      _.getClass shouldBe classOf[RegisteredUpdateQueryMigration[IO]]
+    )
+    DatasetsGraphImagesRemover[IO].asserting(
+      _.getClass shouldBe classOf[RegisteredUpdateQueryMigration[IO]]
+    )
+  }
+
+  it should "remove old keywords and images properties " +
+    "from all datasets in the Datasets graph" in {
+
+      val ds1 -> project1 = anyRenkuProjectEntities
+        .addDataset {
+          datasetEntities(provenanceInternal)
+            .modify(replaceDSKeywords(List.empty))
+            .modify(replaceDSImages(imageUris.generateList(min = 1)))
+        }
+        .generateOne
+        .bimap(_.to[entities.Dataset[entities.Dataset.Provenance.Internal]], _.to[entities.Project])
+      val ds1TopSameAs = ds1.provenance.topmostSameAs
+
+      val ds2 -> project2 = anyRenkuProjectEntities
+        .addDataset {
+          datasetEntities(provenanceInternal)
+            .modify(replaceDSKeywords(datasetKeywords.generateList(min = 1)))
+            .modify(replaceDSImages(List.empty))
+        }
+        .generateOne
+        .bimap(_.to[entities.Dataset[entities.Dataset.Provenance.Internal]], _.to[entities.Project])
+      val ds2TopSameAs = ds2.provenance.topmostSameAs
+
+      for {
+        _ <- provisionProjects(project1, project2).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaKeywords(ds1TopSameAs, ds1)).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaImages(ds1TopSameAs, ds1)).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaKeywords(ds2TopSameAs, ds2)).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaImages(ds2TopSameAs, ds2)).assertNoException
+
+        _ <- fetchKeywords(ds1TopSameAs).asserting(_ shouldBe ds1.additionalInfo.keywords)
+        _ <- fetchImages(ds1TopSameAs).asserting(_ shouldBe ds1.additionalInfo.images.map(_.uri))
+        _ <- fetchKeywords(ds2TopSameAs).asserting(_ shouldBe ds2.additionalInfo.keywords)
+        _ <- fetchImages(ds2TopSameAs).asserting(_ shouldBe ds2.additionalInfo.images.map(_.uri))
+
+        _ <- runUpdate(projectsDataset, DatasetsGraphKeywordsRemover.query).assertNoException
+        _ <- runUpdate(projectsDataset, DatasetsGraphImagesRemover.query).assertNoException
+
+        _ <- fetchKeywords(ds1TopSameAs).asserting(_ shouldBe Nil)
+        _ <- fetchImages(ds1TopSameAs).asserting(_ shouldBe Nil)
+        _ <- fetchKeywords(ds2TopSameAs).asserting(_ shouldBe Nil)
+        _ <- fetchImages(ds2TopSameAs).asserting(_ shouldBe Nil)
+      } yield Succeeded
+    }
+
+  private def fetchKeywords(topSameAs: datasets.TopmostSameAs): IO[List[datasets.Keyword]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test ds keywords",
+        Prefixes of (renku -> "renku", schema -> "schema"),
+        sparql"""|SELECT ?keys
+                 |WHERE {
+                 |   GRAPH ${GraphClass.Datasets.id} {
+                 |     ${topSameAs.asEntityId} schema:keywords ?keys.
+                 |   }
+                 |}
+                 |""".stripMargin
+      )
+    ).map(_.flatMap(_.get("keys").map(datasets.Keyword)))
+
+  private def fetchImages(topSameAs: datasets.TopmostSameAs): IO[List[images.ImageUri]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test ds images",
+        Prefixes of (renku -> "renku", schema -> "schema"),
+        sparql"""|SELECT ?url ?pos
+                 |WHERE {
+                 |   GRAPH ${GraphClass.Datasets.id} {
+                 |     ${topSameAs.asEntityId} schema:image ?imgId.
+                 |     ?imgId schema:contentUrl ?url.
+                 |     ?imgId schema:position ?pos.
+                 |   }
+                 |}
+                 |""".stripMargin
+      )
+    ).map(
+      _.flatMap(row => (row.get("url").map(images.ImageUri(_)) -> row.get("pos").map(_.toInt)).mapN(_ -> _))
+        .sortBy(_._2)
+        .map(_._1)
+    )
+
+  private def insertSchemaKeywords(topSameAs: datasets.TopmostSameAs, ds: entities.Dataset[_]) =
+    ds.additionalInfo.keywords.map { keyword =>
+      SparqlQuery.ofUnsafe(
+        "test insert ds keyword",
+        Prefixes of (renku -> "renku", schema -> "schema"),
+        sparql"""|INSERT DATA {
+                 |  GRAPH ${GraphClass.Datasets.id} {
+                 |    ${topSameAs.asEntityId} schema:keywords ${keyword.asObject}.
+                 |  }
+                 |}
+                 |""".stripMargin
+      )
+    }
+
+  private def insertSchemaImages(topSameAs: datasets.TopmostSameAs, ds: entities.Dataset[_]) =
+    ds.additionalInfo.images.map { image =>
+      SparqlQuery.ofUnsafe(
+        "test insert ds image",
+        Prefixes of (rdf -> "rdf", renku -> "renku", schema -> "schema"),
+        sparql"""|INSERT DATA {
+                 |  GRAPH ${GraphClass.Datasets.id} {
+                 |    ${topSameAs.asEntityId} schema:image ${image.resourceId.asEntityId}.
+                 |    ${image.resourceId.asEntityId} rdf:type schema:ImageObject.
+                 |    ${image.resourceId.asEntityId} schema:contentUrl ${image.uri.asObject}.
+                 |    ${image.resourceId.asEntityId} schema:position ${image.position.asObject}.
+                 |  }
+                 |}
+                 |""".stripMargin
+      )
+    }
+
+  implicit override lazy val ioLogger: Logger[IO] = TestLogger[IO]()
+}

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsGraphPropertiesRemoverSpec.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/tsmigrationrequest/migrations/ProjectsGraphPropertiesRemoverSpec.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.triplesgenerator.events.consumers.tsmigrationrequest.migrations
+
+import cats.effect.IO
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import io.renku.entities.searchgraphs.SearchInfoDatasets
+import io.renku.generators.Generators.Implicits._
+import io.renku.graph.model._
+import io.renku.graph.model.testentities._
+import io.renku.interpreters.TestLogger
+import io.renku.jsonld.syntax._
+import io.renku.logging.TestSparqlQueryTimeRecorder
+import io.renku.metrics.TestMetricsRegistry
+import io.renku.testtools.CustomAsyncIOSpec
+import io.renku.triplesstore.SparqlQuery.Prefixes
+import io.renku.triplesstore._
+import io.renku.triplesstore.client.syntax._
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.Succeeded
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+import org.typelevel.log4cats.Logger
+import tooling.RegisteredUpdateQueryMigration
+
+class ProjectsGraphPropertiesRemoverSpec
+    extends AsyncFlatSpec
+    with CustomAsyncIOSpec
+    with should.Matchers
+    with InMemoryJenaForSpec
+    with ProjectsDataset
+    with SearchInfoDatasets
+    with AsyncMockFactory {
+
+  it should "be a RegisteredUpdateQueryMigration" in {
+    implicit val metricsRegistry: TestMetricsRegistry[IO]     = TestMetricsRegistry[IO]
+    implicit val timeRecorder:    SparqlQueryTimeRecorder[IO] = TestSparqlQueryTimeRecorder[IO].unsafeRunSync()
+
+    ProjectsGraphImagesRemover[IO].asserting(
+      _.getClass shouldBe classOf[RegisteredUpdateQueryMigration[IO]]
+    )
+    ProjectsGraphImagesRemover[IO].asserting(
+      _.getClass shouldBe classOf[RegisteredUpdateQueryMigration[IO]]
+    )
+  }
+
+  it should "remove old keywords and images properties " +
+    "from all projects in the Projects graph" in {
+
+      val project1 = anyRenkuProjectEntities
+        .modify(replaceProjectKeywords(Set.empty))
+        .modify(replaceImages(imageUris.generateList(min = 1)))
+        .generateOne
+        .to[entities.Project]
+      val project2 = anyRenkuProjectEntities
+        .modify(replaceProjectKeywords(projectKeywords.generateSet(min = 1)))
+        .modify(replaceImages(Nil))
+        .generateOne
+        .to[entities.Project]
+
+      for {
+        _ <- provisionProjects(project1, project2).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaKeywords(project1.resourceId, project1)).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaImages(project1.resourceId, project1)).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaKeywords(project2.resourceId, project2)).assertNoException
+        _ <- runUpdates(projectsDataset, insertSchemaImages(project2.resourceId, project2)).assertNoException
+
+        _ <- fetchKeywords(project1.resourceId).asserting(_ shouldBe project1.keywords)
+        _ <- fetchImages(project1.resourceId).asserting(_ shouldBe project1.images.map(_.uri))
+        _ <- fetchKeywords(project2.resourceId).asserting(_ shouldBe project2.keywords)
+        _ <- fetchImages(project2.resourceId).asserting(_ shouldBe project2.images.map(_.uri))
+
+        _ <- runUpdate(projectsDataset, ProjectsGraphKeywordsRemover.query).assertNoException
+        _ <- runUpdate(projectsDataset, ProjectsGraphImagesRemover.query).assertNoException
+
+        _ <- fetchKeywords(project1.resourceId).asserting(_ shouldBe Set.empty)
+        _ <- fetchImages(project1.resourceId).asserting(_ shouldBe Nil)
+        _ <- fetchKeywords(project2.resourceId).asserting(_ shouldBe Set.empty)
+        _ <- fetchImages(project2.resourceId).asserting(_ shouldBe Nil)
+      } yield Succeeded
+    }
+
+  private def fetchKeywords(projectId: projects.ResourceId): IO[Set[projects.Keyword]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test project keywords",
+        Prefixes of (renku -> "renku", schema -> "schema"),
+        sparql"""|SELECT ?keys
+                 |WHERE {
+                 |   GRAPH ${GraphClass.Projects.id} {
+                 |     ${projectId.asEntityId} schema:keywords ?keys.
+                 |   }
+                 |}
+                 |""".stripMargin
+      )
+    ).map(_.flatMap(_.get("keys").map(projects.Keyword)).toSet)
+
+  private def fetchImages(projectId: projects.ResourceId): IO[List[images.ImageUri]] =
+    runSelect(
+      on = projectsDataset,
+      SparqlQuery.ofUnsafe(
+        "test project images",
+        Prefixes of (renku -> "renku", schema -> "schema"),
+        sparql"""|SELECT ?url ?pos
+                 |WHERE {
+                 |   GRAPH ${GraphClass.Projects.id} {
+                 |     ${projectId.asEntityId} schema:image ?imgId.
+                 |     ?imgId schema:contentUrl ?url.
+                 |     ?imgId schema:position ?pos.
+                 |   }
+                 |}
+                 |""".stripMargin
+      )
+    ).map(
+      _.flatMap(row => (row.get("url").map(images.ImageUri(_)) -> row.get("pos").map(_.toInt)).mapN(_ -> _))
+        .sortBy(_._2)
+        .map(_._1)
+    )
+
+  private def insertSchemaKeywords(projectId: projects.ResourceId, project: entities.Project) =
+    project.keywords.toList.map { keyword =>
+      SparqlQuery.ofUnsafe(
+        "test insert project keyword",
+        Prefixes of (renku -> "renku", schema -> "schema"),
+        sparql"""|INSERT DATA {
+                 |  GRAPH ${GraphClass.Projects.id} {
+                 |    ${projectId.asEntityId} schema:keywords ${keyword.asObject}.
+                 |  }
+                 |}
+                 |""".stripMargin
+      )
+    }
+
+  private def insertSchemaImages(projectId: projects.ResourceId, project: entities.Project) =
+    project.images.map { image =>
+      SparqlQuery.ofUnsafe(
+        "test insert project image",
+        Prefixes of (rdf -> "rdf", renku -> "renku", schema -> "schema"),
+        sparql"""|INSERT DATA {
+                 |  GRAPH ${GraphClass.Projects.id} {
+                 |    ${projectId.asEntityId} schema:image ${image.resourceId.asEntityId}.
+                 |    ${image.resourceId.asEntityId} rdf:type schema:ImageObject.
+                 |    ${image.resourceId.asEntityId} schema:contentUrl ${image.uri.asObject}.
+                 |    ${image.resourceId.asEntityId} schema:position ${image.position.asObject}.
+                 |  }
+                 |}
+                 |""".stripMargin
+      )
+    }
+
+  implicit override lazy val ioLogger: Logger[IO] = TestLogger[IO]()
+}


### PR DESCRIPTION
This PR:
- create a TS migration that removes the old unused parts from the graphs:
    - on Project: `schema:keywords`, `schema:image` properties
    - on DS: `schema:keywords`, `schema:image` properties
- cleans-up the queries and encoders (e.g. `DatasetInfoDeleteQuery`)
- cleans-up the ontologies

closes #1666 
