### PR TITLE
feat: Project Create API to accept templateRef and templateParameters

### DIFF
--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -560,6 +560,11 @@ Content-Disposition: form-data; name="templateRef"
 
 0.6.0
 ------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="templateParameters"
+Content-Type: application/json
+
+[{"key":"archive_url","value":"http://host/path"}]
+------WebKitFormBoundary7MA4YWxkTrZu0gW
 Content-Disposition: form-data; name="image"; filename="image.png"
 Content-Type: image/png
 

--- a/knowledge-graph/README.md
+++ b/knowledge-graph/README.md
@@ -556,6 +556,10 @@ Content-Disposition: form-data; name="templateId"
 
 python-minimal
 ------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="templateRef"
+
+0.6.0
+------WebKitFormBoundary7MA4YWxkTrZu0gW
 Content-Disposition: form-data; name="image"; filename="image.png"
 Content-Type: image/png
 

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/multipart/PartEncoder.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/multipart/PartEncoder.scala
@@ -18,7 +18,11 @@
 
 package io.renku.knowledgegraph.multipart
 
+import io.circe.Json
 import io.renku.tinytypes.TinyType
+import org.http4s.Header.ToRaw._
+import org.http4s.MediaType
+import org.http4s.headers.`Content-Type`
 import org.http4s.multipart.Part
 
 trait PartEncoder[F[_], A] {
@@ -32,6 +36,11 @@ object PartEncoder {
 
   implicit def fromPartValueEncoder[F[_], A](implicit pvEnc: PartValueEncoder[A]): PartEncoder[F, A] =
     instance[F, A]((partName: String, a: A) => Part.formData[F](partName, pvEnc(a)))
+
+  implicit def fromPartJsonValueEncoder[F[_]]: PartEncoder[F, Json] =
+    instance[F, Json]((partName: String, a: Json) =>
+      Part.formData[F](partName, a.noSpaces, `Content-Type`(MediaType.application.json))
+    )
 }
 
 trait PartValueEncoder[A] {

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/multipart/syntax.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/multipart/syntax.scala
@@ -23,7 +23,6 @@ import cats.syntax.all._
 import cats.{Functor, MonadThrow}
 import eu.timepit.refined.api.{RefType, Refined}
 import eu.timepit.refined.collection.NonEmpty
-import io.circe.Json
 import io.renku.tinytypes.{From, TinyType, TinyTypeFactory}
 import org.http4s.multipart.{Multipart, Part}
 import org.http4s.{DecodeFailure, DecodeResult, EntityDecoder, MalformedMessageBodyFailure}
@@ -127,7 +126,4 @@ object syntax {
           .pure[F]
       }
     }
-
-  implicit def jsonEntityDecoder[F[_]: Concurrent]: EntityDecoder[F, Json] =
-    org.http4s.circe.jsonOf[F, Json]
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/multipart/syntax.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/multipart/syntax.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import cats.{Functor, MonadThrow}
 import eu.timepit.refined.api.{RefType, Refined}
 import eu.timepit.refined.collection.NonEmpty
+import io.circe.Json
 import io.renku.tinytypes.{From, TinyType, TinyTypeFactory}
 import org.http4s.multipart.{Multipart, Part}
 import org.http4s.{DecodeFailure, DecodeResult, EntityDecoder, MalformedMessageBodyFailure}
@@ -126,4 +127,7 @@ object syntax {
           .pure[F]
       }
     }
