### PR TITLE
feat: Cross-Entity Search results quality improvements

### DIFF
--- a/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/CrossEntitiesSearchSpec.scala
+++ b/acceptance-tests/src/test/scala/io/renku/graph/acceptancetests/knowledgegraph/CrossEntitiesSearchSpec.scala
@@ -33,6 +33,7 @@ import io.renku.graph.model.projects.Role
 import io.renku.graph.model.testentities._
 import io.renku.http.client.UrlEncoder._
 import org.http4s.Status.Ok
+import org.scalacheck.Gen.alphaLowerChar
 import tooling.{AcceptanceSpec, ApplicationServices}
 
 class CrossEntitiesSearchSpec extends AcceptanceSpec with ApplicationServices with TSProvisioning {
@@ -41,7 +42,7 @@ class CrossEntitiesSearchSpec extends AcceptanceSpec with ApplicationServices wi
 
     val user = authUsers.generateOne
 
-    val commonPhrase = nonBlankStrings(minLength = 5).generateOne
+    val commonPhrase = nonBlankStrings(minLength = 5, charsGenerator = alphaLowerChar).generateOne
     val testProject =
       renkuProjectEntities(visibilityPublic, creatorGen = cliShapedPersons)
         .modify(replaceProjectName(sentenceContaining(commonPhrase).generateAs[projects.Name]))

--- a/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/EntitiesFinderSpec.scala
@@ -42,6 +42,7 @@ import io.renku.http.rest.paging.model._
 import io.renku.http.rest.{SortBy, Sorting}
 import io.renku.testtools.IOSpec
 import io.renku.triplesstore._
+import org.scalacheck.Gen.alphaLowerChar
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -155,7 +156,8 @@ class EntitiesFinderSpec
     }
 
     "return entities which name matches the given query, sorted by name" in new TestCase {
-      val query = nonBlankStrings(minLength = 6).generateOne
+
+      val query = nonBlankStrings(minLength = 6, charsGenerator = alphaLowerChar).generateOne
 
       val person = personEntities
         .map(replacePersonName(to = sentenceContaining(query).generateAs(persons.Name)))
@@ -204,7 +206,7 @@ class EntitiesFinderSpec
     }
 
     "return entities which keywords matches the given query, sorted by name" in new TestCase {
-      val query = nonBlankStrings(minLength = 6).generateOne
+      val query = nonBlankStrings(minLength = 6, charsGenerator = alphaLowerChar).generateOne
 
       val soleProject = renkuProjectEntities(visibilityPublic)
         .modify(
@@ -253,7 +255,7 @@ class EntitiesFinderSpec
     }
 
     "return entities which description matches the given query, sorted by name" in new TestCase {
-      val query = nonBlankStrings(minLength = 6).generateOne
+      val query = nonBlankStrings(minLength = 6, charsGenerator = alphaLowerChar).generateOne
 
       val soleProject = renkuProjectEntities(visibilityPublic)
         .modify(
@@ -294,7 +296,7 @@ class EntitiesFinderSpec
     }
 
     "return project entities which namespace matches the given query, sorted by name" in new TestCase {
-      val query = nonBlankStrings(minLength = 6).generateOne
+      val query = nonBlankStrings(minLength = 6, charsGenerator = alphaLowerChar).generateOne
 
       val soleProject = renkuProjectEntities(visibilityPublic)
         .modify(_.copy(slug = projects.Slug(s"$query/${relativePaths(maxSegments = 2).generateOne}")))
@@ -311,7 +313,7 @@ class EntitiesFinderSpec
     }
 
     "return entities which creator name matches the given query, sorted by name" in new TestCase {
-      val query = nonBlankStrings(minLength = 6).generateOne
+      val query = nonBlankStrings(minLength = 6, charsGenerator = alphaLowerChar).generateOne
 
       val projectCreator = personEntities.generateOne.copy(name = sentenceContaining(query).generateAs(persons.Name))
       val soleProject = renkuProjectEntities(visibilityPublic)

--- a/entities-search/src/test/scala/io/renku/entities/search/PersonsEntitiesFinderSpec.scala
+++ b/entities-search/src/test/scala/io/renku/entities/search/PersonsEntitiesFinderSpec.scala
@@ -28,6 +28,7 @@ import io.renku.graph.model._
 import io.renku.graph.model.testentities._
 import io.renku.testtools.IOSpec
 import io.renku.triplesstore.{InMemoryJenaForSpec, ProjectsDataset}
+import org.scalacheck.Gen.alphaLowerChar
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -44,7 +45,7 @@ class PersonsEntitiesFinderSpec
     "return a single person if there are multiple with the same name" in new TestCase {
       // person merging is a temporary solution until we start to return persons ids
 
-      val query = nonBlankStrings(minLength = 3).generateOne
+      val query = nonBlankStrings(minLength = 3, charsGenerator = alphaLowerChar).generateOne
 
       val sharedName      = sentenceContaining(query).generateAs(persons.Name)
       val person1SameName = personEntities.map(_.copy(name = sharedName)).generateOne

--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -57,6 +57,13 @@
       ]
     ]
   ) ;
+  text:analyzer [
+    a text:DefinedAnalyzer ;
+    text:useAnalyzer :preservingAndLetterAnalyzer
+  ] ;
+  text:queryAnalyzer [
+    a text:KeywordAnalyzer
+  ] ;
   text:entityMap :entMap
 .
 
@@ -66,11 +73,7 @@
   text:map (
     [
       text:field "name" ;
-      text:predicate schema:name ;
-      text:analyzer [
-        a text:DefinedAnalyzer ;
-        text:useAnalyzer :preservingAndLetterAnalyzer
-      ]
+      text:predicate schema:name
     ]
     [
       text:field "description" ;
@@ -78,35 +81,19 @@
     ]
     [
       text:field "slug" ;
-      text:predicate renku:slug ;
-      text:analyzer [
-        a text:DefinedAnalyzer ;
-        text:useAnalyzer :preservingAndLetterAnalyzer
-      ]
+      text:predicate renku:slug
     ]
     [
       text:field "projectNamespaces" ;
-      text:predicate renku:projectNamespaces ;
-      text:analyzer [
-        a text:DefinedAnalyzer ;
-        text:useAnalyzer :preservingAndLetterAnalyzer
-      ]
+      text:predicate renku:projectNamespaces
     ]
     [
       text:field "keywords" ;
-      text:predicate schema:keywords ;
-      text:analyzer [
-        a text:DefinedAnalyzer ;
-        text:useAnalyzer :preservingAndLetterAnalyzer
-      ]
+      text:predicate schema:keywords
     ]
     [
       text:field "keywordsConcat" ;
-      text:predicate renku:keywordsConcat ;
-      text:analyzer [
-        a text:DefinedAnalyzer ;
-        text:useAnalyzer :preservingAndLetterAnalyzer
-      ]
+      text:predicate renku:keywordsConcat
     ]
     [
       text:field "creatorsNamesConcat" ;

--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -20,32 +20,21 @@
 
 :text_dataset a  text:TextDataset ;
   text:dataset   :tdb_projects ;
-  text:index     <#indexLucene> ;
+  text:index     :indexLucene ;
 .
 
 :tdb_projects a  tdb2:DatasetTDB2 ;
   tdb2:location  "/fuseki/databases/projects" .
 
-<#indexLucene> a text:TextIndexLucene ;
+:indexLucene a text:TextIndexLucene ;
   text:directory <file:///fuseki/databases/projects/lucene_index> ;
   text:defineAnalyzers (
     [
-      text:defineAnalyzer <#preservingAndLetterAnalyzer> ;
+      text:defineAnalyzer :preservingAndLetterAnalyzer ;
       text:analyzer [
         a text:ConfigurableAnalyzer ;
         text:tokenizer text:StandardTokenizer ;
         text:filters ( :preservingAndLetterFilter )
-      ]
-    ]
-    [
-      text:defineFilter :customFilter ;
-      text:filter [
-        a text:GenericFilter ;
-        text:class "org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter" ;
-        text:params (
-          [ text:paramName "preserveOriginal" ;
-            text:paramValue true ]
-        )
       ]
     ]
     [
@@ -67,10 +56,10 @@
       ]
     ]
   ) ;
-  text:entityMap <#entMap>
+  text:entityMap :entMap
 .
 
-<#entMap> a         text:EntityMap ;
+:entMap a         text:EntityMap ;
   text:defaultField "name" ;
   text:entityField  "uri" ;
   text:map (
@@ -79,7 +68,7 @@
       text:predicate schema:name ;
       text:analyzer [
         a text:DefinedAnalyzer ;
-        text:useAnalyzer <#preservingAndLetterAnalyzer>
+        text:useAnalyzer :preservingAndLetterAnalyzer
       ]
     ]
     [
@@ -91,7 +80,7 @@
       text:predicate renku:slug ;
       text:analyzer [
         a text:DefinedAnalyzer ;
-        text:useAnalyzer <#preservingAndLetterAnalyzer>
+        text:useAnalyzer :preservingAndLetterAnalyzer
       ]
     ]
     [
@@ -99,7 +88,7 @@
       text:predicate renku:projectNamespaces ;
       text:analyzer [
         a text:DefinedAnalyzer ;
-        text:useAnalyzer <#preservingAndLetterAnalyzer>
+        text:useAnalyzer :preservingAndLetterAnalyzer
       ]
     ]
     [
@@ -107,7 +96,7 @@
       text:predicate schema:keywords ;
       text:analyzer [
         a text:DefinedAnalyzer ;
-        text:useAnalyzer <#preservingAndLetterAnalyzer>
+        text:useAnalyzer :preservingAndLetterAnalyzer
       ]
     ]
     [
@@ -115,7 +104,7 @@
       text:predicate renku:keywordsConcat ;
       text:analyzer [
         a text:DefinedAnalyzer ;
-        text:useAnalyzer <#preservingAndLetterAnalyzer>
+        text:useAnalyzer :preservingAndLetterAnalyzer
       ]
     ]
     [

--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -33,7 +33,7 @@
       text:defineAnalyzer :preservingAndLetterAnalyzer ;
       text:analyzer [
         a text:ConfigurableAnalyzer ;
-        text:tokenizer text:StandardTokenizer ;
+        text:tokenizer text:WhitespaceTokenizer ;
         text:filters ( :preservingAndLetterFilter )
       ]
     ]
@@ -45,7 +45,7 @@
         text:params (
           [
             text:paramName "configurationFlags" ;
-            text:paramValue 483
+            text:paramValue 227
           ]
           [
             text:paramName "protWords" ;

--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -28,18 +28,98 @@
 
 <#indexLucene> a text:TextIndexLucene ;
   text:directory <file:///fuseki/databases/projects/lucene_index> ;
-  text:entityMap <#entMap> ;
+  text:defineAnalyzers (
+    [
+      text:defineAnalyzer <#preservingAndLetterAnalyzer> ;
+      text:analyzer [
+        a text:ConfigurableAnalyzer ;
+        text:tokenizer text:StandardTokenizer ;
+        text:filters ( :preservingAndLetterFilter )
+      ]
+    ]
+    [
+      text:defineFilter :customFilter ;
+      text:filter [
+        a text:GenericFilter ;
+        text:class "org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter" ;
+        text:params (
+          [ text:paramName "preserveOriginal" ;
+            text:paramValue true ]
+        )
+      ]
+    ]
+    [
+      text:defineFilter :preservingAndLetterFilter ;
+      text:filter [
+        a text:GenericFilter ;
+        text:class "org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter" ;
+        text:params (
+          [
+            text:paramName "configurationFlags" ;
+            text:paramValue 483
+          ]
+          [
+            text:paramName "protWords" ;
+            text:paramType text:TypeSet ;
+            text:paramValue ()
+          ]
+        )
+      ]
+    ]
+  ) ;
+  text:entityMap <#entMap>
 .
 
 <#entMap> a         text:EntityMap ;
   text:defaultField "name" ;
   text:entityField  "uri" ;
   text:map (
-    [ text:field "name" ;                text:predicate schema:name ]
-    [ text:field "description" ;         text:predicate schema:description ]
-    [ text:field "slug" ;                text:predicate renku:slug ]
-    [ text:field "projectNamespaces" ;   text:predicate renku:projectNamespaces ]
-    [ text:field "keywords" ;            text:predicate schema:keywords ]
-    [ text:field "keywordsConcat" ;      text:predicate renku:keywordsConcat ]
-    [ text:field "creatorsNamesConcat" ; text:predicate renku:creatorsNamesConcat ]
+    [
+      text:field "name" ;
+      text:predicate schema:name ;
+      text:analyzer [
+        a text:DefinedAnalyzer ;
+        text:useAnalyzer <#preservingAndLetterAnalyzer>
+      ]
+    ]
+    [
+      text:field "description" ;
+      text:predicate schema:description
+    ]
+    [
+      text:field "slug" ;
+      text:predicate renku:slug ;
+      text:analyzer [
+        a text:DefinedAnalyzer ;
+        text:useAnalyzer <#preservingAndLetterAnalyzer>
+      ]
+    ]
+    [
+      text:field "projectNamespaces" ;
+      text:predicate renku:projectNamespaces ;
+      text:analyzer [
+        a text:DefinedAnalyzer ;
+        text:useAnalyzer <#preservingAndLetterAnalyzer>
+      ]
+    ]
+    [
+      text:field "keywords" ;
+      text:predicate schema:keywords ;
+      text:analyzer [
+        a text:DefinedAnalyzer ;
+        text:useAnalyzer <#preservingAndLetterAnalyzer>
+      ]
+    ]
+    [
+      text:field "keywordsConcat" ;
+      text:predicate renku:keywordsConcat ;
+      text:analyzer [
+        a text:DefinedAnalyzer ;
+        text:useAnalyzer <#preservingAndLetterAnalyzer>
+      ]
+    ]
+    [
+      text:field "creatorsNamesConcat" ;
+      text:predicate renku:creatorsNamesConcat
+    ]
   ) .

--- a/graph-commons/src/main/resources/projects-ds.ttl
+++ b/graph-commons/src/main/resources/projects-ds.ttl
@@ -45,6 +45,7 @@
         text:params (
           [
             text:paramName "configurationFlags" ;
+            # 227 means setting "preserveOriginal", "1", "stemEnglishPossessive", "0" when the WordDelimiterGraphFilterFactory is used
             text:paramValue 227
           ]
           [

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/QueryTokenizerSpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/QueryTokenizerSpec.scala
@@ -22,8 +22,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 
 class QueryTokenizerSpec extends AnyFlatSpec with should.Matchers {
-  val standard = QueryTokenizer.luceneStandard
-  val letter   = QueryTokenizer.luceneLetters
+  val standard              = QueryTokenizer.luceneStandard
+  val letter                = QueryTokenizer.luceneLetters
+  def preservingWithLetters = QueryTokenizer.lucenePreservingWithLetters
 
   "standard" should "split on whitespace" in {
     val input = "  one two\tthree   four\nfive "
@@ -57,5 +58,25 @@ class QueryTokenizerSpec extends AnyFlatSpec with should.Matchers {
   it should "skip numbers" in {
     val input = "01_test 02 bar"
     letter.split(input) shouldBe List("test", "bar")
+  }
+
+  "preservingWithWhitespace" should "split on whitespaces" in {
+    val text = "  one two\tthree   four\nfive "
+    preservingWithLetters.split(text) shouldBe List("one", "two", "three", "four", "five")
+  }
+
+  it should "split on non-letters and preserve the group" in {
+    val input = "one_two_three"
+    preservingWithLetters.split(input) shouldBe List(input, "one", "two", "three")
+  }
+
+  it should "split on case changes and preserve the group" in {
+    val input = "camelCase"
+    preservingWithLetters.split(input) shouldBe List("camelCase", "camel", "Case")
+  }
+
+  it should "split on whitespaces, preserve the groups and split the groups on non-letters" in {
+    val input = "01_test 02 bar 03-foo"
+    preservingWithLetters.split(input) shouldBe List("01_test", "01", "test", "02", "bar", "03-foo", "03", "foo")
   }
 }


### PR DESCRIPTION
This PR:
* defines a custom Lucene Analyzer that divides text at non-letters as well as keeps groups extracted from splitting on whitespaces;
* applies the analyzer to all the indexed properties except from the `schema:description`;
* makes the default query tokenizer to use the same custom analyzer to tokenise user queries;
* adds TS migrations to update the changed `projects.ttl` and kick off reindexing;

closes #1753 