### PR TITLE
fix: improved failure reporting on unknown errors on event sending

### DIFF
--- a/graph-commons/src/main/scala/io/renku/events/producers/EventSender.scala
+++ b/graph-commons/src/main/scala/io/renku/events/producers/EventSender.scala
@@ -150,6 +150,9 @@ class EventSenderImpl[F[_]: Async: Logger](
       waitAndRetry(retry, exception, context.errorMessage)
     case exception @ (_: ConnectivityException | _: ClientException) =>
       waitAndRetry(retry, exception, context.errorMessage)
+    case exception =>
+      val message = s"${context.errorMessage} - got non-retry-able exception"
+      Logger[F].error(exception)(message) >> new Exception(message, exception).raiseError[F, Status]
   }
 
   private def waitAndRetry(retry: Eval[F[Status]], message: String): F[Status] =


### PR DESCRIPTION
This PR:
* slightly improves exception handling in cases when an unknown/unexpected exception is thrown when sending an event to another service. Simply a nasty `MatchError` is turned into an `Exception` with a better message and the real cause.

closes #1790 