+
+  implicit def jsonEntityDecoder[F[_]: Concurrent]: EntityDecoder[F, Json] =
+    org.http4s.circe.jsonOf[F, Json]
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/EndpointDocs.scala
@@ -86,6 +86,11 @@ object EndpointDocs extends docs.EndpointDocs {
                |
                |0.6.0
                |------WebKitFormBoundary7MA4YWxkTrZu0gW
+               |Content-Disposition: form-data; name="templateParameters"
+               |Content-Type: application/json
+               |
+               |[{"key":"archive_url","value":"http://host/path"}]
+               |------WebKitFormBoundary7MA4YWxkTrZu0gW
                |Content-Disposition: form-data; name="image"; filename="image.png"
                |Content-Type: image/png
                |

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/EndpointDocs.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/EndpointDocs.scala
@@ -82,6 +82,10 @@ object EndpointDocs extends docs.EndpointDocs {
                |
                |python-minimal
                |------WebKitFormBoundary7MA4YWxkTrZu0gW
+               |Content-Disposition: form-data; name="templateRef"
+               |
+               |0.6.0
+               |------WebKitFormBoundary7MA4YWxkTrZu0gW
                |Content-Disposition: form-data; name="image"; filename="image.png"
                |Content-Type: image/png
                |

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/MultipartRequestCodec.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/MultipartRequestCodec.scala
@@ -21,12 +21,13 @@ package io.renku.knowledgegraph.projects.create
 import MultipartRequestCodec.PartName
 import cats.effect.{Async, Sync}
 import cats.syntax.all._
+import io.circe.Json
 import io.renku.core.client.{Template, templates}
 import io.renku.graph.model.projects
 import io.renku.knowledgegraph.multipart.syntax._
 import io.renku.knowledgegraph.projects.images.Image
 import io.renku.knowledgegraph.projects.images.MultipartImageCodecs._
-import org.http4s.multipart.{Multipart, Multiparts}
+import org.http4s.multipart.{Multipart, Multiparts, Part}
 
 private trait MultipartRequestCodec[F[_]] extends MultipartRequestEncoder[F] with MultipartRequestDecoder[F]
 
@@ -52,6 +53,7 @@ private object MultipartRequestCodec {
     val templateRepositoryUrl = "templateRepositoryUrl"
     val templateId            = "templateId"
     val templateRef           = "templateRef"
+    val templateParameters    = "templateParameters"
   }
 }
 
@@ -72,7 +74,10 @@ private class MultipartRequestEncoderImpl[F[_]: Sync] extends MultipartRequestEn
       Vector(
         newProject.maybeDescription.asParts[F](PartName.description),
         newProject.maybeImage.asParts[F](PartName.image),
-        newProject.template.maybeRef.asParts[F](PartName.templateRef)
+        newProject.template.maybeRef.asParts[F](PartName.templateRef),
+        newProject.template.maybeParameters
+          .map(prms => Json.arr(prms.value: _*))
+          .asParts[F](PartName.templateParameters)
       ).flatten
         .appended(newProject.name.asPart[F](PartName.name))
         .appended(newProject.namespace.identifier.asPart[F](PartName.namespaceId))
@@ -109,6 +114,10 @@ private class MultipartRequestDecoderImpl[F[_]: Async] extends MultipartRequestD
   private def templateDecoder(multipart: Multipart[F]) =
     (multipart.part(PartName.templateRepositoryUrl).flatMap(_.as[templates.RepositoryUrl]),
      multipart.part(PartName.templateId).flatMap(_.as[templates.Identifier]),
-     multipart.findPart(PartName.templateRef).map(_.as[Option[templates.Ref]]).sequence.map(_.flatten)
+     multipart.findPart(PartName.templateRef).map(_.as[Option[templates.Ref]]).sequence.map(_.flatten),
+     multipart.findPart(PartName.templateParameters).map(templateParameterValueDecoder).sequence
     ).mapN(Template.apply)
+
+  private def templateParameterValueDecoder: Part[F] => F[templates.Parameters] =
+    _.as[Json].map(_.asArray.map(_.toList).sequence.flatten).map(templates.Parameters)
 }

--- a/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/MultipartRequestCodec.scala
+++ b/knowledge-graph/src/main/scala/io/renku/knowledgegraph/projects/create/MultipartRequestCodec.scala
@@ -24,6 +24,7 @@ import cats.syntax.all._
 import io.circe.Json
 import io.renku.core.client.{Template, templates}
 import io.renku.graph.model.projects
+import io.renku.http.RenkuEntityCodec.jsonEntityDecoder
 import io.renku.knowledgegraph.multipart.syntax._
 import io.renku.knowledgegraph.projects.images.Image
 import io.renku.knowledgegraph.projects.images.MultipartImageCodecs._

