### PR TITLE
fix: Viewed events' date to be decoded to now if in the future

### DIFF
--- a/triples-generator-api/src/main/scala/io/renku/triplesgenerator/api/events/ProjectActivated.scala
+++ b/triples-generator-api/src/main/scala/io/renku/triplesgenerator/api/events/ProjectActivated.scala
@@ -61,7 +61,14 @@ object ProjectActivated {
     for {
       _    <- validateCategory
       slug <- cursor.downField("project").downField("slug").as[projects.Slug]
-      date <- cursor.downField("date").as[DateActivated]
+      date <- cursor
+                .downField("date")
+                .as[Instant]
+                .map {
+                  case i if (i compareTo Instant.now()) > 0 => Instant.now()
+                  case i                                    => i
+                }
+                .map(DateActivated)
     } yield ProjectActivated(slug, date)
   }
 

--- a/triples-generator-api/src/test/scala/io/renku/triplesgenerator/api/events/DatasetViewedEventSpec.scala
+++ b/triples-generator-api/src/test/scala/io/renku/triplesgenerator/api/events/DatasetViewedEventSpec.scala
@@ -18,21 +18,23 @@
 
 package io.renku.triplesgenerator.api.events
 
-import cats.syntax.all._
-import io.renku.generators.Generators.Implicits._
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
 import Generators._
+import cats.syntax.all._
 import io.circe.literal._
 import io.circe.syntax._
+import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
-import io.renku.graph.model.{datasets, persons}
 import io.renku.graph.model.RenkuTinyTypeGenerators.{datasetIdentifiers, datasetViewedDates, personGitLabIds}
+import io.renku.graph.model.{datasets, persons}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.time.Instant
+import java.time.Instant.now
+import java.time.temporal.ChronoUnit.MINUTES
 
 class DatasetViewedEventSpec
     extends AnyWordSpec
@@ -96,6 +98,19 @@ class DatasetViewedEventSpec
       }""".hcursor.as[DatasetViewedEvent]
 
       result.left.value.getMessage() should include(s"Expected DATASET_VIEWED but got $otherCategory")
+    }
+
+    "decode to now if date in the payload is in the future" in {
+
+      val result = json"""{
+        "categoryName": "DATASET_VIEWED",
+        "dataset": {
+          "identifier": "12345"
+        },
+        "date": ${now.plus(1, MINUTES)}
+      }""".hcursor.as[DatasetViewedEvent]
+
+      result.isRight shouldBe true
     }
   }
 

--- a/triples-generator-api/src/test/scala/io/renku/triplesgenerator/api/events/ProjectActivatedSpec.scala
+++ b/triples-generator-api/src/test/scala/io/renku/triplesgenerator/api/events/ProjectActivatedSpec.scala
@@ -18,21 +18,23 @@
 
 package io.renku.triplesgenerator.api.events
 
-import cats.syntax.all._
-import io.renku.generators.Generators.Implicits._
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
 import Generators._
+import cats.syntax.all._
 import io.circe.literal._
 import io.circe.syntax._
+import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.{nonEmptyStrings, timestampsNotInTheFuture}
-import io.renku.graph.model.projects
 import io.renku.graph.model.RenkuTinyTypeGenerators.projectSlugs
+import io.renku.graph.model.projects
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.time.Instant
+import java.time.Instant.now
+import java.time.temporal.ChronoUnit.MINUTES
 
 class ProjectActivatedSpec
     extends AnyWordSpec
@@ -89,6 +91,19 @@ class ProjectActivatedSpec
       }""".hcursor.as[ProjectActivated]
 
       result.left.value.getMessage() should include(s"Expected PROJECT_ACTIVATED but got $otherCategory")
+    }
+
+    "decode to now if date in the payload is in the future" in {
+
+      val result = json"""{
+        "categoryName": "PROJECT_ACTIVATED",
+        "project": {
+          "slug": ${projectSlugs.generateOne}
+        },
+        "date": ${now.plus(1, MINUTES)}
+      }""".hcursor.as[ProjectActivated]
+
+      result.isRight shouldBe true
     }
   }
 

--- a/triples-generator-api/src/test/scala/io/renku/triplesgenerator/api/events/ProjectViewedEventSpec.scala
+++ b/triples-generator-api/src/test/scala/io/renku/triplesgenerator/api/events/ProjectViewedEventSpec.scala
@@ -18,21 +18,23 @@
 
 package io.renku.triplesgenerator.api.events
 
-import cats.syntax.all._
-import io.renku.generators.Generators.Implicits._
-import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
 import Generators._
+import cats.syntax.all._
 import io.circe.literal._
 import io.circe.syntax._
+import io.renku.generators.Generators.Implicits._
 import io.renku.generators.Generators.nonEmptyStrings
-import io.renku.graph.model.{persons, projects}
 import io.renku.graph.model.RenkuTinyTypeGenerators.{personEmails, personGitLabIds, projectSlugs, projectViewedDates}
+import io.renku.graph.model.{persons, projects}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.EitherValues
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.time.Instant
+import java.time.Instant.now
+import java.time.temporal.ChronoUnit.MINUTES
 
 class ProjectViewedEventSpec
     extends AnyWordSpec
@@ -142,6 +144,19 @@ class ProjectViewedEventSpec
       }""".hcursor.as[ProjectViewedEvent]
 
       result.left.value.getMessage() should include(s"Expected PROJECT_VIEWED but got $otherCategory")
+    }
+
+    "decode to now if date in the payload is in the future" in {
+
+      val result = json"""{
+        "categoryName": "PROJECT_VIEWED",
+        "project": {
+          "slug": "project/path"
+        },
+        "date": ${now.plus(1, MINUTES)}
+      }""".hcursor.as[ProjectViewedEvent]
+
+      result.isRight shouldBe true
     }
   }
 


### PR DESCRIPTION
This PR makes the decoders for `PROJECT_ACTIVATED`, `DATASET_VIEWED` and `PROJECT_VIEWED` events use the current time if the date in the JSON payload is in the future.

closes #1806 