### PR TITLE
feat: token-repository to clean-up expiring tokens on daily basis

### DIFF
--- a/graph-commons/src/test/scala/io/renku/microservices/AbstractMicroserviceRunnerTest.scala
+++ b/graph-commons/src/test/scala/io/renku/microservices/AbstractMicroserviceRunnerTest.scala
@@ -20,8 +20,9 @@ package io.renku.microservices
 
 import cats.effect.{ExitCode, IO}
 import fs2.concurrent.{Signal, SignallingRef}
-import scala.language.reflectiveCalls
+
 import scala.concurrent.duration._
+import scala.language.reflectiveCalls
 
 trait AbstractMicroserviceRunnerTest {
 

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/cleanup/ExpiringToken.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/cleanup/ExpiringToken.scala
@@ -16,17 +16,18 @@
  * limitations under the License.
  */
 
-package io.renku.tokenrepository.repository.deletion
+package io.renku.tokenrepository.repository.cleanup
 
-import cats.Show
+import io.renku.graph.model.projects
+import io.renku.http.client.AccessToken
+import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
 
-sealed trait DeletionResult extends Product {
-  lazy val widen: DeletionResult = this
+private trait ExpiringToken {
+  val projectId: projects.GitLabId
+  lazy val widen: ExpiringToken = this
 }
 
-object DeletionResult {
-  case object Deleted    extends DeletionResult
-  case object NotExisted extends DeletionResult
-
-  implicit def show[R <: DeletionResult]: Show[R] = Show.show(_.productPrefix)
+private object ExpiringToken {
+  final case class Decryptable(projectId: projects.GitLabId, token: AccessToken)             extends ExpiringToken
+  final case class NonDecryptable(projectId: projects.GitLabId, token: EncryptedAccessToken) extends ExpiringToken
 }

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensFinder.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensFinder.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+package cleanup
+
+import ProjectsTokensDB.SessionResource
+import cats.effect.Async
+import cats.syntax.all._
+import fs2.Stream
+import io.renku.db.implicits._
+import io.renku.db.{DbClient, SqlStatement}
+import io.renku.graph.model.projects
+import io.renku.tokenrepository.repository.AccessTokenCrypto.EncryptedAccessToken
+import metrics.QueriesExecutionTimes
+import skunk.codec.all.date
+import skunk.implicits._
+import skunk.~
+
+import java.time.{LocalDate, Period}
+
+private trait ExpiringTokensFinder[F[_]] {
+  def findExpiringTokens: Stream[F, ExpiringToken]
+}
+
+private object ExpiringTokensFinder {
+
+  private val chunkSize:              Int    = 10
+  private val periodBeforeExpiration: Period = Period.ofDays(10)
+
+  def apply[F[_]: Async: SessionResource: QueriesExecutionTimes]: F[ExpiringTokensFinder[F]] =
+    AccessTokenCrypto[F]().map(new ExpiringTokensFinderImpl[F](_, periodBeforeExpiration, chunkSize))
+}
+
+private class ExpiringTokensFinderImpl[F[_]: Async: SessionResource: QueriesExecutionTimes](
+    accessTokenCrypto:      AccessTokenCrypto[F],
+    periodBeforeExpiration: Period,
+    chunkSize:              Int
+) extends DbClient[F](Some(QueriesExecutionTimes[F]))
+    with ExpiringTokensFinder[F]
+    with TokenRepositoryTypeSerializers {
+
+  override def findExpiringTokens: Stream[F, ExpiringToken] =
+    fetchAllChunks
+      .flatMap(in => Stream.emits(in))
+
+  private def fetchAllChunks: Stream[F, List[ExpiringToken]] =
+    (Stream.eval(SessionResource[F].useK(measureExecutionTime(query))) ++ fetchAllChunks)
+      .takeWhile(_.nonEmpty)
+
+  private lazy val query =
+    SqlStatement
+      .named("find expiring tokens")
+      .select[LocalDate, (projects.GitLabId, EncryptedAccessToken)](
+        sql"""SELECT project_id, token
+              FROM projects_tokens
+              WHERE expiry_date <= $date
+              LIMIT #${chunkSize.toString}"""
+          .query(projectIdDecoder ~ encryptedAccessTokenDecoder)
+          .map { case (id: projects.GitLabId) ~ (token: EncryptedAccessToken) => id -> token }
+      )
+      .arguments(LocalDate.now() plus periodBeforeExpiration)
+      .build(_.toList)
+      .flatMapResult {
+        _.map { case (id, encToken) =>
+          accessTokenCrypto
+            .decrypt(encToken)
+            .map(t => ExpiringToken.Decryptable(id, t).widen)
+            .handleError(_ => ExpiringToken.NonDecryptable(id, encToken).widen)
+        }.sequence
+      }
+}

--- a/token-repository/src/main/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensRemover.scala
+++ b/token-repository/src/main/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensRemover.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.cleanup
+
+import cats.effect.{Async, Temporal}
+import cats.syntax.all._
+import fs2.Stream
+import io.renku.http.client.GitLabClient
+import io.renku.tokenrepository.repository.ProjectsTokensDB.SessionResource
+import io.renku.tokenrepository.repository.deletion.{DeletionResult, PersistedTokenRemover, TokenRemover}
+import io.renku.tokenrepository.repository.metrics.QueriesExecutionTimes
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
+
+trait ExpiringTokensRemover[F[_]] {
+  def removeExpiringTokens(): F[Unit]
+}
+
+object ExpiringTokensRemover {
+  def apply[F[_]: Async: GitLabClient: SessionResource: Logger: QueriesExecutionTimes]: F[ExpiringTokensRemover[F]] =
+    (ExpiringTokensFinder[F], TokenRemover[F])
+      .mapN(new ExpiringTokensRemoverImpl(_, _, PersistedTokenRemover[F], 1 minute))
+}
+
+private class ExpiringTokensRemoverImpl[F[_]: Async: Logger](tokensFinder: ExpiringTokensFinder[F],
+                                                             tokenRemover:      TokenRemover[F],
+                                                             dbTokenRemover:    PersistedTokenRemover[F],
+                                                             retryDelayOnError: Duration
+) extends ExpiringTokensRemover[F] {
+
+  override def removeExpiringTokens(): F[Unit] =
+    (Stream.eval(Logger[F].info("Removing expiring tokens")) >> findAndRemoveTokens).compile.toList
+      .flatMap(tkns => Logger[F].info(s"Processed ${tkns.length} expired tokens"))
+      .handleErrorWith(waitAndRetry)
+
+  private def findAndRemoveTokens =
+    tokensFinder.findExpiringTokens
+      .evalMap(et => removeToken(et).tupleLeft(et))
+      .evalTap { case (et, result) => Logger[F].info(show"Expiring token for ${et.projectId} $result") }
+
+  private lazy val removeToken: ExpiringToken => F[DeletionResult] = {
+    case ExpiringToken.Decryptable(projectId, token) => tokenRemover.delete(projectId, token.some)
+    case ExpiringToken.NonDecryptable(projectId, _)  => dbTokenRemover.delete(projectId)
+  }
+
+  private lazy val waitAndRetry: Throwable => F[Unit] =
+    Logger[F].error(_)("Expiring tokens clean-up process failed. Retrying") >>
+      Temporal[F].delayBy(removeExpiringTokens(), retryDelayOnError)
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRunnerSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/MicroserviceRunnerSpec.scala
@@ -19,7 +19,7 @@
 package io.renku.tokenrepository
 
 import cats.effect._
-import cats.effect.unsafe.implicits.global
+import cats.effect.testing.scalatest.AsyncIOSpec
 import io.renku.config.certificates.CertificateLoader
 import io.renku.config.sentry.SentryInitializer
 import io.renku.generators.Generators.Implicits._
@@ -29,97 +29,115 @@ import io.renku.interpreters.TestLogger
 import io.renku.interpreters.TestLogger.Level.{Error, Info}
 import io.renku.microservices.{AbstractMicroserviceRunnerTest, CallCounter, ServiceRunCounter}
 import io.renku.tokenrepository.MicroserviceRunnerSpec.CountEffect
+import io.renku.tokenrepository.repository.cleanup.ExpiringTokensRemover
 import io.renku.tokenrepository.repository.init.DbInitializer
 import org.http4s.HttpRoutes
 import org.scalatest.matchers.should
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.{Assertion, Succeeded}
+
 import scala.concurrent.duration._
 
-class MicroserviceRunnerSpec extends AnyWordSpec with should.Matchers {
+class MicroserviceRunnerSpec extends AsyncWordSpec with AsyncIOSpec with should.Matchers {
 
   "run" should {
 
-    "initialise Sentry, load certificate, initialise DB and start HTTP server" in new TestCase {
+    "initialise Sentry, load certificate, initialise DB, kick off token removal and start HTTP server" in runnerTest {
+      runner =>
+        for {
+          _ <- runner.startFor(1.second).asserting(_ shouldBe ExitCode.Success)
 
-      startFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
+          _ <- runner.logger.loggedOnlyF(Info("Service started"))
 
-      logger.loggedOnly(Info("Service started"))
-
-      assertCalledAll.unsafeRunSync()
+          res <- runner.assertCalledAll.assertNoException
+        } yield res
     }
 
-    "fail if Certificate loading fails" in new TestCase {
-
+    "fail if Certificate loading fails" in runnerTest { runner =>
       val exception = exceptions.generateOne
-      certificateLoader.failWith(exception).unsafeRunSync()
-
-      intercept[Exception] {
-        startRunnerForever.unsafeRunSync()
-      } shouldBe exception
+      runner.certificateLoader.failWith(exception) >>
+        runner.startRunnerForever.assertThrowsError[Exception](_ shouldBe exception)
     }
 
-    "fail if Sentry initialization fails" in new TestCase {
-
+    "fail if Sentry initialization fails" in runnerTest { runner =>
       val exception = exceptions.generateOne
-      sentryInitializer.failWith(exception).unsafeRunSync()
-
-      intercept[Exception] {
-        startRunnerForever.unsafeRunSync()
-      } shouldBe exception
+      runner.sentryInitializer.failWith(exception) >>
+        runner.startRunnerForever.assertThrowsError[Exception](_ shouldBe exception)
     }
 
-    "return Success ExitCode even if DB initialisation fails as the process is run in another thread" in new TestCase {
+    "return Success ExitCode even if DB initialisation fails as the process is run in another thread" in runnerTest {
+      runner =>
+        val exception = exceptions.generateOne
+        for {
+          _ <- runner.dbInitializer.failWith(exception)
 
-      val exception = exceptions.generateOne
-      dbInitializer.failWith(exception).unsafeRunSync()
+          _ <- runner.startFor(1.second).asserting(_ shouldBe ExitCode.Success)
+          _ <- runner.assertCalledAllBut(runner.dbInitializer, runner.expiringTokensRemover, runner.microserviceRoutes)
+          _ <- runner.assertNotCalled(runner.expiringTokensRemover, runner.microserviceRoutes)
 
-      startFor(1.second).unsafeRunSync() shouldBe ExitCode.Success
-      assertCalledAllBut(dbInitializer, microserviceRoutes).unsafeRunSync()
-      assertNotCalled(microserviceRoutes).unsafeRunSync()
-
-      logger.logged(Error("DB initialization failed", exception), Info("Service started"))
+          _ <- runner.logger.loggedF(Error("DB initialization failed", exception), Info("Service started"))
+        } yield Succeeded
     }
 
-    "fail if starting the http server fails" in new TestCase {
+    "return Success ExitCode even if Expiring tokens removal fails as the process is run in another thread" in runnerTest {
+      runner =>
+        val exception = exceptions.generateOne
+        for {
+          _ <- runner.expiringTokensRemover.failWith(exception)
 
+          _ <- runner.startFor(1.second).asserting(_ shouldBe ExitCode.Success)
+          _ <- runner.assertCalledAllBut(runner.expiringTokensRemover)
+
+          _ <- runner.logger.loggedF(Error("Expiring Tokens Removal failed", exception), Info("Service started"))
+        } yield Succeeded
+    }
+
+    "fail if starting the http server fails" in runnerTest { runner =>
       val exception = exceptions.generateOne
-      httpServer.failWith(exception).unsafeRunSync()
-
-      intercept[Exception] {
-        startRunnerForever.unsafeRunSync()
-      } shouldBe exception
-
-      assertCalledAllBut(httpServer).unsafeRunSync()
+      runner.httpServer.failWith(exception) >>
+        runner.startRunnerForever.assertThrowsError[Exception](_ shouldBe exception) >>
+        runner.assertCalledAllBut(runner.httpServer).assertNoException
     }
   }
 
-  private trait TestCase extends AbstractMicroserviceRunnerTest {
-    implicit val logger:    TestLogger[IO]                          = TestLogger[IO]()
-    val certificateLoader:  CertificateLoader[IO] with CallCounter  = new CountEffect("CertificateLoader")
-    val sentryInitializer:  SentryInitializer[IO] with CallCounter  = new CountEffect("SentryInitializer")
-    val dbInitializer:      DbInitializer[IO] with CallCounter      = new CountEffect("DbInitializer")
-    val httpServer:         HttpServer[IO] with CallCounter         = new CountEffect("HttpServer")
-    val microserviceRoutes: MicroserviceRoutes[IO] with CallCounter = new CountEffect("MicroServiceRoutes")
+  private class RunnerTest extends AbstractMicroserviceRunnerTest {
+    implicit val logger:       TestLogger[IO]                             = TestLogger[IO]()
+    val certificateLoader:     CertificateLoader[IO] with CallCounter     = new CountEffect("CertificateLoader")
+    val sentryInitializer:     SentryInitializer[IO] with CallCounter     = new CountEffect("SentryInitializer")
+    val dbInitializer:         DbInitializer[IO] with CallCounter         = new CountEffect("DbInitializer")
+    val expiringTokensRemover: ExpiringTokensRemover[IO] with CallCounter = new CountEffect("ExpiringTokensRemover")
+    val httpServer:            HttpServer[IO] with CallCounter            = new CountEffect("HttpServer")
+    val microserviceRoutes:    MicroserviceRoutes[IO] with CallCounter    = new CountEffect("MicroServiceRoutes")
 
-    val runner =
-      new MicroserviceRunner(certificateLoader, sentryInitializer, dbInitializer, httpServer, microserviceRoutes)
+    val runner = new MicroserviceRunner(certificateLoader,
+                                        sentryInitializer,
+                                        dbInitializer,
+                                        expiringTokensRemover,
+                                        httpServer,
+                                        microserviceRoutes
+    )
 
     val all: List[CallCounter] = List(
       certificateLoader,
       sentryInitializer,
       dbInitializer,
+      expiringTokensRemover,
       httpServer,
       microserviceRoutes
     )
   }
+
+  private def runnerTest(f: RunnerTest => IO[Assertion]) = f(new RunnerTest)
 }
 
 object MicroserviceRunnerSpec {
   private class CountEffect(name: String)
       extends ServiceRunCounter(name)
       with DbInitializer[IO]
+      with ExpiringTokensRemover[IO]
       with MicroserviceRoutes[IO] {
-    override def notifyDBReady(): IO[Unit]                     = run
-    override def routes:          Resource[IO, HttpRoutes[IO]] = ???
+    override def notifyDBReady():        IO[Unit]                     = run
+    override def removeExpiringTokens(): IO[Unit]                     = run
+    override def routes:                 Resource[IO, HttpRoutes[IO]] = ???
   }
 }

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensFinderSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensFinderSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository
+package cleanup
+
+import AccessTokenCrypto.EncryptedAccessToken
+import RepositoryGenerators.encryptedAccessTokens
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import creation.TokenDates.ExpiryDate
+import deletion.PersistedTokenRemover
+import io.renku.db.DBConfigProvider.DBConfig
+import io.renku.generators.CommonGraphGenerators.accessTokens
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.exceptions
+import io.renku.graph.model.GraphModelGenerators._
+import io.renku.graph.model.projects
+import io.renku.http.client.AccessToken
+import metrics.{QueriesExecutionTimes, TestQueriesExecutionTimes}
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+
+import java.time.LocalDate.now
+import java.time.Period
+
+class ExpiringTokensFinderSpec
+    extends AsyncFlatSpec
+    with AsyncIOSpec
+    with TokenRepositoryPostgresSpec
+    with should.Matchers
+    with AsyncMockFactory {
+
+  it should "return a stream of ExpiringToken objects for all the projects with tokens expiring in less than the given period" in testDBResource
+    .use { implicit cfg =>
+      for {
+        proj1 <- insertDecryptableToken(projectIds.generateOne, expiryDate = ExpiryDate(now().plusDays(1)))
+        proj2 <- insertDecryptableToken(projectIds.generateOne, expiryDate = ExpiryDate(now().plus(beforeExpiration)))
+        _ <- insertDecryptableToken(projectIds.generateOne,
+                                    expiryDate = ExpiryDate(now().plus(beforeExpiration.plusDays(1)))
+             )
+        res <- finder.findExpiringTokens
+                 .evalTap(pt => PersistedTokenRemover[IO].delete(pt.projectId))
+                 .map(_.projectId)
+                 .compile
+                 .toList
+                 .asserting(_ shouldBe List(proj1, proj2))
+      } yield res
+    }
+
+  it should "return a stream of ExpiringToken objects even if the token fails decryption" in testDBResource
+    .use { implicit cfg =>
+      for {
+        proj1 <- insertNonDecryptableToken(projectIds.generateOne, expiryDate = ExpiryDate(now().plusDays(1)))
+        proj2 <- insertDecryptableToken(projectIds.generateOne, expiryDate = ExpiryDate(now().plus(beforeExpiration)))
+        _ <- insertDecryptableToken(projectIds.generateOne,
+                                    expiryDate = ExpiryDate(now().plus(beforeExpiration.plusDays(1)))
+             )
+        res <- finder.findExpiringTokens
+                 .evalTap(pt => PersistedTokenRemover[IO].delete(pt.projectId))
+                 .map(_.projectId)
+                 .compile
+                 .toList
+                 .asserting(_ shouldBe List(proj1, proj2))
+      } yield res
+    }
+
+  private lazy val beforeExpiration = Period.ofDays(10)
+  private implicit val qet: QueriesExecutionTimes[IO] = TestQueriesExecutionTimes[IO]
+  private lazy val tokenCrypto = mock[AccessTokenCrypto[IO]]
+  private def finder(implicit cfg: DBConfig[ProjectsTokensDB]) =
+    new ExpiringTokensFinderImpl[IO](tokenCrypto, beforeExpiration, chunkSize = 1)
+
+  private def givenSuccessfulDecryption(encToken: EncryptedAccessToken) =
+    (tokenCrypto.decrypt _)
+      .expects(encToken)
+      .returning(accessTokens.generateOne.pure[IO])
+      .anyNumberOfTimes()
+
+  private def givenDecryption(encToken: EncryptedAccessToken, returning: IO[AccessToken]) =
+    (tokenCrypto.decrypt _)
+      .expects(encToken)
+      .returning(returning)
+
+  private def insertDecryptableToken(projectId: projects.GitLabId, expiryDate: ExpiryDate)(implicit
+      cfg: DBConfig[ProjectsTokensDB]
+  ): IO[projects.GitLabId] = {
+    val encToken = encryptedAccessTokens.generateOne
+    givenSuccessfulDecryption(encToken)
+    insert(projectId, projectSlugs.generateOne, encToken, expiryDate).as(projectId)
+  }
+
+  private def insertNonDecryptableToken(projectId: projects.GitLabId, expiryDate: ExpiryDate)(implicit
+      cfg: DBConfig[ProjectsTokensDB]
+  ): IO[projects.GitLabId] = {
+    val encToken = encryptedAccessTokens.generateOne
+    givenDecryption(encToken, returning = exceptions.generateOne.raiseError[IO, Nothing])
+    insert(projectId, projectSlugs.generateOne, encToken, expiryDate).as(projectId)
+  }
+}

--- a/token-repository/src/test/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensRemoverSpec.scala
+++ b/token-repository/src/test/scala/io/renku/tokenrepository/repository/cleanup/ExpiringTokensRemoverSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.renku.tokenrepository.repository.cleanup
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import cats.syntax.all._
+import fs2.Stream
+import io.renku.generators.CommonGraphGenerators.accessTokens
+import io.renku.generators.Generators.Implicits._
+import io.renku.generators.Generators.exceptions
+import io.renku.graph.model.RenkuTinyTypeGenerators.projectIds
+import io.renku.interpreters.TestLogger
+import io.renku.tokenrepository.repository.RepositoryGenerators.{deletionResults, encryptedAccessTokens}
+import io.renku.tokenrepository.repository.deletion.{DeletionResult, PersistedTokenRemover, TokenRemover}
+import org.scalacheck.Gen
+import org.scalamock.scalatest.AsyncMockFactory
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should
+
+import scala.concurrent.duration._
+
+class ExpiringTokensRemoverSpec extends AsyncFlatSpec with AsyncIOSpec with should.Matchers with AsyncMockFactory {
+
+  it should "continue fetching tokens that are about to expire and remove them" in {
+
+    val tokens = expiringTokens.generateList(min = 1)
+    givenTokensFinding(returning = Stream.emits(tokens))
+    tokens.foreach(givenTokenRemoval(_, returning = deletionResults.generateOne.pure[IO]))
+
+    remover.removeExpiringTokens().assertNoException
+  }
+
+  it should "retry if process fails" in {
+
+    val token1 = expiringTokens.generateOne
+    val token2 = expiringTokens.generateOne
+    val token3 = expiringTokens.generateOne
+    givenTokensFinding(returning = Stream(token1, token2, token3))
+    givenTokenRemoval(token1, returning = deletionResults.generateOne.pure[IO])
+    val exception = exceptions.generateOne
+    givenTokenRemoval(token2, returning = exception.raiseError[IO, Nothing])
+
+    givenTokensFinding(returning = Stream(token2, token3))
+    givenTokenRemoval(token2, returning = deletionResults.generateOne.pure[IO])
+    givenTokenRemoval(token3, returning = deletionResults.generateOne.pure[IO])
+
+    remover.removeExpiringTokens().assertNoException
+  }
+
+  private implicit val logger: TestLogger[IO] = TestLogger()
+  private val tokensFinder   = mock[ExpiringTokensFinder[IO]]
+  private val tokenRemover   = mock[TokenRemover[IO]]
+  private val dbTokenRemover = mock[PersistedTokenRemover[IO]]
+  private lazy val remover =
+    new ExpiringTokensRemoverImpl[IO](tokensFinder, tokenRemover, dbTokenRemover, retryDelayOnError = 100 millis)
+
+  private def givenTokensFinding(returning: Stream[IO, ExpiringToken]) =
+    (() => tokensFinder.findExpiringTokens)
+      .expects()
+      .returning(returning)
+
+  private def givenTokenRemoval(expiringToken: ExpiringToken, returning: IO[DeletionResult]) =
+    expiringToken match {
+      case ExpiringToken.Decryptable(projectId, token) =>
+        (tokenRemover.delete _)
+          .expects(projectId, token.some)
+          .returning(returning)
+      case ExpiringToken.NonDecryptable(projectId, _) =>
+        (dbTokenRemover.delete _)
+          .expects(projectId)
+          .returning(returning)
+    }
+
+  private lazy val expiringTokens: Gen[ExpiringToken] =
+    Gen.oneOf(
+      (projectIds, accessTokens).mapN(ExpiringToken.Decryptable.apply),
+      (projectIds, encryptedAccessTokens).mapN(ExpiringToken.NonDecryptable.apply)
+    )
+}


### PR DESCRIPTION
This PR:
* adds a job to the token-repository service that checks for any tokens expiring in 10 days (or less), removes them from TR DB and revokes them from GitLab
* the job to run once a day