### PR TITLE
fix: LuceneQuery sparql encoder to properly encode special chars

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
@@ -60,7 +60,7 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
 
   private def textPart(filters: Criteria.Filters) =
     filters.onQuery(
-      snippet = fr"""(?id ?score) text:query (schema:name ${filters.query.query.asTripleObject}).""",
+      snippet = fr"""(?id ?score) text:query (schema:name ${filters.query}).""",
       matchingScoreVariableName = VarName("score")
     )
 

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQuery.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQuery.scala
@@ -18,6 +18,9 @@
 
 package io.renku.triplesstore.client.sparql
 
+import cats.syntax.all._
+import io.renku.triplesstore.client.model.TripleObjectEncoder
+import io.renku.triplesstore.client.syntax._
 import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil
 
 final class LuceneQuery(val query: String) extends AnyVal {
@@ -41,6 +44,6 @@ object LuceneQuery {
         .mkString(" ")
     )
 
-  implicit val sparqlEncoder: SparqlEncoder[LuceneQuery] =
-    SparqlEncoder.instance(q => Fragment(s"'${q.query}'"))
+  implicit val tripleObjectEncoder: TripleObjectEncoder[LuceneQuery] =
+    TripleObjectEncoder[String].contramap(_.query)
 }

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQueryEncoder.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/LuceneQueryEncoder.scala
@@ -22,5 +22,5 @@ import org.apache.lucene.queryparser.flexible.standard.QueryParserUtil
 
 private object LuceneQueryEncoder {
 
-  def queryAsString(v: String): String = QueryParserUtil.escape(v).replace("\\", "\\\\")
+  def queryAsString(v: String): String = QueryParserUtil.escape(v)
 }

--- a/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/StringInterpolator.scala
+++ b/triples-store-client/src/main/scala/io/renku/triplesstore/client/sparql/StringInterpolator.scala
@@ -36,7 +36,7 @@ class StringInterpolator(private val sc: StringContext) {
   }
 
   private lazy val makeValue: ((Any, Int)) => String = {
-    case (a: LuceneQuery, _)         => a.asSparql.sparql
+    case (a: LuceneQuery, _)         => a.asTripleObject.asSparql.sparql
     case (a: String, _)              => a.asTripleObject.asSparql.sparql
     case (a: Char, _)                => a.toString.asTripleObject.asSparql.sparql
     case (a: Float, _)               => a.asTripleObject.asSparql.sparql

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/SyntaxTest.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/SyntaxTest.scala
@@ -29,7 +29,8 @@ class SyntaxTest extends AnyFlatSpec with should.Matchers {
 
   it should "interpolate a lucene query as string" in {
     val query = LuceneQuery.escape("this is a query?")
-    fr"?id text:query (schema:name $query)" shouldBe Fragment(s"?id text:query (schema:name '${query.query}')")
+    fr"?id text:query (schema:name $query)" shouldBe
+      Fragment(s"?id text:query (schema:name ${query.query.asTripleObject.asSparql.sparql})")
   }
 
   it should "interpolate strings" in {

--- a/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/StringInterpolatorSpec.scala
+++ b/triples-store-client/src/test/scala/io/renku/triplesstore/client/sparql/StringInterpolatorSpec.scala
@@ -34,7 +34,7 @@ class StringInterpolatorSpec extends AnyWordSpec with should.Matchers {
 
     "encode a LuceneQuery if used" in {
       val value = LuceneQuery(s"{${nonEmptyStrings(minLength = 3).generateOne}")
-      fr"$value" shouldBe value.asSparql
+      fr"$value" shouldBe value.asTripleObject.asSparql
     }
 
     "encode a String if used" in {


### PR DESCRIPTION
This PR fixes `LuceneQuery` SPARQL encoders. It was not working for instance for queries like `abc-def`.