### PR TITLE
feat: Cross-Entity Search to allow filtering by owner

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -55,6 +55,10 @@ object Criteria {
     object Query                                  extends TinyTypeFactory[Query](new Query(_)) with NonBlank[Query]
 
     final case class Owned(boolean: Boolean, userId: persons.GitLabId)
+    object Owned {
+      def by(userId:    persons.GitLabId): Owned = Owned(boolean = true, userId)
+      def notBy(userId: persons.GitLabId): Owned = Owned(boolean = false, userId)
+    }
 
     sealed trait EntityType extends StringTinyType with Product
     object EntityType extends TinyTypeFactory[EntityType](EntityTypeApply) {

--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -27,7 +27,7 @@ import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.server.security.model.AuthUser
 import io.renku.tinytypes.constraints.{LocalDateNotInTheFuture, NonBlank}
 import io.renku.tinytypes.json.TinyTypeDecoders
-import io.renku.tinytypes.{LocalDateTinyType, StringTinyType, TinyTypeFactory}
+import io.renku.tinytypes.{BooleanTinyType, LocalDateTinyType, StringTinyType, TinyTypeFactory}
 
 import java.time.LocalDate
 
@@ -42,6 +42,7 @@ object Criteria {
   final case class Filters(maybeQuery:   Option[Filters.Query] = None,
                            entityTypes:  Set[Filters.EntityType] = Set.empty,
                            creators:     Set[persons.Name] = Set.empty,
+                           maybeOwned:   Option[Filters.Owned] = None,
                            visibilities: Set[projects.Visibility] = Set.empty,
                            namespaces:   Set[projects.Namespace] = Set.empty,
                            maybeSince:   Option[Filters.Since] = None,
@@ -53,7 +54,10 @@ object Criteria {
     final class Query private (val value: String) extends AnyVal with StringTinyType
     object Query                                  extends TinyTypeFactory[Query](new Query(_)) with NonBlank[Query]
 
-    sealed trait EntityType extends StringTinyType with Product with Serializable
+    final class Owned private (val value: Boolean) extends AnyVal with BooleanTinyType
+    object Owned                                   extends TinyTypeFactory[Owned](new Owned(_))
+
+    sealed trait EntityType extends StringTinyType with Product
     object EntityType extends TinyTypeFactory[EntityType](EntityTypeApply) {
 
       final case object Project  extends EntityType { override val value: String = "project" }

--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -27,7 +27,7 @@ import io.renku.http.rest.paging.PagingRequest
 import io.renku.http.server.security.model.AuthUser
 import io.renku.tinytypes.constraints.{LocalDateNotInTheFuture, NonBlank}
 import io.renku.tinytypes.json.TinyTypeDecoders
-import io.renku.tinytypes.{BooleanTinyType, LocalDateTinyType, StringTinyType, TinyTypeFactory}
+import io.renku.tinytypes.{LocalDateTinyType, StringTinyType, TinyTypeFactory}
 
 import java.time.LocalDate
 
@@ -54,8 +54,7 @@ object Criteria {
     final class Query private (val value: String) extends AnyVal with StringTinyType
     object Query                                  extends TinyTypeFactory[Query](new Query(_)) with NonBlank[Query]
 
-    final class Owned private (val value: Boolean) extends AnyVal with BooleanTinyType
-    object Owned                                   extends TinyTypeFactory[Owned](new Owned(_))
+    final case class Owned(boolean: Boolean, userId: persons.GitLabId)
 
     sealed trait EntityType extends StringTinyType with Product
     object EntityType extends TinyTypeFactory[EntityType](EntityTypeApply) {

--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -54,11 +54,7 @@ object Criteria {
     final class Query private (val value: String) extends AnyVal with StringTinyType
     object Query                                  extends TinyTypeFactory[Query](new Query(_)) with NonBlank[Query]
 
-    final case class Owned(boolean: Boolean, userId: persons.GitLabId)
-    object Owned {
-      def by(userId:    persons.GitLabId): Owned = Owned(boolean = true, userId)
-      def notBy(userId: persons.GitLabId): Owned = Owned(boolean = false, userId)
-    }
+    final case class Owned(userId: persons.GitLabId)
 
     sealed trait EntityType extends StringTinyType with Product
     object EntityType extends TinyTypeFactory[EntityType](EntityTypeApply) {

--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -135,13 +135,9 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
     filters.maybeOwned match {
-      case Some(Criteria.Filters.Owned(true, ownerId)) =>
+      case Some(Criteria.Filters.Owned(ownerId)) =>
         fr"""|$projIdVar renku:projectVisibility ?visibility .
              |${authSnippets.ownedProjects(ownerId)}
-             |""".stripMargin
-      case Some(Criteria.Filters.Owned(false, ownerId)) =>
-        fr"""|$projIdVar renku:projectVisibility ?visibility .
-             |${authSnippets.notOwnedProjects(ownerId)}
              |""".stripMargin
       case None =>
         fr"""|$projIdVar renku:projectVisibility ?visibility .

--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -137,6 +137,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
     filters.maybeOwned match {
       case Some(Criteria.Filters.Owned(ownerId)) =>
         fr"""|$projIdVar renku:projectVisibility ?visibility .
+             |${visibilitiesPart(filters.visibilities)}
              |${authSnippets.ownedProjects(ownerId)}
              |""".stripMargin
       case None =>
@@ -144,6 +145,11 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
              |${authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)}
              |""".stripMargin
     }
+
+  private lazy val visibilitiesPart: Set[projects.Visibility] => Fragment = {
+    case vis if vis.nonEmpty => fr"""VALUES (?visibility) {${vis.map(_.value)}}."""
+    case _                   => Fragment.empty
+  }
 
   private def resolveProject: Fragment =
     fr"""|    $sameAsVar a renku:DiscoverableDataset;

--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -65,7 +65,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
     imagesVar
   ).map(_.name)
 
-  override def query(criteria: Criteria): Option[String] =
+  override def query(criteria: Criteria): Option[Fragment] =
     criteria.filters.whenRequesting(entityType) {
       fr"""{
           |SELECT DISTINCT $entityTypeVar
@@ -130,7 +130,7 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
           |  }
           |}
           |}
-          |""".stripMargin.sparql
+          |""".stripMargin
     }
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =

--- a/entities-search/src/main/scala/io/renku/entities/search/EntitiesFinder.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/EntitiesFinder.scala
@@ -65,7 +65,7 @@ private class EntitiesFinderImpl[F[_]: Async: NonEmptyParallel: Logger: SparqlQu
     Prefixes of (prov -> "prov", renku -> "renku", schema -> "schema", text -> "text", xsd -> "xsd"),
     s"""|SELECT ${entityQueries.map(_.selectVariables).combineAll.mkString(" ")}
         |WHERE {
-        |  ${entityQueries.flatMap(_.query(criteria)).mkString(" UNION ")}
+        |  ${entityQueries.flatMap(_.query(criteria)).map(_.sparql).mkString(" UNION ")}
         |}
         |${`ORDER BY`(criteria.sorting)}
         |""".stripMargin

--- a/entities-search/src/main/scala/io/renku/entities/search/EntityQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/EntityQuery.scala
@@ -21,12 +21,12 @@ package io.renku.entities.search
 import io.circe.Decoder
 import io.renku.entities.search.Criteria.Filters.EntityType
 import io.renku.triplesstore.ResultsDecoder
-import io.renku.triplesstore.client.sparql.VarName
+import io.renku.triplesstore.client.sparql.{Fragment, VarName}
 
 private[entities] trait EntityQuery[+E <: model.Entity] extends ResultsDecoder with EntityQueryVars {
   val entityType:      EntityType
   val selectVariables: Set[String]
-  def query(criteria: Criteria): Option[String]
+  def query(criteria: Criteria): Option[Fragment]
   def decoder[EE >: E]: Decoder[EE]
 
   def getDecoder[EE >: E](entityType: EntityType): Option[Decoder[EE]] =

--- a/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
@@ -32,7 +32,7 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
 
   override val selectVariables: Set[String] = Set("?entityType", "?matchingScore", "?name")
 
-  override def query(criteria: Criteria): Option[String] =
+  override def query(criteria: Criteria): Option[Fragment] =
     (criteria.filters whenRequesting (entityType, criteria.filters.withNoOrPublicVisibility, criteria.filters.namespaces.isEmpty, criteria.filters.maybeSince.isEmpty, criteria.filters.maybeUntil.isEmpty)) {
       import criteria._
       sparql"""|{
@@ -42,7 +42,7 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
                |      SELECT (SAMPLE(?id) AS ?personId) ?name (MAX(?score) AS ?matchingScore)
                |      WHERE {
                |        ${textPart(criteria.filters)}
-               |        
+               |
                |        GRAPH ${GraphClass.Persons.id} {
                |          ?id a schema:Person;
                |              schema:name ?name.
@@ -55,7 +55,7 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
                |    BIND ('person' AS ?entityType)
                |  }
                |}
-               |""".stripMargin.sparql
+               |""".stripMargin
     }
 
   private def textPart(filters: Criteria.Filters) =

--- a/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
@@ -62,17 +62,10 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
     }
 
   private lazy val filterOnOwned: Option[Criteria.Filters.Owned] => Fragment = {
-    case Some(Criteria.Filters.Owned(true, userId)) =>
+    case Some(Criteria.Filters.Owned(userId)) =>
       fr"""|?id schema:sameAs ?sameAsId.
            |?sameAsId schema:additionalType ${gitLabSameAsAdditionalType.asTripleObject};
            |          schema:identifier ${userId.asObject}.
-           |""".stripMargin
-    case Some(Criteria.Filters.Owned(false, userId)) =>
-      fr"""|?id schema:sameAs ?sameAsId.
-           |FILTER NOT EXISTS {
-           |  ?sameAsId schema:additionalType ${gitLabSameAsAdditionalType.asTripleObject};
-           |            schema:identifier ${userId.asObject}.
-           |}
            |""".stripMargin
     case None => Fragment.empty
   }

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -142,6 +142,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
     filters.maybeOwned match {
       case Some(Criteria.Filters.Owned(ownerId)) =>
         fr"""|$projectIdVar renku:projectVisibility $visibilityVar .
+             |${visibilitiesPart(filters.visibilities)}
              |${authSnippets.ownedProjects(ownerId)}
              |""".stripMargin
       case None =>
@@ -149,6 +150,11 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
              |${authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)}
              |""".stripMargin
     }
+
+  private lazy val visibilitiesPart: Set[projects.Visibility] => Fragment = {
+    case vis if vis.nonEmpty => fr"""VALUES ($visibilityVar) {${vis.map(_.value)}}."""
+    case _                   => Fragment.empty
+  }
 
   private def namespacesPart(ns: Set[projects.Namespace]): Fragment = {
     val matchFrag =

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -140,13 +140,9 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
     filters.maybeOwned match {
-      case Some(Criteria.Filters.Owned(true, ownerId)) =>
+      case Some(Criteria.Filters.Owned(ownerId)) =>
         fr"""|$projectIdVar renku:projectVisibility $visibilityVar .
              |${authSnippets.ownedProjects(ownerId)}
-             |""".stripMargin
-      case Some(Criteria.Filters.Owned(false, ownerId)) =>
-        fr"""|$projectIdVar renku:projectVisibility $visibilityVar .
-             |${authSnippets.notOwnedProjects(ownerId)}
              |""".stripMargin
       case None =>
         fr"""|$projectIdVar renku:projectVisibility $visibilityVar .

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -63,7 +63,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
       imagesVar
     ).map(_.name)
 
-  override def query(criteria: Criteria): Option[String] = (criteria.filters whenRequesting entityType) {
+  override def query(criteria: Criteria): Option[Fragment] = (criteria.filters whenRequesting entityType) {
     import criteria._
     sparql"""|{
              |  SELECT DISTINCT $entityTypeVar $matchingScoreVar $nameVar $slugVar $visibilityVar
@@ -107,7 +107,7 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
              |    }
              |  }
              |}
-             |""".stripMargin.sparql
+             |""".stripMargin
   }
 
   private def textQueryPart: Option[Criteria.Filters.Query] => Fragment = {

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -114,10 +114,8 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
     filters.maybeOwned match {
-      case Some(Criteria.Filters.Owned(true, ownerId)) =>
+      case Some(Criteria.Filters.Owned(ownerId)) =>
         authSnippets.ownedProjects(ownerId)
-      case Some(Criteria.Filters.Owned(false, ownerId)) =>
-        authSnippets.notOwnedProjects(ownerId)
       case None =>
         authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)
     }

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -48,7 +48,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
 
   private val authSnippets = SparqlSnippets(VarName("projectId"))
 
-  override def query(criteria: Criteria): Option[String] = (criteria.filters whenRequesting entityType) {
+  override def query(criteria: Criteria): Option[Fragment] = (criteria.filters whenRequesting entityType) {
     import criteria._
     // format: off
     sparql"""|{
@@ -109,7 +109,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |    BIND ('workflow' AS ?entityType)
         |  }
         |}
-        |""".stripMargin.sparql
+        |""".stripMargin
     // format: on
   }
 

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -96,6 +96,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |                ^renku:hasPlan ?projectId.
         |          ?projectId renku:projectNamespace ?namespace.
         |          ?projectId renku:projectVisibility ?visibility.
+        |          ${maybeFilterOnVisibilities(filters.visibilities)}
         |          BIND (CONCAT(STR(?projectId), STR('::'), STR(?visibility)) AS ?projectIdVisibility)
         |          ${filters.maybeOnNamespace(VarName("namespace"))}
         |          ${filters.maybeOnDateCreated(VarName("date"))}
@@ -119,6 +120,11 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
       case None =>
         authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)
     }
+
+  private lazy val maybeFilterOnVisibilities: Set[projects.Visibility] => Fragment = {
+    case vis if vis.nonEmpty => fr"""VALUES (?visibility) {${vis.map(_.value)}}."""
+    case _                   => Fragment.empty
+  }
 
   private def withoutQuerySnippet: Fragment =
     sparql"""

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -35,20 +35,20 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
 
   override val entityType: EntityType = EntityType.Workflow
 
-  override val selectVariables = Set("?entityType",
-                                     "?matchingScore",
-                                     "?wkId",
-                                     "?name",
-                                     "?date",
-                                     "?maybeDescription",
-                                     "?keywords",
-                                     "?projectIdVisibilities",
-                                     "?workflowTypes"
+  override val selectVariables: Set[String] = Set("?entityType",
+                                                  "?matchingScore",
+                                                  "?wkId",
+                                                  "?name",
+                                                  "?date",
+                                                  "?maybeDescription",
+                                                  "?keywords",
+                                                  "?projectIdVisibilities",
+                                                  "?workflowTypes"
   )
 
   private val authSnippets = SparqlSnippets(VarName("projectId"))
 
-  override def query(criteria: Criteria) = (criteria.filters whenRequesting entityType) {
+  override def query(criteria: Criteria): Option[String] = (criteria.filters whenRequesting entityType) {
     import criteria._
     // format: off
     sparql"""|{
@@ -86,7 +86,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
         |        FILTER (IF (BOUND(?childProjectsIds), !CONTAINS(STR(?childProjectsIds), STR(?projectId)), true))
         |        FILTER (IF (BOUND(?projectsIdsWhereInvalidated), !CONTAINS(STR(?projectsIdsWhereInvalidated), STR(?projectId)), true))
         |
-        |        ${accessRightsAndVisibility(criteria.maybeUser, criteria.filters.visibilities)}
+        |        ${accessRightsAndVisibility(criteria.maybeUser, criteria.filters)}
         |
         |        GRAPH ?projectId {
         |          ?wkId a prov:Plan;
@@ -112,8 +112,15 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
     // format: on
   }
 
-  private def accessRightsAndVisibility(maybeUser: Option[AuthUser], visibilities: Set[projects.Visibility]): Fragment =
-    authSnippets.visibleProjects(maybeUser.map(_.id), visibilities)
+  private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
+    filters.maybeOwned match {
+      case Some(Criteria.Filters.Owned(true, ownerId)) =>
+        authSnippets.ownedProjects(ownerId)
+      case Some(Criteria.Filters.Owned(false, ownerId)) =>
+        authSnippets.notOwnedProjects(ownerId)
+      case None =>
+        authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)
+    }
 
   private def withoutQuerySnippet: Fragment =
     sparql"""
@@ -124,7 +131,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
             |}
             |""".stripMargin
 
-  def withQuerySnippet(query: LuceneQuery) =
+  private def withQuerySnippet(query: LuceneQuery) =
     sparql"""
             |{
             |  SELECT ?wkId (MAX(?score) AS ?matchingScore) (SAMPLE(?projId) AS ?projectId)
@@ -186,7 +193,7 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
     } yield Entity.Workflow(matchingScore, name, visibility, dateCreated, keywords, maybeDescription, workflowTypes)
   }
 
-  def workflowTypeFromString(str: String): Either[String, WorkflowType] =
+  private def workflowTypeFromString(str: String): Either[String, WorkflowType] =
     str match {
       case _ if str.contains(CompositePlan.Ontology.typeDef.clazz.id.show) =>
         Right(WorkflowType.Composite)

--- a/entities-search/src/main/scala/io/renku/entities/search/package.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/package.scala
@@ -35,7 +35,7 @@ package object search {
     lazy val query: LuceneQuery =
       filters.maybeQuery.map(q => LuceneQuery.fuzzy(q.value)).getOrElse(LuceneQuery.queryAll)
 
-    def whenRequesting(entityType: Filters.EntityType, predicates: Boolean*)(query: => String): Option[String] = {
+    def whenRequesting(entityType: Filters.EntityType, predicates: Boolean*)(query: => Fragment): Option[Fragment] = {
       val typeMatching = filters.entityTypes match {
         case t if t.isEmpty => true
         case t              => t contains entityType

--- a/entities-search/src/main/scala/io/renku/entities/search/package.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/package.scala
@@ -43,8 +43,8 @@ package object search {
       Option.when(typeMatching && predicates.forall(_ == true))(query)
     }
 
-    def onQuery(snippet: String, matchingScoreVariableName: String = "?matchingScore"): String =
-      foldQuery(_ => snippet, s"BIND (xsd:float(1.0) AS $matchingScoreVariableName)")
+    def onQuery(snippet: Fragment, matchingScoreVariableName: VarName = VarName("matchingScore")): Fragment =
+      foldQuery(_ => snippet, fr"BIND (xsd:float(1.0) AS $matchingScoreVariableName)")
 
     def foldQuery[A](ifPresent: LuceneQuery => A, ifMissing: => A): A =
       if (query.isQueryAll) ifMissing

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -565,7 +565,7 @@ class EntitiesFinderSpec
 
       val results = IOBody {
         provisionTestProjects(soleProject, dsProject, projectEntities(visibilityPublic).generateOne) *>
-          finder.findEntities(Criteria(Filters(maybeOwned = Criteria.Filters.Owned.by(ownerId).some)))
+          finder.findEntities(Criteria(Filters(maybeOwned = Criteria.Filters.Owned(ownerId).some)))
       }
 
       val expected = List(

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -631,7 +631,7 @@ class EntitiesFinderSpec
         .modify(replaceMembers(Set(owner)))
         .addDataset(datasetEntities(provenanceNonModified).modify(replaceDSCreators(NonEmptyList.of(owner.person))))
         .generateOne
-      val dsAndNonPublicProject @ _ -> nonPublicProject = renkuProjectEntities(visibilityNonPublic)
+      val _ -> nonPublicProject = renkuProjectEntities(visibilityNonPublic)
         .modify(replaceMembers(Set(owner)))
         .addDataset(datasetEntities(provenanceNonModified).modify(replaceDSCreators(NonEmptyList.of(owner.person))))
         .generateOne

--- a/entities-search/src/test/scala/io/renku/entities/search/Generators.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/Generators.scala
@@ -22,7 +22,7 @@ import Criteria._
 import EntityConverters._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{localDatesNotInTheFuture, nonBlankStrings}
-import io.renku.graph.model.testentities
+import io.renku.graph.model.{persons, testentities}
 import model._
 import org.scalacheck.Gen
 import org.scalacheck.Gen.choose
@@ -30,12 +30,12 @@ import testentities._
 
 object Generators {
 
-  val queryParams:    Gen[Filters.Query]      = nonBlankStrings(minLength = 5).map(v => Filters.Query(v.value))
-  val typeParams:     Gen[Filters.EntityType] = Gen.oneOf(Filters.EntityType.all)
-  val ownedParams:    Gen[Filters.Owned]      = Gen.oneOf(true, false).map(Filters.Owned)
-  val sinceParams:    Gen[Filters.Since]      = localDatesNotInTheFuture.toGeneratorOf(Filters.Since)
-  val untilParams:    Gen[Filters.Until]      = localDatesNotInTheFuture.toGeneratorOf(Filters.Until)
-  val matchingScores: Gen[MatchingScore]      = choose(MatchingScore.min.value, 10f).toGeneratorOf(MatchingScore)
+  val queryParams: Gen[Filters.Query]      = nonBlankStrings(minLength = 5).map(v => Filters.Query(v.value))
+  val typeParams:  Gen[Filters.EntityType] = Gen.oneOf(Filters.EntityType.all)
+  def ownedParams(userId: persons.GitLabId): Gen[Filters.Owned] = Gen.oneOf(true, false).map(Filters.Owned(_, userId))
+  val sinceParams:    Gen[Filters.Since] = localDatesNotInTheFuture.toGeneratorOf(Filters.Since)
+  val untilParams:    Gen[Filters.Until] = localDatesNotInTheFuture.toGeneratorOf(Filters.Until)
+  val matchingScores: Gen[MatchingScore] = choose(MatchingScore.min.value, 10f).toGeneratorOf(MatchingScore)
 
   val modelProjects: Gen[model.Entity.Project] = anyProjectEntities.map(_.to[model.Entity.Project])
   val modelDatasets: Gen[model.Entity.Dataset] =

--- a/entities-search/src/test/scala/io/renku/entities/search/Generators.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/Generators.scala
@@ -22,7 +22,7 @@ import Criteria._
 import EntityConverters._
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{localDatesNotInTheFuture, nonBlankStrings}
-import io.renku.graph.model.{persons, testentities}
+import io.renku.graph.model.testentities
 import model._
 import org.scalacheck.Gen
 import org.scalacheck.Gen.choose
@@ -32,7 +32,6 @@ object Generators {
 
   val queryParams: Gen[Filters.Query]      = nonBlankStrings(minLength = 5).map(v => Filters.Query(v.value))
   val typeParams:  Gen[Filters.EntityType] = Gen.oneOf(Filters.EntityType.all)
-  def ownedParams(userId: persons.GitLabId): Gen[Filters.Owned] = Gen.oneOf(true, false).map(Filters.Owned(_, userId))
   val sinceParams:    Gen[Filters.Since] = localDatesNotInTheFuture.toGeneratorOf(Filters.Since)
   val untilParams:    Gen[Filters.Until] = localDatesNotInTheFuture.toGeneratorOf(Filters.Until)
   val matchingScores: Gen[MatchingScore] = choose(MatchingScore.min.value, 10f).toGeneratorOf(MatchingScore)

--- a/entities-search/src/test/scala/io/renku/entities/search/Generators.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/Generators.scala
@@ -32,6 +32,7 @@ object Generators {
 
   val queryParams:    Gen[Filters.Query]      = nonBlankStrings(minLength = 5).map(v => Filters.Query(v.value))
   val typeParams:     Gen[Filters.EntityType] = Gen.oneOf(Filters.EntityType.all)
+  val ownedParams:    Gen[Filters.Owned]      = Gen.oneOf(true, false).map(Filters.Owned)
   val sinceParams:    Gen[Filters.Since]      = localDatesNotInTheFuture.toGeneratorOf(Filters.Since)
   val untilParams:    Gen[Filters.Until]      = localDatesNotInTheFuture.toGeneratorOf(Filters.Until)
   val matchingScores: Gen[MatchingScore]      = choose(MatchingScore.min.value, 10f).toGeneratorOf(MatchingScore)

--- a/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
+++ b/entities-search/src/test/scala/io/renku/entities/searchgraphs/SearchInfoDatasets.scala
@@ -21,7 +21,6 @@ package io.renku.entities.searchgraphs
 import cats.effect.IO
 import cats.syntax.all._
 import io.renku.graph.model.entities.EntityFunctions
-import io.renku.graph.model.projects.Role
 import io.renku.graph.model.{RenkuUrl, datasets, entities, testentities}
 import io.renku.lock.Lock
 import io.renku.logging.{ExecutionTimeRecorder, TestExecutionTimeRecorder}
@@ -70,7 +69,7 @@ trait SearchInfoDatasets {
     implicit val sparqlQueryTimeRecorder: SparqlQueryTimeRecorder[IO] =
       new SparqlQueryTimeRecorder[IO](execTimeRecorder)
     val ps      = ProjectSparqlClient[IO](projectsDSConnectionInfo).map(ProjectAuthService[IO](_, renkuUrl))
-    val members = project.members.flatMap(p => p.person.maybeGitLabId.map(id => ProjectMember(id, Role.Reader)))
+    val members = project.members.flatMap(m => m.person.maybeGitLabId.map(id => ProjectMember(id, m.role)))
     ps.use(_.update(ProjectAuthData(project.slug, members, project.visibility)))
   }
 

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -329,12 +329,12 @@ When the `query` parameter is given, the match is done on the following fields:
 
 **Response**
 
-| Status                       | Description                                      |
-|------------------------------|--------------------------------------------------|
-| OK (200)                     | If results are found; `[]` if nothing is found   |
-| BAD_REQUEST (400)            | If illegal values for query parameters are given |
-| UNAUTHORIZED (401)           | If given auth header cannot be authenticated     |
-| INTERNAL SERVER ERROR (500)  | Otherwise                                        |
+| Status                       | Description                                                                                    |
+|------------------------------|------------------------------------------------------------------------------------------------|
+| OK (200)                     | If results are found; `[]` if nothing is found                                                 |
+| BAD_REQUEST (400)            | If illegal values for query parameters are given or `owned` specified but no auth user present |
+| UNAUTHORIZED (401)           | If given auth header cannot be authenticated                                                   |
+| INTERNAL SERVER ERROR (500)  | Otherwise                                                                                      |
 
 Response headers:
 

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -300,6 +300,7 @@ Allows finding `projects`, `datasets`, `workflows`, and `persons`.
 * `query`      - to filter by matching field (e.g., title, keyword, description, etc. as specified below)
 * `type`       - to filter by entity type(s); allowed values: `project`, `dataset`, `workflow`, and `person`; multiple `type` parameters allowed
 * `creator`    - to filter by creator(s); the filter would require creator's name; multiple `creator` parameters allowed
+* `owned`      - to reduce the results to entities where the caller is an owner; allowed values: `true` and `false`
 * `visibility` - to filter by visibility(ies) (restricted vs. public); allowed values: `public`, `internal`, `private`; multiple `visibility` parameters allowed
 * `namespace`  - to filter by namespace(s); there might be multiple values given; for nested namespaces the whole path has be used, e.g. `group/subgroup` 
 * `since`      - to filter by entity's creation date to >= the given date

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -300,7 +300,7 @@ Allows finding `projects`, `datasets`, `workflows`, and `persons`.
 * `query`      - to filter by matching field (e.g., title, keyword, description, etc. as specified below)
 * `type`       - to filter by entity type(s); allowed values: `project`, `dataset`, `workflow`, and `person`; multiple `type` parameters allowed
 * `creator`    - to filter by creator(s); the filter would require creator's name; multiple `creator` parameters allowed
-* `owned`      - to reduce the results to entities where the caller is an owner; allowed values: `true` and `false`
+* `owned`      - to reduce the results to entities where the caller is an owner; this parameter does not require any value
 * `visibility` - to filter by visibility(ies) (restricted vs. public); allowed values: `public`, `internal`, `private`; multiple `visibility` parameters allowed
 * `namespace`  - to filter by namespace(s); there might be multiple values given; for nested namespaces the whole path has be used, e.g. `group/subgroup` 
 * `since`      - to filter by entity's creation date to >= the given date

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
@@ -85,14 +85,7 @@ object QueryParamDecoders {
     val parameterName: String = "creator"
   }
 
-  private implicit val ownedParameterDecoder: QueryParamDecoder[Owned] =
-    (value: QueryParameterValue) =>
-      value.value.toBooleanOption
-        .toRight(parsingFailure(owned.parameterName))
-        .map(Owned)
-        .toValidatedNel
-
-  object owned extends OptionalValidatingQueryParamDecoderMatcher[Owned]("owned") {
+  object owned extends OptionalValidatingQueryParamDecoderMatcher[Boolean]("owned") {
     val parameterName: String = "owned"
   }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
@@ -85,6 +85,17 @@ object QueryParamDecoders {
     val parameterName: String = "creator"
   }
 
+  private implicit val ownedParameterDecoder: QueryParamDecoder[Owned] =
+    (value: QueryParameterValue) =>
+      value.value.toBooleanOption
+        .toRight(parsingFailure(owned.parameterName))
+        .map(Owned)
+        .toValidatedNel
+
+  object owned extends OptionalValidatingQueryParamDecoderMatcher[Owned]("owned") {
+    val parameterName: String = "owned"
+  }
+
   private implicit val visibilityParameterDecoder: QueryParamDecoder[projects.Visibility] =
     (value: QueryParameterValue) =>
       projects.Visibility

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
@@ -24,7 +24,7 @@ import io.renku.entities.search.Criteria.Filters._
 import io.renku.entities.viewings.search.RecentEntitiesFinder
 import io.renku.graph.model._
 import io.renku.http.rest.paging.model.PerPage
-import org.http4s.dsl.io.{OptionalMultiQueryParamDecoderMatcher, OptionalValidatingQueryParamDecoderMatcher}
+import org.http4s.dsl.io.{FlagQueryParamMatcher, OptionalMultiQueryParamDecoderMatcher, OptionalValidatingQueryParamDecoderMatcher}
 import org.http4s.{ParseFailure, QueryParamDecoder, QueryParameterValue}
 
 import java.time.LocalDate
@@ -85,7 +85,7 @@ object QueryParamDecoders {
     val parameterName: String = "creator"
   }
 
-  object owned extends OptionalValidatingQueryParamDecoderMatcher[Boolean]("owned") {
+  object owned extends FlagQueryParamMatcher("owned") {
     val parameterName: String = "owned"
   }
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -50,7 +50,7 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
     GET(
       "Cross-Entity Search",
       "Finds entities by the given criteria",
-      Uri / "entities" :? query & `type` & creator & visibility & namespace & since & until & sort & page & perPage,
+      Uri / "entities" :? query & `type` & creator & owned & visibility & namespace & since & until & sort & page & perPage,
       Status.Ok -> Response("Found entities",
                             Contents(MediaType.`application/json`("Sample response", example)),
                             responseHeaders
@@ -85,6 +85,12 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
     "creator",
     Schema.String,
     "to filter by creator(s); the filter would require creator's name; multiple creator parameters allowed".some,
+    required = false
+  )
+  private lazy val owned = Parameter.Query(
+    "owned",
+    Schema.String,
+    "to reduce the results to entities where the caller is an owner; allowed values: `true` and `false`".some,
     required = false
   )
   private lazy val visibility = Parameter.Query(

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -90,7 +90,7 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
   private lazy val owned = Parameter.Query(
     "owned",
     Schema.String,
-    "to reduce the results to entities where the caller is an owner; allowed values: `true` and `false`".some,
+    "to reduce the results to entities where the caller is an owner; this parameter does not require any value".some,
     required = false
   )
   private lazy val visibility = Parameter.Query(

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -56,7 +56,7 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
                             responseHeaders
       ),
       Status.BadRequest -> Response(
-        "In case of invalid query parameters",
+        "In case of invalid query parameters or `owned` parameter specified but no auth user present",
         Contents(MediaType.`application/json`("Reason", Message.Info("Invalid parameters")))
       ),
       Status.Unauthorized -> Response(

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
@@ -275,9 +275,7 @@ class MicroserviceRoutesSpec
         "uri"                          -> "criteria",
         uri"/knowledge-graph/entities" -> Criteria(),
         queryParams
-          .map(query =>
-            uri"/knowledge-graph/entities" +? ("query" -> query.value) -> Criteria(Filters(maybeQuery = query.some))
-          )
+          .map(q => uri"/knowledge-graph/entities" +? ("query" -> q.value) -> Criteria(Filters(maybeQuery = q.some)))
           .generateOne,
         typeParams
           .map(t => uri"/knowledge-graph/entities" +? ("type" -> t.value) -> Criteria(Filters(entityTypes = Set(t))))
@@ -293,6 +291,9 @@ class MicroserviceRoutesSpec
           .map(name =>
             uri"/knowledge-graph/entities" +? ("creator" -> name.value) -> Criteria(Filters(creators = Set(name)))
           )
+          .generateOne,
+        ownedParams
+          .map(p => uri"/knowledge-graph/entities" +? ("owned" -> p.value) -> Criteria(Filters(maybeOwned = p.some)))
           .generateOne,
         personNames
           .toGeneratorOfList(min = 2)
@@ -1115,9 +1116,10 @@ class MicroserviceRoutesSpec
       .expects(identifier, maybeAuthUser)
       .returning(returning)
 
-    def givenDSSameAsAuthorizer(sameAs:        model.datasets.SameAs,
-                                maybeAuthUser: Option[AuthUser],
-                                returning: EitherT[IO, EndpointSecurityException, AuthContext[model.datasets.SameAs]]
+    private def givenDSSameAsAuthorizer(
+        sameAs:        model.datasets.SameAs,
+        maybeAuthUser: Option[AuthUser],
+        returning:     EitherT[IO, EndpointSecurityException, AuthContext[model.datasets.SameAs]]
     ) = (datasetSameAsAuthorizer.authorize _)
       .expects(sameAs, maybeAuthUser)
       .returning(returning)

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
@@ -396,10 +396,11 @@ class MicroserviceRoutesSpec
 
     "read the 'owned' query parameter from the uri and pass it to the endpoint when auth user present" in new TestCase {
 
-      val maybeAuthUser = MaybeAuthUser(authUsers.generateOne)
-      val ownedParam    = ownedParams.generateOne
+      val authUser      = authUsers.generateOne
+      val maybeAuthUser = MaybeAuthUser(authUser)
+      val ownedParam    = ownedParams(authUser.id).generateOne
       val criteria      = Criteria(Filters(maybeOwned = ownedParam.some), maybeUser = maybeAuthUser.option)
-      val request       = Request[IO](GET, uri"/knowledge-graph/entities" +? ("owned" -> ownedParam.value))
+      val request       = Request[IO](GET, uri"/knowledge-graph/entities" +? ("owned" -> ownedParam.boolean))
 
       val responseBody = jsons.generateOne
       (entitiesEndpoint.`GET /entities` _)
@@ -416,7 +417,9 @@ class MicroserviceRoutesSpec
     s"return $BadRequest 'owned' query parameter given but no auth user present" in new TestCase {
 
       val response =
-        routes().call(Request[IO](GET, uri"/knowledge-graph/entities" +? ("owned" -> ownedParams.generateOne.value)))
+        routes().call(
+          Request[IO](GET, uri"/knowledge-graph/entities" +? ("owned" -> Gen.oneOf(true, false).generateOne))
+        )
 
       response.status        shouldBe BadRequest
       response.contentType   shouldBe Some(`Content-Type`(application.json))

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/MicroserviceRoutesSpec.scala
@@ -398,9 +398,8 @@ class MicroserviceRoutesSpec
 
       val authUser      = authUsers.generateOne
       val maybeAuthUser = MaybeAuthUser(authUser)
-      val ownedParam    = ownedParams(authUser.id).generateOne
-      val criteria      = Criteria(Filters(maybeOwned = ownedParam.some), maybeUser = maybeAuthUser.option)
-      val request       = Request[IO](GET, uri"/knowledge-graph/entities" +? ("owned" -> ownedParam.boolean))
+      val criteria = Criteria(Filters(maybeOwned = Filters.Owned(authUser.id).some), maybeUser = maybeAuthUser.option)
+      val request  = Request[IO](GET, uri"/knowledge-graph/entities" +? "owned")
 
       val responseBody = jsons.generateOne
       (entitiesEndpoint.`GET /entities` _)
@@ -416,10 +415,7 @@ class MicroserviceRoutesSpec
 
     s"return $BadRequest 'owned' query parameter given but no auth user present" in new TestCase {
 
-      val response =
-        routes().call(
-          Request[IO](GET, uri"/knowledge-graph/entities" +? ("owned" -> Gen.oneOf(true, false).generateOne))
-        )
+      val response = routes().call(Request[IO](GET, uri"/knowledge-graph/entities" +? "owned"))
 
       response.status        shouldBe BadRequest
       response.contentType   shouldBe Some(`Content-Type`(application.json))

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -53,14 +53,6 @@ final class SparqlSnippets(val projectId: VarName) {
          |}
          | """.stripMargin
 
-  def notOwnedProjects(userId: persons.GitLabId): Fragment =
-    fr"""|GRAPH renku:ProjectAuth {
-         |   FILTER NOT EXISTS {
-         |     $projectId renku:memberRole ${ProjectMember(userId, projects.Role.Owner).encoded}.
-         |   }
-         |}
-         | """.stripMargin
-
   def visibleProjects(userId: Option[persons.GitLabId], selectedVisibility: Set[Visibility]): Fragment = {
     val visibilities =
       if (selectedVisibility.isEmpty) Visibility.all

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -19,9 +19,9 @@
 package io.renku.projectauth.util
 
 import cats.syntax.all._
-import io.renku.graph.model.{persons, projects}
 import io.renku.graph.model.projects.Visibility
-import io.renku.projectauth.ProjectAuth
+import io.renku.graph.model.{persons, projects}
+import io.renku.projectauth.{ProjectAuth, ProjectMember}
 import io.renku.triplesstore.client.sparql.{Fragment, VarName}
 import io.renku.triplesstore.client.syntax._
 
@@ -45,6 +45,21 @@ final class SparqlSnippets(val projectId: VarName) {
             |              renku:memberId ${userId.value}.
             |}
             | """.stripMargin
+
+  def ownedProjects(userId: persons.GitLabId): Fragment =
+    fr"""|GRAPH renku:ProjectAuth {
+         |   $projectId a schema:Project;
+         |              renku:memberRole ${ProjectMember(userId, projects.Role.Owner).encoded}.
+         |}
+         | """.stripMargin
+
+  def notOwnedProjects(userId: persons.GitLabId): Fragment =
+    fr"""|GRAPH renku:ProjectAuth {
+         |   FILTER NOT EXISTS {
+         |     $projectId renku:memberRole ${ProjectMember(userId, projects.Role.Owner).encoded}.
+         |   }
+         |}
+         | """.stripMargin
 
   def visibleProjects(userId: Option[persons.GitLabId], selectedVisibility: Set[Visibility]): Fragment = {
     val visibilities =
@@ -89,6 +104,6 @@ object SparqlSnippets {
   def apply(projectVar: VarName): SparqlSnippets =
     new SparqlSnippets(projectVar)
 
-  val default =
+  val default: SparqlSnippets =
     SparqlSnippets(VarName("projectId"))
 }

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/DatasetEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/DatasetEntitiesGenerators.scala
@@ -300,13 +300,13 @@ trait DatasetEntitiesGenerators {
   }
 
   implicit def identificationLens[P <: Dataset.Provenance]: Lens[Dataset[P], Identification] =
-    Lens[Dataset[P], Identification](_.identification)(identification => ds => ds.copy(identification = identification))
+    Lens[Dataset[P], Identification](_.identification)(identification => _.copy(identification = identification))
 
   implicit def provenanceLens[P <: Dataset.Provenance]: Lens[Dataset[P], P] =
-    Lens[Dataset[P], P](_.provenance)(prov => ds => ds.copy(provenance = prov))
+    Lens[Dataset[P], P](_.provenance)(prov => _.copy(provenance = prov))
 
   implicit def additionalInfoLens[P <: Dataset.Provenance]: Lens[Dataset[P], AdditionalInfo] =
-    Lens[Dataset[P], AdditionalInfo](_.additionalInfo)(additionalInfo => ds => ds.copy(additionalInfo = additionalInfo))
+    Lens[Dataset[P], AdditionalInfo](_.additionalInfo)(additionalInfo => _.copy(additionalInfo = additionalInfo))
 
   implicit def creatorsLens[P <: Dataset.Provenance]: Lens[P, NonEmptyList[Person]] =
     Lens[P, NonEmptyList[Person]](_.creators) { crts =>
@@ -318,6 +318,9 @@ trait DatasetEntitiesGenerators {
         case p: Provenance.Modified                         => p.copy(creators = crts.sortBy(_.name)).asInstanceOf[P]
       }
     }
+
+  def replaceDSCreators[P <: Dataset.Provenance](creators: NonEmptyList[Person]): Dataset[P] => Dataset[P] =
+    provenanceLens[P].modify(creatorsLens[P].replace(creators))
 
   def replaceDSName[P <: Dataset.Provenance](to: datasets.Name): Dataset[P] => Dataset[P] =
     identificationLens[P].modify(_.copy(name = to))

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/ProjectEntitiesGenerators.scala
@@ -110,17 +110,15 @@ trait ProjectEntitiesGenerators {
   def removeCreator[P <: Project](): P => P = creatorLens.modify(_ => None)
 
   def replaceProjectCreator[P <: Project](to: Option[Person]): P => P =
-    _.fold(_.copy(maybeCreator = to), _.copy(maybeCreator = to), _.copy(maybeCreator = to), _.copy(maybeCreator = to))
-      .asInstanceOf[P]
+    creatorLens[P].replace(to)
 
   def replaceVisibility[P <: Project](to: Visibility): P => P =
     _.fold(_.copy(visibility = to), _.copy(visibility = to), _.copy(visibility = to), _.copy(visibility = to))
       .asInstanceOf[P]
 
-  def removeMembers[P <: Project](): P => P = membersLens.modify(_ => Set.empty)
+  def removeMembers[P <: Project](): P => P = membersLens.replace(Set.empty)
 
-  def replaceMembers[P <: Project](to: Set[Project.Member]): P => P =
-    _.fold(_.copy(members = to), _.copy(members = to), _.copy(members = to), _.copy(members = to)).asInstanceOf[P]
+  def replaceMembers[P <: Project](to: Set[Project.Member]): P => P = membersLens.replace(to)
 
   def replaceProjectName[P <: Project](to: projects.Name): P => P =
     _.fold(_.copy(name = to), _.copy(name = to), _.copy(name = to), _.copy(name = to)).asInstanceOf[P]


### PR DESCRIPTION
This PR adds a possibility to specify a new `owned` query parameter to the `GET /knowledge-graph/entities` API which reduces entities returned by the API only to those which the caller owns.

closes #1486