### PR TITLE
feat: role filter to replace owned in the Cross-Entity Search API

### DIFF
--- a/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/Criteria.scala
@@ -42,7 +42,7 @@ object Criteria {
   final case class Filters(maybeQuery:   Option[Filters.Query] = None,
                            entityTypes:  Set[Filters.EntityType] = Set.empty,
                            creators:     Set[persons.Name] = Set.empty,
-                           maybeOwned:   Option[Filters.Owned] = None,
+                           roles:        Set[projects.Role] = Set.empty,
                            visibilities: Set[projects.Visibility] = Set.empty,
                            namespaces:   Set[projects.Namespace] = Set.empty,
                            maybeSince:   Option[Filters.Since] = None,

--- a/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/DatasetsQuery.scala
@@ -134,15 +134,15 @@ object DatasetsQuery extends EntityQuery[Entity.Dataset] {
     }
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
-    filters.maybeOwned match {
-      case Some(Criteria.Filters.Owned(ownerId)) =>
+    maybeUser.map(_.id) -> filters.roles match {
+      case Some(userId) -> roles if roles.nonEmpty =>
         fr"""|$projIdVar renku:projectVisibility ?visibility .
              |${visibilitiesPart(filters.visibilities)}
-             |${authSnippets.ownedProjects(ownerId)}
+             |${authSnippets.projectsWithRoles(userId, roles)}
              |""".stripMargin
-      case None =>
+      case maybeUserId -> _ =>
         fr"""|$projIdVar renku:projectVisibility ?visibility .
-             |${authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)}
+             |${authSnippets.visibleProjects(maybeUserId, filters.visibilities)}
              |""".stripMargin
     }
 

--- a/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/PersonsQuery.scala
@@ -22,7 +22,8 @@ import io.circe.Decoder
 import io.renku.entities.search.Criteria.Filters.EntityType
 import io.renku.entities.search.model.{Entity, MatchingScore}
 import io.renku.graph.model.entities.Person.gitLabSameAsAdditionalType
-import io.renku.graph.model.{GraphClass, persons}
+import io.renku.graph.model.{GraphClass, persons, projects}
+import io.renku.http.server.security.model.AuthUser
 import io.renku.triplesstore.client.sparql.{Fragment, VarName}
 import io.renku.triplesstore.client.syntax._
 
@@ -46,7 +47,7 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
                |        GRAPH ${GraphClass.Persons.id} {
                |          ?id a schema:Person;
                |              schema:name ?name.
-               |          ${filterOnOwned(criteria.filters.maybeOwned)}
+               |          ${filterOnRoles(criteria)}
                |        }
                |        ${filters.maybeOnCreatorName(VarName("name"))}
                |      }
@@ -64,13 +65,20 @@ private case object PersonsQuery extends EntityQuery[model.Entity.Person] {
       matchingScoreVariableName = VarName("score")
     )
 
-  private lazy val filterOnOwned: Option[Criteria.Filters.Owned] => Fragment = {
-    case Some(Criteria.Filters.Owned(userId)) =>
+  private def filterOnRoles(criteria: Criteria): Fragment = criteria.maybeUser -> criteria.filters.roles match {
+    case Some(AuthUser(id, _)) -> roles if roles contains projects.Role.Owner =>
       fr"""|?id schema:sameAs ?sameAsId.
            |?sameAsId schema:additionalType ${gitLabSameAsAdditionalType.asTripleObject};
-           |          schema:identifier ${userId.asObject}.
+           |          schema:identifier ${id.asObject}.
            |""".stripMargin
-    case None => Fragment.empty
+    case _ -> roles if roles.nonEmpty =>
+      // this is a hack to filter out all the persons
+      // the assumption is that the caller cannot have an explicit Maintainer or Reader role on a Person
+      fr"""|FILTER EXISTS {
+           |  ?id renku:nonexisting true.
+           |}
+           |""".stripMargin
+    case _ => Fragment.empty
   }
 
   override def decoder[EE >: Entity.Person]: Decoder[EE] = { implicit cursor =>

--- a/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/ProjectsQuery.scala
@@ -139,15 +139,15 @@ private case object ProjectsQuery extends EntityQuery[model.Entity.Project] {
   }
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
-    filters.maybeOwned match {
-      case Some(Criteria.Filters.Owned(ownerId)) =>
+    maybeUser.map(_.id) -> filters.roles match {
+      case Some(userId) -> roles if roles.nonEmpty =>
         fr"""|$projectIdVar renku:projectVisibility $visibilityVar .
              |${visibilitiesPart(filters.visibilities)}
-             |${authSnippets.ownedProjects(ownerId)}
+             |${authSnippets.projectsWithRoles(userId, roles)}
              |""".stripMargin
-      case None =>
+      case maybeUserId -> _ =>
         fr"""|$projectIdVar renku:projectVisibility $visibilityVar .
-             |${authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)}
+             |${authSnippets.visibleProjects(maybeUserId, filters.visibilities)}
              |""".stripMargin
     }
 

--- a/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
+++ b/entities-search/src/main/scala/io/renku/entities/search/WorkflowsQuery.scala
@@ -114,11 +114,11 @@ private case object WorkflowsQuery extends EntityQuery[model.Entity.Workflow] {
   }
 
   private def accessRightsAndVisibility(maybeUser: Option[AuthUser], filters: Criteria.Filters): Fragment =
-    filters.maybeOwned match {
-      case Some(Criteria.Filters.Owned(ownerId)) =>
-        authSnippets.ownedProjects(ownerId)
-      case None =>
-        authSnippets.visibleProjects(maybeUser.map(_.id), filters.visibilities)
+    maybeUser.map(_.id) -> filters.roles match {
+      case Some(userId) -> roles if roles.nonEmpty =>
+        authSnippets.projectsWithRoles(userId, roles)
+      case maybeUserId -> _ =>
+        authSnippets.visibleProjects(maybeUserId, filters.visibilities)
     }
 
   private lazy val maybeFilterOnVisibilities: Set[projects.Visibility] => Fragment = {

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -300,7 +300,7 @@ Allows finding `projects`, `datasets`, `workflows`, and `persons`.
 * `query`      - to filter by matching field (e.g., title, keyword, description, etc. as specified below)
 * `type`       - to filter by entity type(s); allowed values: `project`, `dataset`, `workflow`, and `person`; multiple `type` parameters allowed
 * `creator`    - to filter by creator(s); the filter would require creator's name; multiple `creator` parameters allowed
-* `owned`      - to reduce the results to entities where the caller is an owner; this parameter does not require any value
+* `role`       - to filter by the caller role(s) on the entity; allowed values: `owner`, `maintainer`, `developer`, `reporter` and `guest`; multiple parameters allowed; an authorization header needs to be passed otherwise a `BAD_REQUEST (400)` status will be returned 
 * `visibility` - to filter by visibility(ies) (restricted vs. public); allowed values: `public`, `internal`, `private`; multiple `visibility` parameters allowed
 * `namespace`  - to filter by namespace(s); there might be multiple values given; for nested namespaces the whole path has be used, e.g. `group/subgroup` 
 * `since`      - to filter by entity's creation date to >= the given date
@@ -327,14 +327,19 @@ When the `query` parameter is given, the match is done on the following fields:
 * the `page` query parameter is optional and defaults to `1`.
 * the `per_page` query parameter is optional and defaults to `20`; max value is `100`.
 
+**Security**
+The API takes an authorization token (optional) the request header as:
+- `Authorization: Bearer <token>` with oauth token obtained from gitlab
+- `PRIVATE-TOKEN: <token>` with user's personal access token in gitlab
+
 **Response**
 
-| Status                       | Description                                                                                    |
-|------------------------------|------------------------------------------------------------------------------------------------|
-| OK (200)                     | If results are found; `[]` if nothing is found                                                 |
-| BAD_REQUEST (400)            | If illegal values for query parameters are given or `owned` specified but no auth user present |
-| UNAUTHORIZED (401)           | If given auth header cannot be authenticated                                                   |
-| INTERNAL SERVER ERROR (500)  | Otherwise                                                                                      |
+| Status                       | Description                                                                                   |
+|------------------------------|-----------------------------------------------------------------------------------------------|
+| OK (200)                     | If results are found; `[]` if nothing is found                                                |
+| BAD_REQUEST (400)            | If illegal values for query parameters are given or `role` specified but no auth user present |
+| UNAUTHORIZED (401)           | If given auth header cannot be authenticated                                                  |
+| INTERNAL SERVER ERROR (500)  | Otherwise                                                                                     |
 
 Response headers:
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/QueryParamDecoders.scala
@@ -24,7 +24,7 @@ import io.renku.entities.search.Criteria.Filters._
 import io.renku.entities.viewings.search.RecentEntitiesFinder
 import io.renku.graph.model._
 import io.renku.http.rest.paging.model.PerPage
-import org.http4s.dsl.io.{FlagQueryParamMatcher, OptionalMultiQueryParamDecoderMatcher, OptionalValidatingQueryParamDecoderMatcher}
+import org.http4s.dsl.io.{OptionalMultiQueryParamDecoderMatcher, OptionalValidatingQueryParamDecoderMatcher}
 import org.http4s.{ParseFailure, QueryParamDecoder, QueryParameterValue}
 
 import java.time.LocalDate
@@ -85,8 +85,15 @@ object QueryParamDecoders {
     val parameterName: String = "creator"
   }
 
-  object owned extends FlagQueryParamMatcher("owned") {
-    val parameterName: String = "owned"
+  private implicit val roleParameterDecoder: QueryParamDecoder[projects.Role] =
+    (value: QueryParameterValue) =>
+      projects.Role
+        .from(value.value)
+        .leftMap(_ => parsingFailure(roles.parameterName))
+        .toValidatedNel
+
+  object roles extends OptionalMultiQueryParamDecoderMatcher[projects.Role]("role") {
+    val parameterName: String = "role"
   }
 
   private implicit val visibilityParameterDecoder: QueryParamDecoder[projects.Visibility] =

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/entities/EndpointDocs.scala
@@ -18,7 +18,7 @@
 
 package io.renku.knowledgegraph.entities
 
-import cats.MonadThrow
+import cats.{MonadThrow, Show}
 import cats.implicits._
 import eu.timepit.refined.auto._
 import io.circe.Json
@@ -34,6 +34,7 @@ import io.renku.knowledgegraph.docs
 import io.renku.knowledgegraph.docs.model.Operation.GET
 import io.renku.knowledgegraph.docs.model._
 import io.renku.knowledgegraph.entities.ModelEncoders._
+import io.renku.tinytypes.TinyType
 
 import java.time.Instant
 
@@ -50,13 +51,13 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
     GET(
       "Cross-Entity Search",
       "Finds entities by the given criteria",
-      Uri / "entities" :? query & `type` & creator & owned & visibility & namespace & since & until & sort & page & perPage,
+      Uri / "entities" :? query & `type` & creator & role & visibility & namespace & since & until & sort & page & perPage,
       Status.Ok -> Response("Found entities",
                             Contents(MediaType.`application/json`("Sample response", example)),
                             responseHeaders
       ),
       Status.BadRequest -> Response(
-        "In case of invalid query parameters or `owned` parameter specified but no auth user present",
+        "In case of invalid query parameters or `role` specified but no auth user present",
         Contents(MediaType.`application/json`("Reason", Message.Info("Invalid parameters")))
       ),
       Status.Unauthorized -> Response(
@@ -87,16 +88,16 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
     "to filter by creator(s); the filter would require creator's name; multiple creator parameters allowed".some,
     required = false
   )
-  private lazy val owned = Parameter.Query(
-    "owned",
+  private lazy val role = Parameter.Query(
+    "role",
     Schema.String,
-    "to reduce the results to entities where the caller is an owner; this parameter does not require any value".some,
+    s"to filter by the caller role(s) on the entity; allowed values: ${toAllowedOptions(projects.Role.all.toList)}; multiple parameters allowed; an authorization header needs to be passed otherwise a `BAD_REQUEST (400)` status will be returned".some,
     required = false
   )
   private lazy val visibility = Parameter.Query(
     "visibility",
     Schema.String,
-    "to filter by visibility(ies) (restricted vs. public); allowed values: 'public', 'internal', 'private'; multiple visibility parameters allowed".some,
+    s"to filter by visibility(ies) (restricted vs. public); allowed values: ${toAllowedOptions(projects.Visibility.all)}; multiple parameters allowed".some,
     required = false
   )
   private lazy val namespace = Parameter.Query(
@@ -135,6 +136,9 @@ private class EndpointDocsImpl()(implicit gitLabUrl: GitLabUrl, renkuApiUrl: ren
     "the per_page query parameter is optional and defaults to 20; max value is 100.".some,
     required = false
   )
+
+  private def toAllowedOptions[TT <: TinyType: Show](options: Iterable[TT]) =
+    options.map(v => show"'$v'").mkString(", ")
 
   private lazy val responseHeaders = Map(
     "Total"       -> Header("The total number of entities".some, Schema.Integer),

--- a/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
+++ b/project-auth/src/main/scala/io/renku/projectauth/util/SparqlSnippets.scala
@@ -46,12 +46,17 @@ final class SparqlSnippets(val projectId: VarName) {
             |}
             | """.stripMargin
 
-  def ownedProjects(userId: persons.GitLabId): Fragment =
-    fr"""|GRAPH renku:ProjectAuth {
-         |   $projectId a schema:Project;
-         |              renku:memberRole ${ProjectMember(userId, projects.Role.Owner).encoded}.
-         |}
-         | """.stripMargin
+  def projectsWithRoles(userId: persons.GitLabId, roles: Set[projects.Role]): Fragment =
+    roles match {
+      case rls if rls.isEmpty => Fragment.empty
+      case rls =>
+        fr"""|GRAPH renku:ProjectAuth {
+             |   $projectId a schema:Project;
+             |              renku:memberRole ?memberRole.
+             |   VALUES (?memberRole) { ${rls.map(ProjectMember(userId, _).encoded)} }
+             |}
+             | """.stripMargin
+    }
 
   def visibleProjects(userId: Option[persons.GitLabId], selectedVisibility: Set[Visibility]): Fragment = {
     val visibilities =

--- a/project-auth/src/test/scala/io/renku/projectauth/Generators.scala
+++ b/project-auth/src/test/scala/io/renku/projectauth/Generators.scala
@@ -31,7 +31,7 @@ object Generators {
     Gen.oneOf(fixedIds).map(persons.GitLabId.apply)
 
   val memberGen: Gen[ProjectMember] = for {
-    role <- RenkuTinyTypeGenerators.roleGen
+    role <- RenkuTinyTypeGenerators.projectRoles
     id   <- gitLabIds
   } yield ProjectMember(id, role)
 

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
@@ -18,6 +18,7 @@
 
 package io.renku.graph.model
 
+import cats.Show
 import cats.data.{NonEmptyList, Validated}
 import cats.kernel.Order
 import cats.syntax.all._
@@ -271,7 +272,7 @@ object projects {
       fromString(str).fold(sys.error, identity)
 
     /** Translated from here: https://docs.gitlab.com/ee/api/members.html#roles */
-    def fromGitLabAccessLevel(accessLevel: Int) =
+    def fromGitLabAccessLevel(accessLevel: Int): Role =
       accessLevel match {
         case n if n >= 50 => Owner
         case n if n >= 40 => Maintainer
@@ -296,5 +297,8 @@ object projects {
 
     implicit val jsonEncoder: Encoder[Role] =
       Encoder.encodeString.contramap(_.asString)
+
+    implicit def show[R <: Role]: Show[R] =
+      Show.show(_.asString)
   }
 }

--- a/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
+++ b/renku-model-tiny-types/src/main/scala/io/renku/graph/model/projects.scala
@@ -238,7 +238,7 @@ object projects {
 
   object Role extends TinyTypeFactory[Role](RoleInstantiator) {
     case object Owner extends Role {
-      override val value: String = "value"
+      override val value: String = "owner"
 
       override def compare(that: Role): Int =
         if (that == this) 0 else 1

--- a/renku-model-tiny-types/src/test/scala/io/renku/graph/model/RenkuTinyTypeGenerators.scala
+++ b/renku-model-tiny-types/src/test/scala/io/renku/graph/model/RenkuTinyTypeGenerators.scala
@@ -23,7 +23,6 @@ import io.renku.generators.Generators
 import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators._
 import io.renku.graph.model.images.{ImageResourceId, ImageUri}
-import io.renku.graph.model.projects.Role
 import io.renku.graph.model.versions.{CliVersion, SchemaVersion}
 import io.renku.tinytypes.InstantTinyType
 import org.scalacheck.Gen
@@ -34,9 +33,6 @@ import java.time.{Instant, LocalDate, ZoneOffset}
 import scala.util.Random
 
 trait RenkuTinyTypeGenerators {
-
-  val roleGen: Gen[Role] =
-    Gen.oneOf(Role.all.toList)
 
   def associationResourceIdGen: Gen[associations.ResourceId] =
     Generators.validatedUrls.map(_.value).map(associations.ResourceId)
@@ -125,6 +121,7 @@ trait RenkuTinyTypeGenerators {
   implicit val projectDescriptions: Gen[projects.Description] =
     Generators.paragraphs() map (v => projects.Description(v.value))
   implicit val projectVisibilities: Gen[projects.Visibility] = Gen.oneOf(projects.Visibility.all.toList)
+  implicit val projectRoles:        Gen[projects.Role]       = Gen.oneOf(projects.Role.all.toList)
 
   def projectCreatedDates(min: Instant = Instant.EPOCH): Gen[projects.DateCreated] =
     Generators.timestamps(min, max = Instant.now()).toGeneratorOf(projects.DateCreated)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/EntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/EntitiesGenerators.scala
@@ -98,7 +98,7 @@ trait EntitiesGenerators
   ): Gen[GitLabMember] =
     for {
       user <- gitLabUserGen(gitLabIds, maybeEmails)
-      role <- roleGen
+      role <- projectRoles
     } yield GitLabMember(user, Role.toGitLabAccessLevel(role))
 
   def personEntities(
@@ -118,7 +118,7 @@ trait EntitiesGenerators
   ): Gen[Project.Member] =
     for {
       p    <- personEntities(maybeGitLabIds, maybeEmails)
-      role <- roleGen
+      role <- projectRoles
     } yield Project.Member(p, role)
 
   def replacePersonName(to: persons.Name): Person => Person = _.copy(name = to)

--- a/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
+++ b/renku-model/src/test/scala/io/renku/graph/model/testentities/generators/RenkuProjectEntitiesGenerators.scala
@@ -148,7 +148,7 @@ trait RenkuProjectEntitiesGenerators {
     name     <- personNames
     username <- personUsernames
     gitLabId <- personGitLabIds
-    role     <- roleGen
+    role     <- projectRoles
   } yield GitLabMember(name, username, gitLabId, None, Role.toGitLabAccessLevel(role))
 
   implicit lazy val projectMembersWithEmail: Gen[GitLabMember] = for {

--- a/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/Generators.scala
+++ b/triples-generator/src/test/scala/io/renku/triplesgenerator/events/consumers/membersync/Generators.scala
@@ -18,8 +18,7 @@
 
 package io.renku.triplesgenerator.events.consumers.membersync
 
-import io.renku.graph.model.GraphModelGenerators.{personGitLabIds, personNames}
-import io.renku.graph.model.RenkuTinyTypeGenerators
+import io.renku.graph.model.GraphModelGenerators.{personGitLabIds, personNames, projectRoles}
 import io.renku.graph.model.projects.Role
 import org.scalacheck.Gen
 
@@ -28,7 +27,7 @@ private trait Generators {
   implicit val gitLabProjectMembers: Gen[GitLabProjectMember] = for {
     id   <- personGitLabIds
     name <- personNames
-    role <- RenkuTinyTypeGenerators.roleGen
+    role <- projectRoles
   } yield GitLabProjectMember(id, name, Role.toGitLabAccessLevel(role))
 }
 


### PR DESCRIPTION
This PR:
* removes the old `owned` filter from the Cross-Entity Search API
* adds a new `role` filter to the Cross-Entity Search API that can take multiple values and allows finding entities where the caller has the specified roles.

closes #1486 