--- a/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/create/EndpointSpec.scala
+++ b/knowledge-graph/src/test/scala/io/renku/knowledgegraph/projects/create/EndpointSpec.scala
@@ -57,14 +57,12 @@ class EndpointSpec
     MultipartRequestEncoder[IO].encode(newProject).map(mp => Request[IO]().withEntity(mp).putHeaders(mp.headers)) >>=
       (req => endpoint.`POST /projects`(req, authUser)) >>= { response =>
       response.pure[IO].asserting(_.status shouldBe Status.Created) >>
-        response
-          .as[Message]
-          .asserting {
-            _ shouldBe Message.Info.fromJsonUnsafe(json"""{
+        response.as[Message].asserting {
+          _ shouldBe Message.Info.fromJsonUnsafe(json"""{
               "message": "Project created",
               "slug":     $slug
             }""")
-          }
+        }
     }
   }
 

--- a/renku-core-client/src/main/scala/io/renku/core/client/NewProject.scala
+++ b/renku-core-client/src/main/scala/io/renku/core/client/NewProject.scala
@@ -38,8 +38,9 @@ object NewProject {
     case NewProject(projectRepository, namespace, name, maybeDescription, keywords, template, branch, _) =>
       Json.obj(
         List(
-          ("url"                -> template.repositoryUrl.asJson).some,
-          ("identifier"         -> template.identifier.asJson).some,
+          ("url"        -> template.repositoryUrl.asJson).some,
+          ("identifier" -> template.identifier.asJson).some,
+          template.maybeRef.map("ref" -> _.asJson),
           ("project_repository" -> projectRepository.asJson).some,
           ("project_namespace"  -> namespace.asJson).some,
           ("project_name"       -> name.asJson).some,

--- a/renku-core-client/src/main/scala/io/renku/core/client/NewProject.scala
+++ b/renku-core-client/src/main/scala/io/renku/core/client/NewProject.scala
@@ -41,6 +41,7 @@ object NewProject {
           ("url"        -> template.repositoryUrl.asJson).some,
           ("identifier" -> template.identifier.asJson).some,
           template.maybeRef.map("ref" -> _.asJson),
+          template.maybeParameters.map("parameters" -> _.value.asJson),
           ("project_repository" -> projectRepository.asJson).some,
           ("project_namespace"  -> namespace.asJson).some,
           ("project_name"       -> name.asJson).some,

--- a/renku-core-client/src/main/scala/io/renku/core/client/Template.scala
+++ b/renku-core-client/src/main/scala/io/renku/core/client/Template.scala
@@ -18,12 +18,14 @@
 
 package io.renku.core.client
 
+import io.circe.Json
 import io.renku.tinytypes.constraints.{NonBlank, Url}
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory, UrlTinyType}
 
-final case class Template(repositoryUrl: templates.RepositoryUrl,
-                          identifier:    templates.Identifier,
-                          maybeRef:      Option[templates.Ref]
+final case class Template(repositoryUrl:   templates.RepositoryUrl,
+                          identifier:      templates.Identifier,
+                          maybeRef:        Option[templates.Ref],
+                          maybeParameters: Option[templates.Parameters]
 )
 
 object templates {
@@ -36,4 +38,6 @@ object templates {
 
   final class Ref private (val value: String) extends AnyVal with StringTinyType
   implicit object Ref                         extends TinyTypeFactory[Ref](new Ref(_)) with NonBlank[Ref]
+
+  final case class Parameters(value: List[Json])
 }

--- a/renku-core-client/src/main/scala/io/renku/core/client/Template.scala
+++ b/renku-core-client/src/main/scala/io/renku/core/client/Template.scala
@@ -21,7 +21,10 @@ package io.renku.core.client
 import io.renku.tinytypes.constraints.{NonBlank, Url}
 import io.renku.tinytypes.{StringTinyType, TinyTypeFactory, UrlTinyType}
 
-final case class Template(repositoryUrl: templates.RepositoryUrl, identifier: templates.Identifier)
+final case class Template(repositoryUrl: templates.RepositoryUrl,
+                          identifier:    templates.Identifier,
+                          maybeRef:      Option[templates.Ref]
+)
 
 object templates {
 
@@ -30,4 +33,7 @@ object templates {
 
   final class Identifier private (val value: String) extends AnyVal with StringTinyType
   implicit object Identifier extends TinyTypeFactory[Identifier](new Identifier(_)) with NonBlank[Identifier]
+
+  final class Ref private (val value: String) extends AnyVal with StringTinyType
+  implicit object Ref                         extends TinyTypeFactory[Ref](new Ref(_)) with NonBlank[Ref]
 }

--- a/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
@@ -95,9 +95,10 @@ object Generators {
 
   implicit val templateRepositoryUrls: Gen[templates.RepositoryUrl] = httpUrls().toGeneratorOf(templates.RepositoryUrl)
   implicit val templateIdentifiers:    Gen[templates.Identifier]    = noDashUuid.toGeneratorOf(templates.Identifier)
+  implicit val templateRefs:           Gen[templates.Ref]           = semanticVersions.toGeneratorOf(templates.Ref)
 
   implicit val templatesGen: Gen[Template] =
-    (templateRepositoryUrls, templateIdentifiers).mapN(Template.apply)
+    (templateRepositoryUrls, templateIdentifiers, templateRefs.toGeneratorOfOptions).mapN(Template.apply)
 
   implicit lazy val newProjectsGen: Gen[NewProject] =
     (projectRepositories,

--- a/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/Generators.scala
@@ -96,9 +96,15 @@ object Generators {
   implicit val templateRepositoryUrls: Gen[templates.RepositoryUrl] = httpUrls().toGeneratorOf(templates.RepositoryUrl)
   implicit val templateIdentifiers:    Gen[templates.Identifier]    = noDashUuid.toGeneratorOf(templates.Identifier)
   implicit val templateRefs:           Gen[templates.Ref]           = semanticVersions.toGeneratorOf(templates.Ref)
+  implicit val templateParams: Gen[templates.Parameters] =
+    jsons.toGeneratorOfList(min = 1).toGeneratorOf(templates.Parameters)
 
   implicit val templatesGen: Gen[Template] =
-    (templateRepositoryUrls, templateIdentifiers, templateRefs.toGeneratorOfOptions).mapN(Template.apply)
+    (templateRepositoryUrls,
+     templateIdentifiers,
+     templateRefs.toGeneratorOfOptions,
+     templateParams.toGeneratorOfOptions
+    ).mapN(Template.apply)
 
   implicit lazy val newProjectsGen: Gen[NewProject] =
     (projectRepositories,

--- a/renku-core-client/src/test/scala/io/renku/core/client/NewProjectSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/NewProjectSpec.scala
@@ -21,27 +21,27 @@ package io.renku.core.client
 import Generators.newProjectsGen
 import io.circe.literal._
 import io.circe.syntax._
-import io.renku.generators.Generators.Implicits._
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class NewProjectSpec extends AnyFlatSpec with should.Matchers with EitherValues {
+class NewProjectSpec extends AnyFlatSpec with should.Matchers with EitherValues with ScalaCheckPropertyChecks {
 
   it should "encode to JSON" in {
-
-    val newProject = newProjectsGen.generateOne
-
-    newProject.asJson shouldBe
-      json"""{
-        "url":                 ${newProject.template.repositoryUrl},
-        "identifier":          ${newProject.template.identifier},
-        "project_repository":  ${newProject.projectRepository},
-        "project_namespace":   ${newProject.namespace},
-        "project_name":        ${newProject.name},
-        "project_keywords":    ${newProject.keywords},
-        "project_description": ${newProject.maybeDescription},
-        "initial_branch":      ${newProject.branch}
-      }""".dropNullValues
+    forAll(newProjectsGen) { newProject =>
+      newProject.asJson shouldBe
+        json"""{
+          "url":                 ${newProject.template.repositoryUrl},
+          "identifier":          ${newProject.template.identifier},
+          "ref":                 ${newProject.template.maybeRef},
+          "project_repository":  ${newProject.projectRepository},
+          "project_namespace":   ${newProject.namespace},
+          "project_name":        ${newProject.name},
+          "project_keywords":    ${newProject.keywords},
+          "project_description": ${newProject.maybeDescription},
+          "initial_branch":      ${newProject.branch}
+        }""".dropNullValues
+    }
   }
 }

--- a/renku-core-client/src/test/scala/io/renku/core/client/NewProjectSpec.scala
+++ b/renku-core-client/src/test/scala/io/renku/core/client/NewProjectSpec.scala
@@ -35,6 +35,7 @@ class NewProjectSpec extends AnyFlatSpec with should.Matchers with EitherValues 
           "url":                 ${newProject.template.repositoryUrl},
           "identifier":          ${newProject.template.identifier},
           "ref":                 ${newProject.template.maybeRef},
+          "parameters":          ${newProject.template.maybeParameters.map(_.value)},
           "project_repository":  ${newProject.projectRepository},
           "project_namespace":   ${newProject.namespace},
           "project_name":        ${newProject.name},


### PR DESCRIPTION
This PR makes the Project Create API:
* to accept a new `projectRef` string part
* to accept a new `projectParameters` JSON part containing an array of key-value pair objects

/deploy