### PR TITLE
fix: Hook validation to read all GL hooks

### DIFF
--- a/webhook-service/src/test/scala/io/renku/webhookservice/hookfetcher/ProjectHookFetcherSpec.scala
+++ b/webhook-service/src/test/scala/io/renku/webhookservice/hookfetcher/ProjectHookFetcherSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.webhookservice.hookfetcher
 
 import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
 import cats.syntax.all._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
@@ -33,90 +34,81 @@ import io.renku.http.client.{AccessToken, GitLabClient}
 import io.renku.http.server.EndpointTester.jsonEntityEncoder
 import io.renku.http.tinytypes.TinyTypeURIEncoder._
 import io.renku.interpreters.TestLogger
-import io.renku.stubbing.ExternalServiceStubbing
-import io.renku.testtools.{GitLabClientTools, IOSpec}
+import io.renku.testtools.GitLabClientTools
 import io.renku.webhookservice.WebhookServiceGenerators.{hookIdAndUrls, projectHookUrls}
 import io.renku.webhookservice.hookfetcher.ProjectHookFetcher.HookIdAndUrl
 import org.http4s.implicits.http4sLiteralsSyntax
 import org.http4s.{Request, Response, Status, Uri}
 import org.scalacheck.Gen
-import org.scalamock.scalatest.MockFactory
+import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.OptionValues
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
 
 class ProjectHookFetcherSpec
-    extends AnyWordSpec
-    with MockFactory
-    with ExternalServiceStubbing
+    extends AsyncFlatSpec
+    with AsyncIOSpec
+    with AsyncMockFactory
     with GitLabClientTools[IO]
     with should.Matchers
-    with OptionValues
-    with IOSpec {
+    with OptionValues {
 
-  "fetchProjectHooks" should {
+  it should "return list of project hooks" in {
 
-    "return list of project hooks" in new TestCase {
-
-      val idAndUrls = hookIdAndUrls.toGeneratorOfNonEmptyList(2).generateOne.toList
-
-      (gitLabClient
-        .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, Option[List[HookIdAndUrl]]])(
-          _: Option[AccessToken]
-        ))
-        .expects(uri, endpointName, *, accessToken.some)
-        .returning(idAndUrls.some.pure[IO])
-
-      fetcher
-        .fetchProjectHooks(projectId, accessToken)
-        .unsafeRunSync()
-        .value should contain theSameElementsAs idAndUrls
-    }
-
-    "return the list of hooks if the response is Ok" in new TestCase {
-
-      val id  = positiveInts().generateOne.value
-      val url = projectHookUrls.generateOne
-      mapResponse((Status.Ok, Request(), Response().withEntity(json"""[{"id":$id, "url":${url.value}}]""")))
-        .unsafeRunSync() shouldBe List(HookIdAndUrl(id, url)).some
-    }
-
-    "return an empty list of hooks if the project does not exists" in new TestCase {
-      mapResponse(Status.NotFound, Request(), Response()).unsafeRunSync() shouldBe List.empty[HookIdAndUrl].some
-    }
-
-    Status.Unauthorized :: Status.Forbidden :: Nil foreach { status =>
-      show"return None if remote client responds with $status" in new TestCase {
-        mapResponse(status, Request(), Response()).unsafeRunSync() shouldBe None
-      }
-    }
-
-    "return an Exception if remote client responds with status any of OK , NOT_FOUND, UNAUTHORIZED or FORBIDDEN" in new TestCase {
-      intercept[Exception] {
-        mapResponse(Status.ServiceUnavailable, Request(), Response()).unsafeRunSync()
-      }
-    }
-
-    "return a RuntimeException if remote client responds with unexpected body" in new TestCase {
-      intercept[RuntimeException] {
-        mapResponse((Status.Ok, Request(), Response().withEntity("""{}"""))).unsafeRunSync()
-      }.getMessage should include("Could not decode JSON")
-    }
-  }
-
-  private trait TestCase {
     val projectId = projectIds.generateOne
     val uri       = uri"projects" / projectId / "hooks"
     val endpointName: String Refined NonEmpty = "project-hooks"
     val accessToken = accessTokens.generateOne
+    val idAndUrls   = hookIdAndUrls.toGeneratorOfNonEmptyList(2).generateOne.toList
 
-    implicit val logger:       TestLogger[IO]   = TestLogger[IO]()
-    implicit val gitLabClient: GitLabClient[IO] = mock[GitLabClient[IO]]
-    val fetcher = new ProjectHookFetcherImpl[IO]
+    (glClient
+      .get(_: Uri, _: String Refined NonEmpty)(_: ResponseMappingF[IO, Option[List[HookIdAndUrl]]])(
+        _: Option[AccessToken]
+      ))
+      .expects(uri, endpointName, *, accessToken.some)
+      .returning(idAndUrls.some.pure[IO])
 
-    val mapResponse = captureMapping(gitLabClient)(fetcher.fetchProjectHooks(projectId, accessToken).unsafeRunSync(),
-                                                   Gen.const(Option.empty[List[HookIdAndUrl]]),
-                                                   underlyingMethod = Get
-    )
+    fetcher
+      .fetchProjectHooks(projectId, accessToken)
+      .asserting(_.value should contain theSameElementsAs idAndUrls)
   }
+
+  it should "return the list of hooks if the response is Ok" in {
+
+    val id  = positiveInts().generateOne.value
+    val url = projectHookUrls.generateOne
+    mapResponse((Status.Ok, Request(), Response().withEntity(json"""[{"id":$id, "url":${url.value}}]""")))
+      .asserting(_ shouldBe List(HookIdAndUrl(id, url)).some)
+  }
+
+  it should "return an empty list of hooks if the project does not exists" in {
+    mapResponse(Status.NotFound, Request(), Response()).asserting(_ shouldBe List.empty[HookIdAndUrl].some)
+  }
+
+  Status.Unauthorized :: Status.Forbidden :: Nil foreach { status =>
+    it should show"return None if remote client responds with $status" in {
+      mapResponse(status, Request(), Response()).asserting(_ shouldBe None)
+    }
+  }
+
+  it should "return an Exception if remote client responds with status any of OK , NOT_FOUND, UNAUTHORIZED or FORBIDDEN" in {
+    intercept[Exception] {
+      mapResponse(Status.ServiceUnavailable, Request(), Response()).assertNoException
+    } shouldBe a[MatchError]
+  }
+
+  it should "return a RuntimeException if remote client responds with unexpected body" in {
+    mapResponse((Status.Ok, Request(), Response().withEntity("""{}""")))
+      .assertThrowsError[Exception](_.getMessage should include("Could not decode JSON"))
+  }
+
+  private implicit val logger:        TestLogger[IO]   = TestLogger[IO]()
+  private implicit lazy val glClient: GitLabClient[IO] = mock[GitLabClient[IO]]
+  private lazy val fetcher = new ProjectHookFetcherImpl[IO]
+
+  private lazy val mapResponse = captureMapping(glClient)(
+    fetcher.fetchProjectHooks(projectIds.generateOne, accessTokens.generateOne).unsafeRunSync(),
+    Gen.const(Option.empty[List[HookIdAndUrl]]),
+    underlyingMethod = Get
+  )
 }


### PR DESCRIPTION
This PR fixes the Hook Validation process so it fetches all hooks from GL (not the 1st page only).